### PR TITLE
Bundle Leaflet CSS via webpack instead of loading from CDN

### DIFF
--- a/therr-client-web/noop-css-loader.js
+++ b/therr-client-web/noop-css-loader.js
@@ -1,0 +1,4 @@
+// Ignore CSS imports during server-side builds
+module.exports = function noopCssLoader() {
+    return '';
+};

--- a/therr-client-web/webpack.server.config.js
+++ b/therr-client-web/webpack.server.config.js
@@ -85,6 +85,17 @@ const common = merge([
     parts.clean(),
     parts.loadSvg(),
     parts.processTypescript([PATHS.src], false),
+    // Ignore CSS imports on the server (they are only needed client-side)
+    {
+        module: {
+            rules: [
+                {
+                    test: /\.css$/,
+                    loader: require.resolve('./noop-css-loader'),
+                },
+            ],
+        },
+    },
     parts.generateSourcemaps('source-map'),
     parts.deDupe(),
 ]);


### PR DESCRIPTION
Root cause: Helmet CSP styleSrc directive doesn't include unpkg.com,
so the dynamically injected Leaflet CSS link was blocked by the
browser. The link.onload still fired but the stylesheet was empty,
causing tiles to render without positioning CSS (white gaps, misaligned
tile fragments).

Fix: import 'leaflet/dist/leaflet.css' at the top of SpacesMap. Since
SpacesMap is already lazy-loaded via React.lazy(), webpack bundles the
CSS into the same chunk. It loads with the component, is served from
the same origin (passes CSP), and is available synchronously before
the map initializes.

Removed all the loadLeafletCss/Promise.all machinery that was trying
to work around a problem that was fundamentally unsolvable via timing.

https://claude.ai/code/session_01MGeaxwPAx2V2sq6E7cgbq7