### PR TITLE
fix: replace broken slider with numeric input and add placeholder images

### DIFF
--- a/TherrMobile/__tests__/routes/ContentCreation.test.tsx
+++ b/TherrMobile/__tests__/routes/ContentCreation.test.tsx
@@ -419,40 +419,102 @@ describe('Content Creation Visibility Settings', () => {
 });
 
 describe('Content Creation Radius Settings', () => {
-    const DEFAULT_RADIUS = 25;
-    const MIN_RADIUS_PRIVATE = 5;
-    const MAX_RADIUS_PRIVATE = 100;
-    const MIN_RADIUS_PUBLIC = 25;
-    const MAX_RADIUS_PUBLIC = 500;
+    const DEFAULT_RADIUS = 10;
+    const MIN_RADIUS_PRIVATE = 3;
+    const MAX_RADIUS_PRIVATE = 50;
+    const MIN_RADIUS_PUBLIC = 3;
+    const MAX_RADIUS_PUBLIC = 50;
 
     describe('Radius Constraints', () => {
         it('should have correct default radius', () => {
-            expect(DEFAULT_RADIUS).toBe(25);
+            expect(DEFAULT_RADIUS).toBe(10);
         });
 
         it('should have correct private radius range', () => {
             expect(MIN_RADIUS_PRIVATE).toBeLessThan(MAX_RADIUS_PRIVATE);
-            expect(MIN_RADIUS_PRIVATE).toBe(5);
-            expect(MAX_RADIUS_PRIVATE).toBe(100);
+            expect(MIN_RADIUS_PRIVATE).toBe(3);
+            expect(MAX_RADIUS_PRIVATE).toBe(50);
         });
 
         it('should have correct public radius range', () => {
             expect(MIN_RADIUS_PUBLIC).toBeLessThan(MAX_RADIUS_PUBLIC);
-            expect(MIN_RADIUS_PUBLIC).toBe(25);
-            expect(MAX_RADIUS_PUBLIC).toBe(500);
+            expect(MIN_RADIUS_PUBLIC).toBe(3);
+            expect(MAX_RADIUS_PUBLIC).toBe(50);
         });
     });
 
-    describe('onSliderChange', () => {
-        it('should update radius value', () => {
-            let inputs = { radius: DEFAULT_RADIUS };
+    describe('Radius Numeric Input', () => {
+        // Simulates the stripping logic used in EditMoment/EditSpace onChangeText
+        const stripNonNumeric = (text: string): string => {
+            return text.replace(/[^0-9]/g, '');
+        };
 
-            const onSliderChange = (name: string, value: number) => {
-                inputs = { ...inputs, [name]: value };
-            };
+        // Simulates the onBlur clamping logic
+        const clampRadius = (value: string | number, min: number, max: number): number => {
+            const num = parseInt(String(value), 10);
+            if (isNaN(num) || num < min) {
+                return min;
+            } else if (num > max) {
+                return max;
+            }
+            return num;
+        };
 
-            onSliderChange('radius', 75);
-            expect(inputs.radius).toBe(75);
+        // Simulates the sanitization done in onSubmit before sending to API
+        const sanitizeRadiusForSubmit = (radius: any, min: number, max: number): number => {
+            return Math.max(min, Math.min(max, parseInt(radius, 10) || min));
+        };
+
+        it('should strip non-numeric characters from input', () => {
+            expect(stripNonNumeric('12abc')).toBe('12');
+            expect(stripNonNumeric('abc')).toBe('');
+            expect(stripNonNumeric('1.5')).toBe('15');
+            expect(stripNonNumeric('-10')).toBe('10');
+            expect(stripNonNumeric('25')).toBe('25');
+        });
+
+        it('should allow empty string during editing', () => {
+            const stripped = stripNonNumeric('');
+            expect(stripped).toBe('');
+        });
+
+        it('should clamp radius below minimum to minimum on blur', () => {
+            expect(clampRadius('1', MIN_RADIUS_PRIVATE, MAX_RADIUS_PRIVATE)).toBe(MIN_RADIUS_PRIVATE);
+            expect(clampRadius('0', MIN_RADIUS_PUBLIC, MAX_RADIUS_PUBLIC)).toBe(MIN_RADIUS_PUBLIC);
+        });
+
+        it('should clamp radius above maximum to maximum on blur', () => {
+            expect(clampRadius('999', MIN_RADIUS_PRIVATE, MAX_RADIUS_PRIVATE)).toBe(MAX_RADIUS_PRIVATE);
+            expect(clampRadius('100', MIN_RADIUS_PUBLIC, MAX_RADIUS_PUBLIC)).toBe(MAX_RADIUS_PUBLIC);
+        });
+
+        it('should clamp empty string to minimum on blur', () => {
+            expect(clampRadius('', MIN_RADIUS_PRIVATE, MAX_RADIUS_PRIVATE)).toBe(MIN_RADIUS_PRIVATE);
+            expect(clampRadius('', MIN_RADIUS_PUBLIC, MAX_RADIUS_PUBLIC)).toBe(MIN_RADIUS_PUBLIC);
+        });
+
+        it('should accept valid radius values within range on blur', () => {
+            expect(clampRadius('10', MIN_RADIUS_PRIVATE, MAX_RADIUS_PRIVATE)).toBe(10);
+            expect(clampRadius('25', MIN_RADIUS_PUBLIC, MAX_RADIUS_PUBLIC)).toBe(25);
+        });
+
+        it('should sanitize empty string radius to minimum on submit', () => {
+            expect(sanitizeRadiusForSubmit('', MIN_RADIUS_PRIVATE, MAX_RADIUS_PRIVATE)).toBe(MIN_RADIUS_PRIVATE);
+            expect(sanitizeRadiusForSubmit('', MIN_RADIUS_PUBLIC, MAX_RADIUS_PUBLIC)).toBe(MIN_RADIUS_PUBLIC);
+        });
+
+        it('should sanitize NaN radius to minimum on submit', () => {
+            expect(sanitizeRadiusForSubmit('abc', MIN_RADIUS_PRIVATE, MAX_RADIUS_PRIVATE)).toBe(MIN_RADIUS_PRIVATE);
+        });
+
+        it('should clamp out-of-range radius on submit', () => {
+            expect(sanitizeRadiusForSubmit('999', MIN_RADIUS_PRIVATE, MAX_RADIUS_PRIVATE)).toBe(MAX_RADIUS_PRIVATE);
+            expect(sanitizeRadiusForSubmit('0', MIN_RADIUS_PRIVATE, MAX_RADIUS_PRIVATE)).toBe(MIN_RADIUS_PRIVATE);
+        });
+
+        it('should pass through valid radius on submit', () => {
+            expect(sanitizeRadiusForSubmit('25', MIN_RADIUS_PRIVATE, MAX_RADIUS_PRIVATE)).toBe(25);
+            expect(sanitizeRadiusForSubmit(10, MIN_RADIUS_PUBLIC, MAX_RADIUS_PUBLIC)).toBe(10);
         });
     });
 });

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -523,6 +523,7 @@
         "maxViews": "Max views (per person)",
         "expiresAt": "Countdown",
         "radius": "Radius: {meters} meters",
+        "radiusPlaceholder": "Radius ({min}-{max} meters)",
         "unselected": "Select a Space"
       },
       "headers": {
@@ -650,6 +651,7 @@
         "maxViews": "Max views (per person)",
         "expiresAt": "Countdown",
         "radius": "Radius: {meters} meters",
+        "radiusPlaceholder": "Radius ({min}-{max} meters)",
         "incentiveRequirement": "Reward Requirement",
         "unselectedIncentiveRequirement": "Select a Requirement",
         "incentiveReward": "Reward for Participation",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -523,6 +523,7 @@
         "maxViews": "Máx. vistas (por persona)",
         "expiresAt": "Cuenta regresiva",
         "radius": "Radio: {meters} metros",
+        "radiusPlaceholder": "Radio ({min}-{max} metros)",
         "unselected": "Seleccionar un espacio"
       },
       "headers": {
@@ -650,6 +651,7 @@
         "maxViews": "Máx. vistas (por persona)",
         "expiresAt": "Cuenta regresiva",
         "radius": "Radio: {meters} metros",
+        "radiusPlaceholder": "Radio ({min}-{max} metros)",
         "incentiveRequirement": "Requisito de recompensa",
         "unselectedIncentiveRequirement": "Seleccionar un requisito",
         "incentiveReward": "Recompensa por participación",

--- a/TherrMobile/main/routes/EditMoment.tsx
+++ b/TherrMobile/main/routes/EditMoment.tsx
@@ -734,9 +734,9 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
                                     <LottieView
                                         source={require('../assets/missing-image-storefront.json')}
                                         resizeMode="contain"
-                                        speed={1}
+                                        speed={0.8}
                                         autoPlay
-                                        loop={false}
+                                        loop
                                         style={{
                                             width: viewportWidth - (2 * this.themeAccentLayout.styles.container.padding),
                                             height: 160,
@@ -884,8 +884,10 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
                         style={[this.themeForms.styles.inputSliderContainer, { paddingBottom: 20 }]}
                     >
                         <RoundInput
-                            containerStyle={{ marginBottom: 4 }}
-                            placeholder={this.translate('forms.editMoment.labels.radius', { meters: '' })}
+                            placeholder={this.translate('forms.editMoment.labels.radiusPlaceholder', {
+                                min: MIN_RADIUS_PRIVATE,
+                                max: MAX_RADIUS_PRIVATE,
+                            })}
                             value={inputs.radius === '' ? '' : String(inputs.radius)}
                             onChangeText={(text) => {
                                 const stripped = text.replace(/[^0-9]/g, '');
@@ -906,9 +908,9 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
                             keyboardType="number-pad"
                             themeForms={this.themeForms}
                         />
-                        <Text style={this.themeForms.styles.inputLabelDark}>
+                        {inputs.radius !== '' && <Text style={this.themeForms.styles.inputLabelDark}>
                             {`${this.translate('forms.editMoment.labels.radius', { meters: inputs.radius })}`}
-                        </Text>
+                        </Text>}
                     </View>
                     <Alert
                         containerStyles={addMargins({

--- a/TherrMobile/main/routes/EditMoment.tsx
+++ b/TherrMobile/main/routes/EditMoment.tsx
@@ -326,6 +326,8 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
             longitude = route.params.area?.longitude;
         }
 
+        const sanitizedRadius = Math.max(MIN_RADIUS_PRIVATE, Math.min(MAX_RADIUS_PRIVATE, parseInt(radius, 10) || MIN_RADIUS_PRIVATE));
+
         const createArgs: any = {
             category,
             fromUserId: user.details.id,
@@ -337,7 +339,7 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
             latitude,
             longitude,
             maxViews,
-            radius,
+            radius: sanitizedRadius,
             rating,
             skipReward: shouldSkipRewards,
             spaceId,

--- a/TherrMobile/main/routes/EditSpace.tsx
+++ b/TherrMobile/main/routes/EditSpace.tsx
@@ -891,9 +891,9 @@ export class EditSpace extends React.PureComponent<IEditSpaceProps, IEditSpaceSt
                                             <LottieView
                                                 source={require('../assets/missing-image-storefront.json')}
                                                 resizeMode="contain"
-                                                speed={1}
+                                                speed={0.8}
                                                 autoPlay
-                                                loop={false}
+                                                loop
                                                 style={{
                                                     width: viewportWidth - (2 * this.themeAccentLayout.styles.container.padding),
                                                     height: 160,
@@ -1140,8 +1140,10 @@ export class EditSpace extends React.PureComponent<IEditSpaceProps, IEditSpaceSt
                             style={this.themeForms.styles.inputSliderContainer}
                         >
                             <RoundInput
-                                containerStyle={{ marginBottom: 4 }}
-                                placeholder={this.translate('forms.editSpace.labels.radius', { meters: '' })}
+                                placeholder={this.translate('forms.editSpace.labels.radiusPlaceholder', {
+                                    min: MIN_RADIUS_PUBLIC,
+                                    max: MAX_RADIUS_PUBLIC,
+                                })}
                                 value={inputs.radius === '' ? '' : String(inputs.radius)}
                                 onChangeText={(text) => {
                                     const stripped = text.replace(/[^0-9]/g, '');
@@ -1162,9 +1164,9 @@ export class EditSpace extends React.PureComponent<IEditSpaceProps, IEditSpaceSt
                                 keyboardType="number-pad"
                                 themeForms={this.themeForms}
                             />
-                            <Text style={this.themeForms.styles.inputLabelDark}>
+                            {inputs.radius !== '' && <Text style={this.themeForms.styles.inputLabelDark}>
                                 {`${this.translate('forms.editSpace.labels.radius', { meters: inputs.radius })}`}
-                            </Text>
+                            </Text>}
                             <Text style={this.themeForms.styles.inputLabelDark}>
                                 {`${this.translate('forms.editSpace.labels.cost', { pointCost: 0 })}`}
                             </Text>

--- a/TherrMobile/main/routes/EditSpace.tsx
+++ b/TherrMobile/main/routes/EditSpace.tsx
@@ -424,6 +424,8 @@ export class EditSpace extends React.PureComponent<IEditSpaceProps, IEditSpaceSt
             longitude,
         } = route.params;
 
+        const sanitizedRadius = Math.max(MIN_RADIUS_PUBLIC, Math.min(MAX_RADIUS_PUBLIC, parseInt(radius, 10) || MIN_RADIUS_PUBLIC));
+
         let createArgs: any = {
             category,
             featuredIncentiveKey,
@@ -439,7 +441,7 @@ export class EditSpace extends React.PureComponent<IEditSpaceProps, IEditSpaceSt
             latitude: addressLatitude || latitude,
             longitude: addressLongitude || longitude,
             maxViews,
-            radius,
+            radius: sanitizedRadius,
             expiresAt,
         };
 


### PR DESCRIPTION
Replace @react-native-community/slider with RoundInput (number-pad) for
radius selection on EditMoment and EditSpace pages. Add LottieView
placeholder animation (missing-image-storefront) when no image is selected,
matching the existing EditEvent pattern.

https://claude.ai/code/session_0189Jsvcftv2AqkLmX93AedN