### PR TITLE
2. feat: add unclaimed space email flow with claim CTA and edit space page

### DIFF
--- a/scripts/import-spaces/transforms/mapToSpace.ts
+++ b/scripts/import-spaces/transforms/mapToSpace.ts
@@ -29,6 +29,7 @@ export interface ISpaceInsertParams {
   phoneNumber: string;
   businessEmail: string;
   websiteUrl: string;
+  businessEmail: string;
   isPointOfInterest: boolean;
   openingHours: string | null;
   isMatureContent: boolean;
@@ -128,6 +129,7 @@ export function mapOsmToSpace(element: IOsmElement, city: ICityConfig, userId: s
     phoneNumber: tags.phone || tags['contact:phone'] || '',
     businessEmail: tags.email || tags['contact:email'] || '',
     websiteUrl: tags.website || tags['contact:website'] || '',
+    businessEmail: tags.email || tags['contact:email'] || '',
     isPointOfInterest: true,
     openingHours: openingHours ? JSON.stringify(openingHours) : null,
     isMatureContent: false,

--- a/therr-client-web/src/locales/en-us/dictionary.json
+++ b/therr-client-web/src/locales/en-us/dictionary.json
@@ -775,6 +775,44 @@
         "getFullExperience": "Get the full experience on Therr app",
         "helpful": "Helpful",
         "notHelpful": "Not helpful"
+      },
+      "claimSpace": {
+        "title": "Is this your business?",
+        "body": "Claim this space to update your business info, add photos, and connect with customers who are searching for you.",
+        "claimButton": "Claim This Space",
+        "editButton": "Edit Space",
+        "alreadyHaveAccount": "Already have an account? Sign in",
+        "pendingTitle": "Claim Request Pending",
+        "pendingBody": "A claim request for this space has been submitted and is currently under review.",
+        "successMessage": "Your claim request has been submitted. You will be notified once it is approved.",
+        "errorMessage": "There was an error submitting your claim. Please try again later."
+      }
+    },
+    "editSpace": {
+      "pageTitle": "Edit Space",
+      "successMessage": "Your space has been updated successfully.",
+      "errorGeneric": "An error occurred while saving. Please try again.",
+      "headings": {
+        "contactInfo": "Contact Information"
+      },
+      "labels": {
+        "businessName": "Business Name",
+        "category": "Category",
+        "selectCategory": "Select a category",
+        "description": "Description",
+        "hashTags": "Tags",
+        "hashTagsHint": "Comma-separated (e.g. coffee, wifi, outdoor seating)",
+        "image": "Business Photo",
+        "chooseImage": "Choose an image",
+        "phoneNumber": "Phone Number",
+        "websiteUrl": "Website",
+        "menuUrl": "Menu URL",
+        "orderUrl": "Order / Delivery URL",
+        "reservationUrl": "Reservation URL"
+      },
+      "buttons": {
+        "save": "Save Changes",
+        "backToSpace": "Back to Space"
       }
     },
     "viewMoment": {

--- a/therr-client-web/src/locales/en-us/dictionary.json
+++ b/therr-client-web/src/locales/en-us/dictionary.json
@@ -778,7 +778,7 @@
       },
       "claimSpace": {
         "title": "Is this your business?",
-        "body": "Claim this space to update your business info, add photos, and connect with customers who are searching for you.",
+        "body": "Claim this space to see real-time customer activity, get paired with complementary local businesses, and reward customers who spread the word. Update your info, add photos, and take control of your presence.",
         "claimButton": "Claim This Space",
         "editButton": "Edit Space",
         "alreadyHaveAccount": "Already have an account? Sign in",

--- a/therr-client-web/src/locales/es/dictionary.json
+++ b/therr-client-web/src/locales/es/dictionary.json
@@ -775,6 +775,44 @@
         "getFullExperience": "Obtén la experiencia completa en la app Therr",
         "helpful": "Útil",
         "notHelpful": "No útil"
+      },
+      "claimSpace": {
+        "title": "¿Es este tu negocio?",
+        "body": "Reclama este espacio para actualizar la información de tu negocio, agregar fotos y conectar con los clientes que te están buscando.",
+        "claimButton": "Reclamar este espacio",
+        "editButton": "Editar espacio",
+        "alreadyHaveAccount": "¿Ya tienes una cuenta? Inicia sesión",
+        "pendingTitle": "Solicitud de reclamo pendiente",
+        "pendingBody": "Se ha enviado una solicitud de reclamo para este espacio y está siendo revisada.",
+        "successMessage": "Tu solicitud de reclamo ha sido enviada. Serás notificado una vez que sea aprobada.",
+        "errorMessage": "Hubo un error al enviar tu solicitud. Por favor, intenta de nuevo más tarde."
+      }
+    },
+    "editSpace": {
+      "pageTitle": "Editar espacio",
+      "successMessage": "Tu espacio ha sido actualizado exitosamente.",
+      "errorGeneric": "Ocurrió un error al guardar. Por favor, intenta de nuevo.",
+      "headings": {
+        "contactInfo": "Información de contacto"
+      },
+      "labels": {
+        "businessName": "Nombre del negocio",
+        "category": "Categoría",
+        "selectCategory": "Selecciona una categoría",
+        "description": "Descripción",
+        "hashTags": "Etiquetas",
+        "hashTagsHint": "Separadas por comas (ej. café, wifi, terraza)",
+        "image": "Foto del negocio",
+        "chooseImage": "Elegir una imagen",
+        "phoneNumber": "Número de teléfono",
+        "websiteUrl": "Sitio web",
+        "menuUrl": "URL del menú",
+        "orderUrl": "URL de pedidos / entregas",
+        "reservationUrl": "URL de reservaciones"
+      },
+      "buttons": {
+        "save": "Guardar cambios",
+        "backToSpace": "Volver al espacio"
       }
     },
     "viewMoment": {

--- a/therr-client-web/src/locales/es/dictionary.json
+++ b/therr-client-web/src/locales/es/dictionary.json
@@ -778,7 +778,7 @@
       },
       "claimSpace": {
         "title": "¿Es este tu negocio?",
-        "body": "Reclama este espacio para actualizar la información de tu negocio, agregar fotos y conectar con los clientes que te están buscando.",
+        "body": "Reclama este espacio para ver la actividad de clientes en tiempo real, conectarte con negocios locales complementarios y recompensar a los clientes que difunden tu negocio. Actualiza tu información, agrega fotos y toma el control de tu presencia.",
         "claimButton": "Reclamar este espacio",
         "editButton": "Editar espacio",
         "alreadyHaveAccount": "¿Ya tienes una cuenta? Inicia sesión",

--- a/therr-client-web/src/locales/fr-ca/dictionary.json
+++ b/therr-client-web/src/locales/fr-ca/dictionary.json
@@ -739,7 +739,7 @@
       },
       "claimSpace": {
         "title": "C'est votre entreprise?",
-        "body": "Réclamez cet espace pour mettre à jour les informations de votre entreprise, ajouter des photos et entrer en contact avec les clients qui vous recherchent.",
+        "body": "Réclamez cet espace pour voir l'activité de vos clients en temps réel, être jumelé avec des entreprises locales complémentaires et récompenser les clients qui parlent de vous. Mettez à jour vos informations, ajoutez des photos et prenez le contrôle de votre présence.",
         "claimButton": "Réclamer cet espace",
         "editButton": "Modifier l'espace",
         "alreadyHaveAccount": "Vous avez déjà un compte? Connectez-vous",

--- a/therr-client-web/src/locales/fr-ca/dictionary.json
+++ b/therr-client-web/src/locales/fr-ca/dictionary.json
@@ -736,6 +736,44 @@
         "getFullExperience": "Profitez de l'expérience complète sur l'application Therr",
         "helpful": "Utile",
         "notHelpful": "Pas utile"
+      },
+      "claimSpace": {
+        "title": "C'est votre entreprise?",
+        "body": "Réclamez cet espace pour mettre à jour les informations de votre entreprise, ajouter des photos et entrer en contact avec les clients qui vous recherchent.",
+        "claimButton": "Réclamer cet espace",
+        "editButton": "Modifier l'espace",
+        "alreadyHaveAccount": "Vous avez déjà un compte? Connectez-vous",
+        "pendingTitle": "Demande de réclamation en attente",
+        "pendingBody": "Une demande de réclamation pour cet espace a été soumise et est en cours de révision.",
+        "successMessage": "Votre demande de réclamation a été soumise. Vous serez notifié une fois qu'elle sera approuvée.",
+        "errorMessage": "Une erreur s'est produite lors de la soumission de votre demande. Veuillez réessayer plus tard."
+      }
+    },
+    "editSpace": {
+      "pageTitle": "Modifier l'espace",
+      "successMessage": "Votre espace a été mis à jour avec succès.",
+      "errorGeneric": "Une erreur s'est produite lors de la sauvegarde. Veuillez réessayer.",
+      "headings": {
+        "contactInfo": "Coordonnées"
+      },
+      "labels": {
+        "businessName": "Nom de l'entreprise",
+        "category": "Catégorie",
+        "selectCategory": "Sélectionner une catégorie",
+        "description": "Description",
+        "hashTags": "Étiquettes",
+        "hashTagsHint": "Séparées par des virgules (ex. café, wifi, terrasse)",
+        "image": "Photo de l'entreprise",
+        "chooseImage": "Choisir une image",
+        "phoneNumber": "Numéro de téléphone",
+        "websiteUrl": "Site web",
+        "menuUrl": "URL du menu",
+        "orderUrl": "URL de commande / livraison",
+        "reservationUrl": "URL de réservation"
+      },
+      "buttons": {
+        "save": "Enregistrer les modifications",
+        "backToSpace": "Retour à l'espace"
       }
     },
     "viewGroup": {

--- a/therr-client-web/src/routes/CreateProfile.tsx
+++ b/therr-client-web/src/routes/CreateProfile.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import ReactGA from 'react-ga4';
+import { Location } from 'react-router-dom';
 import { ErrorCodes } from 'therr-js-utilities/constants';
 import { IUserState } from 'therr-react/types';
 import { ApiService } from 'therr-react/services';
@@ -10,9 +11,10 @@ import VerifyPhoneCodeForm from '../components/forms/VerifyPhoneCodeForm';
 import UsersActions from '../redux/actions/UsersActions';
 import withNavigation from '../wrappers/withNavigation';
 import withTranslation from '../wrappers/withTranslation';
-import { routeAfterLogin } from './Login';
+import { getReturnTo, routeAfterLogin } from './Login';
 
 interface ICreateProfileRouterProps {
+    location: Location;
     navigation: any;
 }
 
@@ -129,7 +131,9 @@ export class CreateProfileComponent extends React.Component<ICreateProfileProps,
     };
 
     onSubmitCode = (updateArgs: any) => {
-        const { navigation, updateUser, user } = this.props;
+        const {
+            location, navigation, updateUser, user,
+        } = this.props;
         this.setState({
             errorMessage: '',
             isSubmitting: true,
@@ -139,7 +143,9 @@ export class CreateProfileComponent extends React.Component<ICreateProfileProps,
                 updateUser(user.details.id, {
                     phoneNumber: this.state.phoneNumber,
                 }).then(() => {
-                    navigation.navigate(routeAfterLogin, {
+                    const returnTo = getReturnTo(location?.search);
+                    const destination = returnTo || routeAfterLogin;
+                    navigation.navigate(destination, {
                         state: {
                             successMessage: this.props.translate('pages.createProfile.createProfileSuccess'),
                         },

--- a/therr-client-web/src/routes/EditSpace.tsx
+++ b/therr-client-web/src/routes/EditSpace.tsx
@@ -4,17 +4,24 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { NavigateFunction } from 'react-router-dom';
 import {
-    Alert, Card, Container, Stack, Textarea,
+    Alert, Card, Container, Stack, Textarea, FileInput,
 } from '@mantine/core';
 import {
     MantineButton,
     MantineInput,
+    MantineSelect,
 } from 'therr-react/components/mantine';
 import { IMapState, IUserState } from 'therr-react/types';
 import { MapActions } from 'therr-react/redux/actions';
 import { MapsService } from 'therr-react/services';
+import { Categories } from 'therr-js-utilities/constants';
 import withNavigation from '../wrappers/withNavigation';
 import withTranslation from '../wrappers/withTranslation';
+
+const categoryOptions = Categories.SpaceCategories.map((cat: string) => ({
+    value: cat,
+    label: cat.replace('categories.', '').replace('/', ' / ').replace(/^\w/, (c) => c.toUpperCase()),
+}));
 
 interface IEditSpaceRouterProps {
     navigation: {
@@ -43,12 +50,15 @@ interface IEditSpaceState {
         notificationMsg: string;
         message: string;
         addressReadable: string;
+        category: string;
+        hashTags: string;
         phoneNumber: string;
         websiteUrl: string;
         menuUrl: string;
         orderUrl: string;
         reservationUrl: string;
     };
+    imageFile: File | null;
     isLoading: boolean;
     isSubmitting: boolean;
     errorReason: string;
@@ -76,12 +86,15 @@ export class EditSpaceComponent extends React.Component<IEditSpaceProps, IEditSp
                 notificationMsg: '',
                 message: '',
                 addressReadable: '',
+                category: '',
+                hashTags: '',
                 phoneNumber: '',
                 websiteUrl: '',
                 menuUrl: '',
                 orderUrl: '',
                 reservationUrl: '',
             },
+            imageFile: null,
             isLoading: true,
             isSubmitting: false,
             errorReason: '',
@@ -134,6 +147,8 @@ export class EditSpaceComponent extends React.Component<IEditSpaceProps, IEditSp
                 notificationMsg: space.notificationMsg || '',
                 message: space.message || '',
                 addressReadable: space.addressReadable || '',
+                category: space.category || '',
+                hashTags: space.hashTags || '',
                 phoneNumber: space.phoneNumber || '',
                 websiteUrl: space.websiteUrl || '',
                 menuUrl: space.menuUrl || '',
@@ -166,6 +181,21 @@ export class EditSpaceComponent extends React.Component<IEditSpaceProps, IEditSp
         });
     };
 
+    onCategoryChange = (value: string | null) => {
+        this.setState({
+            inputs: {
+                ...this.state.inputs,
+                category: value || '',
+            },
+            errorReason: '',
+            isSuccess: false,
+        });
+    };
+
+    onImageChange = (file: File | null) => {
+        this.setState({ imageFile: file });
+    };
+
     isFormDisabled = () => {
         const { inputs, isSubmitting } = this.state;
         return isSubmitting || !inputs.notificationMsg;
@@ -177,20 +207,48 @@ export class EditSpaceComponent extends React.Component<IEditSpaceProps, IEditSp
         if (this.isFormDisabled()) return;
 
         const { routeParams, updateSpace } = this.props;
-        const { inputs } = this.state;
+        const { inputs, imageFile } = this.state;
+        const { spaceId } = routeParams;
 
         this.setState({ isSubmitting: true, errorReason: '', isSuccess: false });
 
-        updateSpace(routeParams.spaceId, {
+        const updateArgs: any = {
             notificationMsg: inputs.notificationMsg,
             message: inputs.message,
             addressReadable: inputs.addressReadable,
+            category: inputs.category,
+            hashTags: inputs.hashTags,
             phoneNumber: inputs.phoneNumber,
             websiteUrl: inputs.websiteUrl,
             menuUrl: inputs.menuUrl,
             orderUrl: inputs.orderUrl,
             reservationUrl: inputs.reservationUrl,
-        }).then(() => {
+        };
+
+        const imageUploadPromise = imageFile
+            ? MapsService.getSignedUrlPublicBucket({
+                action: 'write',
+                filename: `spaces/${spaceId}/${imageFile.name}`,
+                areaType: 'spaces',
+            }).then((response: any) => {
+                const signedUrl = response?.data?.url;
+                if (signedUrl) {
+                    return fetch(signedUrl, {
+                        method: 'PUT',
+                        body: imageFile,
+                        headers: { 'Content-Type': imageFile.type },
+                    }).then(() => {
+                        updateArgs.medias = [{
+                            type: 'USER_IMAGE_PUBLIC',
+                            path: `spaces/${spaceId}/${imageFile.name}`,
+                        }];
+                    });
+                }
+                return undefined;
+            })
+            : Promise.resolve();
+
+        imageUploadPromise.then(() => updateSpace(spaceId, updateArgs)).then(() => {
             this.setState({ isSuccess: true, errorReason: '' });
             window.scrollTo({ top: 0, behavior: 'smooth' });
         }).catch((error: any) => {
@@ -284,6 +342,32 @@ export class EditSpaceComponent extends React.Component<IEditSpaceProps, IEditSp
                                 onEnter={this.onSubmit}
                                 translateFn={translate}
                                 label={translate('pages.editSpace.labels.address')}
+                            />
+
+                            <MantineSelect
+                                id="edit_space_category"
+                                label={translate('pages.editSpace.labels.category')}
+                                value={inputs.category}
+                                onChange={this.onCategoryChange}
+                                data={categoryOptions}
+                                placeholder={translate('pages.editSpace.labels.selectCategory')}
+                            />
+
+                            <MantineInput
+                                id="edit_space_hashTags"
+                                name="hashTags"
+                                value={inputs.hashTags}
+                                onChange={this.onInputChange}
+                                label={translate('pages.editSpace.labels.hashTags')}
+                                description={translate('pages.editSpace.labels.hashTagsHint')}
+                            />
+
+                            <FileInput
+                                label={translate('pages.editSpace.labels.image')}
+                                accept="image/*"
+                                onChange={this.onImageChange}
+                                placeholder={translate('pages.editSpace.labels.chooseImage')}
+                                clearable
                             />
 
                             <h2 className="edit-profile-section-title">

--- a/therr-client-web/src/routes/EditSpace.tsx
+++ b/therr-client-web/src/routes/EditSpace.tsx
@@ -136,6 +136,7 @@ export class EditSpaceComponent extends React.Component<IEditSpaceProps, IEditSp
                     this.props.navigation.navigate('/user/profile');
                 }
             }).catch(() => {
+                this.setState({ isLoading: false });
                 this.props.navigation.navigate('/user/profile');
             });
         }

--- a/therr-client-web/src/routes/Login.tsx
+++ b/therr-client-web/src/routes/Login.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import LogRocket from 'logrocket';
+import qs from 'qs';
 import { IUserState } from 'therr-react/types';
 import { AccessLevels } from 'therr-js-utilities/constants';
 import { Location, NavigateFunction } from 'react-router-dom';
@@ -17,13 +18,28 @@ export const shouldRenderLoginForm = (props: ILoginProps) => !props.user
 
 export const routeAfterLogin = '/explore';
 
-export const getRouteAfterLogin = (user: IUserState) => {
+/**
+ * Extracts and validates the returnTo query parameter from a location search string.
+ * Only allows relative paths starting with '/' to prevent open redirect vulnerabilities.
+ */
+export const getReturnTo = (locationSearch?: string): string | undefined => {
+    if (!locationSearch) return undefined;
+    const searchParams = qs.parse(locationSearch, { ignoreQueryPrefix: true });
+    const returnTo = searchParams?.returnTo as string;
+    if (returnTo && returnTo.startsWith('/') && !returnTo.startsWith('//')) {
+        return returnTo;
+    }
+    return undefined;
+};
+
+export const getRouteAfterLogin = (user: IUserState, returnTo?: string) => {
     const accessLevels = user?.details?.accessLevels || [];
     if (accessLevels.includes(AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES)
         && !accessLevels.includes(AccessLevels.EMAIL_VERIFIED)) {
-        return '/create-profile';
+        const returnToParam = returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : '';
+        return `/create-profile${returnToParam}`;
     }
-    return routeAfterLogin;
+    return returnTo || routeAfterLogin;
 };
 
 interface ILoginRouterProps {
@@ -68,7 +84,8 @@ export class LoginComponent extends React.Component<ILoginProps, ILoginState> {
                 name: `${nextProps.user.details.firstName} ${nextProps.user.details.lastName}`,
                 email: nextProps.user.details.email,
             });
-            const destination = getRouteAfterLogin(nextProps.user);
+            const returnTo = getReturnTo(nextProps.location?.search);
+            const destination = getRouteAfterLogin(nextProps.user, returnTo);
             setTimeout(() => nextProps.navigation.navigate(destination));
             return null;
         }

--- a/therr-client-web/src/routes/Register.tsx
+++ b/therr-client-web/src/routes/Register.tsx
@@ -7,7 +7,7 @@ import qs from 'qs';
 import { IUserState } from 'therr-react/types';
 import RegisterForm from '../components/forms/RegisterForm';
 import UsersActions from '../redux/actions/UsersActions';
-import { getRouteAfterLogin, shouldRenderLoginForm } from './Login';
+import { getReturnTo, getRouteAfterLogin, shouldRenderLoginForm } from './Login';
 import withNavigation from '../wrappers/withNavigation';
 import withTranslation from '../wrappers/withTranslation';
 
@@ -57,7 +57,8 @@ export class RegisterComponent extends React.Component<IRegisterProps, IRegister
                 name: `${nextProps.user.details.firstName} ${nextProps.user.details.lastName}`,
                 email: nextProps.user.details.email,
             });
-            const destination = getRouteAfterLogin(nextProps.user);
+            const returnTo = getReturnTo(nextProps.location?.search);
+            const destination = getRouteAfterLogin(nextProps.user, returnTo);
             setTimeout(() => nextProps.navigation.navigate(destination));
             return null;
         }
@@ -123,7 +124,9 @@ export class RegisterComponent extends React.Component<IRegisterProps, IRegister
             ...credentials,
             inviteCode: credentials.inviteCode || inviteCode,
         }).then((response: any) => {
-            this.props.navigation.navigate('/login', {
+            const returnTo = getReturnTo(this.props.location?.search);
+            const returnToParam = returnTo ? `?returnTo=${encodeURIComponent(returnTo)}` : '';
+            this.props.navigation.navigate(`/login${returnToParam}`, {
                 state: {
                     successMessage: this.props.translate('pages.register.registerSuccess'),
                 },

--- a/therr-client-web/src/routes/ViewSpace.tsx
+++ b/therr-client-web/src/routes/ViewSpace.tsx
@@ -11,6 +11,7 @@ import {
     ActionIcon, Container, Stack, Group, Title, Text, Badge, Anchor,
     Divider, Image, Skeleton, Breadcrumbs, Tooltip,
     SimpleGrid, Rating as MantineRating, Paper, Avatar,
+    Button, Alert,
 } from '@mantine/core';
 import withNavigation from '../wrappers/withNavigation';
 import withTranslation from '../wrappers/withTranslation';
@@ -66,6 +67,9 @@ interface IViewSpaceState {
     isPairingsLoading: boolean;
     pairingFeedback: { [id: string]: boolean };
     isLinkCopied: boolean;
+    isClaimLoading: boolean;
+    claimMessage: string;
+    claimMessageType: 'success' | 'error' | '';
 }
 
 const mapStateToProps = (state: any) => ({
@@ -101,6 +105,9 @@ export class ViewSpaceComponent extends React.Component<IViewSpaceProps, IViewSp
             isPairingsLoading: false,
             pairingFeedback: {},
             isLinkCopied: false,
+            isClaimLoading: false,
+            claimMessage: '',
+            claimMessageType: '',
         };
     }
 
@@ -180,6 +187,113 @@ export class ViewSpaceComponent extends React.Component<IViewSpaceProps, IViewSp
     };
 
     login = (credentials: any) => this.props.login(credentials);
+
+    handleClaimSpace = () => {
+        const { user, translate } = this.props;
+        const { spaceId } = this.state;
+
+        if (!user?.isAuthenticated) {
+            this.props.navigation.navigate(`/register?returnTo=/spaces/${spaceId}`);
+            return;
+        }
+
+        this.setState({ isClaimLoading: true, claimMessage: '', claimMessageType: '' });
+        MapsService.claimSpace(spaceId)
+            .then(() => {
+                this.setState({
+                    isClaimLoading: false,
+                    claimMessage: translate('pages.viewSpace.claimSpace.successMessage'),
+                    claimMessageType: 'success',
+                });
+            })
+            .catch(() => {
+                this.setState({
+                    isClaimLoading: false,
+                    claimMessage: translate('pages.viewSpace.claimSpace.errorMessage'),
+                    claimMessageType: 'error',
+                });
+            });
+    };
+
+    renderClaimCTA(space: any): JSX.Element | null {
+        const { user, translate } = this.props;
+        const { isClaimLoading, claimMessage, claimMessageType } = this.state;
+        const isAuthenticated = user?.isAuthenticated;
+        const isOwner = isAuthenticated && user?.details?.id === space.fromUserId;
+
+        if (claimMessageType === 'success') {
+            return (
+                <Alert color="green" radius="md" mt="md">
+                    <Text fw={500}>{claimMessage}</Text>
+                </Alert>
+            );
+        }
+
+        if (space.isClaimPending || space.requestedByUserId) {
+            return (
+                <Paper withBorder p="lg" radius="md" mt="md" style={{ borderColor: '#fbbf24', backgroundColor: '#fffbeb' }}>
+                    <Text fw={600} size="lg">{translate('pages.viewSpace.claimSpace.pendingTitle')}</Text>
+                    <Text size="sm" mt="xs" c="dimmed">{translate('pages.viewSpace.claimSpace.pendingBody')}</Text>
+                </Paper>
+            );
+        }
+
+        if (!space.isUnclaimed) {
+            if (isOwner) {
+                return (
+                    <Group mt="md">
+                        <Button
+                            component="a"
+                            href={`/spaces/${space.id}/edit`}
+                            variant="filled"
+                            size="md"
+                        >
+                            {translate('pages.viewSpace.claimSpace.editButton')}
+                        </Button>
+                    </Group>
+                );
+            }
+            return null;
+        }
+
+        return (
+            <Paper withBorder p="lg" radius="md" mt="md" style={{ borderColor: '#1C7F8A', backgroundColor: '#f0fdfa' }}>
+                <Title order={3} size="h4">{translate('pages.viewSpace.claimSpace.title')}</Title>
+                <Text size="sm" mt="xs">{translate('pages.viewSpace.claimSpace.body')}</Text>
+                {claimMessage && claimMessageType === 'error' && (
+                    <Text size="sm" c="red" mt="xs">{claimMessage}</Text>
+                )}
+                <Group mt="md" gap="md">
+                    {isAuthenticated ? (
+                        <Button
+                            onClick={this.handleClaimSpace}
+                            loading={isClaimLoading}
+                            variant="filled"
+                            size="md"
+                            color="teal"
+                        >
+                            {translate('pages.viewSpace.claimSpace.claimButton')}
+                        </Button>
+                    ) : (
+                        <>
+                            <Button
+                                component="a"
+                                href={`/register?returnTo=/spaces/${space.id}`}
+                                variant="filled"
+                                size="md"
+                                color="teal"
+                            >
+                                {translate('pages.viewSpace.claimSpace.claimButton')}
+                            </Button>
+                            <Anchor href={`/login?returnTo=/spaces/${space.id}`} size="sm">
+                                {translate('pages.viewSpace.claimSpace.alreadyHaveAccount')}
+                            </Anchor>
+                        </>
+                    )}
+                </Group>
+            </Paper>
+        );
+    }
 
     renderSkeleton(): JSX.Element {
         return (
@@ -616,6 +730,9 @@ export class ViewSpaceComponent extends React.Component<IViewSpaceProps, IViewSp
 
                     {/* Action Links */}
                     {this.renderActionLinks(space)}
+
+                    {/* Claim This Space CTA */}
+                    {this.renderClaimCTA(space)}
 
                     <Divider />
 

--- a/therr-client-web/src/routes/__tests__/Login.test.ts
+++ b/therr-client-web/src/routes/__tests__/Login.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Mock socket-io-middleware before any imports that depend on it
+jest.mock('../../socket-io-middleware', () => ({
+    socketIO: {
+        on: jest.fn(),
+        emit: jest.fn(),
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+    },
+}));
+
+// Mock UsersActions to avoid its transitive socket dependency
+jest.mock('../../redux/actions/UsersActions', () => ({
+    default: {},
+}));
+
+import { AccessLevels } from 'therr-js-utilities/constants';
+import { getReturnTo, getRouteAfterLogin } from '../Login';
+
+describe('getReturnTo', () => {
+    it('returns the path for a valid returnTo param', () => {
+        expect(getReturnTo('?returnTo=/spaces/123')).toBe('/spaces/123');
+    });
+
+    it('returns undefined when locationSearch is undefined', () => {
+        expect(getReturnTo(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when locationSearch is empty string', () => {
+        expect(getReturnTo('')).toBeUndefined();
+    });
+
+    it('returns undefined when returnTo param is absent', () => {
+        expect(getReturnTo('?foo=bar')).toBeUndefined();
+    });
+
+    it('rejects double-slash open redirect attempts', () => {
+        expect(getReturnTo('?returnTo=//evil.com')).toBeUndefined();
+    });
+
+    it('rejects absolute URL redirect attempts', () => {
+        expect(getReturnTo('?returnTo=https://evil.com')).toBeUndefined();
+    });
+
+    it('allows paths with query params', () => {
+        expect(getReturnTo('?returnTo=/spaces/123?claim=true')).toBe('/spaces/123?claim=true');
+    });
+
+    it('handles encoded returnTo values', () => {
+        const encoded = encodeURIComponent('/spaces/abc');
+        expect(getReturnTo(`?returnTo=${encoded}`)).toBe('/spaces/abc');
+    });
+});
+
+describe('getRouteAfterLogin', () => {
+    const verifiedUser: any = {
+        details: {
+            accessLevels: [AccessLevels.EMAIL_VERIFIED],
+        },
+    };
+
+    const incompleteUser: any = {
+        details: {
+            accessLevels: [AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
+        },
+    };
+
+    const nullUser: any = {
+        details: {},
+    };
+
+    it('returns /explore when no returnTo and user is verified', () => {
+        expect(getRouteAfterLogin(verifiedUser)).toBe('/explore');
+    });
+
+    it('returns returnTo path when user is verified', () => {
+        expect(getRouteAfterLogin(verifiedUser, '/spaces/123')).toBe('/spaces/123');
+    });
+
+    it('returns /create-profile when user needs profile and no returnTo', () => {
+        expect(getRouteAfterLogin(incompleteUser)).toBe('/create-profile');
+    });
+
+    it('returns /create-profile with encoded returnTo when user needs profile', () => {
+        const result = getRouteAfterLogin(incompleteUser, '/spaces/123');
+        expect(result).toBe(`/create-profile?returnTo=${encodeURIComponent('/spaces/123')}`);
+    });
+
+    it('returns /explore when user has no access levels and no returnTo', () => {
+        expect(getRouteAfterLogin(nullUser)).toBe('/explore');
+    });
+
+    it('returns returnTo when user has no access levels', () => {
+        expect(getRouteAfterLogin(nullUser, '/spaces/abc')).toBe('/spaces/abc');
+    });
+
+    it('returns /explore when user has both verified and missing properties', () => {
+        const bothUser: any = {
+            details: {
+                accessLevels: [
+                    AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES,
+                    AccessLevels.EMAIL_VERIFIED,
+                ],
+            },
+        };
+        expect(getRouteAfterLogin(bothUser)).toBe('/explore');
+    });
+});

--- a/therr-public-library/therr-js-utilities/src/constants/enums/MetricNames.ts
+++ b/therr-public-library/therr-js-utilities/src/constants/enums/MetricNames.ts
@@ -11,6 +11,9 @@ enum MetricNames {
   SPACE_DISLIKE = 'space.user.dislike',
   SPACE_SUPER_DISLIKE = 'space.user.superDislike',
 
+  // MARKETING
+  SPACE_UNCLAIMED_EMAIL_SENT = 'space.marketing.unclaimedEmailSent',
+
   // USER
   USER_CONTENT_PREF_CAT_PREFIX = 'user.content.preferences.categories.'
 }

--- a/therr-services/maps-service/src/handlers/spaces.ts
+++ b/therr-services/maps-service/src/handlers/spaces.ts
@@ -321,6 +321,7 @@ const getSpaceDetails = (req, res) => {
             const serializedSpace = {
                 ...space,
                 message: space.message?.replace(/"/g, '\\"'),
+                isUnclaimed: space.fromUserId === SUPER_ADMIN_ID && !space.requestedByUserId,
             };
 
             const promises = [

--- a/therr-services/maps-service/src/store/SpacesStore.ts
+++ b/therr-services/maps-service/src/store/SpacesStore.ts
@@ -46,7 +46,6 @@ export interface ICreateSpaceParams extends ICreateAreaParams {
     reservationUrl?: string;
     businessTransactionId?: string;
     businessTransactionName?: string;
-    businessEmail?: string;
     isPointOfInterest?: boolean;
     addressStreetAddress?: string;
     addressRegion?: string;
@@ -604,7 +603,6 @@ export default class SpacesStore {
                 reservationUrl: params.reservationUrl,
                 businessTransactionId: params.businessTransactionId,
                 businessTransactionName: params.businessTransactionName,
-                businessEmail: params.businessEmail,
                 isPointOfInterest: params.isPointOfInterest,
                 addressStreetAddress: params.addressStreetAddress,
                 addressRegion: params.addressRegion,
@@ -696,7 +694,6 @@ export default class SpacesStore {
                 reservationUrl: params.reservationUrl,
                 businessTransactionId: params.businessTransactionId,
                 businessTransactionName: params.businessTransactionName,
-                businessEmail: params.businessEmail,
                 isPointOfInterest: params.isPointOfInterest,
                 addressStreetAddress: params.addressStreetAddress,
                 addressRegion: params.addressRegion,

--- a/therr-services/maps-service/src/store/SpacesStore.ts
+++ b/therr-services/maps-service/src/store/SpacesStore.ts
@@ -46,6 +46,7 @@ export interface ICreateSpaceParams extends ICreateAreaParams {
     reservationUrl?: string;
     businessTransactionId?: string;
     businessTransactionName?: string;
+    businessEmail?: string;
     isPointOfInterest?: boolean;
     addressStreetAddress?: string;
     addressRegion?: string;
@@ -215,6 +216,8 @@ export default class SpacesStore {
             .toString();
 
         return this.db.read.query(queryString).then((response) => {
+            // Strip internal-only fields from API responses
+            response.rows.forEach((s) => { delete s.businessEmail; }); // eslint-disable-line no-param-reassign
             const configuredResponse = formatSQLJoinAsJSON(response.rows, []);
             return configuredResponse;
         });
@@ -418,6 +421,8 @@ export default class SpacesStore {
             .toString();
 
         return this.db.read.query(queryString).then((response) => {
+            // Strip internal-only fields from API responses
+            response.rows.forEach((s) => { delete s.businessEmail; }); // eslint-disable-line no-param-reassign
             const configuredResponse = formatSQLJoinAsJSON(response.rows, []);
             return configuredResponse;
         });
@@ -462,7 +467,11 @@ export default class SpacesStore {
         query = query.orderBy('dist')
             .limit(5);
 
-        return this.db.read.query(query.toString()).then((response) => response.rows);
+        return this.db.read.query(query.toString()).then((response) => {
+            // Strip internal-only fields from API responses
+            response.rows.forEach((s) => { delete s.businessEmail; }); // eslint-disable-line no-param-reassign
+            return response.rows;
+        });
     }
 
     findSpaces(internalReqHeaders: InternalConfigHeaders, spaceIds, filters, options: any = {}) {
@@ -488,6 +497,9 @@ export default class SpacesStore {
         }
 
         return this.db.read.query(query.toString()).then(async ({ rows: spaces }) => {
+            // Strip internal-only fields from API responses
+            spaces.forEach((s) => { delete s.businessEmail; }); // eslint-disable-line no-param-reassign
+
             if (options.withMedia || options.withUser || options.withRatings) {
                 const mediaIds: string[] = [];
                 const userIds: string[] = [];
@@ -592,6 +604,7 @@ export default class SpacesStore {
                 reservationUrl: params.reservationUrl,
                 businessTransactionId: params.businessTransactionId,
                 businessTransactionName: params.businessTransactionName,
+                businessEmail: params.businessEmail,
                 isPointOfInterest: params.isPointOfInterest,
                 addressStreetAddress: params.addressStreetAddress,
                 addressRegion: params.addressRegion,
@@ -683,6 +696,7 @@ export default class SpacesStore {
                 reservationUrl: params.reservationUrl,
                 businessTransactionId: params.businessTransactionId,
                 businessTransactionName: params.businessTransactionName,
+                businessEmail: params.businessEmail,
                 isPointOfInterest: params.isPointOfInterest,
                 addressStreetAddress: params.addressStreetAddress,
                 addressRegion: params.addressRegion,

--- a/therr-services/maps-service/tests/unit/SpacesStore.test.ts
+++ b/therr-services/maps-service/tests/unit/SpacesStore.test.ts
@@ -298,6 +298,91 @@ describe('SpacesStore', () => {
         });
     });
 
+    describe('searchSpaces - businessEmail stripping', () => {
+        it('strips businessEmail from search results', () => {
+            const mockRows = [
+                { id: '1', notificationMsg: 'Test', businessEmail: 'secret@example.com' },
+                { id: '2', notificationMsg: 'Test2', businessEmail: 'other@example.com' },
+            ];
+            const mockStore = {
+                read: {
+                    query: sinon.stub().resolves({ rows: mockRows }),
+                },
+            };
+            const mockMediaStore = {
+                write: {
+                    query: sinon.stub().resolves({}),
+                },
+            };
+            const store = new SpacesStore(mockStore, mockMediaStore);
+            return store.searchSpaces({
+                pagination: { itemsPerPage: 10, pageNumber: 1 },
+                filterBy: 'distance',
+                query: 5,
+                longitude: 15,
+                latitude: -1,
+            }, []).then((results: any) => {
+                // Results go through formatSQLJoinAsJSON, so check the raw rows were mutated
+                mockRows.forEach((row: any) => {
+                    expect(row).to.not.have.property('businessEmail');
+                });
+            });
+        });
+    });
+
+    describe('findSpaces - businessEmail stripping', () => {
+        it('strips businessEmail from found spaces', () => {
+            const mockRows = [
+                { id: 'abc', notificationMsg: 'Place', businessEmail: 'biz@example.com', mediaIds: '' },
+            ];
+            const mockStore = {
+                read: {
+                    query: sinon.stub().resolves({ rows: mockRows }),
+                },
+            };
+            const mockMediaStore = {
+                write: {
+                    query: sinon.stub().resolves({}),
+                },
+            };
+            const store = new SpacesStore(mockStore, mockMediaStore);
+            const mockHeaders = { 'x-platform': 'test', 'x-brand-variation': 'therr', 'x-localecode': 'en-us' } as any;
+            return store.findSpaces(mockHeaders, ['abc'], { limit: 1 }).then(({ spaces }: any) => {
+                spaces.forEach((space: any) => {
+                    expect(space).to.not.have.property('businessEmail');
+                });
+            });
+        });
+    });
+
+    describe('updateSpace - businessEmail support', () => {
+        it('includes businessEmail in the update query when provided', () => {
+            const mockStore = {
+                read: {
+                    query: sinon.stub().resolves({ rows: [] }),
+                },
+                write: {
+                    query: sinon.stub().resolves({ rows: [{ id: 'space-1' }] }),
+                },
+            };
+            const mockMediaStore = {
+                write: {
+                    query: sinon.stub().resolves({}),
+                },
+            };
+            const store = new SpacesStore(mockStore, mockMediaStore);
+            return store.updateSpace('space-1', {
+                fromUserId: 'user-1',
+                businessEmail: 'contact@business.com',
+                notificationMsg: 'Updated Name',
+            }).then(() => {
+                const queryStr = mockStore.write.query.args[0][0];
+                expect(queryStr).to.include('businessEmail');
+                expect(queryStr).to.include('contact@business.com');
+            });
+        });
+    });
+
     describe('getById', () => {
         it('queries with a join request', () => {
             const mockId = '12345';

--- a/therr-services/users-service/src/api/email/for-business/sendUnclaimedSpaceEmail.ts
+++ b/therr-services/users-service/src/api/email/for-business/sendUnclaimedSpaceEmail.ts
@@ -1,0 +1,42 @@
+/* eslint-disable quotes */
+/* eslint-disable max-len */
+import sendEmail from '../sendEmail';
+import * as globalConfig from '../../../../../../global-config';
+import translate from '../../../utilities/translator';
+
+export interface ISendUnclaimedSpaceEmailConfig {
+    charset?: string;
+    locale?: string;
+    subject: string;
+    toAddresses: string[];
+    agencyDomainName: string;
+    brandVariation: string;
+}
+
+export interface ITemplateParams {
+    spaceName: string;
+    spaceId: string;
+    addressReadable?: string;
+}
+
+export default (emailParams: ISendUnclaimedSpaceEmailConfig, templateParams: ITemplateParams) => {
+    const locale = emailParams.locale || 'en-us';
+
+    const spaceUrl = `${globalConfig[process.env.NODE_ENV].hostFull}/spaces/${templateParams.spaceId}?claim=true`;
+    const htmlConfig = {
+        header: translate(locale, 'emails.unclaimedSpace.header'),
+        preheaderText: translate(locale, 'emails.unclaimedSpace.preheaderText'),
+        dearUser: translate(locale, 'emails.unclaimedSpace.dearUser', { spaceName: templateParams.spaceName }),
+        body1: translate(locale, 'emails.unclaimedSpace.body1', { spaceName: templateParams.spaceName }),
+        body2: translate(locale, 'emails.unclaimedSpace.body2'),
+        bodyBold: translate(locale, 'emails.unclaimedSpace.bodyBold'),
+        postBody1: translate(locale, 'emails.unclaimedSpace.postBody1'),
+        buttonHref: spaceUrl,
+        buttonText: translate(locale, 'emails.unclaimedSpace.buttonText'),
+    };
+
+    return sendEmail({
+        ...emailParams,
+        subject: emailParams.subject || translate(locale, 'emails.unclaimedSpace.subject', { spaceName: templateParams.spaceName }),
+    }, htmlConfig);
+};

--- a/therr-services/users-service/src/api/email/for-business/sendUnclaimedSpaceEmail.ts
+++ b/therr-services/users-service/src/api/email/for-business/sendUnclaimedSpaceEmail.ts
@@ -16,18 +16,29 @@ export interface ISendUnclaimedSpaceEmailConfig {
 export interface ITemplateParams {
     spaceName: string;
     spaceId: string;
+    missingFields?: string[];
 }
 
 export default (emailParams: ISendUnclaimedSpaceEmailConfig, templateParams: ITemplateParams) => {
     const locale = emailParams.locale || 'en-us';
 
     const spaceUrl = `${globalConfig[process.env.NODE_ENV].hostFull}/spaces/${templateParams.spaceId}?claim=true`;
-    const htmlConfig = {
+    let body3: string | undefined;
+    if (templateParams.missingFields?.length) {
+        const intro = translate(locale, 'emails.unclaimedSpace.missingFieldsIntro');
+        const fieldLabels = templateParams.missingFields.map(
+            (field) => translate(locale, `emails.unclaimedSpace.missingFieldLabels.${field}`) || field,
+        );
+        body3 = `${intro} ${fieldLabels.join(', ')}.`;
+    }
+
+    const htmlConfig: any = {
         header: translate(locale, 'emails.unclaimedSpace.header'),
         preheaderText: translate(locale, 'emails.unclaimedSpace.preheaderText'),
         dearUser: translate(locale, 'emails.unclaimedSpace.dearUser', { spaceName: templateParams.spaceName }),
         body1: translate(locale, 'emails.unclaimedSpace.body1', { spaceName: templateParams.spaceName }),
         body2: translate(locale, 'emails.unclaimedSpace.body2'),
+        body3,
         bodyBold: translate(locale, 'emails.unclaimedSpace.bodyBold'),
         postBody1: translate(locale, 'emails.unclaimedSpace.postBody1'),
         buttonHref: spaceUrl,

--- a/therr-services/users-service/src/api/email/for-business/sendUnclaimedSpaceEmail.ts
+++ b/therr-services/users-service/src/api/email/for-business/sendUnclaimedSpaceEmail.ts
@@ -16,7 +16,6 @@ export interface ISendUnclaimedSpaceEmailConfig {
 export interface ITemplateParams {
     spaceName: string;
     spaceId: string;
-    addressReadable?: string;
 }
 
 export default (emailParams: ISendUnclaimedSpaceEmailConfig, templateParams: ITemplateParams) => {

--- a/therr-services/users-service/src/api/email/for-business/sendUnclaimedSpaceEmail.ts
+++ b/therr-services/users-service/src/api/email/for-business/sendUnclaimedSpaceEmail.ts
@@ -1,8 +1,11 @@
 /* eslint-disable quotes */
 /* eslint-disable max-len */
+import { MetricNames, MetricValueTypes } from 'therr-js-utilities/constants';
+import logSpan from 'therr-js-utilities/log-or-update-span';
 import sendEmail from '../sendEmail';
 import * as globalConfig from '../../../../../../global-config';
 import translate from '../../../utilities/translator';
+import Store from '../../../store';
 
 export interface ISendUnclaimedSpaceEmailConfig {
     charset?: string;
@@ -19,8 +22,46 @@ export interface ITemplateParams {
     missingFields?: string[];
 }
 
-export default (emailParams: ISendUnclaimedSpaceEmailConfig, templateParams: ITemplateParams) => {
+/**
+ * Check if an unclaimed space email has already been sent for this spaceId
+ * by looking for an existing metric record.
+ */
+export const hasAlreadySentEmail = (spaceId: string): Promise<boolean> => Store.userMetrics.get({
+    name: MetricNames.SPACE_UNCLAIMED_EMAIL_SENT,
+}).then((rows) => rows.some((row) => {
+    const dims = typeof row.dimensions === 'string' ? JSON.parse(row.dimensions) : row.dimensions;
+    return dims?.spaceId === spaceId;
+})).catch(() => false);
+
+/**
+ * Log that an unclaimed space email was sent, for dedup tracking.
+ */
+const logEmailSentMetric = (spaceId: string, businessEmail: string): Promise<any> => Store.userMetrics.create({
+    name: MetricNames.SPACE_UNCLAIMED_EMAIL_SENT,
+    userId: '', // system-level metric, no user context
+    value: '1',
+    valueType: MetricValueTypes.NUMBER,
+    dimensions: JSON.stringify({ spaceId, businessEmail }),
+}).catch((err) => {
+    logSpan({
+        level: 'error',
+        messageOrigin: 'API_SERVER',
+        messages: ['Failed to log unclaimed space email metric'],
+        traceArgs: {
+            'error.message': err?.message,
+            'space.id': spaceId,
+        },
+    });
+});
+
+export default async (emailParams: ISendUnclaimedSpaceEmailConfig, templateParams: ITemplateParams) => {
     const locale = emailParams.locale || 'en-us';
+
+    // Check if email was already sent for this space
+    const alreadySent = await hasAlreadySentEmail(templateParams.spaceId);
+    if (alreadySent) {
+        return { alreadySent: true };
+    }
 
     const spaceUrl = `${globalConfig[process.env.NODE_ENV].hostFull}/spaces/${templateParams.spaceId}?claim=true`;
     let body3: string | undefined;
@@ -45,8 +86,13 @@ export default (emailParams: ISendUnclaimedSpaceEmailConfig, templateParams: ITe
         buttonText: translate(locale, 'emails.unclaimedSpace.buttonText'),
     };
 
-    return sendEmail({
+    const result = await sendEmail({
         ...emailParams,
         subject: emailParams.subject || translate(locale, 'emails.unclaimedSpace.subject', { spaceName: templateParams.spaceName }),
     }, htmlConfig);
+
+    // Log the metric after successful send (fire-and-forget)
+    logEmailSentMetric(templateParams.spaceId, emailParams.toAddresses[0]);
+
+    return result;
 };

--- a/therr-services/users-service/src/locales/en-us/dictionary.json
+++ b/therr-services/users-service/src/locales/en-us/dictionary.json
@@ -164,6 +164,17 @@
             "postBody1": "Thanks for choosing Therr for Business! We're constantly improving our tools to help you reach more local customers. Your feedback is always welcome.",
             "buttonText": "Go to Dashboard"
         },
+        "unclaimedSpace": {
+            "subject": "People are searching for {spaceName}",
+            "header": "Your Business Is Getting Noticed",
+            "preheaderText": "Your business is being discovered. Claim your free listing today.",
+            "dearUser": "Hello, {spaceName}!",
+            "body1": "People in your area are discovering {spaceName} on Therr. Your business already has a listing that potential customers are viewing right now. Anyone can see your space — but only you can control how it looks.",
+            "body2": "Claim your free business page to update your hours, photos, contact info, and more. Stand out from the competition and connect directly with customers who are actively searching for businesses like yours.",
+            "bodyBold": "It only takes 60 seconds to get started.",
+            "buttonText": "See Your Business Page",
+            "postBody1": "Already have an account? Simply log in and claim your space from the business page."
+        },
         "dashboardSubscriberIntro": {
             "header": "Welcome to {brandName}!",
             "dearUser": "Welcome!",

--- a/therr-services/users-service/src/locales/en-us/dictionary.json
+++ b/therr-services/users-service/src/locales/en-us/dictionary.json
@@ -173,7 +173,16 @@
             "body2": "Claim your free business page to update your hours, photos, contact info, and more. Stand out from the competition and connect directly with customers who are actively searching for businesses like yours.",
             "bodyBold": "It only takes 60 seconds to get started.",
             "buttonText": "See Your Business Page",
-            "postBody1": "Already have an account? Simply log in and claim your space from the business page."
+            "postBody1": "Already have an account? Simply log in and claim your space from the business page.",
+            "missingFieldsIntro": "Your listing is still missing some key details:",
+            "missingFieldLabels": {
+                "openingHours": "business hours",
+                "phoneNumber": "phone number",
+                "websiteUrl": "website",
+                "menuUrl": "menu",
+                "photos": "photos",
+                "description": "a detailed description"
+            }
         },
         "dashboardSubscriberIntro": {
             "header": "Welcome to {brandName}!",

--- a/therr-services/users-service/src/locales/en-us/dictionary.json
+++ b/therr-services/users-service/src/locales/en-us/dictionary.json
@@ -167,10 +167,10 @@
         "unclaimedSpace": {
             "subject": "People are searching for {spaceName}",
             "header": "Your Business Is Getting Noticed",
-            "preheaderText": "Your business is being discovered. Claim your free listing today.",
+            "preheaderText": "Customers are discovering and talking about your business. Claim your free listing today.",
             "dearUser": "Hello, {spaceName}!",
-            "body1": "People in your area are discovering {spaceName} on Therr. Your business already has a listing that potential customers are viewing right now. Anyone can see your space — but only you can control how it looks.",
-            "body2": "Claim your free business page to update your hours, photos, contact info, and more. Stand out from the competition and connect directly with customers who are actively searching for businesses like yours.",
+            "body1": "People in your area are discovering {spaceName} on Therr — and they're sharing what's happening at your business in real time. Customers are posting about their experiences, flagging deals, and letting others know when things are busy or when the vibe is great. Your business already has a listing. The question is: who's controlling the story?",
+            "body2": "When you claim your page, you unlock tools Google can't offer: see real-time customer reports about your business, get paired with complementary local spots that send you foot traffic, and reward customers who spread the word. This isn't just a listing — it's a living, community-powered presence.",
             "bodyBold": "It only takes 60 seconds to get started.",
             "buttonText": "See Your Business Page",
             "postBody1": "Already have an account? Simply log in and claim your space from the business page.",

--- a/therr-services/users-service/src/locales/es/dictionary.json
+++ b/therr-services/users-service/src/locales/es/dictionary.json
@@ -164,6 +164,17 @@
             "postBody1": "¡Gracias por elegir Therr for Business! Estamos mejorando constantemente nuestras herramientas para ayudarte a llegar a más clientes locales. Tus comentarios siempre son bienvenidos.",
             "buttonText": "Ir al panel de control"
         },
+        "unclaimedSpace": {
+            "subject": "La gente está buscando {spaceName}",
+            "header": "Tu negocio está llamando la atención",
+            "preheaderText": "Tu negocio está siendo descubierto. Reclama tu listado gratuito hoy.",
+            "dearUser": "¡Hola, {spaceName}!",
+            "body1": "Personas en tu área están descubriendo {spaceName} en Therr. Tu negocio ya tiene un listado que los clientes potenciales están viendo ahora mismo. Cualquiera puede ver tu espacio, pero solo tú puedes controlar cómo se ve.",
+            "body2": "Reclama tu página de negocio gratuita para actualizar tus horarios, fotos, información de contacto y más. Destaca entre la competencia y conecta directamente con clientes que están buscando negocios como el tuyo.",
+            "bodyBold": "Solo toma 60 segundos para comenzar.",
+            "buttonText": "Ver tu página de negocio",
+            "postBody1": "¿Ya tienes una cuenta? Simplemente inicia sesión y reclama tu espacio desde la página del negocio."
+        },
         "dashboardSubscriberIntro": {
             "header": "¡Bienvenido/a a {brandName}!",
             "dearUser": "¡Bienvenido/a!",

--- a/therr-services/users-service/src/locales/es/dictionary.json
+++ b/therr-services/users-service/src/locales/es/dictionary.json
@@ -173,7 +173,16 @@
             "body2": "Reclama tu página de negocio gratuita para actualizar tus horarios, fotos, información de contacto y más. Destaca entre la competencia y conecta directamente con clientes que están buscando negocios como el tuyo.",
             "bodyBold": "Solo toma 60 segundos para comenzar.",
             "buttonText": "Ver tu página de negocio",
-            "postBody1": "¿Ya tienes una cuenta? Simplemente inicia sesión y reclama tu espacio desde la página del negocio."
+            "postBody1": "¿Ya tienes una cuenta? Simplemente inicia sesión y reclama tu espacio desde la página del negocio.",
+            "missingFieldsIntro": "A tu listado todavía le faltan algunos detalles clave:",
+            "missingFieldLabels": {
+                "openingHours": "horario de atención",
+                "phoneNumber": "número de teléfono",
+                "websiteUrl": "sitio web",
+                "menuUrl": "menú",
+                "photos": "fotos",
+                "description": "una descripción detallada"
+            }
         },
         "dashboardSubscriberIntro": {
             "header": "¡Bienvenido/a a {brandName}!",

--- a/therr-services/users-service/src/locales/es/dictionary.json
+++ b/therr-services/users-service/src/locales/es/dictionary.json
@@ -167,10 +167,10 @@
         "unclaimedSpace": {
             "subject": "La gente está buscando {spaceName}",
             "header": "Tu negocio está llamando la atención",
-            "preheaderText": "Tu negocio está siendo descubierto. Reclama tu listado gratuito hoy.",
+            "preheaderText": "Los clientes están descubriendo y hablando de tu negocio. Reclama tu listado gratuito hoy.",
             "dearUser": "¡Hola, {spaceName}!",
-            "body1": "Personas en tu área están descubriendo {spaceName} en Therr. Tu negocio ya tiene un listado que los clientes potenciales están viendo ahora mismo. Cualquiera puede ver tu espacio, pero solo tú puedes controlar cómo se ve.",
-            "body2": "Reclama tu página de negocio gratuita para actualizar tus horarios, fotos, información de contacto y más. Destaca entre la competencia y conecta directamente con clientes que están buscando negocios como el tuyo.",
+            "body1": "Personas en tu área están descubriendo {spaceName} en Therr — y están compartiendo lo que pasa en tu negocio en tiempo real. Los clientes publican sobre sus experiencias, señalan ofertas y avisan a otros cuando hay mucha gente o cuando el ambiente es genial. Tu negocio ya tiene un listado. La pregunta es: ¿quién controla la historia?",
+            "body2": "Cuando reclamas tu página, desbloqueas herramientas que Google no puede ofrecer: ve reportes de clientes en tiempo real sobre tu negocio, conéctate con negocios locales complementarios que te envían clientes, y recompensa a quienes difunden tu negocio. Esto no es solo un listado — es una presencia viva impulsada por la comunidad.",
             "bodyBold": "Solo toma 60 segundos para comenzar.",
             "buttonText": "Ver tu página de negocio",
             "postBody1": "¿Ya tienes una cuenta? Simplemente inicia sesión y reclama tu espacio desde la página del negocio.",

--- a/therr-services/users-service/tests/unit/email-sendUnclaimedSpaceEmail.test.ts
+++ b/therr-services/users-service/tests/unit/email-sendUnclaimedSpaceEmail.test.ts
@@ -3,13 +3,14 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 import { expect } from 'chai';
 import sinon from 'sinon';
-import * as globalConfig from '../../../../global-config';
-import sendUnclaimedSpaceEmail from '../../src/api/email/for-business/sendUnclaimedSpaceEmail';
+import sendUnclaimedSpaceEmail, { hasAlreadySentEmail } from '../../src/api/email/for-business/sendUnclaimedSpaceEmail';
 import { awsSES } from '../../src/api/aws';
 import Store from '../../src/store';
 
 describe('sendUnclaimedSpaceEmail', () => {
     let sesStub: sinon.SinonStub;
+    let metricsGetStub: sinon.SinonStub;
+    let metricsCreateStub: sinon.SinonStub;
 
     beforeEach(() => {
         // Stub AWS SES to prevent actual email sending
@@ -20,6 +21,10 @@ describe('sendUnclaimedSpaceEmail', () => {
         // Stub Store methods to prevent DB calls during blacklist check
         sinon.stub(Store.blacklistedEmails, 'get').resolves([]);
         sinon.stub(Store.users, 'getUserByEmail').resolves([]);
+
+        // Stub userMetrics for tracking
+        metricsGetStub = sinon.stub(Store.userMetrics, 'get').resolves([]);
+        metricsCreateStub = sinon.stub(Store.userMetrics, 'create').resolves([{ id: 'metric-1' }]);
     });
 
     afterEach(() => {
@@ -102,5 +107,72 @@ describe('sendUnclaimedSpaceEmail', () => {
         expect(sesStub.calledOnce).to.be.true;
         const htmlBody = sesStub.args[0][0].Content.Simple.Body.Html.Data;
         expect(htmlBody).to.include('Test Coffee Shop');
+    });
+
+    describe('email tracking', () => {
+        it('logs a metric after sending the email', async () => {
+            await sendUnclaimedSpaceEmail(baseEmailParams, baseTemplateParams);
+
+            expect(metricsCreateStub.calledOnce).to.be.true;
+            const createArgs = metricsCreateStub.args[0][0];
+            expect(createArgs.name).to.equal('space.marketing.unclaimedEmailSent');
+            expect(createArgs.value).to.equal('1');
+            const dims = JSON.parse(createArgs.dimensions);
+            expect(dims.spaceId).to.equal('space-123');
+            expect(dims.businessEmail).to.equal('business@example.com');
+        });
+
+        it('skips sending and returns alreadySent if email was previously sent for this space', async () => {
+            metricsGetStub.resolves([{
+                dimensions: JSON.stringify({ spaceId: 'space-123', businessEmail: 'business@example.com' }),
+            }]);
+
+            const result = await sendUnclaimedSpaceEmail(baseEmailParams, baseTemplateParams);
+
+            expect(result).to.deep.equal({ alreadySent: true });
+            expect(sesStub.called).to.be.false;
+            expect(metricsCreateStub.called).to.be.false;
+        });
+
+        it('sends email when metrics exist but for a different spaceId', async () => {
+            metricsGetStub.resolves([{
+                dimensions: JSON.stringify({ spaceId: 'other-space', businessEmail: 'other@example.com' }),
+            }]);
+
+            await sendUnclaimedSpaceEmail(baseEmailParams, baseTemplateParams);
+
+            expect(sesStub.calledOnce).to.be.true;
+            expect(metricsCreateStub.calledOnce).to.be.true;
+        });
+    });
+
+    describe('hasAlreadySentEmail', () => {
+        it('returns false when no metrics exist', async () => {
+            metricsGetStub.resolves([]);
+            const result = await hasAlreadySentEmail('space-123');
+            expect(result).to.be.false;
+        });
+
+        it('returns true when a matching metric exists', async () => {
+            metricsGetStub.resolves([{
+                dimensions: JSON.stringify({ spaceId: 'space-123' }),
+            }]);
+            const result = await hasAlreadySentEmail('space-123');
+            expect(result).to.be.true;
+        });
+
+        it('returns false when metrics exist but for different spaces', async () => {
+            metricsGetStub.resolves([{
+                dimensions: JSON.stringify({ spaceId: 'other-space' }),
+            }]);
+            const result = await hasAlreadySentEmail('space-123');
+            expect(result).to.be.false;
+        });
+
+        it('returns false when the metrics query fails', async () => {
+            metricsGetStub.rejects(new Error('DB error'));
+            const result = await hasAlreadySentEmail('space-123');
+            expect(result).to.be.false;
+        });
     });
 });

--- a/therr-services/users-service/tests/unit/email-sendUnclaimedSpaceEmail.test.ts
+++ b/therr-services/users-service/tests/unit/email-sendUnclaimedSpaceEmail.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable quotes, max-len */
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as globalConfig from '../../../../global-config';
+import sendUnclaimedSpaceEmail from '../../src/api/email/for-business/sendUnclaimedSpaceEmail';
+import { awsSES } from '../../src/api/aws';
+import Store from '../../src/store';
+
+describe('sendUnclaimedSpaceEmail', () => {
+    let sesStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        // Stub AWS SES to prevent actual email sending
+        sesStub = sinon.stub(awsSES, 'sendEmail').callsFake((_params: any, callback: any) => {
+            callback(null, { MessageId: 'test-message-id' });
+        });
+
+        // Stub Store methods to prevent DB calls during blacklist check
+        sinon.stub(Store.blacklistedEmails, 'get').resolves([]);
+        sinon.stub(Store.users, 'getUserByEmail').resolves([]);
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    const baseEmailParams = {
+        subject: '',
+        toAddresses: ['business@example.com'],
+        agencyDomainName: 'therr.com',
+        brandVariation: 'therr',
+        locale: 'en-us',
+    };
+
+    const baseTemplateParams = {
+        spaceName: 'Test Coffee Shop',
+        spaceId: 'space-123',
+    };
+
+    it('calls sendEmail with the correct buttonHref containing spaceId', async () => {
+        await sendUnclaimedSpaceEmail(baseEmailParams, baseTemplateParams);
+
+        expect(sesStub.calledOnce).to.be.true;
+        const params = sesStub.args[0][0];
+        const htmlBody = params.Content.Simple.Body.Html.Data;
+        expect(htmlBody).to.include('/spaces/space-123');
+        expect(htmlBody).to.include('claim');
+    });
+
+    it('uses translated subject as fallback when subject is empty', async () => {
+        await sendUnclaimedSpaceEmail({ ...baseEmailParams, subject: '' }, baseTemplateParams);
+
+        expect(sesStub.calledOnce).to.be.true;
+        const params = sesStub.args[0][0];
+        const subject = params.Content.Simple.Subject.Data;
+        expect(subject).to.be.a('string');
+        expect(subject.length).to.be.greaterThan(0);
+        expect(subject).to.include('Test Coffee Shop');
+    });
+
+    it('uses provided subject when explicitly set', async () => {
+        await sendUnclaimedSpaceEmail({ ...baseEmailParams, subject: 'Custom Subject' }, baseTemplateParams);
+
+        expect(sesStub.calledOnce).to.be.true;
+        const params = sesStub.args[0][0];
+        expect(params.Content.Simple.Subject.Data).to.equal('Custom Subject');
+    });
+
+    it('does not include missing fields text when missingFields is not provided', async () => {
+        await sendUnclaimedSpaceEmail(baseEmailParams, baseTemplateParams);
+
+        expect(sesStub.calledOnce).to.be.true;
+        const htmlBody = sesStub.args[0][0].Content.Simple.Body.Html.Data;
+        expect(htmlBody).to.not.include('missing some key details');
+    });
+
+    it('includes missing field labels in email body when missingFields is provided', async () => {
+        await sendUnclaimedSpaceEmail(baseEmailParams, {
+            ...baseTemplateParams,
+            missingFields: ['openingHours', 'phoneNumber'],
+        });
+
+        expect(sesStub.calledOnce).to.be.true;
+        const htmlBody = sesStub.args[0][0].Content.Simple.Body.Html.Data;
+        expect(htmlBody).to.include('business hours');
+        expect(htmlBody).to.include('phone number');
+    });
+
+    it('sends to the correct recipient address', async () => {
+        await sendUnclaimedSpaceEmail(baseEmailParams, baseTemplateParams);
+
+        expect(sesStub.calledOnce).to.be.true;
+        const params = sesStub.args[0][0];
+        expect(params.Destination.ToAddresses).to.deep.equal(['business@example.com']);
+    });
+
+    it('includes spaceName in the email body', async () => {
+        await sendUnclaimedSpaceEmail(baseEmailParams, baseTemplateParams);
+
+        expect(sesStub.calledOnce).to.be.true;
+        const htmlBody = sesStub.args[0][0].Content.Simple.Body.Html.Data;
+        expect(htmlBody).to.include('Test Coffee Shop');
+    });
+});


### PR DESCRIPTION
Build a complete flow for business owners to discover, claim, and edit their
unclaimed spaces. Includes a marketing email template, "Claim This Space" CTA
on the ViewSpace page, returnTo query param support in the auth flow for
frictionless redirect after login/register, and a new EditSpace web page
with essential fields plus image upload.

https://claude.ai/code/session_01Ghv58sHpTpjJbd5Hkh5iQG