### PR TITLE
fix: add armeabi-v7a (32-bit ARM) to Android build architectures

### DIFF
--- a/TherrMobile/android/gradle.properties
+++ b/TherrMobile/android/gradle.properties
@@ -30,7 +30,7 @@ android.enableJetifier=true
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=arm64-v8a,x86_64
+reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86_64
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in


### PR DESCRIPTION
ZTE Blade A35 Core (Android 13) runs in 32-bit ARM mode and crashes with
SoLoaderDSONotFoundError for libworklets.so because only arm64-v8a and
x86_64 were included. Adding armeabi-v7a ensures native libraries from
react-native-reanimated are packaged for 32-bit ARM devices.

With App Bundles, Google Play only delivers the relevant ABI per device,
so this does not increase download size for 64-bit users.

https://claude.ai/code/session_01RU5JUxwcyqpVxKN6Dj3HE9