### PR TITLE
Add email & website finder script for imported spaces

### DIFF
--- a/.claude/skills/find-space-contacts/SKILL.md
+++ b/.claude/skills/find-space-contacts/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: find-space-contacts
+description: Find business emails and websites for imported spaces by researching each business on the web. Use when enriching space contact data.
+disable-model-invocation: true
+user-invocable: true
+allowed-tools: WebSearch, WebFetch, Bash(npx ts-node scripts/import-spaces/query-spaces*), Bash(npx ts-node scripts/import-spaces/update-space-contact*)
+argument-hint: [--mode email|website|both] [--city name] [--limit n]
+---
+
+# Find Space Contacts
+
+You are a business researcher. Your job is to find accurate business email addresses and websites for spaces in the Therr database.
+
+## Workflow
+
+### Step 1: Query spaces needing enrichment
+
+Run the query script to get a batch of spaces. Pass through any arguments the user provided:
+
+```
+npx ts-node scripts/import-spaces/query-spaces $ARGUMENTS
+```
+
+Default arguments if none provided: `--mode both --limit 5`
+
+The script outputs JSON to stdout with space details (id, name, category, address, existing websiteUrl/businessEmail). **It handles all database credentials internally — you will never see or need env vars.**
+
+### Step 2: Research each space
+
+For each space in the results, use `WebSearch` and `WebFetch` to find the business's:
+- **Official website** (if missing)
+- **Business email address** (if missing)
+
+#### Research strategy
+
+1. **Search** for the business by name + city + region (e.g., `"Joe's Pizza" Eugene OR`)
+2. **Evaluate results** — look for the business's own domain (not Yelp, Facebook, Google Maps, etc.)
+3. **Fetch the candidate website** to verify it belongs to this specific business:
+   - Does the page title or content mention the business name?
+   - Does the address on the site match the space's address?
+   - Is this the right location (not a different branch)?
+4. **Find email** — check the website for:
+   - `mailto:` links
+   - Contact page (`/contact`, `/about`)
+   - Footer content
+   - Look for a business email, not generic addresses like `noreply@` or social media accounts
+5. **Assess confidence:**
+   - **High**: Business name matches, address matches, email domain matches website domain
+   - **Medium**: Business name matches, no address to cross-check, but website looks right
+   - **Low**: Ambiguous match — skip this space
+
+**Only proceed with high or medium confidence matches.**
+
+#### What NOT to do
+- Do not guess or fabricate email addresses
+- Do not use personal email addresses found on review sites
+- Do not associate a website with the wrong business location (e.g., a chain's corporate site for a local franchise, unless that's the only website)
+- Do not use social media profile URLs as the website — find the actual business domain
+
+### Step 3: Update each space
+
+For each space where you found contact info with sufficient confidence, run the update script:
+
+```
+npx ts-node scripts/import-spaces/update-space-contact --id <space-uuid> [--email "found@email.com"] [--website "https://found-website.com"] [--source-image]
+```
+
+- Only pass `--email` if you found a business email
+- Only pass `--website` if the space didn't have one and you found it
+- Add `--source-image` if the space has no media and you found/confirmed a website
+
+The script updates the database and returns a JSON result confirming what was changed.
+
+### Step 4: Report results
+
+After processing all spaces, give a summary:
+- How many spaces were processed
+- How many emails found
+- How many websites found
+- How many images sourced
+- Any spaces you skipped and why (low confidence, couldn't find info, etc.)
+
+## Important rules
+
+- **Accuracy over quantity**: It's better to skip a space than to save wrong data. We will use these emails to contact businesses.
+- **Verify before saving**: Always fetch the candidate website and check that it matches the business before calling the update script.
+- **One business at a time**: Research each business individually. Don't batch-assume.
+- **Respect rate limits**: Pause briefly between web fetches to be a good citizen.
+- **No secrets**: You never need database credentials, API keys, or .env files. The scripts handle all of that.

--- a/package-lock.json
+++ b/package-lock.json
@@ -990,6 +990,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
       "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -999,8 +1000,8 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1029,7 +1030,8 @@
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/@babel/eslint-parser": {
       "version": "7.28.5",
@@ -1082,6 +1084,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
@@ -1098,6 +1101,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -1105,7 +1109,8 @@
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.28.5",
@@ -1250,6 +1255,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
@@ -1381,6 +1387,7 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.27.2",
@@ -2978,7 +2985,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3022,7 +3028,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3376,7 +3381,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -4573,6 +4577,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -4591,6 +4596,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -4813,7 +4819,6 @@
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.8.tgz",
       "integrity": "sha512-96qygbkTjRhdkzd5HDU8fMziemN/h758/EwrFu7TlWrEP10Vw076u+Ap/sG6OT4RGPZYYoHrTlT+mkCZblWHuw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -4981,7 +4986,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4990,7 +4994,6 @@
       "version": "0.41.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.41.2.tgz",
       "integrity": "sha512-JEV2RAqijAFdWeT6HddYymfnkiRu2ASxoTBr4WsnGJhOjWZkEy6vp+Sx9ozr1NaIODOa2HUyckExIqQjn6qywQ==",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -5407,7 +5410,6 @@
       "version": "0.39.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz",
       "integrity": "sha512-9BJ8lMcOzEN0lu+Qji801y707oFO4xT3db6cosPvl+k7ItUHKN5ofWqtSbM9gbt1H4JJ/4/2TVrqI9Rq7hNv6Q==",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -5592,7 +5594,6 @@
       "version": "0.39.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz",
       "integrity": "sha512-9BJ8lMcOzEN0lu+Qji801y707oFO4xT3db6cosPvl+k7ItUHKN5ofWqtSbM9gbt1H4JJ/4/2TVrqI9Rq7hNv6Q==",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -6936,7 +6937,6 @@
       "version": "0.39.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.39.1.tgz",
       "integrity": "sha512-9BJ8lMcOzEN0lu+Qji801y707oFO4xT3db6cosPvl+k7ItUHKN5ofWqtSbM9gbt1H4JJ/4/2TVrqI9Rq7hNv6Q==",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -7805,7 +7805,6 @@
       "version": "2.11.7",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
       "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -9024,6 +9023,7 @@
       "version": "8.56.12",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
       "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "*",
@@ -9034,6 +9034,7 @@
       "version": "3.7.7",
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "dev": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -9043,6 +9044,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -9380,7 +9382,6 @@
       "version": "20.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
       "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -9441,7 +9442,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -9842,7 +9842,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -10048,6 +10047,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
@@ -10058,24 +10058,28 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
@@ -10087,12 +10091,14 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -10105,6 +10111,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
@@ -10114,6 +10121,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
@@ -10123,12 +10131,14 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -10145,6 +10155,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -10158,6 +10169,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -10170,6 +10182,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -10184,6 +10197,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
@@ -10241,12 +10255,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/abab": {
@@ -10290,7 +10306,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10321,6 +10336,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -10380,7 +10396,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10396,6 +10411,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -10412,6 +10428,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -10427,7 +10444,8 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -11559,6 +11577,7 @@
       "version": "2.9.11",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
       "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -11755,6 +11774,7 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
       "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11770,7 +11790,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11823,7 +11842,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "node_modules/buffer-writer": {
       "version": "2.0.0",
@@ -12021,6 +12041,7 @@
       "version": "1.0.30001762",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001762.tgz",
       "integrity": "sha512-PxZwGNvH7Ak8WX5iXzoK1KPZttBXNPuaOvI2ZYU7NrlM+d9Ov+TUvlLOBNGzVXAntMSMMlJPd+jY6ovrVjSmUw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12094,7 +12115,6 @@
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/chartist/-/chartist-0.11.4.tgz",
       "integrity": "sha512-H4AimxaUD738/u9Mq8t27J4lh6STsLi4BQHt65nOtpLk3xyrBPaLiLMrHw7/WV9CmsjGA02WihjuL5qpSagLYw==",
-      "peer": true,
       "engines": {
         "node": ">=4.6.0"
       }
@@ -12244,6 +12264,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "dev": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -14326,6 +14347,7 @@
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
       "integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/email-validator": {
@@ -14472,6 +14494,7 @@
       "version": "5.18.4",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
       "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -14518,7 +14541,6 @@
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
       "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array.prototype.flat": "^1.2.3",
         "cheerio": "^1.0.0-rc.3",
@@ -14702,6 +14724,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -14837,7 +14860,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -15017,7 +15039,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -15110,7 +15131,6 @@
       "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -15141,7 +15161,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -15175,7 +15194,6 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15226,6 +15244,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -15625,6 +15644,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -15636,6 +15656,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
       "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -15644,6 +15665,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -15708,7 +15730,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -15754,7 +15775,6 @@
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.7.0.tgz",
       "integrity": "sha512-vhwIdRoqcYB/72TK3tRZI+0ttS8Ytrk24GfmsxDXK9o9IhHNO5bXRiXQSExPQ4GbaE5tvIS7j1SGrxsuWs+sGA==",
-      "peer": true,
       "engines": {
         "node": ">= 12.9.0"
       },
@@ -16033,6 +16053,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -16898,6 +16919,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -17095,6 +17117,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/global-modules": {
@@ -19129,7 +19152,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -21011,6 +21033,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -21024,6 +21047,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -21032,6 +21056,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -21213,7 +21238,8 @@
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -21236,6 +21262,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -21376,7 +21403,6 @@
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -21615,6 +21641,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.11.5"
@@ -21877,8 +21904,7 @@
     "node_modules/logrocket": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/logrocket/-/logrocket-3.0.1.tgz",
-      "integrity": "sha512-jOWG+jEzobKVxGytzZ+4KGm2kiMQMRTHab2uDWQyVZcHfEF38BlCH1yjQVY4LCmuQUwZitP9biMzJZnyUQ0dtQ==",
-      "peer": true
+      "integrity": "sha512-jOWG+jEzobKVxGytzZ+4KGm2kiMQMRTHab2uDWQyVZcHfEF38BlCH1yjQVY4LCmuQUwZitP9biMzJZnyUQ0dtQ=="
     },
     "node_modules/logrocket-react": {
       "version": "5.0.1",
@@ -22082,7 +22108,8 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -22532,7 +22559,6 @@
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -22587,6 +22613,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22797,6 +22824,7 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-rsa": {
@@ -22920,7 +22948,6 @@
       "integrity": "sha512-U42vQ4czpKa0QdI1hu950XuNhYqgoM+ZF1HT+VuUHL9hPfDPVvNQyltmMqdE9bUHMVa+8yNbc3QKTj8zQhlVxQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
         "@istanbuljs/schema": "^0.1.2",
@@ -23795,7 +23822,6 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.10.0.tgz",
       "integrity": "sha512-ke7o7qSTMb47iwzOSaZMfeR7xToFdkE71ifIipOAAaLIM0DYzfOAXlgFFmYUIE2BcJtvnVlGCID84ZzCegE8CQ==",
-      "peer": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
@@ -23877,7 +23903,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24027,6 +24052,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -24042,7 +24068,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -24713,7 +24738,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -25273,7 +25297,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -25425,7 +25448,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -25543,7 +25565,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -25796,8 +25817,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-logger": {
       "version": "3.0.6",
@@ -25969,6 +25989,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26772,6 +26793,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -26791,8 +26813,8 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -26808,6 +26830,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -26818,7 +26841,8 @@
     "node_modules/schema-utils/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/scmp": {
       "version": "2.1.0",
@@ -26857,6 +26881,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -27471,7 +27496,6 @@
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
       "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
-      "peer": true,
       "dependencies": {
         "debug": "~4.3.4",
         "ws": "~8.17.1"
@@ -27603,6 +27627,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -27612,6 +27637,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28075,7 +28101,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -28813,6 +28838,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -28887,6 +28913,7 @@
       "version": "5.36.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
       "integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -28904,6 +28931,7 @@
       "version": "5.3.17",
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
       "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
@@ -28936,7 +28964,8 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -29417,7 +29446,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -29495,8 +29523,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -29688,7 +29715,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -29817,6 +29843,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -30108,6 +30135,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.0.tgz",
       "integrity": "sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
@@ -30140,8 +30168,8 @@
       "version": "5.104.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -30482,6 +30510,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
       "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -30491,6 +30520,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }

--- a/scripts/import-spaces/README.md
+++ b/scripts/import-spaces/README.md
@@ -144,6 +144,91 @@ Requires GCS credentials in addition to the standard DB credentials:
 - `MAPS_SERVICE_GOOGLE_CREDENTIALS_BASE64` — base64-encoded GCS service account JSON
 - `BUCKET_PUBLIC_USER_DATA` — GCS bucket name for public user media
 
+### 3. Source Emails & Websites
+
+Find business email addresses by crawling websites, and discover websites for spaces that don't have one via web search. Business emails enable future outreach to encourage businesses to claim and manage their own spaces.
+
+```bash
+npx ts-node scripts/import-spaces/source-emails-websites [options]
+```
+
+Run `--help` for full details:
+
+```bash
+npx ts-node scripts/import-spaces/source-emails-websites --help
+```
+
+#### Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--city <name>` | Filter by addressLocality | `all` |
+| `--category <name>` | Filter by Therr category string | `all` |
+| `--mode <mode>` | What to find: `email`, `website`, or `both` | `both` |
+| `--limit <n>` | Max spaces to process | no limit |
+| `--delay <ms>` | Delay between requests in ms | `2000` |
+| `--user-id <uuid>` | Override fromUserId for media records | `568bf5d2-...` |
+| `--source-images` | Also source images for spaces with a website but no media | off |
+| `--dry-run` | Crawl and log without updating | off |
+
+#### Modes
+
+- **`email`**: Crawls existing `websiteUrl` for email addresses (mailto links, contact pages, plaintext patterns)
+- **`website`**: Searches the web (DuckDuckGo) to discover websites for spaces that lack one. Only saves when confidence is high (business name matches domain/page title).
+- **`both`**: Runs email extraction first, then website discovery
+
+#### Email Extraction Strategy
+
+Emails are extracted in priority order:
+
+1. **`mailto:` links** on the homepage
+2. **Plaintext email patterns** in the page body
+3. **Contact/About page** — if no emails found on the homepage, follows `/contact`, `/about` links and repeats
+
+Emails are filtered to reject noreply addresses, social media domains, and false positives. Emails matching the website's own domain are ranked highest.
+
+#### Website Discovery
+
+Uses DuckDuckGo HTML search with the business name + city + region. Confidence checks:
+
+1. The search result domain or title must match the business name (fuzzy word matching)
+2. The actual page `<title>` is fetched to double-check the match
+
+Only high-confidence matches are saved to avoid associating wrong websites with spaces.
+
+#### Examples
+
+Preview email extraction for Eugene spaces:
+
+```bash
+npx ts-node scripts/import-spaces/source-emails-websites --mode email --city eugene --dry-run --limit 5
+```
+
+Find websites for spaces without one:
+
+```bash
+npx ts-node scripts/import-spaces/source-emails-websites --mode website --city chicago --limit 20
+```
+
+Full pipeline — emails, websites, and images:
+
+```bash
+npx ts-node scripts/import-spaces/source-emails-websites --mode both --source-images --limit 100
+```
+
+#### Idempotency
+
+- Email mode targets spaces where `businessEmail IS NULL` and `websiteUrl` exists
+- Website mode targets spaces where `websiteUrl IS NULL` or empty
+
+Already-processed spaces are never re-processed. Safe to re-run.
+
+#### Environment
+
+Standard DB credentials required. If `--source-images` is used, GCS credentials are also needed:
+- `MAPS_SERVICE_GOOGLE_CREDENTIALS_BASE64` — base64-encoded GCS service account JSON
+- `BUCKET_PUBLIC_USER_DATA` — GCS bucket name for public user media
+
 ## Data Source
 
 Data comes from the [OpenStreetMap Overpass API](https://overpass-api.de/) (free, no API key required). OSM data is licensed under [ODbL](https://opendatacommons.org/licenses/odbl/).
@@ -151,7 +236,7 @@ Data comes from the [OpenStreetMap Overpass API](https://overpass-api.de/) (free
 The script queries OSM by city bounding box and amenity/shop/tourism tags, then maps the results to Therr's space schema including:
 
 - Name, address, city, state, postal code
-- Phone number, website URL
+- Phone number, business email, website URL
 - Opening hours (converted to Therr JSON format)
 - Category mapping (OSM amenity tags -> Therr categories)
 - Geospatial data (PostGIS geometry)
@@ -162,10 +247,13 @@ The script queries OSM by city bounding box and amenity/shop/tourism tags, then 
 scripts/import-spaces/
 ├── index.ts                 # Import entry point — CLI arg parsing, DB insert
 ├── source-images.ts         # Source images entry point — crawl, upload, update
+├── source-emails-websites.ts # Source emails/websites — email extraction, web search
 ├── config.ts                # City bounding boxes, category mappings
 ├── sources/
 │   ├── osm.ts               # Overpass API fetcher (with 429 retry)
-│   └── crawl.ts             # Website crawling + image extraction
+│   ├── crawl.ts             # Website crawling + image extraction
+│   ├── crawlEmails.ts       # Website crawling + email extraction
+│   └── searchWeb.ts         # DuckDuckGo web search for business websites
 ├── transforms/
 │   ├── mapToSpace.ts         # OSM element -> Therr space params
 │   └── parseHours.ts         # OSM opening_hours -> Therr JSON

--- a/scripts/import-spaces/index.ts
+++ b/scripts/import-spaces/index.ts
@@ -130,7 +130,7 @@ async function insertSpaces(db: Pool, spaces: ISpaceInsertParams[]): Promise<num
              "isForSale", "isHirable", "isPromotional", "isExclusiveToGroups",
              category, "areaType", valuation, region,
              "addressReadable", "addressStreetAddress", "addressRegion", "addressLocality", "postalCode",
-             "phoneNumber", "websiteUrl", "isPointOfInterest", "openingHours",
+             "phoneNumber", "businessEmail", "websiteUrl", "isPointOfInterest", "openingHours",
              geom, "geomCenter")
           VALUES
             ($1, $2, $3, $4, $5,
@@ -140,8 +140,8 @@ async function insertSpaces(db: Pool, spaces: ISpaceInsertParams[]): Promise<num
              $18, $19, $20, $21,
              $22, $23, $24, $25,
              $26, $27, $28, $29, $30::integer,
-             $31, $32, $33, $34::jsonb,
-             ST_SetSRID(ST_Buffer(ST_MakePoint($11::float8, $10::float8)::geography, $35::float8)::geometry, 4326),
+             $31, $32, $33, $34, $35::jsonb,
+             ST_SetSRID(ST_Buffer(ST_MakePoint($11::float8, $10::float8)::geography, $36::float8)::geometry, 4326),
              ST_SetSRID(ST_MakePoint($11::float8, $10::float8), 4326))
           ON CONFLICT DO NOTHING
           RETURNING id`,
@@ -153,8 +153,8 @@ async function insertSpaces(db: Pool, spaces: ISpaceInsertParams[]): Promise<num
             space.isForSale, space.isHirable, space.isPromotional, space.isExclusiveToGroups,
             space.category, space.areaType, space.valuation, space.region,
             space.addressReadable, space.addressStreetAddress, space.addressRegion, space.addressLocality, space.postalCode,
-            space.phoneNumber, space.websiteUrl, space.isPointOfInterest, space.openingHours,
-            space.radius, // $35: separate param for ST_Buffer to avoid type ambiguity
+            space.phoneNumber, space.businessEmail, space.websiteUrl, space.isPointOfInterest, space.openingHours,
+            space.radius, // $36: separate param for ST_Buffer to avoid type ambiguity
           ],
         );
         if (result.rowCount && result.rowCount > 0) {

--- a/scripts/import-spaces/query-spaces.ts
+++ b/scripts/import-spaces/query-spaces.ts
@@ -121,32 +121,35 @@ async function main() {
     await db.query('SELECT 1');
   } catch (err: any) {
     log(`Database connection failed: ${err.message}`);
+    await db.end();
     process.exit(1);
   }
 
-  const spaces = await querySpaces(db, args);
-  log(`Found ${spaces.length} spaces.`);
+  try {
+    const spaces = await querySpaces(db, args);
+    log(`Found ${spaces.length} spaces.`);
 
-  // Output clean JSON to stdout (no secrets, no connection info)
-  const output = spaces.map((s) => ({
-    id: s.id,
-    name: s.notificationMsg,
-    category: s.category,
-    websiteUrl: s.websiteUrl || null,
-    businessEmail: s.businessEmail || null,
-    phoneNumber: s.phoneNumber || null,
-    hasMedia: !!(s.mediaIds && s.mediaIds !== '') || !!(s.medias && s.medias.length > 0),
-    address: {
-      street: s.addressStreetAddress || null,
-      city: s.addressLocality || null,
-      region: s.addressRegion || null,
-      postalCode: s.postalCode || null,
-    },
-  }));
+    // Output clean JSON to stdout (no secrets, no connection info)
+    const output = spaces.map((s) => ({
+      id: s.id,
+      name: s.notificationMsg,
+      category: s.category,
+      websiteUrl: s.websiteUrl || null,
+      businessEmail: s.businessEmail || null,
+      phoneNumber: s.phoneNumber || null,
+      hasMedia: !!(s.mediaIds && s.mediaIds !== '') || !!(s.medias && s.medias.length > 0),
+      address: {
+        street: s.addressStreetAddress || null,
+        city: s.addressLocality || null,
+        region: s.addressRegion || null,
+        postalCode: s.postalCode || null,
+      },
+    }));
 
-  console.log(JSON.stringify(output, null, 2));
-
-  await db.end();
+    console.log(JSON.stringify(output, null, 2));
+  } finally {
+    await db.end();
+  }
 }
 
 main().catch((err) => {

--- a/scripts/import-spaces/query-spaces.ts
+++ b/scripts/import-spaces/query-spaces.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Query spaces needing email/website enrichment and output as JSON to stdout.
+ * Designed to be called by the /find-space-contacts slash command.
+ *
+ * Usage:
+ *   npx ts-node scripts/import-spaces/query-spaces --mode email --city eugene --limit 5
+ *   npx ts-node scripts/import-spaces/query-spaces --mode website --limit 10
+ *   npx ts-node scripts/import-spaces/query-spaces --mode both --limit 20
+ *
+ * Output: JSON array of space objects to stdout. All logging goes to stderr.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { Pool } from 'pg';
+import { CITIES } from './config';
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+function log(msg: string) {
+  process.stderr.write(`${msg}\n`);
+}
+
+interface ICliArgs {
+  city: string;
+  category: string;
+  mode: 'email' | 'website' | 'both';
+  limit: number;
+}
+
+function parseArgs(): ICliArgs {
+  const args = process.argv.slice(2);
+  const parsed: Record<string, string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith('--') && i + 1 < args.length) {
+      parsed[args[i].replace('--', '')] = args[i + 1];
+      i++;
+    }
+  }
+
+  const mode = parsed.mode || 'both';
+  if (mode !== 'email' && mode !== 'website' && mode !== 'both') {
+    log(`Invalid --mode: "${mode}". Must be "email", "website", or "both".`);
+    process.exit(1);
+  }
+
+  return {
+    city: parsed.city || 'all',
+    category: parsed.category || 'all',
+    mode: mode as 'email' | 'website' | 'both',
+    limit: parsed.limit ? parseInt(parsed.limit, 10) : 10,
+  };
+}
+
+function createDbPool(): Pool {
+  return new Pool({
+    host: process.env.DB_HOST_MAIN_WRITE,
+    user: process.env.DB_USER_MAIN_WRITE,
+    password: process.env.DB_PASSWORD_MAIN_WRITE,
+    database: process.env.MAPS_SERVICE_DATABASE,
+    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
+    max: 3,
+    idleTimeoutMillis: 10000,
+    connectionTimeoutMillis: 10000,
+  });
+}
+
+async function querySpaces(db: Pool, args: ICliArgs) {
+  const conditions: string[] = [];
+  const params: (string | number)[] = [];
+  let paramIdx = 1;
+
+  if (args.mode === 'email') {
+    conditions.push('"businessEmail" IS NULL');
+    conditions.push(`"websiteUrl" IS NOT NULL`);
+    conditions.push(`"websiteUrl" != ''`);
+  } else if (args.mode === 'website') {
+    conditions.push(`("websiteUrl" IS NULL OR "websiteUrl" = '')`);
+  } else {
+    // both: spaces missing either email or website
+    conditions.push(`("businessEmail" IS NULL OR "websiteUrl" IS NULL OR "websiteUrl" = '')`);
+  }
+
+  if (args.city !== 'all') {
+    const cityConfig = CITIES[args.city];
+    if (cityConfig) {
+      conditions.push(`"addressLocality" ILIKE $${paramIdx}`);
+      params.push(`%${cityConfig.name}%`);
+      paramIdx++;
+    }
+  }
+
+  if (args.category !== 'all') {
+    conditions.push(`category = $${paramIdx}`);
+    params.push(args.category);
+    paramIdx++;
+  }
+
+  let query = `SELECT id, "notificationMsg", category, "websiteUrl", "businessEmail",
+      "phoneNumber", "mediaIds", medias, "fromUserId",
+      "addressStreetAddress", "addressLocality", "addressRegion", "postalCode"
+    FROM main.spaces
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY RANDOM()
+    LIMIT $${paramIdx}`;
+  params.push(args.limit);
+
+  const result = await db.query(query, params);
+  return result.rows;
+}
+
+async function main() {
+  const args = parseArgs();
+  log(`Querying spaces: mode=${args.mode}, city=${args.city}, category=${args.category}, limit=${args.limit}`);
+
+  const db = createDbPool();
+
+  try {
+    await db.query('SELECT 1');
+  } catch (err: any) {
+    log(`Database connection failed: ${err.message}`);
+    process.exit(1);
+  }
+
+  const spaces = await querySpaces(db, args);
+  log(`Found ${spaces.length} spaces.`);
+
+  // Output clean JSON to stdout (no secrets, no connection info)
+  const output = spaces.map((s) => ({
+    id: s.id,
+    name: s.notificationMsg,
+    category: s.category,
+    websiteUrl: s.websiteUrl || null,
+    businessEmail: s.businessEmail || null,
+    phoneNumber: s.phoneNumber || null,
+    hasMedia: !!(s.mediaIds && s.mediaIds !== '') || !!(s.medias && s.medias.length > 0),
+    address: {
+      street: s.addressStreetAddress || null,
+      city: s.addressLocality || null,
+      region: s.addressRegion || null,
+      postalCode: s.postalCode || null,
+    },
+  }));
+
+  console.log(JSON.stringify(output, null, 2));
+
+  await db.end();
+}
+
+main().catch((err) => {
+  log(`Fatal error: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/import-spaces/source-emails-websites.ts
+++ b/scripts/import-spaces/source-emails-websites.ts
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+/**
+ * CLI tool to find business emails and websites for imported spaces.
+ *
+ * For spaces with a websiteUrl: crawls the site for email addresses.
+ * For spaces without a websiteUrl: searches the web to discover their website.
+ * Optionally sources images when a website is available and the space has no media.
+ *
+ * Usage:
+ *   npx ts-node scripts/import-spaces/source-emails-websites --city eugene --dry-run --limit 5
+ *   npx ts-node scripts/import-spaces/source-emails-websites --mode email --source-images --limit 50
+ *
+ * Requires .env at project root or scripts/import-spaces/.env with DB + GCS credentials.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { Pool } from 'pg';
+import { CITIES, IMPORT_USER_ID } from './config';
+import { crawlForEmails } from './sources/crawlEmails';
+import { searchForWebsite } from './sources/searchWeb';
+import { crawlForImages } from './sources/crawl';
+import { downloadAndValidateImage } from './utils/imageValidation';
+import { uploadImage } from './utils/gcs';
+
+// Load .env from scripts/import-spaces/ first, fall back to root .env
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+// ── Help ─────────────────────────────────────────────────────────────────────
+function printHelp() {
+  const cityList = Object.keys(CITIES).join(', ');
+  console.log(`
+Source Emails & Websites CLI — Find contact info for imported spaces.
+
+Usage:
+  npx ts-node scripts/import-spaces/source-emails-websites [options]
+
+Options:
+  --city <name>        Filter by addressLocality (default: all)
+                       Available: ${cityList}, all
+  --category <name>    Filter by Therr category string (default: all)
+                       e.g. "categories.restaurant/food", "categories.bar/drinks"
+  --mode <mode>        What to find (default: both)
+                       "email"   — only find emails for spaces with a website
+                       "website" — only find websites for spaces without one
+                       "both"    — find emails and websites
+  --limit <n>          Max spaces to process (default: no limit)
+  --delay <ms>         Delay between requests in ms (default: 2000)
+  --user-id <uuid>     Override fromUserId for media records
+                       (default: ${IMPORT_USER_ID})
+  --source-images      Also source images for spaces with a website but no media
+  --dry-run            Crawl and log results without updating database
+  --help, -h           Show this help message
+
+Examples:
+  npx ts-node scripts/import-spaces/source-emails-websites --city eugene --dry-run --limit 5
+  npx ts-node scripts/import-spaces/source-emails-websites --mode email --limit 50
+  npx ts-node scripts/import-spaces/source-emails-websites --mode website --city chicago --limit 20
+  npx ts-node scripts/import-spaces/source-emails-websites --mode both --source-images --limit 100
+`);
+}
+
+interface ICliArgs {
+  city: string;
+  category: string;
+  mode: 'email' | 'website' | 'both';
+  dryRun: boolean;
+  sourceImages: boolean;
+  limit: number;
+  delay: number;
+  userId: string;
+}
+
+// ── CLI arg parsing ──────────────────────────────────────────────────────────
+function parseArgs(): ICliArgs {
+  const args = process.argv.slice(2);
+  const parsed: Record<string, string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--help' || args[i] === '-h') {
+      printHelp();
+      process.exit(0);
+    } else if (args[i] === '--dry-run') {
+      parsed.dryRun = 'true';
+    } else if (args[i] === '--source-images') {
+      parsed.sourceImages = 'true';
+    } else if (args[i].startsWith('--') && i + 1 < args.length) {
+      parsed[args[i].replace('--', '')] = args[i + 1];
+      i++;
+    }
+  }
+
+  const mode = parsed.mode || 'both';
+  if (mode !== 'email' && mode !== 'website' && mode !== 'both') {
+    console.error(`Invalid --mode: "${mode}". Must be "email", "website", or "both".`);
+    process.exit(1);
+  }
+
+  return {
+    city: parsed.city || 'all',
+    category: parsed.category || 'all',
+    mode: mode as 'email' | 'website' | 'both',
+    dryRun: parsed.dryRun === 'true',
+    sourceImages: parsed.sourceImages === 'true',
+    limit: parsed.limit ? parseInt(parsed.limit, 10) : 0,
+    delay: parsed.delay ? parseInt(parsed.delay, 10) : 2000,
+    userId: parsed['user-id'] || IMPORT_USER_ID,
+  };
+}
+
+// ── DB connection ────────────────────────────────────────────────────────────
+function createDbPool(): Pool {
+  return new Pool({
+    host: process.env.DB_HOST_MAIN_WRITE,
+    user: process.env.DB_USER_MAIN_WRITE,
+    password: process.env.DB_PASSWORD_MAIN_WRITE,
+    database: process.env.MAPS_SERVICE_DATABASE,
+    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
+    max: 5,
+    idleTimeoutMillis: 10000,
+    connectionTimeoutMillis: 10000,
+  });
+}
+
+interface ISpaceRow {
+  id: string;
+  notificationMsg: string;
+  category: string;
+  websiteUrl: string | null;
+  mediaIds: string | null;
+  medias: any | null;
+  fromUserId: string;
+  addressLocality: string;
+  addressRegion: string;
+}
+
+// ── Query spaces needing emails/websites ─────────────────────────────────────
+async function querySpacesForEmails(db: Pool, args: ICliArgs): Promise<ISpaceRow[]> {
+  const conditions = [
+    '"businessEmail" IS NULL',
+    `"websiteUrl" != ''`,
+    '"websiteUrl" IS NOT NULL',
+  ];
+  return querySpacesWithConditions(db, args, conditions);
+}
+
+async function querySpacesForWebsites(db: Pool, args: ICliArgs): Promise<ISpaceRow[]> {
+  const conditions = [
+    `("websiteUrl" IS NULL OR "websiteUrl" = '')`,
+  ];
+  return querySpacesWithConditions(db, args, conditions);
+}
+
+async function querySpacesWithConditions(db: Pool, args: ICliArgs, conditions: string[]): Promise<ISpaceRow[]> {
+  const params: (string | number)[] = [];
+  let paramIdx = 1;
+
+  if (args.city !== 'all') {
+    const cityConfig = CITIES[args.city];
+    if (cityConfig) {
+      conditions.push(`"addressLocality" ILIKE $${paramIdx}`);
+      params.push(`%${cityConfig.name}%`);
+      paramIdx++;
+    }
+  }
+
+  if (args.category !== 'all') {
+    conditions.push(`category = $${paramIdx}`);
+    params.push(args.category);
+    paramIdx++;
+  }
+
+  let query = `SELECT id, "notificationMsg", category, "websiteUrl", "mediaIds", medias,
+      "fromUserId", "addressLocality", "addressRegion"
+    FROM main.spaces
+    WHERE ${conditions.join(' AND ')}
+    ORDER BY RANDOM()`;
+
+  if (args.limit > 0) {
+    query += ` LIMIT $${paramIdx}`;
+    params.push(args.limit);
+  }
+
+  const result = await db.query(query, params);
+  return result.rows;
+}
+
+// ── Sleep helper ─────────────────────────────────────────────────────────────
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+// ── Check if space needs images ──────────────────────────────────────────────
+function spaceNeedsImages(space: ISpaceRow): boolean {
+  return (!space.mediaIds || space.mediaIds === '') && !space.medias;
+}
+
+// ── Image sourcing (reuses existing pipeline) ────────────────────────────────
+async function sourceImageForSpace(
+  db: Pool,
+  space: ISpaceRow,
+  websiteUrl: string,
+  userId: string,
+  progress: string,
+): Promise<boolean> {
+  const candidates = await crawlForImages(websiteUrl);
+  if (candidates.length === 0) return false;
+
+  // Try each candidate until one validates
+  for (const candidate of candidates) {
+    const validImage = await downloadAndValidateImage(candidate.imageUrl);
+    if (!validImage) continue;
+
+    console.log(`${progress}   Image found (${candidate.source}): ${validImage.width}x${validImage.height}`);
+
+    const storagePath = await uploadImage(userId, space.id, validImage.buffer, validImage.contentType);
+
+    // Insert media record
+    const mediaResult = await db.query(
+      `INSERT INTO main.media ("fromUserId", "altText", type, path)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id`,
+      [userId, space.notificationMsg, 'user-image-public', storagePath],
+    );
+    const mediaId = mediaResult.rows[0].id;
+
+    // Update space with media references
+    const medias = JSON.stringify([{ path: storagePath, type: 'user-image-public' }]);
+    await db.query(
+      `UPDATE main.spaces
+       SET "mediaIds" = $1::text,
+           medias = $2::jsonb,
+           "updatedAt" = NOW()
+       WHERE id = $3`,
+      [String(mediaId), medias, space.id],
+    );
+
+    console.log(`${progress}   Uploaded image: ${storagePath}`);
+    return true;
+  }
+
+  return false;
+}
+
+// ── Process spaces that need emails ──────────────────────────────────────────
+async function processEmailSpaces(db: Pool, args: ICliArgs, counters: ICounters) {
+  const spaces = await querySpacesForEmails(db, args);
+  console.log(`Found ${spaces.length} spaces with websites needing email extraction.\n`);
+
+  for (let i = 0; i < spaces.length; i++) {
+    const space = spaces[i];
+    const progress = `[email ${i + 1}/${spaces.length}]`;
+
+    try {
+      const emailResults = await crawlForEmails(space.websiteUrl!);
+
+      if (emailResults.length === 0) {
+        console.log(`${progress} SKIP (no email found): ${space.notificationMsg} — ${space.websiteUrl}`);
+        counters.skippedNoEmail++;
+        if (i < spaces.length - 1) await sleep(args.delay);
+        continue;
+      }
+
+      const bestEmail = emailResults[0];
+      console.log(`${progress} EMAIL FOUND (${bestEmail.source}): ${bestEmail.email} — ${space.notificationMsg}`);
+
+      if (args.dryRun) {
+        if (emailResults.length > 1) {
+          console.log(`  Other candidates: ${emailResults.slice(1).map((e) => e.email).join(', ')}`);
+        }
+        counters.dryRunEmails++;
+      } else {
+        await db.query(
+          `UPDATE main.spaces SET "businessEmail" = $1, "updatedAt" = NOW() WHERE id = $2`,
+          [bestEmail.email, space.id],
+        );
+        counters.emailsFound++;
+      }
+
+      // Optionally source images
+      if (args.sourceImages && spaceNeedsImages(space) && space.websiteUrl) {
+        if (args.dryRun) {
+          console.log(`${progress}   Would also source image from ${space.websiteUrl}`);
+        } else {
+          const imageSourced = await sourceImageForSpace(db, space, space.websiteUrl, space.fromUserId || args.userId, progress);
+          if (imageSourced) counters.imagesFound++;
+        }
+      }
+    } catch (err: any) {
+      console.error(`${progress} ERROR: ${space.notificationMsg} — ${err.message}`);
+      counters.errors++;
+    }
+
+    if (i < spaces.length - 1) await sleep(args.delay);
+  }
+}
+
+// ── Process spaces that need websites ────────────────────────────────────────
+async function processWebsiteSpaces(db: Pool, args: ICliArgs, counters: ICounters) {
+  const spaces = await querySpacesForWebsites(db, args);
+  console.log(`Found ${spaces.length} spaces needing website discovery.\n`);
+
+  for (let i = 0; i < spaces.length; i++) {
+    const space = spaces[i];
+    const progress = `[web ${i + 1}/${spaces.length}]`;
+
+    try {
+      const searchResult = await searchForWebsite(
+        space.notificationMsg,
+        space.addressLocality || '',
+        space.addressRegion || '',
+      );
+
+      if (!searchResult) {
+        console.log(`${progress} SKIP (no website found): ${space.notificationMsg}`);
+        counters.skippedNoWebsite++;
+        if (i < spaces.length - 1) await sleep(args.delay);
+        continue;
+      }
+
+      console.log(`${progress} WEBSITE FOUND (${searchResult.confidence}): ${searchResult.websiteUrl} — ${space.notificationMsg}`);
+      console.log(`${progress}   Matched on: ${searchResult.matchedOn}`);
+
+      if (args.dryRun) {
+        counters.dryRunWebsites++;
+      } else {
+        await db.query(
+          `UPDATE main.spaces SET "websiteUrl" = $1, "updatedAt" = NOW() WHERE id = $2`,
+          [searchResult.websiteUrl, space.id],
+        );
+        counters.websitesFound++;
+      }
+
+      // Try to find email from the newly discovered website
+      const emailResults = await crawlForEmails(searchResult.websiteUrl);
+      if (emailResults.length > 0) {
+        const bestEmail = emailResults[0];
+        console.log(`${progress}   EMAIL FOUND (${bestEmail.source}): ${bestEmail.email}`);
+
+        if (args.dryRun) {
+          counters.dryRunEmails++;
+        } else {
+          await db.query(
+            `UPDATE main.spaces SET "businessEmail" = $1, "updatedAt" = NOW() WHERE id = $2`,
+            [bestEmail.email, space.id],
+          );
+          counters.emailsFound++;
+        }
+      }
+
+      // Optionally source images from the newly discovered website
+      if (args.sourceImages && spaceNeedsImages(space)) {
+        if (args.dryRun) {
+          console.log(`${progress}   Would also source image from ${searchResult.websiteUrl}`);
+        } else {
+          const imageSourced = await sourceImageForSpace(
+            db, space, searchResult.websiteUrl, space.fromUserId || args.userId, progress,
+          );
+          if (imageSourced) counters.imagesFound++;
+        }
+      }
+    } catch (err: any) {
+      console.error(`${progress} ERROR: ${space.notificationMsg} — ${err.message}`);
+      counters.errors++;
+    }
+
+    if (i < spaces.length - 1) await sleep(args.delay);
+  }
+}
+
+// ── Counters ─────────────────────────────────────────────────────────────────
+interface ICounters {
+  emailsFound: number;
+  websitesFound: number;
+  imagesFound: number;
+  skippedNoEmail: number;
+  skippedNoWebsite: number;
+  dryRunEmails: number;
+  dryRunWebsites: number;
+  errors: number;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  const args = parseArgs();
+  console.log('\nSource Emails & Websites CLI');
+  console.log(`  City:          ${args.city}`);
+  console.log(`  Category:      ${args.category}`);
+  console.log(`  Mode:          ${args.mode}`);
+  console.log(`  Source images:  ${args.sourceImages}`);
+  console.log(`  Dry run:       ${args.dryRun}`);
+  console.log(`  Limit:         ${args.limit || 'none'}`);
+  console.log(`  Delay:         ${args.delay}ms`);
+  console.log('');
+
+  const db = createDbPool();
+
+  // Test connection
+  try {
+    await db.query('SELECT 1');
+    console.log('Database connection established.\n');
+  } catch (err: any) {
+    console.error(`Database connection failed: ${err.message}`);
+    console.error('Make sure .env is configured with DB_HOST_MAIN_WRITE, DB_USER_MAIN_WRITE, etc.');
+    process.exit(1);
+  }
+
+  const counters: ICounters = {
+    emailsFound: 0,
+    websitesFound: 0,
+    imagesFound: 0,
+    skippedNoEmail: 0,
+    skippedNoWebsite: 0,
+    dryRunEmails: 0,
+    dryRunWebsites: 0,
+    errors: 0,
+  };
+
+  // Phase 1: Find emails for spaces that have websites
+  if (args.mode === 'email' || args.mode === 'both') {
+    console.log('── Phase 1: Email extraction from existing websites ──────────────');
+    await processEmailSpaces(db, args, counters);
+    console.log('');
+  }
+
+  // Phase 2: Find websites for spaces that don't have them
+  if (args.mode === 'website' || args.mode === 'both') {
+    console.log('── Phase 2: Website discovery via web search ─────────────────────');
+    await processWebsiteSpaces(db, args, counters);
+    console.log('');
+  }
+
+  // Summary
+  console.log('══════════════════════════════════════');
+  if (args.dryRun) {
+    console.log(`Emails found (dry run):     ${counters.dryRunEmails}`);
+    console.log(`Websites found (dry run):   ${counters.dryRunWebsites}`);
+  } else {
+    console.log(`Emails found & saved:       ${counters.emailsFound}`);
+    console.log(`Websites found & saved:     ${counters.websitesFound}`);
+    console.log(`Images sourced:             ${counters.imagesFound}`);
+  }
+  console.log(`Skipped (no email):         ${counters.skippedNoEmail}`);
+  console.log(`Skipped (no website):       ${counters.skippedNoWebsite}`);
+  console.log(`Errors:                     ${counters.errors}`);
+  console.log('══════════════════════════════════════\n');
+
+  await db.end();
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/import-spaces/sources/crawlEmails.ts
+++ b/scripts/import-spaces/sources/crawlEmails.ts
@@ -1,0 +1,256 @@
+/**
+ * Website crawling for email extraction.
+ * Extracts business email addresses from a website by checking mailto links,
+ * plaintext patterns, and optionally following a contact page.
+ */
+
+export interface IEmailCrawlResult {
+  email: string;
+  source: 'mailto' | 'text' | 'contact-page-mailto' | 'contact-page-text';
+}
+
+// Generic/junk email domains to reject
+const JUNK_EMAIL_DOMAINS = [
+  'facebook.com',
+  'google.com',
+  'gmail.com',
+  'yelp.com',
+  'instagram.com',
+  'twitter.com',
+  'youtube.com',
+  'linkedin.com',
+  'tripadvisor.com',
+  'wix.com',
+  'squarespace.com',
+  'wordpress.com',
+  'wordpress.org',
+  'w3.org',
+  'schema.org',
+  'example.com',
+  'sentry.io',
+  'cloudflare.com',
+];
+
+// Prefixes that indicate automated/noreply addresses
+const JUNK_EMAIL_PREFIXES = [
+  'noreply',
+  'no-reply',
+  'no_reply',
+  'donotreply',
+  'do-not-reply',
+  'mailer-daemon',
+  'postmaster',
+  'hostmaster',
+  'webmaster',
+  'abuse',
+  'root',
+  'admin@wix',
+  'admin@squarespace',
+];
+
+// Patterns that indicate false positives from image filenames or CSS
+const FALSE_POSITIVE_PATTERNS = [
+  /@2x\b/i,
+  /@3x\b/i,
+  /@4x\b/i,
+  /\.(png|jpg|jpeg|gif|svg|webp|css|js)$/i,
+];
+
+const EMAIL_REGEX = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+
+function isJunkEmail(email: string): boolean {
+  const lower = email.toLowerCase();
+  const domain = lower.split('@')[1];
+
+  if (JUNK_EMAIL_DOMAINS.some((d) => domain === d)) return true;
+  if (JUNK_EMAIL_PREFIXES.some((p) => lower.startsWith(p))) return true;
+  if (FALSE_POSITIVE_PATTERNS.some((p) => p.test(lower))) return true;
+  // Reject emails with very long local parts (likely encoded strings)
+  if (lower.split('@')[0].length > 64) return true;
+
+  return false;
+}
+
+/**
+ * Extract emails from mailto: links in HTML.
+ */
+function extractMailtoEmails(html: string): string[] {
+  const results: string[] = [];
+  const mailtoRegex = /href=["']mailto:([^"'?]+)/gi;
+  let match: RegExpExecArray | null;
+
+  // eslint-disable-next-line no-cond-assign
+  while ((match = mailtoRegex.exec(html)) !== null) {
+    const email = decodeURIComponent(match[1]).trim().toLowerCase();
+    if (email.includes('@') && !isJunkEmail(email)) {
+      results.push(email);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Strip HTML tags and extract emails from plaintext content.
+ */
+function extractTextEmails(html: string): string[] {
+  // Remove script/style blocks, then strip tags
+  const stripped = html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ');
+
+  const results: string[] = [];
+  let match: RegExpExecArray | null;
+
+  // eslint-disable-next-line no-cond-assign
+  while ((match = EMAIL_REGEX.exec(stripped)) !== null) {
+    const email = match[0].toLowerCase();
+    if (!isJunkEmail(email)) {
+      results.push(email);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Find a contact or about page URL in the HTML.
+ */
+function findContactPageUrl(html: string, baseUrl: string): string | null {
+  const patterns = [
+    /href=["']([^"']*\/contact(?:-us)?[^"']*)["']/gi,
+    /href=["']([^"']*\/about(?:-us)?[^"']*)["']/gi,
+    /href=["']([^"']*\/kontakt[^"']*)["']/gi,
+    /href=["']([^"']*\/contacto[^"']*)["']/gi,
+  ];
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(html);
+    if (match) {
+      try {
+        return new URL(match[1], baseUrl).href;
+      } catch {
+        // Invalid URL, skip
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Fetch a page and return its HTML, or null on failure.
+ */
+async function fetchPage(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(10000),
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; TherSpaceBot/1.0)',
+        Accept: 'text/html',
+      },
+    });
+
+    if (!response.ok) return null;
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('text/html') && !contentType.includes('application/xhtml')) return null;
+
+    return response.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Deduplicate emails (case-insensitive) and prioritize those matching the website domain.
+ */
+function rankEmails(
+  emails: { email: string; source: IEmailCrawlResult['source'] }[],
+  websiteDomain: string,
+): IEmailCrawlResult[] {
+  const seen = new Set<string>();
+  const unique: IEmailCrawlResult[] = [];
+
+  for (const entry of emails) {
+    const lower = entry.email.toLowerCase();
+    if (!seen.has(lower)) {
+      seen.add(lower);
+      unique.push({ email: lower, source: entry.source });
+    }
+  }
+
+  // Sort: domain-matching emails first, then by source priority (mailto > text)
+  const sourcePriority: Record<string, number> = {
+    mailto: 0,
+    'contact-page-mailto': 1,
+    text: 2,
+    'contact-page-text': 3,
+  };
+
+  unique.sort((a, b) => {
+    const aDomainMatch = a.email.endsWith(`@${websiteDomain}`) ? 0 : 1;
+    const bDomainMatch = b.email.endsWith(`@${websiteDomain}`) ? 0 : 1;
+    if (aDomainMatch !== bDomainMatch) return aDomainMatch - bDomainMatch;
+    return (sourcePriority[a.source] || 99) - (sourcePriority[b.source] || 99);
+  });
+
+  return unique.slice(0, 3);
+}
+
+/**
+ * Crawl a website URL and extract email addresses.
+ * Returns ranked candidates (best first), or empty array if none found.
+ */
+export async function crawlForEmails(url: string): Promise<IEmailCrawlResult[]> {
+  try {
+    let normalizedUrl = url;
+    if (!normalizedUrl.startsWith('http://') && !normalizedUrl.startsWith('https://')) {
+      normalizedUrl = `https://${normalizedUrl}`;
+    }
+
+    let websiteDomain = '';
+    try {
+      websiteDomain = new URL(normalizedUrl).hostname.replace(/^www\./, '');
+    } catch {
+      return [];
+    }
+
+    const html = await fetchPage(normalizedUrl);
+    if (!html) return [];
+
+    const allEmails: { email: string; source: IEmailCrawlResult['source'] }[] = [];
+
+    // Step 1: mailto links on homepage
+    for (const email of extractMailtoEmails(html)) {
+      allEmails.push({ email, source: 'mailto' });
+    }
+
+    // Step 2: plaintext emails on homepage
+    for (const email of extractTextEmails(html)) {
+      allEmails.push({ email, source: 'text' });
+    }
+
+    // Step 3: If no emails found, try the contact/about page
+    if (allEmails.length === 0) {
+      const contactUrl = findContactPageUrl(html, normalizedUrl);
+      if (contactUrl) {
+        const contactHtml = await fetchPage(contactUrl);
+        if (contactHtml) {
+          for (const email of extractMailtoEmails(contactHtml)) {
+            allEmails.push({ email, source: 'contact-page-mailto' });
+          }
+          for (const email of extractTextEmails(contactHtml)) {
+            allEmails.push({ email, source: 'contact-page-text' });
+          }
+        }
+      }
+    }
+
+    return rankEmails(allEmails, websiteDomain);
+  } catch {
+    return [];
+  }
+}

--- a/scripts/import-spaces/sources/searchWeb.ts
+++ b/scripts/import-spaces/sources/searchWeb.ts
@@ -1,0 +1,258 @@
+/**
+ * Lightweight web search to find a business website given its name and location.
+ * Uses DuckDuckGo HTML search (no API key required).
+ *
+ * Only returns a result when confidence is high — the discovered page title or
+ * domain must clearly match the business name, so we don't associate the wrong
+ * website with a space.
+ */
+
+// Social media, directory, and review sites that are never a business's own website
+const REJECT_DOMAINS = [
+  'facebook.com',
+  'instagram.com',
+  'twitter.com',
+  'x.com',
+  'linkedin.com',
+  'yelp.com',
+  'tripadvisor.com',
+  'foursquare.com',
+  'yellowpages.com',
+  'bbb.org',
+  'mapquest.com',
+  'google.com',
+  'apple.com',
+  'grubhub.com',
+  'doordash.com',
+  'ubereats.com',
+  'opentable.com',
+  'seamless.com',
+  'postmates.com',
+  'wikipedia.org',
+  'wikidata.org',
+  'pinterest.com',
+  'tiktok.com',
+  'youtube.com',
+  'nextdoor.com',
+  'menulog.com',
+  'zomato.com',
+  'allmenus.com',
+  'chamberofcommerce.com',
+  'manta.com',
+  'superpages.com',
+  'whitepages.com',
+  'duckduckgo.com',
+];
+
+/**
+ * Clean and validate a discovered URL — ensure it looks like a real business website.
+ */
+function isLikelyBusinessWebsite(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname.replace(/^www\./, '');
+    return !REJECT_DOMAINS.some((d) => hostname === d || hostname.endsWith(`.${d}`));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Normalize a string for fuzzy matching: lowercase, remove punctuation, collapse whitespace.
+ */
+function normalize(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[''`]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Check if the business name is a confident match against a domain or page title.
+ * We require that a substantial portion of the business name words appear in the target.
+ */
+function isConfidentMatch(businessName: string, domain: string, pageTitle?: string): boolean {
+  const nameNorm = normalize(businessName);
+  const nameWords = nameNorm.split(' ').filter((w) => w.length > 2); // skip tiny words like "of", "the", "a"
+
+  if (nameWords.length === 0) return false;
+
+  // Check 1: Does the domain contain the business name (collapsed)?
+  // e.g., "Joe's Pizza" → "joespizza" vs domain "joespizza.com"
+  const nameCollapsed = nameNorm.replace(/\s+/g, '');
+  const domainBase = domain.replace(/^www\./, '').split('.')[0].toLowerCase();
+  if (domainBase.includes(nameCollapsed) || nameCollapsed.includes(domainBase)) {
+    return true;
+  }
+
+  // Check 2: Do most business name words appear in the domain?
+  const domainNorm = domain.toLowerCase().replace(/[^a-z0-9]/g, '');
+  let domainHits = 0;
+  for (const word of nameWords) {
+    if (domainNorm.includes(word)) domainHits++;
+  }
+  if (domainHits >= Math.ceil(nameWords.length * 0.6)) {
+    return true;
+  }
+
+  // Check 3: Does the page title contain most of the business name words?
+  if (pageTitle) {
+    const titleNorm = normalize(pageTitle);
+    let titleHits = 0;
+    for (const word of nameWords) {
+      if (titleNorm.includes(word)) titleHits++;
+    }
+    if (titleHits >= Math.ceil(nameWords.length * 0.6)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+interface IDdgResult {
+  url: string;
+  title: string;
+}
+
+/**
+ * Extract URLs and titles from DuckDuckGo HTML search results.
+ */
+function extractDdgResults(html: string): IDdgResult[] {
+  const results: IDdgResult[] = [];
+
+  // DuckDuckGo HTML results: <a class="result__a" href="...">Title</a>
+  const resultRegex = /class="result__a"[^>]*href=["']([^"']+)["'][^>]*>([^<]*)</gi;
+  let match: RegExpExecArray | null;
+
+  // eslint-disable-next-line no-cond-assign
+  while ((match = resultRegex.exec(html)) !== null) {
+    let href = match[1];
+    const title = match[2].trim();
+
+    // DDG wraps results in a redirect: //duckduckgo.com/l/?uddg=<url>&...
+    if (href.includes('uddg=')) {
+      const uddgMatch = href.match(/uddg=([^&]+)/);
+      if (uddgMatch) {
+        href = decodeURIComponent(uddgMatch[1]);
+      }
+    }
+
+    if (href.startsWith('http://') || href.startsWith('https://')) {
+      results.push({ url: href, title });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Fetch the <title> tag from a URL for secondary verification.
+ */
+async function fetchPageTitle(url: string): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(8000),
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; TherSpaceBot/1.0)',
+        Accept: 'text/html',
+      },
+    });
+
+    if (!response.ok) return null;
+
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('text/html') && !contentType.includes('application/xhtml')) return null;
+
+    const html = await response.text();
+    const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+    return titleMatch?.[1]?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export interface IWebSearchResult {
+  websiteUrl: string;
+  confidence: 'high' | 'medium';
+  matchedOn: string;
+}
+
+/**
+ * Search for a business website using DuckDuckGo HTML search.
+ * Only returns a result when we have high confidence the URL belongs to this business.
+ *
+ * Confidence checks:
+ * 1. The search result's domain or title must match the business name
+ * 2. The actual page <title> is fetched to double-check (avoids stale/wrong search snippets)
+ *
+ * @param businessName - The name of the business
+ * @param city - The city (for location context)
+ * @param region - The state/region (for location context)
+ */
+export async function searchForWebsite(
+  businessName: string,
+  city: string,
+  region: string,
+): Promise<IWebSearchResult | null> {
+  try {
+    const query = `${businessName} ${city} ${region} official website`;
+    const searchUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
+
+    const response = await fetch(searchUrl, {
+      signal: AbortSignal.timeout(10000),
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; TherSpaceBot/1.0)',
+        Accept: 'text/html',
+      },
+    });
+
+    if (!response.ok) return null;
+
+    const html = await response.text();
+    const ddgResults = extractDdgResults(html);
+
+    // Only check the top 3 results to avoid false positives from lower-ranked results
+    const candidateResults = ddgResults.filter((r) => isLikelyBusinessWebsite(r.url)).slice(0, 3);
+
+    for (const candidate of candidateResults) {
+      let domain = '';
+      try {
+        domain = new URL(candidate.url).hostname;
+      } catch {
+        continue;
+      }
+
+      // Check 1: Does the search result title/domain match the business name?
+      if (isConfidentMatch(businessName, domain, candidate.title)) {
+        // Check 2: Verify by fetching the actual page title
+        const pageTitle = await fetchPageTitle(candidate.url);
+        if (pageTitle && isConfidentMatch(businessName, domain, pageTitle)) {
+          return {
+            websiteUrl: candidate.url,
+            confidence: 'high',
+            matchedOn: `domain+title: ${domain} / "${pageTitle}"`,
+          };
+        }
+
+        // If page title fetch failed but domain strongly matches, still accept
+        const nameCollapsed = normalize(businessName).replace(/\s+/g, '');
+        const domainBase = domain.replace(/^www\./, '').split('.')[0].toLowerCase();
+        if (domainBase.includes(nameCollapsed) || nameCollapsed.includes(domainBase)) {
+          return {
+            websiteUrl: candidate.url,
+            confidence: 'medium',
+            matchedOn: `domain: ${domain}`,
+          };
+        }
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/import-spaces/transforms/mapToSpace.ts
+++ b/scripts/import-spaces/transforms/mapToSpace.ts
@@ -27,6 +27,7 @@ export interface ISpaceInsertParams {
   addressLocality: string;
   postalCode: number | null;
   phoneNumber: string;
+  businessEmail: string;
   websiteUrl: string;
   isPointOfInterest: boolean;
   openingHours: string | null;
@@ -125,6 +126,7 @@ export function mapOsmToSpace(element: IOsmElement, city: ICityConfig, userId: s
     addressLocality: tags['addr:city'] || city.name,
     postalCode: tags['addr:postcode'] ? parseInt(tags['addr:postcode'], 10) || null : null,
     phoneNumber: tags.phone || tags['contact:phone'] || '',
+    businessEmail: tags.email || tags['contact:email'] || '',
     websiteUrl: tags.website || tags['contact:website'] || '',
     isPointOfInterest: true,
     openingHours: openingHours ? JSON.stringify(openingHours) : null,

--- a/scripts/import-spaces/update-space-contact.ts
+++ b/scripts/import-spaces/update-space-contact.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Update a space's contact info (email, website) and optionally source an image.
+ * Designed to be called by the /find-space-contacts slash command.
+ *
+ * Usage:
+ *   npx ts-node scripts/import-spaces/update-space-contact \
+ *     --id <space-uuid> \
+ *     --email "info@business.com" \
+ *     --website "https://business.com" \
+ *     --source-image
+ *
+ * All arguments are optional except --id. Only provided fields are updated.
+ * Output: JSON result to stdout. Logging goes to stderr.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { Pool } from 'pg';
+import { IMPORT_USER_ID } from './config';
+import { crawlForImages } from './sources/crawl';
+import { downloadAndValidateImage } from './utils/imageValidation';
+import { uploadImage } from './utils/gcs';
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+function log(msg: string) {
+  process.stderr.write(`${msg}\n`);
+}
+
+interface ICliArgs {
+  id: string;
+  email: string | null;
+  website: string | null;
+  sourceImage: boolean;
+  userId: string;
+}
+
+function parseArgs(): ICliArgs {
+  const args = process.argv.slice(2);
+  const parsed: Record<string, string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--source-image') {
+      parsed.sourceImage = 'true';
+    } else if (args[i].startsWith('--') && i + 1 < args.length) {
+      parsed[args[i].replace('--', '')] = args[i + 1];
+      i++;
+    }
+  }
+
+  if (!parsed.id) {
+    log('Error: --id <space-uuid> is required.');
+    process.exit(1);
+  }
+
+  if (!parsed.email && !parsed.website && parsed.sourceImage !== 'true') {
+    log('Error: At least one of --email, --website, or --source-image must be provided.');
+    process.exit(1);
+  }
+
+  return {
+    id: parsed.id,
+    email: parsed.email || null,
+    website: parsed.website || null,
+    sourceImage: parsed.sourceImage === 'true',
+    userId: parsed['user-id'] || IMPORT_USER_ID,
+  };
+}
+
+function createDbPool(): Pool {
+  return new Pool({
+    host: process.env.DB_HOST_MAIN_WRITE,
+    user: process.env.DB_USER_MAIN_WRITE,
+    password: process.env.DB_PASSWORD_MAIN_WRITE,
+    database: process.env.MAPS_SERVICE_DATABASE,
+    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
+    max: 3,
+    idleTimeoutMillis: 10000,
+    connectionTimeoutMillis: 10000,
+  });
+}
+
+interface IUpdateResult {
+  spaceId: string;
+  emailUpdated: boolean;
+  websiteUpdated: boolean;
+  imageSourced: boolean;
+  imagePath: string | null;
+}
+
+async function main() {
+  const args = parseArgs();
+  const db = createDbPool();
+
+  try {
+    await db.query('SELECT 1');
+  } catch (err: any) {
+    log(`Database connection failed: ${err.message}`);
+    process.exit(1);
+  }
+
+  const result: IUpdateResult = {
+    spaceId: args.id,
+    emailUpdated: false,
+    websiteUpdated: false,
+    imageSourced: false,
+    imagePath: null,
+  };
+
+  // Verify space exists and get current data
+  const spaceResult = await db.query(
+    `SELECT id, "notificationMsg", "fromUserId", "websiteUrl", "businessEmail", "mediaIds", medias
+     FROM main.spaces WHERE id = $1`,
+    [args.id],
+  );
+
+  if (spaceResult.rows.length === 0) {
+    log(`Error: Space ${args.id} not found.`);
+    console.log(JSON.stringify({ error: 'Space not found', spaceId: args.id }));
+    await db.end();
+    process.exit(1);
+  }
+
+  const space = spaceResult.rows[0];
+
+  // Update email
+  if (args.email && !space.businessEmail) {
+    await db.query(
+      `UPDATE main.spaces SET "businessEmail" = $1, "updatedAt" = NOW() WHERE id = $2`,
+      [args.email, args.id],
+    );
+    result.emailUpdated = true;
+    log(`Updated email: ${args.email}`);
+  }
+
+  // Update website
+  if (args.website && (!space.websiteUrl || space.websiteUrl === '')) {
+    await db.query(
+      `UPDATE main.spaces SET "websiteUrl" = $1, "updatedAt" = NOW() WHERE id = $2`,
+      [args.website, args.id],
+    );
+    result.websiteUpdated = true;
+    log(`Updated website: ${args.website}`);
+  }
+
+  // Source image
+  if (args.sourceImage) {
+    const websiteUrl = args.website || space.websiteUrl;
+    const hasMedia = (space.mediaIds && space.mediaIds !== '') || (space.medias && space.medias.length > 0);
+
+    if (!websiteUrl) {
+      log('Skipping image sourcing: no website URL available.');
+    } else if (hasMedia) {
+      log('Skipping image sourcing: space already has media.');
+    } else {
+      log(`Sourcing image from: ${websiteUrl}`);
+      const candidates = await crawlForImages(websiteUrl);
+
+      for (const candidate of candidates) {
+        const validImage = await downloadAndValidateImage(candidate.imageUrl);
+        if (!validImage) continue;
+
+        const userId = space.fromUserId || args.userId;
+        const storagePath = await uploadImage(userId, args.id, validImage.buffer, validImage.contentType);
+
+        // Insert media record
+        const mediaResult = await db.query(
+          `INSERT INTO main.media ("fromUserId", "altText", type, path)
+           VALUES ($1, $2, $3, $4)
+           RETURNING id`,
+          [userId, space.notificationMsg, 'user-image-public', storagePath],
+        );
+        const mediaId = mediaResult.rows[0].id;
+
+        // Update space with media references
+        const medias = JSON.stringify([{ path: storagePath, type: 'user-image-public' }]);
+        await db.query(
+          `UPDATE main.spaces
+           SET "mediaIds" = $1::text,
+               medias = $2::jsonb,
+               "updatedAt" = NOW()
+           WHERE id = $3`,
+          [String(mediaId), medias, args.id],
+        );
+
+        result.imageSourced = true;
+        result.imagePath = storagePath;
+        log(`Uploaded image: ${storagePath}`);
+        break;
+      }
+
+      if (!result.imageSourced) {
+        log('No valid image found on website.');
+      }
+    }
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+  await db.end();
+}
+
+main().catch((err) => {
+  log(`Fatal error: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/import-spaces/update-space-contact.ts
+++ b/scripts/import-spaces/update-space-contact.ts
@@ -97,107 +97,110 @@ async function main() {
     await db.query('SELECT 1');
   } catch (err: any) {
     log(`Database connection failed: ${err.message}`);
-    process.exit(1);
-  }
-
-  const result: IUpdateResult = {
-    spaceId: args.id,
-    emailUpdated: false,
-    websiteUpdated: false,
-    imageSourced: false,
-    imagePath: null,
-  };
-
-  // Verify space exists and get current data
-  const spaceResult = await db.query(
-    `SELECT id, "notificationMsg", "fromUserId", "websiteUrl", "businessEmail", "mediaIds", medias
-     FROM main.spaces WHERE id = $1`,
-    [args.id],
-  );
-
-  if (spaceResult.rows.length === 0) {
-    log(`Error: Space ${args.id} not found.`);
-    console.log(JSON.stringify({ error: 'Space not found', spaceId: args.id }));
     await db.end();
     process.exit(1);
   }
 
-  const space = spaceResult.rows[0];
+  try {
+    const result: IUpdateResult = {
+      spaceId: args.id,
+      emailUpdated: false,
+      websiteUpdated: false,
+      imageSourced: false,
+      imagePath: null,
+    };
 
-  // Update email
-  if (args.email && !space.businessEmail) {
-    await db.query(
-      `UPDATE main.spaces SET "businessEmail" = $1, "updatedAt" = NOW() WHERE id = $2`,
-      [args.email, args.id],
+    // Verify space exists and get current data
+    const spaceResult = await db.query(
+      `SELECT id, "notificationMsg", "fromUserId", "websiteUrl", "businessEmail", "mediaIds", medias
+       FROM main.spaces WHERE id = $1`,
+      [args.id],
     );
-    result.emailUpdated = true;
-    log(`Updated email: ${args.email}`);
-  }
 
-  // Update website
-  if (args.website && (!space.websiteUrl || space.websiteUrl === '')) {
-    await db.query(
-      `UPDATE main.spaces SET "websiteUrl" = $1, "updatedAt" = NOW() WHERE id = $2`,
-      [args.website, args.id],
-    );
-    result.websiteUpdated = true;
-    log(`Updated website: ${args.website}`);
-  }
+    if (spaceResult.rows.length === 0) {
+      log(`Error: Space ${args.id} not found.`);
+      console.log(JSON.stringify({ error: 'Space not found', spaceId: args.id }));
+      process.exit(1);
+    }
 
-  // Source image
-  if (args.sourceImage) {
-    const websiteUrl = args.website || space.websiteUrl;
-    const hasMedia = (space.mediaIds && space.mediaIds !== '') || (space.medias && space.medias.length > 0);
+    const space = spaceResult.rows[0];
 
-    if (!websiteUrl) {
-      log('Skipping image sourcing: no website URL available.');
-    } else if (hasMedia) {
-      log('Skipping image sourcing: space already has media.');
-    } else {
-      log(`Sourcing image from: ${websiteUrl}`);
-      const candidates = await crawlForImages(websiteUrl);
+    // Update email
+    if (args.email && !space.businessEmail) {
+      await db.query(
+        `UPDATE main.spaces SET "businessEmail" = $1, "updatedAt" = NOW() WHERE id = $2`,
+        [args.email, args.id],
+      );
+      result.emailUpdated = true;
+      log(`Updated email: ${args.email}`);
+    }
 
-      for (const candidate of candidates) {
-        const validImage = await downloadAndValidateImage(candidate.imageUrl);
-        if (!validImage) continue;
+    // Update website
+    if (args.website && (!space.websiteUrl || space.websiteUrl === '')) {
+      await db.query(
+        `UPDATE main.spaces SET "websiteUrl" = $1, "updatedAt" = NOW() WHERE id = $2`,
+        [args.website, args.id],
+      );
+      result.websiteUpdated = true;
+      log(`Updated website: ${args.website}`);
+    }
 
-        const userId = space.fromUserId || args.userId;
-        const storagePath = await uploadImage(userId, args.id, validImage.buffer, validImage.contentType);
+    // Source image
+    if (args.sourceImage) {
+      const websiteUrl = args.website || space.websiteUrl;
+      const hasMedia = (space.mediaIds && space.mediaIds !== '') || (space.medias && space.medias.length > 0);
 
-        // Insert media record
-        const mediaResult = await db.query(
-          `INSERT INTO main.media ("fromUserId", "altText", type, path)
-           VALUES ($1, $2, $3, $4)
-           RETURNING id`,
-          [userId, space.notificationMsg, 'user-image-public', storagePath],
-        );
-        const mediaId = mediaResult.rows[0].id;
+      if (!websiteUrl) {
+        log('Skipping image sourcing: no website URL available.');
+      } else if (hasMedia) {
+        log('Skipping image sourcing: space already has media.');
+      } else {
+        log(`Sourcing image from: ${websiteUrl}`);
+        const candidates = await crawlForImages(websiteUrl);
 
-        // Update space with media references
-        const medias = JSON.stringify([{ path: storagePath, type: 'user-image-public' }]);
-        await db.query(
-          `UPDATE main.spaces
-           SET "mediaIds" = $1::text,
-               medias = $2::jsonb,
-               "updatedAt" = NOW()
-           WHERE id = $3`,
-          [String(mediaId), medias, args.id],
-        );
+        for (const candidate of candidates) {
+          const validImage = await downloadAndValidateImage(candidate.imageUrl);
+          if (!validImage) continue;
 
-        result.imageSourced = true;
-        result.imagePath = storagePath;
-        log(`Uploaded image: ${storagePath}`);
-        break;
-      }
+          const userId = space.fromUserId || args.userId;
+          const storagePath = await uploadImage(userId, args.id, validImage.buffer, validImage.contentType);
 
-      if (!result.imageSourced) {
-        log('No valid image found on website.');
+          // Insert media record
+          const mediaResult = await db.query(
+            `INSERT INTO main.media ("fromUserId", "altText", type, path)
+             VALUES ($1, $2, $3, $4)
+             RETURNING id`,
+            [userId, space.notificationMsg, 'user-image-public', storagePath],
+          );
+          const mediaId = mediaResult.rows[0].id;
+
+          // Update space with media references
+          const medias = JSON.stringify([{ path: storagePath, type: 'user-image-public' }]);
+          await db.query(
+            `UPDATE main.spaces
+             SET "mediaIds" = $1::text,
+                 medias = $2::jsonb,
+                 "updatedAt" = NOW()
+             WHERE id = $3`,
+            [String(mediaId), medias, args.id],
+          );
+
+          result.imageSourced = true;
+          result.imagePath = storagePath;
+          log(`Uploaded image: ${storagePath}`);
+          break;
+        }
+
+        if (!result.imageSourced) {
+          log('No valid image found on website.');
+        }
       }
     }
-  }
 
-  console.log(JSON.stringify(result, null, 2));
-  await db.end();
+    console.log(JSON.stringify(result, null, 2));
+  } finally {
+    await db.end();
+  }
 }
 
 main().catch((err) => {

--- a/therr-services/maps-service/src/store/SpacesStore.ts
+++ b/therr-services/maps-service/src/store/SpacesStore.ts
@@ -39,6 +39,7 @@ export interface ICreateSpaceParams extends ICreateAreaParams {
     featuredIncentiveRewardValue?: number;
     featuredIncentiveCurrencyId?: string;
     phoneNumber?: string;
+    businessEmail?: string;
     websiteUrl?: string;
     menuUrl?: string;
     orderUrl?: string;
@@ -572,6 +573,7 @@ export default class SpacesStore {
                 featuredIncentiveRewardValue: params.featuredIncentiveRewardValue,
                 featuredIncentiveCurrencyId: params.featuredIncentiveCurrencyId,
                 phoneNumber: params.phoneNumber,
+                businessEmail: params.businessEmail,
                 websiteUrl: params.websiteUrl,
                 menuUrl: params.menuUrl,
                 orderUrl: params.orderUrl,
@@ -662,6 +664,7 @@ export default class SpacesStore {
                 incentiveCurrencyId: params.incentiveCurrencyId,
                 mediaIds: mediaIds || params.mediaIds || undefined,
                 phoneNumber: params.phoneNumber,
+                businessEmail: params.businessEmail,
                 websiteUrl: params.websiteUrl,
                 menuUrl: params.menuUrl,
                 orderUrl: params.orderUrl,

--- a/therr-services/maps-service/src/store/migrations/20260325000000_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20260325000000_main.spaces.js
@@ -1,0 +1,7 @@
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
+    table.string('businessEmail').nullable();
+});
+
+exports.down = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
+    table.dropColumn('businessEmail');
+});


### PR DESCRIPTION
Adds a new CLI script (source-emails-websites.ts) that crawls business websites
to extract email addresses and searches the web to discover websites for spaces
that lack one. Business emails enable future outreach to encourage businesses
to claim and manage their own spaces.

Key changes:
- New script: scripts/import-spaces/source-emails-websites.ts
- New module: sources/crawlEmails.ts (mailto links, plaintext, contact pages)
- New module: sources/searchWeb.ts (DuckDuckGo search with confidence checks)
- New migration: adds businessEmail column to main.spaces
- Updated SpacesStore, mapToSpace, and import index to support businessEmail
- Supports --mode email/website/both, --source-images flag, --dry-run

https://claude.ai/code/session_018LYSysF2MTuBApLPhPkDwb