### PR TITLE
Optimize image rendering across web and mobile apps

### DIFF
--- a/TherrMobile/main/utilities/content.ts
+++ b/TherrMobile/main/utilities/content.ts
@@ -16,9 +16,11 @@ const getUserContentUri = (media, height = screenWidth, width = screenWidth, aut
     // Round to 100s increase odds of device overlap being cached
     const minImageHeight = Math.ceil((height * 1.25) / 100) * 100;
     const minImageWidth = Math.ceil((width * 1.25) / 100) * 100;
+    // Use lower quality for small thumbnails where compression artifacts are not visible
+    const quality = (height <= 200 && width <= 200) ? 75 : 85;
 
     let url = `${BASE_ENDPOINT}${media?.path}`;
-    url = `${url}?tr=h-${minImageHeight},w-${minImageWidth}`;
+    url = `${url}?tr=h-${minImageHeight},w-${minImageWidth},f-auto,q-${quality}`;
     if (!autocrop) {
         // Preserve original image dimensions
         url = `${url},c-at_least`;
@@ -32,7 +34,7 @@ const getUserImageUri = (user, size = screenWidth) => {
          * In the max-size crop strategy, whole image content is preserved (no cropping),
          * the aspect ratio is preserved, but one of the dimensions (height or width) is adjusted.
          */
-        return `${BASE_ENDPOINT}${user.details.media.profilePicture.path}?tr=h-${size},w-${size}`;
+        return `${BASE_ENDPOINT}${user.details.media.profilePicture.path}?tr=h-${size},w-${size},f-auto,q-90`;
     }
 
     return `https://robohash.org/${user.details?.id}?set=set5&size=${size}x${size}`;

--- a/therr-client-web-dashboard/src/utilities/getUserContentUri.ts
+++ b/therr-client-web-dashboard/src/utilities/getUserContentUri.ts
@@ -5,8 +5,10 @@ const BASE_ENDPOINT = globalConfig[process.env.NODE_ENV].baseImageKitEndpoint
     : `${globalConfig[process.env.NODE_ENV].baseApiGatewayRoute}/user-files/`;
 
 const getUserContentUri = (media, height = 1048, width = 1048, autocrop = false) => {
+    // Use lower quality for small thumbnails where compression artifacts are not visible
+    const quality = (height <= 200 && width <= 200) ? 75 : 85;
     let url = `${BASE_ENDPOINT}${media.path}`;
-    url = `${url}?tr=h-${height},w-${width}`;
+    url = `${url}?tr=h-${height},w-${width},f-auto,q-${quality}`;
     if (!autocrop) {
         // Preserve original image dimensions
         url = `${url},c-at_least`;

--- a/therr-client-web-dashboard/src/utilities/getUserImageUri.ts
+++ b/therr-client-web-dashboard/src/utilities/getUserImageUri.ts
@@ -10,7 +10,7 @@ const getUserImageUri = (user, size = 200) => {
          * In the max-size crop strategy, whole image content is preserved (no cropping),
          * the aspect ratio is preserved, but one of the dimensions (height or width) is adjusted.
          */
-        return `${BASE_ENDPOINT}${user.details.media.profilePicture.path}?tr=${size},${size}`;
+        return `${BASE_ENDPOINT}${user.details.media.profilePicture.path}?tr=h-${size},w-${size},f-auto,q-90`;
     }
 
     return `https://robohash.org/${user.details?.id}?set=set1&size=${size}x${size}`;

--- a/therr-client-web/src/components/ProgressiveImage.tsx
+++ b/therr-client-web/src/components/ProgressiveImage.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { Image } from '@mantine/core';
+
+interface IProgressiveImageProps {
+    src: string;
+    alt: string;
+    className?: string;
+    fallbackSrc?: string;
+    radius?: string;
+    fetchPriority?: 'high' | 'low' | 'auto';
+}
+
+/**
+ * Progressive image component that shows a tiny blurred placeholder
+ * while the full-resolution image loads (blur-up effect).
+ * Works with ImageKit URLs by appending blur and resize transforms.
+ */
+const ProgressiveImage: React.FC<IProgressiveImageProps> = ({
+    src,
+    alt,
+    className,
+    fallbackSrc,
+    radius,
+    fetchPriority,
+}) => {
+    const [isLoaded, setIsLoaded] = React.useState(false);
+    const imgRef = React.useRef<HTMLImageElement>(null);
+
+    // Build a tiny blurred placeholder URL from the ImageKit source
+    const placeholderSrc = React.useMemo(() => {
+        if (!src || !src.includes('?tr=')) return undefined;
+        // Replace size params with tiny size + blur
+        return src.replace(/\?tr=(.*)/, '?tr=h-40,w-40,bl-30,q-50,f-auto');
+    }, [src]);
+
+    React.useEffect(() => {
+        setIsLoaded(false);
+    }, [src]);
+
+    // Check if the image was already cached/loaded before React hydrated
+    React.useEffect(() => {
+        if (imgRef.current?.complete && imgRef.current?.naturalWidth > 0) {
+            setIsLoaded(true);
+        }
+    }, []);
+
+    if (!placeholderSrc) {
+        return (
+            <Image
+                src={src}
+                alt={alt}
+                className={className}
+                fallbackSrc={fallbackSrc}
+                radius={radius}
+                fetchPriority={fetchPriority}
+            />
+        );
+    }
+
+    return (
+        <div style={{ position: 'relative', overflow: 'hidden', borderRadius: radius === 'md' ? 'var(--mantine-radius-md)' : undefined }}>
+            {/* Blurred placeholder - always rendered, hidden once full image loads */}
+            {!isLoaded && (
+                <Image
+                    src={placeholderSrc}
+                    alt=""
+                    className={className}
+                    radius={radius}
+                    style={{
+                        filter: 'blur(20px)',
+                        transform: 'scale(1.1)',
+                    }}
+                />
+            )}
+            {/* Full resolution image */}
+            <Image
+                ref={imgRef}
+                src={src}
+                alt={alt}
+                className={className}
+                fallbackSrc={fallbackSrc}
+                radius={radius}
+                fetchPriority={fetchPriority}
+                onLoad={() => setIsLoaded(true)}
+                style={!isLoaded ? {
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    height: '100%',
+                    opacity: 0,
+                } : undefined}
+            />
+        </div>
+    );
+};
+
+export default ProgressiveImage;

--- a/therr-client-web/src/components/ProgressiveImage.tsx
+++ b/therr-client-web/src/components/ProgressiveImage.tsx
@@ -10,11 +10,6 @@ interface IProgressiveImageProps {
     fetchPriority?: 'high' | 'low' | 'auto';
 }
 
-/**
- * Progressive image component that shows a tiny blurred placeholder
- * while the full-resolution image loads (blur-up effect).
- * Works with ImageKit URLs by appending blur and resize transforms.
- */
 const ProgressiveImage: React.FC<IProgressiveImageProps> = ({
     src,
     alt,
@@ -24,25 +19,16 @@ const ProgressiveImage: React.FC<IProgressiveImageProps> = ({
     fetchPriority,
 }) => {
     const [isLoaded, setIsLoaded] = React.useState(false);
-    const imgRef = React.useRef<HTMLImageElement>(null);
 
     // Build a tiny blurred placeholder URL from the ImageKit source
     const placeholderSrc = React.useMemo(() => {
         if (!src || !src.includes('?tr=')) return undefined;
-        // Replace size params with tiny size + blur
         return src.replace(/\?tr=(.*)/, '?tr=h-40,w-40,bl-30,q-50,f-auto');
     }, [src]);
 
     React.useEffect(() => {
         setIsLoaded(false);
     }, [src]);
-
-    // Check if the image was already cached/loaded before React hydrated
-    React.useEffect(() => {
-        if (imgRef.current?.complete && imgRef.current?.naturalWidth > 0) {
-            setIsLoaded(true);
-        }
-    }, []);
 
     if (!placeholderSrc) {
         return (
@@ -57,24 +43,14 @@ const ProgressiveImage: React.FC<IProgressiveImageProps> = ({
         );
     }
 
+    const borderRadius = radius === 'md'
+        ? 'var(--mantine-radius-md)'
+        : undefined;
+
     return (
-        <div style={{ position: 'relative', overflow: 'hidden', borderRadius: radius === 'md' ? 'var(--mantine-radius-md)' : undefined }}>
-            {/* Blurred placeholder - always rendered, hidden once full image loads */}
-            {!isLoaded && (
-                <Image
-                    src={placeholderSrc}
-                    alt=""
-                    className={className}
-                    radius={radius}
-                    style={{
-                        filter: 'blur(20px)',
-                        transform: 'scale(1.1)',
-                    }}
-                />
-            )}
-            {/* Full resolution image */}
+        <div style={{ position: 'relative', overflow: 'hidden', borderRadius }}>
+            {/* Full resolution image - always in DOM for SSR/SEO */}
             <Image
-                ref={imgRef}
                 src={src}
                 alt={alt}
                 className={className}
@@ -82,14 +58,26 @@ const ProgressiveImage: React.FC<IProgressiveImageProps> = ({
                 radius={radius}
                 fetchPriority={fetchPriority}
                 onLoad={() => setIsLoaded(true)}
-                style={!isLoaded ? {
+            />
+            {/* Blurred placeholder overlay - fades out when full image loads */}
+            <Image
+                src={placeholderSrc}
+                alt=""
+                aria-hidden="true"
+                className={className}
+                radius={radius}
+                style={{
                     position: 'absolute',
                     top: 0,
                     left: 0,
                     width: '100%',
                     height: '100%',
-                    opacity: 0,
-                } : undefined}
+                    filter: 'blur(20px)',
+                    transform: 'scale(1.1)',
+                    opacity: isLoaded ? 0 : 1,
+                    transition: 'opacity 0.3s ease-out',
+                    pointerEvents: 'none',
+                }}
             />
         </div>
     );

--- a/therr-client-web/src/routes/Discovered/Tile.tsx
+++ b/therr-client-web/src/routes/Discovered/Tile.tsx
@@ -87,6 +87,7 @@ const Tile: React.FC<ITileProps> = ({ area, areaType, userDetails }) => {
                         alt={area.notificationMsg || area.fromUserName}
                         height={200}
                         fit="cover"
+                        loading="lazy"
                     />
                 </Card.Section>
             )}

--- a/therr-client-web/src/routes/ViewEvent.tsx
+++ b/therr-client-web/src/routes/ViewEvent.tsx
@@ -16,6 +16,7 @@ import {
 import withNavigation from '../wrappers/withNavigation';
 import withTranslation from '../wrappers/withTranslation';
 import getUserContentUri from '../utilities/getUserContentUri';
+import ProgressiveImage from '../components/ProgressiveImage';
 
 const formatCategoryLabel = (category: string): string => {
     if (!category) return '';
@@ -242,6 +243,7 @@ export class ViewEventComponent extends React.Component<IViewEventProps, IViewEv
                                     h={80}
                                     radius="sm"
                                     fit="cover"
+                                    loading="lazy"
                                 />
                             )}
                             <Stack gap={4}>
@@ -368,12 +370,13 @@ export class ViewEventComponent extends React.Component<IViewEventProps, IViewEv
                     {/* Hero Image */}
                     {eventMedia && (
                         <div className="event-hero-image-wrapper">
-                            <Image
+                            <ProgressiveImage
                                 src={eventMedia}
                                 alt={event.notificationMsg}
                                 className="event-hero-image"
                                 fallbackSrc="/assets/images/meta-image-logo.png"
                                 radius="md"
+                                fetchPriority="high"
                             />
                         </div>
                     )}
@@ -417,10 +420,10 @@ export class ViewEventComponent extends React.Component<IViewEventProps, IViewEv
                         <Text fw={600} ta="center">{this.props.translate('pages.viewSpace.labels.getFullExperience')}</Text>
                         <Group justify="center" mt="sm" gap="md">
                             <Anchor href="https://apps.apple.com/us/app/therr/id1569988763?platform=iphone" target="_blank" rel="noreferrer">
-                                <Image aria-label="apple store link" maw={120} src="/assets/images/apple-store-download-button.svg" alt="Download Therr on the App Store" />
+                                <Image aria-label="apple store link" maw={120} src="/assets/images/apple-store-download-button.svg" alt="Download Therr on the App Store" loading="lazy" />
                             </Anchor>
                             <Anchor href="https://play.google.com/store/apps/details?id=app.therrmobile" target="_blank" rel="noreferrer">
-                                <Image aria-label="play store link" maw={120} src="/assets/images/play-store-download-button.svg" alt="Download Therr on Google Play" />
+                                <Image aria-label="play store link" maw={120} src="/assets/images/play-store-download-button.svg" alt="Download Therr on Google Play" loading="lazy" />
                             </Anchor>
                         </Group>
                     </Paper>

--- a/therr-client-web/src/routes/ViewMoment.tsx
+++ b/therr-client-web/src/routes/ViewMoment.tsx
@@ -13,6 +13,7 @@ import {
 import withNavigation from '../wrappers/withNavigation';
 import withTranslation from '../wrappers/withTranslation';
 import getUserContentUri from '../utilities/getUserContentUri';
+import ProgressiveImage from '../components/ProgressiveImage';
 
 const formatCategoryLabel = (category: string): string => {
     if (!category) return '';
@@ -192,6 +193,7 @@ export class ViewMomentComponent extends React.Component<IViewMomentProps, IView
                                 h={80}
                                 radius="sm"
                                 fit="cover"
+                                loading="lazy"
                             />
                         )}
                         <Stack gap={4}>
@@ -234,12 +236,13 @@ export class ViewMomentComponent extends React.Component<IViewMomentProps, IView
                     {/* Hero Image */}
                     {momentMedia && (
                         <div className="moment-hero-image-wrapper">
-                            <Image
+                            <ProgressiveImage
                                 src={momentMedia}
                                 alt={moment.notificationMsg}
                                 className="moment-hero-image"
                                 fallbackSrc="/assets/images/meta-image-logo.png"
                                 radius="md"
+                                fetchPriority="high"
                             />
                         </div>
                     )}

--- a/therr-client-web/src/routes/ViewSpace.tsx
+++ b/therr-client-web/src/routes/ViewSpace.tsx
@@ -15,6 +15,7 @@ import {
 import withNavigation from '../wrappers/withNavigation';
 import withTranslation from '../wrappers/withTranslation';
 import getUserContentUri from '../utilities/getUserContentUri';
+import ProgressiveImage from '../components/ProgressiveImage';
 
 const formatCategoryLabel = (category: string): string => {
     if (!category) return '';
@@ -385,6 +386,7 @@ export class ViewSpaceComponent extends React.Component<IViewSpaceProps, IViewSp
                         radius="sm"
                         mah={200}
                         fit="cover"
+                        loading="lazy"
                     />
                 )}
                 {moment.hashTags && (
@@ -449,6 +451,7 @@ export class ViewSpaceComponent extends React.Component<IViewSpaceProps, IViewSp
                                         fit="cover"
                                         radius="sm"
                                         mb="sm"
+                                        loading="lazy"
                                     />
                                 )}
                                 <Anchor href={`/spaces/${pairing.id}`} fw={600} size="sm">
@@ -550,12 +553,13 @@ export class ViewSpaceComponent extends React.Component<IViewSpaceProps, IViewSp
                     {/* Hero Image */}
                     {spaceMedia && (
                         <div className="space-hero-image-wrapper">
-                            <Image
+                            <ProgressiveImage
                                 src={spaceMedia}
                                 alt={space.notificationMsg}
                                 className="space-hero-image"
                                 fallbackSrc="/assets/images/meta-image-logo.png"
                                 radius="md"
+                                fetchPriority="high"
                             />
                         </div>
                     )}
@@ -625,6 +629,7 @@ export class ViewSpaceComponent extends React.Component<IViewSpaceProps, IViewSp
                                         maw={120}
                                         src="/assets/images/apple-store-download-button.svg"
                                         alt="Download Therr on the App Store"
+                                        loading="lazy"
                                     />
                                 </Anchor>
                                 <Anchor href="https://play.google.com/store/apps/details?id=app.therrmobile" target="_blank" rel="noreferrer">
@@ -633,6 +638,7 @@ export class ViewSpaceComponent extends React.Component<IViewSpaceProps, IViewSp
                                         maw={120}
                                         src="/assets/images/play-store-download-button.svg"
                                         alt="Download Therr on Google Play"
+                                        loading="lazy"
                                     />
                                 </Anchor>
                             </Group>

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -562,6 +562,7 @@ const renderMomentView = (req, res, config, {
     const momentMediaUri = mediaPath && mediaType === Content.mediaTypes.USER_IMAGE_PUBLIC
         ? getUserContentUri(moment.medias[0], 600, 600)
         : content?.media?.[mediaPath];
+
     if (momentMediaUri) {
         if (momentMediaUri.includes('.jpg') || momentMediaUri.includes('.jpeg') || momentMediaUri.includes('.png')) {
             metaImgUrl = momentMediaUri;
@@ -661,6 +662,7 @@ const renderSpaceView = (req, res, config, {
     const spaceMediaUri = mediaPath && mediaType === Content.mediaTypes.USER_IMAGE_PUBLIC
         ? getUserContentUri(space?.medias[0], 600, 600)
         : content?.media?.[mediaPath];
+
     if (spaceMediaUri) {
         if (spaceMediaUri.includes('.jpg') || spaceMediaUri.includes('.jpeg') || spaceMediaUri.includes('.png')) {
             metaImgUrl = spaceMediaUri;

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -560,10 +560,8 @@ const renderMomentView = (req, res, config, {
     const mediaPath = (moment.medias?.[0]?.path);
     const mediaType = (moment.medias?.[0]?.type);
     const momentMediaUri = mediaPath && mediaType === Content.mediaTypes.USER_IMAGE_PUBLIC
-        ? getUserContentUri(moment.medias[0])
+        ? getUserContentUri(moment.medias[0], 600, 600)
         : content?.media?.[mediaPath];
-
-    // TODO: Use an image optimized for meta image
     if (momentMediaUri) {
         if (momentMediaUri.includes('.jpg') || momentMediaUri.includes('.jpeg') || momentMediaUri.includes('.png')) {
             metaImgUrl = momentMediaUri;
@@ -661,10 +659,8 @@ const renderSpaceView = (req, res, config, {
     const mediaPath = (space.medias?.[0]?.path);
     const mediaType = (space.medias?.[0]?.type);
     const spaceMediaUri = mediaPath && mediaType === Content.mediaTypes.USER_IMAGE_PUBLIC
-        ? getUserContentUri(space?.medias[0])
+        ? getUserContentUri(space?.medias[0], 600, 600)
         : content?.media?.[mediaPath];
-
-    // TODO: Use an image optimized for meta image (ImageKit)
     if (spaceMediaUri) {
         if (spaceMediaUri.includes('.jpg') || spaceMediaUri.includes('.jpeg') || spaceMediaUri.includes('.png')) {
             metaImgUrl = spaceMediaUri;
@@ -879,7 +875,7 @@ const renderEventView = (req, res, config, {
     const mediaPath = (event?.medias?.[0]?.path);
     const mediaType = (event?.medias?.[0]?.type);
     const eventMediaUri = mediaPath && mediaType === Content.mediaTypes.USER_IMAGE_PUBLIC
-        ? getUserContentUri(event.medias[0])
+        ? getUserContentUri(event.medias[0], 600, 600)
         : content?.media?.[mediaPath];
 
     if (eventMediaUri) {
@@ -1193,7 +1189,7 @@ const renderGroupView = (req, res, config, {
     const mediaPath = group?.media?.[0]?.path;
     const mediaType = group?.media?.[0]?.type;
     const groupMediaUri = mediaPath && mediaType === Content.mediaTypes.USER_IMAGE_PUBLIC
-        ? getUserContentUri(group.media[0])
+        ? getUserContentUri(group.media[0], 600, 600)
         : undefined;
 
     if (groupMediaUri) {

--- a/therr-client-web/src/utilities/getUserContentUri.ts
+++ b/therr-client-web/src/utilities/getUserContentUri.ts
@@ -5,8 +5,10 @@ const BASE_ENDPOINT = globalConfig[process.env.NODE_ENV].baseImageKitEndpoint
     : `${globalConfig[process.env.NODE_ENV].baseApiGatewayRoute}/user-files/`;
 
 const getUserContentUri = (media, height = 1048, width = 1048, autocrop = false) => {
+    // Use lower quality for small thumbnails where compression artifacts are not visible
+    const quality = (height <= 200 && width <= 200) ? 75 : 85;
     let url = `${BASE_ENDPOINT}${media.path}`;
-    url = `${url}?tr=h-${height},w-${width}`;
+    url = `${url}?tr=h-${height},w-${width},f-auto,q-${quality}`;
     if (!autocrop) {
         // Preserve original image dimensions
         url = `${url},c-at_least`;

--- a/therr-client-web/src/utilities/getUserImageUri.ts
+++ b/therr-client-web/src/utilities/getUserImageUri.ts
@@ -10,7 +10,7 @@ const getUserImageUri = (user, size = 200) => {
          * In the max-size crop strategy, whole image content is preserved (no cropping),
          * the aspect ratio is preserved, but one of the dimensions (height or width) is adjusted.
          */
-        return `${BASE_ENDPOINT}${user.details.media.profilePicture.path}?tr=${size},${size}`;
+        return `${BASE_ENDPOINT}${user.details.media.profilePicture.path}?tr=h-${size},w-${size},f-auto,q-90`;
     }
 
     return `https://robohash.org/${user.details?.id}?set=set1&size=${size}x${size}`;


### PR DESCRIPTION
- Add ImageKit auto-format (f-auto) to serve WebP/AVIF based on browser support (25-50% size reduction)
- Fix malformed ImageKit transformation syntax in web getUserImageUri (was ?tr=200,200, now ?tr=h-200,w-200)
- Add context-appropriate quality params: q-90 for profile pics, q-85 for hero images, q-75 for thumbnails
- Right-size SSR OG meta images from default 1048x1048 to 600x600
- Add loading="lazy" to below-fold images (discovery tiles, space cards, store buttons)
- Add fetchPriority="high" to hero images on detail pages
- Add ProgressiveImage component with blur-up placeholder for hero images

https://claude.ai/code/session_01CBjz3PGz5U7a8wZYGQBp9g