### PR TITLE
Remove k8s readiness probes from web client and API gateway

### DIFF
--- a/k8s/prod/api-gateway-service-deployment.yaml
+++ b/k8s/prod/api-gateway-service-deployment.yaml
@@ -65,14 +65,6 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
           failureThreshold: 3
-        readinessProbe:
-          httpGet:
-            path: /healthcheck
-            port: 7770
-          initialDelaySeconds: 20
-          periodSeconds: 5
-          timeoutSeconds: 3
-          failureThreshold: 2
         env:
         - name: API_GATEWAY_PORT
           value: "7770"

--- a/k8s/prod/client-deployment.yaml
+++ b/k8s/prod/client-deployment.yaml
@@ -56,14 +56,6 @@ spec:
           periodSeconds: 15
           timeoutSeconds: 5
           failureThreshold: 3
-        readinessProbe:
-          httpGet:
-            path: /healthcheck
-            port: 7070
-          initialDelaySeconds: 60
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 5
         env:
           - name: USERS_SERVICE_API_PORT
             value: "7771"


### PR DESCRIPTION
Readiness probes cause 503 errors during frontend deployments until the
container is fully ready. These probes make sense for backend services
but unnecessarily affect availability of the web client and API gateway.
Liveness probes are retained for crash detection.

https://claude.ai/code/session_01BubRGkWgbRjrC6QCSrPbkE