### PR TITLE
Fix mobile map broken tiles by bundling Leaflet CSS

### DIFF
--- a/therr-client-web/src/components/SpacesMap.tsx
+++ b/therr-client-web/src/components/SpacesMap.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import 'leaflet/dist/leaflet.css';
 
 interface ISpace {
     id: string;
@@ -25,23 +26,7 @@ const escapeHtml = (str: string): string => {
     return div.innerHTML;
 };
 
-const LEAFLET_CSS_ID = 'leaflet-css';
 const ICON_CDN = 'https://unpkg.com/leaflet@1.9.4/dist/images';
-
-const loadLeafletCss = (): Promise<void> => {
-    if (document.getElementById(LEAFLET_CSS_ID)) return Promise.resolve();
-    return new Promise((resolve) => {
-        const link = document.createElement('link');
-        link.id = LEAFLET_CSS_ID;
-        link.rel = 'stylesheet';
-        link.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
-        link.onload = () => resolve();
-        link.onerror = () => resolve();
-        document.head.appendChild(link);
-        // Fallback for environments where onload doesn't fire (e.g., jsdom)
-        setTimeout(resolve, 3000);
-    });
-};
 
 const SpacesMap: React.FC<ISpacesMapProps> = ({
     spaces,
@@ -97,12 +82,9 @@ const SpacesMap: React.FC<ISpacesMapProps> = ({
 
         let cancelled = false;
 
-        // Wait for both Leaflet CSS and JS before initializing the map.
-        // Leaflet requires its CSS to be loaded for correct tile positioning.
-        Promise.all([
-            loadLeafletCss(),
-            import('leaflet'),
-        ]).then(([, leafletModule]) => {
+        // Leaflet CSS is bundled via the import at the top of this file,
+        // so it's available synchronously before the map initializes.
+        import('leaflet').then((leafletModule) => {
             if (cancelled || !mapRef.current) return;
 
             const L = leafletModule.default || leafletModule;
@@ -139,7 +121,6 @@ const SpacesMap: React.FC<ISpacesMapProps> = ({
             leafletMapRef.current = map;
 
             // Force Leaflet to recalculate container size on next frame
-            // (handles case where CSS loaded before map init)
             requestAnimationFrame(() => {
                 if (map && !cancelled) {
                     map.invalidateSize();

--- a/therr-client-web/src/components/__tests__/SpacesMap.test.tsx
+++ b/therr-client-web/src/components/__tests__/SpacesMap.test.tsx
@@ -74,13 +74,6 @@ describe('SpacesMap', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mapLayers.length = 0;
-        // Pre-create leaflet-css element so loadLeafletCss resolves immediately
-        // (jsdom doesn't fire link.onload, which would cause Promise.all to hang)
-        if (!document.getElementById('leaflet-css')) {
-            const link = document.createElement('link');
-            link.id = 'leaflet-css';
-            document.head.appendChild(link);
-        }
         // Restore mock return values cleared by clearAllMocks
         mockMarker.addTo.mockImplementation(() => {
             mapLayers.push(mockMarker);


### PR DESCRIPTION
## Summary
- **Bundle Leaflet CSS via webpack instead of CDN** — Root cause: Helmet's CSP `style-src` directive doesn't include `unpkg.com`, so the dynamically injected Leaflet CSS `<link>` was silently blocked by the browser. Tiles rendered without positioning styles, causing white gaps and misaligned fragments. Now uses `import 'leaflet/dist/leaflet.css'` which webpack bundles into the lazy-loaded chunk, served from the same origin (passes CSP).
- **Reduce map heights for mobile** — Compact: 250px → 200px, Expanded: 400px → 300px. Previous expanded height consumed the entire mobile viewport.
- **Add `invalidateSize()` safety net** — Calls `map.invalidateSize()` via `requestAnimationFrame` after init.

Note: Marker icons still load from `unpkg.com` which is fine — `imgSrc` already allows it in the CSP config.

## Test plan
- [x] All 13 SpacesMap unit tests pass
- [ ] Verify map tiles render fully on mobile (no white gaps or misaligned fragments)
- [ ] Verify compact map (200px) shows map preview with space cards visible below
- [ ] Verify expanded map (300px) fits on mobile viewport without hiding all content
- [ ] Verify map works on desktop at both compact and expanded sizes
- [ ] Verify ViewSpace, ViewEvent, ViewMoment maps still render correctly

https://claude.ai/code/session_01MGeaxwPAx2V2sq6E7cgbq7