### PR TITLE
Add processed-spaces tracking to avoid duplicate metadata lookups

### DIFF
--- a/scripts/import-spaces/data/.gitignore
+++ b/scripts/import-spaces/data/.gitignore
@@ -1,0 +1,2 @@
+# Processed-spaces tracking files are local to each environment
+processed/

--- a/scripts/import-spaces/manage-space.ts
+++ b/scripts/import-spaces/manage-space.ts
@@ -739,13 +739,14 @@ async function main() {
     // ── Enrich-existing mode ──
     let spaces = await querySpacesForEnrichment(db, args);
     if (!args.noSkipProcessed && !args.singleId) {
+      // Only filter by failure types. Success types (WEBSITE_FOUND, etc.) mean
+      // the field was populated in DB, but the space may still need other
+      // enrichment (e.g., has website but still needs email/image). The DB
+      // query already excludes spaces with all fields populated.
       const { filtered, skippedCount } = filterProcessedSpaces(spaces, [
         ProcessedType.NO_WEBSITE_FOUND,
         ProcessedType.NO_EMAIL_FOUND,
         ProcessedType.NO_IMAGE_FOUND,
-        ProcessedType.WEBSITE_FOUND,
-        ProcessedType.EMAIL_FOUND,
-        ProcessedType.IMAGE_FOUND,
       ]);
       if (skippedCount > 0) {
         console.log(`Skipping ${skippedCount} previously processed space(s).`);

--- a/scripts/import-spaces/manage-space.ts
+++ b/scripts/import-spaces/manage-space.ts
@@ -39,6 +39,12 @@ import { crawlForImages } from './sources/crawl';
 import { crawlForDetails, fetchPage } from './sources/crawlDetails';
 import { downloadAndValidateImage } from './utils/imageValidation';
 import { uploadImage } from './utils/gcs';
+import {
+  ProcessedType,
+  markProcessed,
+  filterProcessedSpaces,
+  getProcessedStats,
+} from './utils/processedSpaces';
 import { CITY_TIMEZONE_MAP } from './transforms/parseHours';
 
 // Load .env from scripts/import-spaces/ first, fall back to root .env
@@ -74,6 +80,7 @@ Options:
   --skip-dedup         Skip duplicate checking during import
   --skip-enrich        Import only — skip the enrichment phase
   --dry-run            Preview results without database changes
+  --no-skip-processed  Re-process spaces even if previously attempted
   --help, -h           Show this help message
 
 Examples:
@@ -106,6 +113,7 @@ interface ICliArgs {
   limit: number;
   delay: number;
   userId: string;
+  noSkipProcessed: boolean;
 }
 
 // ── CLI arg parsing ──────────────────────────────────────────────────────────
@@ -123,6 +131,8 @@ function parseArgs(): ICliArgs {
       parsed.skipDedup = 'true';
     } else if (args[i] === '--skip-enrich') {
       parsed.skipEnrich = 'true';
+    } else if (args[i] === '--no-skip-processed') {
+      parsed.noSkipProcessed = 'true';
     } else if (args[i] === '--enrich-existing') {
       parsed.enrichExisting = 'true';
     } else if (args[i].startsWith('--') && i + 1 < args.length) {
@@ -151,6 +161,7 @@ function parseArgs(): ICliArgs {
     limit: parsed.limit ? parseInt(parsed.limit, 10) : 0,
     delay: parsed.delay ? parseInt(parsed.delay, 10) : 2000,
     userId: parsed['user-id'] || IMPORT_USER_ID,
+    noSkipProcessed: parsed.noSkipProcessed === 'true',
   };
 }
 
@@ -450,10 +461,14 @@ async function enrichSpace(
           `UPDATE main.spaces SET "websiteUrl" = $1, "updatedAt" = NOW() WHERE id = $2`,
           [websiteUrl, space.id],
         );
+        markProcessed(ProcessedType.WEBSITE_FOUND, space.id, space.notificationMsg);
       }
       counters.websitesFound++;
     } else {
       console.log(`${progress} No website found for: ${space.notificationMsg}`);
+      if (!args.dryRun) {
+        markProcessed(ProcessedType.NO_WEBSITE_FOUND, space.id, space.notificationMsg);
+      }
       return; // Can't do much without a website
     }
   }
@@ -480,8 +495,11 @@ async function enrichSpace(
           `UPDATE main.spaces SET "businessEmail" = $1, "updatedAt" = NOW() WHERE id = $2`,
           [bestEmail.email, space.id],
         );
+        markProcessed(ProcessedType.EMAIL_FOUND, space.id, space.notificationMsg);
       }
       counters.emailsFound++;
+    } else if (!args.dryRun) {
+      markProcessed(ProcessedType.NO_EMAIL_FOUND, space.id, space.notificationMsg);
     }
   }
 
@@ -541,7 +559,12 @@ async function enrichSpace(
       const imageSourced = await sourceImageForSpace(
         db, space, websiteUrl, space.fromUserId || args.userId, progress,
       );
-      if (imageSourced) counters.imagesFound++;
+      if (imageSourced) {
+        counters.imagesFound++;
+        markProcessed(ProcessedType.IMAGE_FOUND, space.id, space.notificationMsg);
+      } else {
+        markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
+      }
     }
   }
 }
@@ -714,7 +737,21 @@ async function main() {
 
   if (args.enrichExisting) {
     // ── Enrich-existing mode ──
-    const spaces = await querySpacesForEnrichment(db, args);
+    let spaces = await querySpacesForEnrichment(db, args);
+    if (!args.noSkipProcessed && !args.singleId) {
+      const { filtered, skippedCount } = filterProcessedSpaces(spaces, [
+        ProcessedType.NO_WEBSITE_FOUND,
+        ProcessedType.NO_EMAIL_FOUND,
+        ProcessedType.NO_IMAGE_FOUND,
+        ProcessedType.WEBSITE_FOUND,
+        ProcessedType.EMAIL_FOUND,
+        ProcessedType.IMAGE_FOUND,
+      ]);
+      if (skippedCount > 0) {
+        console.log(`Skipping ${skippedCount} previously processed space(s).`);
+      }
+      spaces = filtered;
+    }
     if (spaces.length === 0) {
       console.log('No spaces found needing enrichment.');
     } else {
@@ -742,6 +779,18 @@ async function main() {
   }
 
   printSummary(args, counters);
+
+  // Show processed-spaces tracking stats
+  const stats = getProcessedStats();
+  const hasStats = Object.values(stats).some((v) => v > 0);
+  if (hasStats) {
+    console.log('Processed-spaces tracking:');
+    for (const [type, count] of Object.entries(stats)) {
+      if (count > 0) console.log(`  ${type}: ${count}`);
+    }
+    console.log('');
+  }
+
   await db.end();
 }
 

--- a/scripts/import-spaces/source-emails-websites.ts
+++ b/scripts/import-spaces/source-emails-websites.ts
@@ -21,6 +21,12 @@ import { searchForWebsite } from './sources/searchWeb';
 import { crawlForImages } from './sources/crawl';
 import { downloadAndValidateImage } from './utils/imageValidation';
 import { uploadImage } from './utils/gcs';
+import {
+  ProcessedType,
+  markProcessed,
+  filterProcessedSpaces,
+  getProcessedStats,
+} from './utils/processedSpaces';
 
 // Load .env from scripts/import-spaces/ first, fall back to root .env
 dotenv.config({ path: path.resolve(__dirname, '.env') });
@@ -50,6 +56,7 @@ Options:
                        (default: ${IMPORT_USER_ID})
   --source-images      Also source images for spaces with a website but no media
   --dry-run            Crawl and log results without updating database
+  --no-skip-processed  Re-process spaces even if previously attempted
   --help, -h           Show this help message
 
 Examples:
@@ -69,6 +76,7 @@ interface ICliArgs {
   limit: number;
   delay: number;
   userId: string;
+  noSkipProcessed: boolean;
 }
 
 // ── CLI arg parsing ──────────────────────────────────────────────────────────
@@ -84,6 +92,8 @@ function parseArgs(): ICliArgs {
       parsed.dryRun = 'true';
     } else if (args[i] === '--source-images') {
       parsed.sourceImages = 'true';
+    } else if (args[i] === '--no-skip-processed') {
+      parsed.noSkipProcessed = 'true';
     } else if (args[i].startsWith('--') && i + 1 < args.length) {
       parsed[args[i].replace('--', '')] = args[i + 1];
       i++;
@@ -105,6 +115,7 @@ function parseArgs(): ICliArgs {
     limit: parsed.limit ? parseInt(parsed.limit, 10) : 0,
     delay: parsed.delay ? parseInt(parsed.delay, 10) : 2000,
     userId: parsed['user-id'] || IMPORT_USER_ID,
+    noSkipProcessed: parsed.noSkipProcessed === 'true',
   };
 }
 
@@ -244,7 +255,19 @@ async function sourceImageForSpace(
 
 // ── Process spaces that need emails ──────────────────────────────────────────
 async function processEmailSpaces(db: Pool, args: ICliArgs, counters: ICounters) {
-  const spaces = await querySpacesForEmails(db, args);
+  let spaces = await querySpacesForEmails(db, args);
+
+  if (!args.noSkipProcessed) {
+    const { filtered, skippedCount } = filterProcessedSpaces(spaces, [
+      ProcessedType.NO_EMAIL_FOUND,
+      ProcessedType.EMAIL_FOUND,
+    ]);
+    if (skippedCount > 0) {
+      console.log(`Skipping ${skippedCount} previously processed space(s) for email lookup.`);
+    }
+    spaces = filtered;
+  }
+
   console.log(`Found ${spaces.length} spaces with websites needing email extraction.\n`);
 
   for (let i = 0; i < spaces.length; i++) {
@@ -256,6 +279,9 @@ async function processEmailSpaces(db: Pool, args: ICliArgs, counters: ICounters)
 
       if (emailResults.length === 0) {
         console.log(`${progress} SKIP (no email found): ${space.notificationMsg} — ${space.websiteUrl}`);
+        if (!args.dryRun) {
+          markProcessed(ProcessedType.NO_EMAIL_FOUND, space.id, space.notificationMsg);
+        }
         counters.skippedNoEmail++;
         if (i < spaces.length - 1) await sleep(args.delay);
         continue;
@@ -274,6 +300,7 @@ async function processEmailSpaces(db: Pool, args: ICliArgs, counters: ICounters)
           `UPDATE main.spaces SET "businessEmail" = $1, "updatedAt" = NOW() WHERE id = $2`,
           [bestEmail.email, space.id],
         );
+        markProcessed(ProcessedType.EMAIL_FOUND, space.id, space.notificationMsg);
         counters.emailsFound++;
       }
 
@@ -297,7 +324,19 @@ async function processEmailSpaces(db: Pool, args: ICliArgs, counters: ICounters)
 
 // ── Process spaces that need websites ────────────────────────────────────────
 async function processWebsiteSpaces(db: Pool, args: ICliArgs, counters: ICounters) {
-  const spaces = await querySpacesForWebsites(db, args);
+  let spaces = await querySpacesForWebsites(db, args);
+
+  if (!args.noSkipProcessed) {
+    const { filtered, skippedCount } = filterProcessedSpaces(spaces, [
+      ProcessedType.NO_WEBSITE_FOUND,
+      ProcessedType.WEBSITE_FOUND,
+    ]);
+    if (skippedCount > 0) {
+      console.log(`Skipping ${skippedCount} previously processed space(s) for website lookup.`);
+    }
+    spaces = filtered;
+  }
+
   console.log(`Found ${spaces.length} spaces needing website discovery.\n`);
 
   for (let i = 0; i < spaces.length; i++) {
@@ -313,6 +352,9 @@ async function processWebsiteSpaces(db: Pool, args: ICliArgs, counters: ICounter
 
       if (!searchResult) {
         console.log(`${progress} SKIP (no website found): ${space.notificationMsg}`);
+        if (!args.dryRun) {
+          markProcessed(ProcessedType.NO_WEBSITE_FOUND, space.id, space.notificationMsg);
+        }
         counters.skippedNoWebsite++;
         if (i < spaces.length - 1) await sleep(args.delay);
         continue;
@@ -328,6 +370,7 @@ async function processWebsiteSpaces(db: Pool, args: ICliArgs, counters: ICounter
           `UPDATE main.spaces SET "websiteUrl" = $1, "updatedAt" = NOW() WHERE id = $2`,
           [searchResult.websiteUrl, space.id],
         );
+        markProcessed(ProcessedType.WEBSITE_FOUND, space.id, space.notificationMsg);
         counters.websitesFound++;
       }
 
@@ -444,6 +487,17 @@ async function main() {
   console.log(`Skipped (no website):       ${counters.skippedNoWebsite}`);
   console.log(`Errors:                     ${counters.errors}`);
   console.log('══════════════════════════════════════\n');
+
+  // Show processed-spaces tracking stats
+  const stats = getProcessedStats();
+  const hasStats = Object.values(stats).some((v) => v > 0);
+  if (hasStats) {
+    console.log('Processed-spaces tracking:');
+    for (const [type, count] of Object.entries(stats)) {
+      if (count > 0) console.log(`  ${type}: ${count}`);
+    }
+    console.log('');
+  }
 
   await db.end();
 }

--- a/scripts/import-spaces/source-emails-websites.ts
+++ b/scripts/import-spaces/source-emails-websites.ts
@@ -310,7 +310,12 @@ async function processEmailSpaces(db: Pool, args: ICliArgs, counters: ICounters)
           console.log(`${progress}   Would also source image from ${space.websiteUrl}`);
         } else {
           const imageSourced = await sourceImageForSpace(db, space, space.websiteUrl, space.fromUserId || args.userId, progress);
-          if (imageSourced) counters.imagesFound++;
+          if (imageSourced) {
+            counters.imagesFound++;
+            markProcessed(ProcessedType.IMAGE_FOUND, space.id, space.notificationMsg);
+          } else {
+            markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
+          }
         }
       }
     } catch (err: any) {
@@ -387,8 +392,11 @@ async function processWebsiteSpaces(db: Pool, args: ICliArgs, counters: ICounter
             `UPDATE main.spaces SET "businessEmail" = $1, "updatedAt" = NOW() WHERE id = $2`,
             [bestEmail.email, space.id],
           );
+          markProcessed(ProcessedType.EMAIL_FOUND, space.id, space.notificationMsg);
           counters.emailsFound++;
         }
+      } else if (!args.dryRun) {
+        markProcessed(ProcessedType.NO_EMAIL_FOUND, space.id, space.notificationMsg);
       }
 
       // Optionally source images from the newly discovered website
@@ -399,7 +407,12 @@ async function processWebsiteSpaces(db: Pool, args: ICliArgs, counters: ICounter
           const imageSourced = await sourceImageForSpace(
             db, space, searchResult.websiteUrl, space.fromUserId || args.userId, progress,
           );
-          if (imageSourced) counters.imagesFound++;
+          if (imageSourced) {
+            counters.imagesFound++;
+            markProcessed(ProcessedType.IMAGE_FOUND, space.id, space.notificationMsg);
+          } else {
+            markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
+          }
         }
       }
     } catch (err: any) {

--- a/scripts/import-spaces/source-images.ts
+++ b/scripts/import-spaces/source-images.ts
@@ -15,6 +15,12 @@ import { CITIES, IMPORT_USER_ID } from './config';
 import { crawlForImages, ICrawlResult } from './sources/crawl';
 import { downloadAndValidateImage } from './utils/imageValidation';
 import { uploadImage } from './utils/gcs';
+import {
+  ProcessedType,
+  markProcessed,
+  filterProcessedSpaces,
+  getProcessedStats,
+} from './utils/processedSpaces';
 
 // Load .env from scripts/import-spaces/ first, fall back to root .env
 dotenv.config({ path: path.resolve(__dirname, '.env') });
@@ -39,6 +45,7 @@ Options:
   --user-id <uuid>     Override fromUserId for media records
                        (default: ${IMPORT_USER_ID})
   --dry-run            Crawl and log results without uploading/updating
+  --no-skip-processed  Re-process spaces even if previously attempted
   --help, -h           Show this help message
 
 Examples:
@@ -54,6 +61,7 @@ interface ICliArgs {
   limit: number;
   delay: number;
   userId: string;
+  noSkipProcessed: boolean;
 }
 
 // ── CLI arg parsing ──────────────────────────────────────────────────────────
@@ -67,6 +75,8 @@ function parseArgs(): ICliArgs {
       process.exit(0);
     } else if (args[i] === '--dry-run') {
       parsed.dryRun = 'true';
+    } else if (args[i] === '--no-skip-processed') {
+      parsed.noSkipProcessed = 'true';
     } else if (args[i].startsWith('--') && i + 1 < args.length) {
       parsed[args[i].replace('--', '')] = args[i + 1];
       i++;
@@ -80,6 +90,7 @@ function parseArgs(): ICliArgs {
     limit: parsed.limit ? parseInt(parsed.limit, 10) : 0,
     delay: parsed.delay ? parseInt(parsed.delay, 10) : 2000,
     userId: parsed['user-id'] || IMPORT_USER_ID,
+    noSkipProcessed: parsed.noSkipProcessed === 'true',
   };
 }
 
@@ -174,7 +185,19 @@ async function main() {
     process.exit(1);
   }
 
-  const spaces = await querySpaces(db, args);
+  let spaces = await querySpaces(db, args);
+
+  if (!args.noSkipProcessed) {
+    const { filtered, skippedCount } = filterProcessedSpaces(spaces, [
+      ProcessedType.NO_IMAGE_FOUND,
+      ProcessedType.IMAGE_FOUND,
+    ]);
+    if (skippedCount > 0) {
+      console.log(`Skipping ${skippedCount} previously processed space(s) for image lookup.`);
+    }
+    spaces = filtered;
+  }
+
   console.log(`Found ${spaces.length} spaces needing images.\n`);
 
   if (spaces.length === 0) {
@@ -198,6 +221,9 @@ async function main() {
       const candidates = await crawlForImages(space.websiteUrl);
       if (candidates.length === 0) {
         console.log(`${progress} SKIP (no image found): ${space.notificationMsg} — ${space.websiteUrl}`);
+        if (!args.dryRun) {
+          markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
+        }
         skippedNoImage++;
         if (i < spaces.length - 1) await sleep(args.delay);
         continue;
@@ -226,6 +252,7 @@ async function main() {
 
       if (!validImage) {
         console.log(`  SKIP (all candidates invalid/too small): ${space.notificationMsg}`);
+        markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
         skippedTooSmall++;
         if (i < spaces.length - 1) await sleep(args.delay);
         continue;
@@ -259,6 +286,7 @@ async function main() {
       );
 
       console.log(`  Updated space ${space.id} with media ${mediaId}`);
+      markProcessed(ProcessedType.IMAGE_FOUND, space.id, space.notificationMsg);
       updated++;
     } catch (err: any) {
       console.error(`${progress} ERROR: ${space.notificationMsg} — ${err.message}`);
@@ -280,6 +308,17 @@ async function main() {
   console.log(`Skipped (too small):      ${skippedTooSmall}`);
   console.log(`Errors:                   ${errors}`);
   console.log('══════════════════════════════════════\n');
+
+  // Show processed-spaces tracking stats
+  const stats = getProcessedStats();
+  const hasStats = Object.values(stats).some((v) => v > 0);
+  if (hasStats) {
+    console.log('Processed-spaces tracking:');
+    for (const [type, count] of Object.entries(stats)) {
+      if (count > 0) console.log(`  ${type}: ${count}`);
+    }
+    console.log('');
+  }
 
   await db.end();
 }

--- a/scripts/import-spaces/utils/processedSpaces.ts
+++ b/scripts/import-spaces/utils/processedSpaces.ts
@@ -57,8 +57,13 @@ function loadFile(type: ProcessedType): IProcessedFile {
   if (!fs.existsSync(fp)) {
     return { type, updatedAt: new Date().toISOString(), entries: [] };
   }
-  const raw = fs.readFileSync(fp, 'utf-8');
-  return JSON.parse(raw) as IProcessedFile;
+  try {
+    const raw = fs.readFileSync(fp, 'utf-8');
+    return JSON.parse(raw) as IProcessedFile;
+  } catch (err) {
+    console.error(`Warning: Could not parse ${fp}, starting fresh. Error: ${(err as Error).message}`);
+    return { type, updatedAt: new Date().toISOString(), entries: [] };
+  }
 }
 
 /**

--- a/scripts/import-spaces/utils/processedSpaces.ts
+++ b/scripts/import-spaces/utils/processedSpaces.ts
@@ -1,0 +1,157 @@
+/**
+ * Tracks space IDs that have been processed for each metadata lookup type.
+ *
+ * Stores results in JSON files under scripts/import-spaces/data/processed/.
+ * Each lookup type gets its own file so scripts can skip IDs that have already
+ * been attempted (e.g., spaces where no website was found won't be re-searched).
+ *
+ * Files:
+ *   no-website-found.json   — website search returned no results
+ *   no-email-found.json     — email extraction found nothing
+ *   no-image-found.json     — no valid image could be sourced
+ *   website-found.json      — website was successfully discovered
+ *   email-found.json        — email was successfully extracted
+ *   image-found.json        — image was successfully sourced
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DATA_DIR = path.resolve(__dirname, '..', 'data', 'processed');
+
+export enum ProcessedType {
+  NO_WEBSITE_FOUND = 'no-website-found',
+  NO_EMAIL_FOUND = 'no-email-found',
+  NO_IMAGE_FOUND = 'no-image-found',
+  WEBSITE_FOUND = 'website-found',
+  EMAIL_FOUND = 'email-found',
+  IMAGE_FOUND = 'image-found',
+}
+
+interface IProcessedEntry {
+  id: string;
+  name: string;
+  processedAt: string;
+}
+
+interface IProcessedFile {
+  type: string;
+  updatedAt: string;
+  entries: IProcessedEntry[];
+}
+
+function ensureDataDir(): void {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+}
+
+function filePath(type: ProcessedType): string {
+  return path.join(DATA_DIR, `${type}.json`);
+}
+
+/**
+ * Load all entries from a processed-spaces JSON file.
+ */
+function loadFile(type: ProcessedType): IProcessedFile {
+  const fp = filePath(type);
+  if (!fs.existsSync(fp)) {
+    return { type, updatedAt: new Date().toISOString(), entries: [] };
+  }
+  const raw = fs.readFileSync(fp, 'utf-8');
+  return JSON.parse(raw) as IProcessedFile;
+}
+
+/**
+ * Save a processed-spaces file back to disk.
+ */
+function saveFile(data: IProcessedFile): void {
+  ensureDataDir();
+  const fp = path.join(DATA_DIR, `${data.type}.json`);
+  data.updatedAt = new Date().toISOString();
+  fs.writeFileSync(fp, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Load the set of all processed space IDs for a given type.
+ */
+export function loadProcessedIds(type: ProcessedType): Set<string> {
+  const data = loadFile(type);
+  return new Set(data.entries.map((e) => e.id));
+}
+
+/**
+ * Load processed IDs from multiple types and return the union.
+ */
+export function loadProcessedIdsMulti(types: ProcessedType[]): Set<string> {
+  const combined = new Set<string>();
+  for (const type of types) {
+    for (const id of loadProcessedIds(type)) {
+      combined.add(id);
+    }
+  }
+  return combined;
+}
+
+/**
+ * Mark a single space ID as processed for a given type.
+ */
+export function markProcessed(type: ProcessedType, id: string, name: string): void {
+  const data = loadFile(type);
+  // Avoid duplicates
+  if (data.entries.some((e) => e.id === id)) return;
+
+  data.entries.push({
+    id,
+    name,
+    processedAt: new Date().toISOString(),
+  });
+  saveFile(data);
+}
+
+/**
+ * Mark multiple space IDs as processed for a given type in a single write.
+ */
+export function markProcessedBatch(type: ProcessedType, items: Array<{ id: string; name: string }>): void {
+  if (items.length === 0) return;
+
+  const data = loadFile(type);
+  const existing = new Set(data.entries.map((e) => e.id));
+  const now = new Date().toISOString();
+
+  for (const item of items) {
+    if (!existing.has(item.id)) {
+      data.entries.push({ id: item.id, name: item.name, processedAt: now });
+      existing.add(item.id);
+    }
+  }
+
+  saveFile(data);
+}
+
+/**
+ * Filter an array of spaces, removing any whose ID appears in the given
+ * processed types. Returns the filtered array and the count of skipped items.
+ */
+export function filterProcessedSpaces<T extends { id: string }>(
+  spaces: T[],
+  types: ProcessedType[],
+): { filtered: T[]; skippedCount: number } {
+  const processedIds = loadProcessedIdsMulti(types);
+  const filtered = spaces.filter((s) => !processedIds.has(s.id));
+  return {
+    filtered,
+    skippedCount: spaces.length - filtered.length,
+  };
+}
+
+/**
+ * Get summary stats for all processed-spaces files.
+ */
+export function getProcessedStats(): Record<string, number> {
+  const stats: Record<string, number> = {};
+  for (const type of Object.values(ProcessedType)) {
+    const data = loadFile(type);
+    stats[type] = data.entries.length;
+  }
+  return stats;
+}


### PR DESCRIPTION
Scripts now record space IDs in JSON files (per lookup type) after each
processing attempt. On subsequent runs, already-processed IDs are skipped
by default. Use --no-skip-processed to override this behavior.

Tracking types: no-website-found, no-email-found, no-image-found,
website-found, email-found, image-found.

https://claude.ai/code/session_01JhHtkmuGkEHYtisnLDmvYX