### PR TITLE
Close quick report bottom sheet when tapping on the map

### DIFF
--- a/TherrMobile/main/routes/Map/TherrMapView.tsx
+++ b/TherrMobile/main/routes/Map/TherrMapView.tsx
@@ -87,6 +87,8 @@ export interface ITherrMapViewProps extends IStoreProps {
     filteredMoments: any;
     filteredSpaces: any;
     hideCreateActions: () => any;
+    isQuickReportOpen: boolean;
+    closeQuickReport: () => void;
     isScrollEnabled: boolean;
     onPreviewBottomSheetClose: any;
     onPreviewBottomSheetOpen: any;
@@ -317,6 +319,11 @@ class TherrMapView extends React.PureComponent<ITherrMapViewProps, ITherrMapView
      * On press handler for any map press. Handles pressing an area, and determines when view or bottom-sheet menu to open
      */
     handleMapPress = (event: MapPressEvent | MarkerPressEvent, shouldToggleOnly = false, restoreScrollIndex = 0) => {
+        if (this.props.isQuickReportOpen) {
+            this.props.closeQuickReport();
+            return;
+        }
+
         const { nativeEvent } = event;
         const {
             circleCenter,

--- a/TherrMobile/main/routes/Map/index.tsx
+++ b/TherrMobile/main/routes/Map/index.tsx
@@ -1910,6 +1910,8 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
                                 onPreviewBottomSheetOpen={this.onPreviewBottomSheetOpen}
                                 shouldFollowUserLocation={shouldFollowUserLocation}
                                 shouldRenderMapCircles={shouldRenderMapCircles}
+                                isQuickReportOpen={bottomSheetContentType === 'quick-report'}
+                                closeQuickReport={this.closeBottomSheet}
                                 hideCreateActions={this.hideCreateActions}
                                 isScrollEnabled={isScrollEnabled}
                                 onMapLayout={this.onMapLayout}

--- a/TherrMobile/main/routes/Map/index.tsx
+++ b/TherrMobile/main/routes/Map/index.tsx
@@ -1717,6 +1717,8 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
         this.setState({
             areButtonsVisible: true,
             areLayersVisible: false,
+            bottomSheetContentType: 'nearby',
+            bottomSheetSnapPoints: defaultSnapPoints,
             shouldFollowUserLocation: false,
             isScrollEnabled: true,
         });


### PR DESCRIPTION
Prevents map action buttons from toggling and overlapping the quick
report bottom sheet. When the quick report sheet is open, a map tap
now closes it and returns early instead of processing space/moment
selection.

https://claude.ai/code/session_01ARya4bDsu4GkuPK1Yjs45W