### PR TITLE
fix: improve build diff detection to correctly identify changed services

### DIFF
--- a/_bin/apply-to-changed.sh
+++ b/_bin/apply-to-changed.sh
@@ -92,4 +92,4 @@ for i in "${arr[@]}"; do
   fi
 done
 
-printMessageSuccess "'${COMMAND}' command run on all Libraries, services, and frontend apps with changes or changes to respective dependencies!"${NC}
+printMessageSuccess "'${COMMAND}' command run on all Libraries, services, and frontend apps with changes or changes to respective dependencies!"

--- a/_bin/apply-to-changed.sh
+++ b/_bin/apply-to-changed.sh
@@ -22,42 +22,42 @@ fi
 
 # Library directories: styles
 if has_diff_changes $TARGET_BRANCH "therr-public-library/therr-styles"; then
+  HAS_ANY_LIBRARY_CHANGES=true
+  HAS_STYLES_LIBRARY_CHANGES=true
+  pushd "therr-public-library/therr-styles"
   if [ -f package.json ]; then
-    HAS_ANY_LIBRARY_CHANGES=true
-    HAS_STYLES_LIBRARY_CHANGES=true
-    pushd "therr-public-library/therr-styles"
     printMessageNeutral "Running command '${COMMAND}': therr-public-library/therr-styles"
     eval $COMMAND
   fi
-    popd
+  popd
 else
   printMessageNeutral "Skipping command '${COMMAND}': therr-public-library/therr-styles (No Changes)"
 fi
 
 # Library directories: js-utilities
 if has_diff_changes $TARGET_BRANCH "therr-public-library/therr-js-utilities"; then
+  HAS_ANY_LIBRARY_CHANGES=true
+  HAS_UTILITIES_LIBRARY_CHANGES=true
+  pushd "therr-public-library/therr-js-utilities"
   if [ -f package.json ]; then
-    HAS_ANY_LIBRARY_CHANGES=true
-    HAS_UTILITIES_LIBRARY_CHANGES=true
-    pushd "therr-public-library/therr-js-utilities"
     printMessageNeutral "Running command '${COMMAND}': therr-public-library/therr-js-utilities"
     eval $COMMAND
   fi
-    popd
+  popd
 else
   printMessageNeutral "Skipping command '${COMMAND}': therr-public-library/therr-js-utilities (No Changes)"
 fi
 
 # Library directories: react
-if has_diff_changes $TARGET_BRANCH "therr-public-library/therr-react" || "$HAS_UTILITIES_LIBRARY_CHANGES" = true || "$HAS_STYLES_LIBRARY_CHANGES" = true; then
+if has_diff_changes $TARGET_BRANCH "therr-public-library/therr-react" || [ "$HAS_UTILITIES_LIBRARY_CHANGES" = "true" ] || [ "$HAS_STYLES_LIBRARY_CHANGES" = "true" ]; then
+  HAS_ANY_LIBRARY_CHANGES=true
+  HAS_REACT_LIBRARY_CHANGES=true
+  pushd "therr-public-library/therr-react"
   if [ -f package.json ]; then
-    HAS_ANY_LIBRARY_CHANGES=true
-    HAS_REACT_LIBRARY_CHANGES=true
-    pushd "therr-public-library/therr-react"
     printMessageNeutral "Running command '${COMMAND}': therr-public-library/therr-react"
     eval $COMMAND
   fi
-    popd
+  popd
 else
   printMessageNeutral "Skipping command '${COMMAND}': therr-public-library/therr-react (No Changes)"
 fi
@@ -65,13 +65,13 @@ fi
 # UI Apps
 declare -a arr=("therr-client-web" "therr-client-web-dashboard" "TherrMobile")
 for i in "${arr[@]}"; do
-  if has_diff_changes $TARGET_BRANCH ${i} || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILES_CHANGES" = true; then
+  if has_diff_changes $TARGET_BRANCH ${i} || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILES_CHANGES" = "true" ]; then
+    pushd ${i}
     if [ -f package.json ]; then
-      pushd ${i}
       printMessageNeutral "Running command '${COMMAND}': ${i}"
       eval $COMMAND
     fi
-      popd
+    popd
   else
     printMessageNeutral "Skipping command '${COMMAND}': ${i} (No Changes)"
   fi
@@ -80,13 +80,13 @@ done
 # Services
 declare -a arr=("therr-api-gateway" "therr-services/push-notifications-service" "therr-services/maps-service" "therr-services/messages-service" "therr-services/reactions-service" "therr-services/users-service" "therr-services/websocket-service")
 for i in "${arr[@]}"; do
-  if has_diff_changes $TARGET_BRANCH ${i} || "$HAS_UTILITIES_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILES_CHANGES" = true; then
+  if has_diff_changes $TARGET_BRANCH ${i} || [ "$HAS_UTILITIES_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILES_CHANGES" = "true" ]; then
+    pushd ${i}
     if [ -f package.json ]; then
-      pushd ${i}
       printMessageNeutral "Running command '${COMMAND}': ${i}"
       eval $COMMAND
     fi
-      popd
+    popd
   else
     printMessageNeutral "Skipping command '${COMMAND}': ${i} (No Changes)"
   fi

--- a/_bin/cicd/build-changed-services.sh
+++ b/_bin/cicd/build-changed-services.sh
@@ -29,18 +29,18 @@ fi
 
 should_build_web_app()
 {
-  has_diff_changes general "therr-client-web" || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_diff_changes general "therr-client-web" || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 should_build_web_app_dashboard()
 {
-  has_diff_changes general "therr-client-web-dashboard" || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_diff_changes general "therr-client-web-dashboard" || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 should_build_service()
 {
   SERVICE_DIR=$1
-  has_diff_changes general $SERVICE_DIR || "$HAS_UTILITIES_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_diff_changes general $SERVICE_DIR || [ "$HAS_UTILITIES_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 SERVICES_BUILT=0

--- a/_bin/cicd/build.sh
+++ b/_bin/cicd/build.sh
@@ -37,7 +37,6 @@ if has_prev_diff_changes "therr-public-library/therr-js-utilities"; then
   HAS_UTILITIES_LIBRARY_CHANGES=true
 fi
 
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_build_web_app()
 {
   has_prev_diff_changes "therr-client-web" || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]

--- a/_bin/cicd/build.sh
+++ b/_bin/cicd/build.sh
@@ -40,21 +40,19 @@ fi
 # This is reliant on the previous commit being a single merge commit with all prior changes
 should_build_web_app()
 {
-  has_prev_diff_changes "therr-client-web" || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes "therr-client-web" || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 # NOTE: This is currently included in the web app build (container)
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_build_web_app_dashboard()
 {
-  has_prev_diff_changes "therr-client-web-dashboard" || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes "therr-client-web-dashboard" || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_build_service()
 {
   SERVICE_DIR=$1
-  has_prev_diff_changes $SERVICE_DIR || "$HAS_UTILITIES_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes $SERVICE_DIR || [ "$HAS_UTILITIES_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 # Docker Build

--- a/_bin/cicd/deploy.sh
+++ b/_bin/cicd/deploy.sh
@@ -42,24 +42,21 @@ if has_prev_diff_changes "therr-public-library/therr-js-utilities"; then
   HAS_UTILITIES_LIBRARY_CHANGES=true
 fi
 
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_deploy_web_app()
 {
-  has_prev_diff_changes "therr-client-web" || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes "therr-client-web" || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 # NOTE: This is currently included in the web app build (container)
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_deploy_web_app_dashboard()
 {
-  has_prev_diff_changes "therr-client-web-dashboard" || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes "therr-client-web-dashboard" || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_deploy_service()
 {
   SERVICE_DIR=$1
-  has_prev_diff_changes $SERVICE_DIR $GIT_SHA || "$HAS_UTILITIES_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes $SERVICE_DIR || [ "$HAS_UTILITIES_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 # Kubectl Apply

--- a/_bin/cicd/publish.sh
+++ b/_bin/cicd/publish.sh
@@ -39,66 +39,63 @@ if has_prev_diff_changes "therr-public-library/therr-js-utilities"; then
   HAS_UTILITIES_LIBRARY_CHANGES=true
 fi
 
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_publish_web_app()
 {
-  has_prev_diff_changes "therr-client-web" || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes "therr-client-web" || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 # NOTE: This is currently included in the web app build (container)
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_publish_web_app_dashboard()
 {
-  has_prev_diff_changes "therr-client-web-dashboard" || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes "therr-client-web-dashboard" || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_publish_service()
 {
   SERVICE_DIR=$1
-  has_prev_diff_changes $SERVICE_DIR || "$HAS_UTILITIES_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes $SERVICE_DIR || [ "$HAS_UTILITIES_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 NUMBER_SERVICES_PUBLISHED=0
 
 # Docker Publish
 if should_publish_web_app || should_publish_web_app_dashboard; then
-  ((NUMBER_SERVICES_PUBLISHED=i+1))
+  ((NUMBER_SERVICES_PUBLISHED+=1))
   docker push therrapp/client-web$SUFFIX:latest
   docker push therrapp/client-web$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-api-gateway"; then
-  ((NUMBER_SERVICES_PUBLISHED=i+1))
+  ((NUMBER_SERVICES_PUBLISHED+=1))
   docker push therrapp/api-gateway$SUFFIX:latest
   docker push therrapp/api-gateway$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/maps-service"; then
-  ((NUMBER_SERVICES_PUBLISHED=i+1))
+  ((NUMBER_SERVICES_PUBLISHED+=1))
   docker push therrapp/maps-service$SUFFIX:latest
   docker push therrapp/maps-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/messages-service"; then
-  ((NUMBER_SERVICES_PUBLISHED=i+1))
+  ((NUMBER_SERVICES_PUBLISHED+=1))
   docker push therrapp/messages-service$SUFFIX:latest
   docker push therrapp/messages-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/push-notifications-service"; then
-  ((NUMBER_SERVICES_PUBLISHED=i+1))
+  ((NUMBER_SERVICES_PUBLISHED+=1))
   docker push therrapp/push-notifications-service$SUFFIX:latest
   docker push therrapp/push-notifications-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/reactions-service"; then
-  ((NUMBER_SERVICES_PUBLISHED=i+1))
+  ((NUMBER_SERVICES_PUBLISHED+=1))
   docker push therrapp/reactions-service$SUFFIX:latest
   docker push therrapp/reactions-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/users-service"; then
-  ((NUMBER_SERVICES_PUBLISHED=i+1))
+  ((NUMBER_SERVICES_PUBLISHED+=1))
   docker push therrapp/users-service$SUFFIX:latest
   docker push therrapp/users-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/websocket-service"; then
-  ((NUMBER_SERVICES_PUBLISHED=i+1))
+  ((NUMBER_SERVICES_PUBLISHED+=1))
   docker push therrapp/websocket-service$SUFFIX:latest
   docker push therrapp/websocket-service$SUFFIX:$GIT_SHA
 fi

--- a/_bin/cicd/publish.sh
+++ b/_bin/cicd/publish.sh
@@ -60,42 +60,42 @@ NUMBER_SERVICES_PUBLISHED=0
 
 # Docker Publish
 if should_publish_web_app || should_publish_web_app_dashboard; then
-  ((NUMBER_SERVICES_PUBLISHED+=1))
+  NUMBER_SERVICES_PUBLISHED=$((NUMBER_SERVICES_PUBLISHED + 1))
   docker push therrapp/client-web$SUFFIX:latest
   docker push therrapp/client-web$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-api-gateway"; then
-  ((NUMBER_SERVICES_PUBLISHED+=1))
+  NUMBER_SERVICES_PUBLISHED=$((NUMBER_SERVICES_PUBLISHED + 1))
   docker push therrapp/api-gateway$SUFFIX:latest
   docker push therrapp/api-gateway$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/maps-service"; then
-  ((NUMBER_SERVICES_PUBLISHED+=1))
+  NUMBER_SERVICES_PUBLISHED=$((NUMBER_SERVICES_PUBLISHED + 1))
   docker push therrapp/maps-service$SUFFIX:latest
   docker push therrapp/maps-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/messages-service"; then
-  ((NUMBER_SERVICES_PUBLISHED+=1))
+  NUMBER_SERVICES_PUBLISHED=$((NUMBER_SERVICES_PUBLISHED + 1))
   docker push therrapp/messages-service$SUFFIX:latest
   docker push therrapp/messages-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/push-notifications-service"; then
-  ((NUMBER_SERVICES_PUBLISHED+=1))
+  NUMBER_SERVICES_PUBLISHED=$((NUMBER_SERVICES_PUBLISHED + 1))
   docker push therrapp/push-notifications-service$SUFFIX:latest
   docker push therrapp/push-notifications-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/reactions-service"; then
-  ((NUMBER_SERVICES_PUBLISHED+=1))
+  NUMBER_SERVICES_PUBLISHED=$((NUMBER_SERVICES_PUBLISHED + 1))
   docker push therrapp/reactions-service$SUFFIX:latest
   docker push therrapp/reactions-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/users-service"; then
-  ((NUMBER_SERVICES_PUBLISHED+=1))
+  NUMBER_SERVICES_PUBLISHED=$((NUMBER_SERVICES_PUBLISHED + 1))
   docker push therrapp/users-service$SUFFIX:latest
   docker push therrapp/users-service$SUFFIX:$GIT_SHA
 fi
 if should_publish_service "therr-services/websocket-service"; then
-  ((NUMBER_SERVICES_PUBLISHED+=1))
+  NUMBER_SERVICES_PUBLISHED=$((NUMBER_SERVICES_PUBLISHED + 1))
   docker push therrapp/websocket-service$SUFFIX:latest
   docker push therrapp/websocket-service$SUFFIX:$GIT_SHA
 fi

--- a/_bin/cicd/test-changed-services-unit.sh
+++ b/_bin/cicd/test-changed-services-unit.sh
@@ -30,7 +30,7 @@ fi
 should_test_service()
 {
   SERVICE_DIR=$1
-  has_diff_changes general $SERVICE_DIR || "$HAS_UTILITIES_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_diff_changes general $SERVICE_DIR || [ "$HAS_UTILITIES_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 # =============================================================================

--- a/_bin/cicd/test-microservices-integration.sh
+++ b/_bin/cicd/test-microservices-integration.sh
@@ -40,11 +40,10 @@ if has_prev_diff_changes "therr-public-library/therr-js-utilities"; then
   HAS_UTILITIES_LIBRARY_CHANGES=true
 fi
 
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_test_service()
 {
   SERVICE_DIR=$1
-  has_prev_diff_changes $SERVICE_DIR || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes $SERVICE_DIR || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 # =============================================================================

--- a/_bin/cicd/test-microservices-unit.sh
+++ b/_bin/cicd/test-microservices-unit.sh
@@ -40,11 +40,10 @@ if has_prev_diff_changes "therr-public-library/therr-js-utilities"; then
   HAS_UTILITIES_LIBRARY_CHANGES=true
 fi
 
-# This is reliant on the previous commit being a single merge commit with all prior changes
 should_test_service()
 {
   SERVICE_DIR=$1
-  has_prev_diff_changes $SERVICE_DIR || "$HAS_ANY_LIBRARY_CHANGES" = true || "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = true
+  has_prev_diff_changes $SERVICE_DIR || [ "$HAS_ANY_LIBRARY_CHANGES" = "true" ] || [ "$HAS_GLOBAL_CONFIG_FILE_CHANGES" = "true" ]
 }
 
 # =============================================================================

--- a/_bin/lib/has_diff_changes.sh
+++ b/_bin/lib/has_diff_changes.sh
@@ -4,12 +4,24 @@ set -e
 
 source ./_bin/lib/colorize.sh
 
+# Cache fetched branches to avoid redundant network calls
+_FETCHED_BRANCHES=""
+
+_fetch_once()
+{
+    local BRANCH=$1
+    if [[ "$_FETCHED_BRANCHES" != *"|$BRANCH|"* ]]; then
+        git fetch origin "$BRANCH"
+        _FETCHED_BRANCHES="${_FETCHED_BRANCHES}|$BRANCH|"
+    fi
+}
+
 has_diff_changes()
 {
     ORIGIN_BRANCH=$1
     DIR=$2
-    
-    git fetch origin $ORIGIN_BRANCH
+
+    _fetch_once "$ORIGIN_BRANCH"
     NUM_FILES_CHANGED=$(git diff --name-only origin/$ORIGIN_BRANCH -- $DIR | wc -l)
 
     if [[ ${NUM_FILES_CHANGED} -gt 0 ]]; then
@@ -40,7 +52,7 @@ has_prev_diff_changes()
         fi
     fi
 
-    git fetch origin $COMPARE_BRANCH
+    _fetch_once "$COMPARE_BRANCH"
     MERGE_BASE=$(git merge-base HEAD origin/$COMPARE_BRANCH)
     NUM_FILES_CHANGED=$(git diff $MERGE_BASE --name-only -- $DIR | wc -l)
 

--- a/_bin/lib/has_diff_changes.sh
+++ b/_bin/lib/has_diff_changes.sh
@@ -23,11 +23,29 @@ has_diff_changes()
 has_prev_diff_changes()
 {
     DIR=$1
-    
-    NUM_FILES_CHANGED=$(git diff HEAD^1 --name-only -- $DIR | wc -l)
+    CURRENT_BRANCH=${CICD_BRANCH:-$CIRCLE_BRANCH}
+
+    if [ "$CURRENT_BRANCH" = "stage" ]; then
+        COMPARE_BRANCH="general"
+    elif [ "$CURRENT_BRANCH" = "main" ]; then
+        COMPARE_BRANCH="stage"
+    else
+        # Fallback to HEAD^1 for unknown branches
+        NUM_FILES_CHANGED=$(git diff HEAD^1 --name-only -- $DIR | wc -l)
+        if [[ ${NUM_FILES_CHANGED} -gt 0 ]]; then
+            printMessageWarning "Found ${NUM_FILES_CHANGED} files changed w/ 'git diff HEAD^1 -- $DIR'"
+            return 0
+        else
+            return 1
+        fi
+    fi
+
+    git fetch origin $COMPARE_BRANCH
+    MERGE_BASE=$(git merge-base HEAD origin/$COMPARE_BRANCH)
+    NUM_FILES_CHANGED=$(git diff $MERGE_BASE --name-only -- $DIR | wc -l)
 
     if [[ ${NUM_FILES_CHANGED} -gt 0 ]]; then
-        printMessageWarning "Found ${NUM_FILES_CHANGED} files changed w/ 'git diff HEAD^1 --name-only -- $DIR'"
+        printMessageWarning "Found ${NUM_FILES_CHANGED} files changed w/ 'git diff $MERGE_BASE -- $DIR'"
         return 0
     else
         return 1


### PR DESCRIPTION
- Fix broken boolean checks: "$VAR" = true without [ ] brackets silently
  failed, preventing dependency cascading (e.g. library changes never
  triggered downstream service rebuilds)
- Replace HEAD^1 diff with merge-base comparison in has_prev_diff_changes()
  so stage/main builds capture all accumulated changes regardless of merge
  strategy, not just the last commit
- Fix pushd/popd ordering in apply-to-changed.sh to prevent directory stack
  corruption when package.json is missing
- Fix undefined variable in publish.sh counter (i+1 → +=1)
- Remove stale $GIT_SHA arg passed to has_prev_diff_changes in deploy.sh

https://claude.ai/code/session_012EGazpoAkiEcJAy7soozTD