### PR TITLE
Trigger deployment pipeline for web client and maps service

### DIFF
--- a/therr-client-web/src/index.tsx
+++ b/therr-client-web/src/index.tsx
@@ -1,3 +1,4 @@
+// Trigger deployment pipeline
 import * as React from 'react';
 import LogRocket from 'logrocket';
 import setupLogRocketReact from 'logrocket-react';

--- a/therr-services/maps-service/src/index.ts
+++ b/therr-services/maps-service/src/index.ts
@@ -1,3 +1,4 @@
+// Trigger deployment pipeline
 /* eslint-disable import/no-import-module-exports */
 import tracing from './tracing'; // eslint-disable-line import/order
 import express from 'express';


### PR DESCRIPTION
## Summary
- Touches `therr-client-web` and `maps-service` to trigger the CI build pipeline via stage
- No functional changes — adds a comment to each service's entry point

## Context
A PR was accidentally merged directly to main, bypassing the stage → main deployment flow. This PR targets stage so the proper pipeline (general → stage → main) can be followed.

## Test plan
- [ ] Verify CI build triggers for web client and maps service
- [ ] Merge to stage, then merge stage → main to trigger deploy

https://claude.ai/code/session_018EbyHZM33iWmjrqjHLYmi3