### PR TITLE
Add Create Event CTA button to ViewGroup events tab

### DIFF
--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1290,6 +1290,9 @@
         "creator": "Group Creator",
         "admin": "Admin / Moderator",
         "eventHost": "Event Host"
+      },
+      "buttons": {
+        "createEvent": "Create Event"
       }
     },
     "viewSpace": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1290,6 +1290,9 @@
         "creator": "Creador del grupo",
         "admin": "Admin / Moderador",
         "eventHost": "Anfitrión de eventos"
+      },
+      "buttons": {
+        "createEvent": "Crear Evento"
       }
     },
     "viewSpace": {

--- a/TherrMobile/main/routes/Groups/ViewGroup.tsx
+++ b/TherrMobile/main/routes/Groups/ViewGroup.tsx
@@ -418,6 +418,16 @@ class ViewGroup extends React.Component<IViewGroupProps, IViewGroupState> {
         navToViewContent(content, user, navigation.navigate);
     };
 
+    goToCreateEvent = () => {
+        const { navigation, route } = this.props;
+        const { id: forumId } = route.params;
+
+        navigation.navigate('EditEvent', {
+            area: { groupId: forumId },
+            imageDetails: {},
+        });
+    };
+
     goToViewMap = (lat, long) => {
         const { navigation } = this.props;
 
@@ -574,6 +584,18 @@ class ViewGroup extends React.Component<IViewGroupProps, IViewGroupState> {
                                 </Pressable>
                             );
                         }}
+                        ListHeaderComponent={
+                            <View style={[spacingStyles.marginHorizLg, spacingStyles.padVertMd]}>
+                                <PaperButton
+                                    mode="contained"
+                                    icon="calendar-plus"
+                                    onPress={this.goToCreateEvent}
+                                    style={{ borderRadius: 20 }}
+                                >
+                                    {this.translate('pages.viewGroup.buttons.createEvent')}
+                                </PaperButton>
+                            </View>
+                        }
                         ListEmptyComponent={<View style={spacingStyles.marginHorizLg}>
                             <ListEmpty iconName="calendar" theme={this.theme} text={this.getEmptyListMessage(GROUP_CAROUSEL_TABS.EVENTS)} />
                         </View>}


### PR DESCRIPTION
Adds a "Create Event" button at the top of the upcoming events tab in ViewGroup.
The button navigates to EditEvent with the current group pre-selected, streamlining
event creation for group members.

https://claude.ai/code/session_01FVBrJ5TPbH1HtGLvBfghVx