### PR TITLE
Fix Google Places autocomplete locationbias and radius parameters

### DIFF
--- a/TherrMobile/env-config.js
+++ b/TherrMobile/env-config.js
@@ -32,6 +32,9 @@ const featureFlags = {
     // Groups Features
     ENABLE_FORUMS: true,
     ENABLE_ACTIVITY_SCHEDULER: true,
+
+    // Search Providers
+    ENABLE_MAPBOX_SEARCH: false,
 };
 
 // TODO: Find a way to import this from global config

--- a/TherrMobile/main/components/Input/CityAutocompleteInput.tsx
+++ b/TherrMobile/main/components/Input/CityAutocompleteInput.tsx
@@ -53,7 +53,6 @@ const CityAutocompleteInput = ({
             MapsService.getPlacesSearchAutoComplete({
                 latitude: '0',
                 longitude: '0',
-                apiKey: '',
                 input: text,
                 types: '(cities)',
             }).then((response) => {

--- a/TherrMobile/main/components/Input/HeaderSearchInput.tsx
+++ b/TherrMobile/main/components/Input/HeaderSearchInput.tsx
@@ -8,11 +8,13 @@ import 'react-native-gesture-handler';
 import { MapActions } from 'therr-react/redux/actions';
 import { IContentState, IMapState as IMapReduxState } from 'therr-react/types';
 import DeviceInfo from 'react-native-device-info';
+import { FeatureFlags } from 'therr-js-utilities/constants';
 import RoundInput from './';
 import translator from '../../services/translator';
 import { ITherrThemeColors, ITherrThemeColorVariations } from '../../styles/themes';
 import TherrIcon from '../TherrIcon';
 import { DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from '../../constants';
+import getConfig from '../../utilities/getConfig';
 
 
 const { width: screenWidth } = Dimensions.get('window');
@@ -105,12 +107,13 @@ export class HeaderSearchInput extends React.Component<IHeaderSearchInputProps, 
         setSearchDropdownVisibility(!!text?.length);
 
         this.throttleTimeoutId = setTimeout(() => {
+            const config = getConfig();
+            const useMapboxSearch = config.featureFlags?.[FeatureFlags.ENABLE_MAPBOX_SEARCH] === true;
             getPlacesSearchAutoComplete({
                 longitude: map?.longitude || DEFAULT_LONGITUDE.toString(),
                 latitude: map?.latitude || DEFAULT_LATITUDE.toString(),
-                // radius,
                 input: text,
-            });
+            }, useMapboxSearch);
         }, 300);
     };
 

--- a/TherrMobile/main/components/SearchTypeAheadResults.tsx
+++ b/TherrMobile/main/components/SearchTypeAheadResults.tsx
@@ -53,7 +53,7 @@ const SearchTypeAheadResults = ({
             )}
             <FlatList
                 data={searchPredictionResults}
-                keyExtractor={(item) => String(item.place_id)}
+                keyExtractor={(item) => String(item.place_id || item.mapbox_id)}
                 renderItem={({ item }) => renderListItem(item, { handleSelect, styles: themeSearch.styles })}
                 ItemSeparatorComponent={getItemSeparator}
                 keyboardShouldPersistTaps="always"

--- a/TherrMobile/main/routes/EditSpace.tsx
+++ b/TherrMobile/main/routes/EditSpace.tsx
@@ -23,7 +23,9 @@ import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
 import { showToast } from '../utilities/toasts';
 import DropDown from '../components/Input/DropDown';
 // import Alert from '../components/Alert';
+import { FeatureFlags } from 'therr-js-utilities/constants';
 import translator from '../services/translator';
+import getConfig from '../utilities/getConfig';
 import { isDarkTheme } from '../styles/themes';
 import { buildStyles, addMargins } from '../styles';
 import { buildStyles as buildAlertStyles } from '../styles/alerts';
@@ -630,13 +632,14 @@ export class EditSpace extends React.PureComponent<IEditSpaceProps, IEditSpaceSt
         });
 
         this.throttleAddressTimeoutId = setTimeout(() => {
+            const config = getConfig();
+            const useMapboxSearch = config.featureFlags?.[FeatureFlags.ENABLE_MAPBOX_SEARCH] === true;
             getPlacesSearchAutoComplete({
                 longitude: userLon?.toString() || longitude?.toString() || map?.longitude || DEFAULT_LONGITUDE.toString(),
                 latitude: userLat?.toString() || latitude?.toString() || map?.latitude || DEFAULT_LATITUDE.toString(),
-                // radius,
                 input: text,
                 types: 'establishment',
-            }).finally(() => {
+            }, useMapboxSearch).finally(() => {
                 this.setState({ isSearchingAddress: false });
             });
         }, 500);
@@ -660,6 +663,11 @@ export class EditSpace extends React.PureComponent<IEditSpaceProps, IEditSpaceSt
 
         this.setSearchDropdownVisibility(false);
 
+        if (selection?.provider === 'mapbox' && selection?.mapbox_id) {
+            this.handleMapboxSearchSelect(selection);
+            return;
+        }
+
         MapsService.getPlaceDetails({
             apiKey: Platform.OS === 'ios' ? GOOGLE_APIS_IOS_KEY : GOOGLE_APIS_ANDROID_KEY,
             placeId: selection?.place_id,
@@ -670,53 +678,78 @@ export class EditSpace extends React.PureComponent<IEditSpaceProps, IEditSpaceSt
             shouldIncludeRating: true,
         }).then((response) => {
             const result = response.data?.result;
-            const geometry = result?.geometry;
-            const formatted_address = result?.formatted_address;
-            const modifiedInputs = {
-                ...this.state.inputs,
-            };
-            if (formatted_address) {
-                modifiedInputs.address = formatted_address;
-                modifiedInputs.addressReadable = formatted_address;
-            }
-            if (!this.state.isBusinessAccount) {
-                // Always set notificationMsg to place name for non-business
-                if (result?.name) {
-                    modifiedInputs.notificationMsg = result.name;
-                }
-                if (!modifiedInputs.category) {
-                    modifiedInputs.category = 'uncategorized';
-                }
-            } else if (!modifiedInputs.notificationMsg && result?.name) {
-                modifiedInputs.notificationMsg = result.name;
-            }
-            if (geometry?.location) {
-                modifiedInputs.addressLatitude = geometry.location.lat;
-                modifiedInputs.addressLongitude = geometry.location.lng;
-            }
-            if (result?.website) {
-                modifiedInputs.addressWebsite = result?.website;
-            }
-            if (result?.rating) {
-                modifiedInputs.addressRating = {
-                    rating: result?.rating,
-                    total: result?.user_ratings_total || 0,
-                };
-            }
-            if (result?.opening_hours?.weekday_text) {
-                modifiedInputs.addressOpeningHours = result?.opening_hours?.weekday_text;
-            }
-            if (result?.international_phone_number) {
-                modifiedInputs.addressIntlPhone = result?.international_phone_number.replace(/\s/g, '').replace(/-/g, '');
-            }
-            this.setState({
-                addressInputText: this.state.isBusinessAccount
-                    ? (result?.name || formatted_address)
-                    : (formatted_address || result?.name || ''),
-                inputs: modifiedInputs,
-            });
+            this.applyPlaceDetailsToInputs(result);
         }).catch((error) => {
             console.log(error);
+        });
+    };
+
+    handleMapboxSearchSelect = (selection) => {
+        MapsService.getMapboxRetrieve(selection.mapbox_id).then((response) => {
+            const feature = response.data?.features?.[0];
+            if (feature) {
+                const props = feature.properties || {};
+                const [lng, lat] = feature.geometry?.coordinates || [];
+                const result = {
+                    name: props.name || '',
+                    formatted_address: props.full_address || props.place_formatted || '',
+                    geometry: lat && lng ? { location: { lat, lng } } : undefined,
+                    website: props.metadata?.website || undefined,
+                    international_phone_number: props.metadata?.phone || undefined,
+                };
+                this.applyPlaceDetailsToInputs(result);
+            }
+        }).catch((error) => {
+            console.log(error);
+        });
+    };
+
+    applyPlaceDetailsToInputs = (result) => {
+        if (!result) return;
+
+        const geometry = result?.geometry;
+        const formatted_address = result?.formatted_address;
+        const modifiedInputs = {
+            ...this.state.inputs,
+        };
+        if (formatted_address) {
+            modifiedInputs.address = formatted_address;
+            modifiedInputs.addressReadable = formatted_address;
+        }
+        if (!this.state.isBusinessAccount) {
+            if (result?.name) {
+                modifiedInputs.notificationMsg = result.name;
+            }
+            if (!modifiedInputs.category) {
+                modifiedInputs.category = 'uncategorized';
+            }
+        } else if (!modifiedInputs.notificationMsg && result?.name) {
+            modifiedInputs.notificationMsg = result.name;
+        }
+        if (geometry?.location) {
+            modifiedInputs.addressLatitude = geometry.location.lat;
+            modifiedInputs.addressLongitude = geometry.location.lng;
+        }
+        if (result?.website) {
+            modifiedInputs.addressWebsite = result?.website;
+        }
+        if (result?.rating) {
+            modifiedInputs.addressRating = {
+                rating: result?.rating,
+                total: result?.user_ratings_total || 0,
+            };
+        }
+        if (result?.opening_hours?.weekday_text) {
+            modifiedInputs.addressOpeningHours = result?.opening_hours?.weekday_text;
+        }
+        if (result?.international_phone_number) {
+            modifiedInputs.addressIntlPhone = result?.international_phone_number.replace(/\s/g, '').replace(/-/g, '');
+        }
+        this.setState({
+            addressInputText: this.state.isBusinessAccount
+                ? (result?.name || formatted_address)
+                : (formatted_address || result?.name || ''),
+            inputs: modifiedInputs,
         });
     };
 

--- a/TherrMobile/main/routes/Events/EditEvent.tsx
+++ b/TherrMobile/main/routes/Events/EditEvent.tsx
@@ -22,7 +22,9 @@ import LottieView from 'lottie-react-native';
 import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
 import DropDown from '../../components/Input/DropDown';
 // import Alert from '../components/Alert';
+import { FeatureFlags } from 'therr-js-utilities/constants';
 import translator from '../../services/translator';
+import getConfig from '../../utilities/getConfig';
 import { isDarkTheme } from '../../styles/themes';
 import { buildStyles, addMargins } from '../../styles';
 import { buildStyles as buildAlertStyles } from '../../styles/alerts';
@@ -676,13 +678,14 @@ export class EditEvent extends React.Component<IEditEventProps, IEditEventState>
         });
 
         this.throttleAddressTimeoutId = setTimeout(() => {
+            const config = getConfig();
+            const useMapboxSearch = config.featureFlags?.[FeatureFlags.ENABLE_MAPBOX_SEARCH] === true;
             getPlacesSearchAutoComplete({
                 longitude: map?.longitude || DEFAULT_LONGITUDE.toString(),
                 latitude: map?.latitude || DEFAULT_LATITUDE.toString(),
-                // radius,
                 input: text,
                 types: 'establishment',
-            });
+            }, useMapboxSearch);
         }, 500);
 
         if (invoker === 'input' && text === addressInputText) {
@@ -710,6 +713,11 @@ export class EditEvent extends React.Component<IEditEventProps, IEditEventState>
 
         this.setSearchDropdownVisibility(false);
 
+        if (selection?.provider === 'mapbox' && selection?.mapbox_id) {
+            this.handleMapboxSearchSelect(selection);
+            return;
+        }
+
         MapsService.getPlaceDetails({
             apiKey: Platform.OS === 'ios' ? GOOGLE_APIS_IOS_KEY : GOOGLE_APIS_ANDROID_KEY,
             placeId: selection?.place_id,
@@ -720,43 +728,69 @@ export class EditEvent extends React.Component<IEditEventProps, IEditEventState>
             shouldIncludeRating: true,
         }).then((response) => {
             const result = response.data?.result;
-            const geometry = result?.geometry;
-            const formatted_address = result?.formatted_address;
-            const modifiedInputs = {
-                ...this.state.inputs,
-            };
-            if (formatted_address) {
-                modifiedInputs.addressInputText = formatted_address;
-                modifiedInputs.addressReadable = formatted_address;
-            }
-            if (result?.name) {
-                modifiedInputs.addressNotificationMsg = result.name;
-            }
-            if (geometry?.location) {
-                modifiedInputs.addressLatitude = geometry.location.lat;
-                modifiedInputs.addressLongitude = geometry.location.lng;
-            }
-            if (result?.website) {
-                modifiedInputs.addressWebsite = result?.website;
-            }
-            if (result?.rating) {
-                modifiedInputs.addressRating = {
-                    rating: result?.rating,
-                    total: result?.user_ratings_total || 0,
-                };
-            }
-            if (result?.opening_hours?.weekday_text) {
-                modifiedInputs.addressOpeningHours = result?.opening_hours?.weekday_text;
-            }
-            if (result?.international_phone_number) {
-                modifiedInputs.addressIntlPhone = result?.international_phone_number.replace(/\s/g, '').replace(/-/g, '');
-            }
-            this.setState({
-                addressInputText: result?.name || formatted_address,
-                inputs: modifiedInputs,
-            });
+            this.applyPlaceDetailsToInputs(result);
         }).catch((error) => {
             console.log(error);
+        });
+    };
+
+    handleMapboxSearchSelect = (selection) => {
+        MapsService.getMapboxRetrieve(selection.mapbox_id).then((response) => {
+            const feature = response.data?.features?.[0];
+            if (feature) {
+                const props = feature.properties || {};
+                const [lng, lat] = feature.geometry?.coordinates || [];
+                const result = {
+                    name: props.name || '',
+                    formatted_address: props.full_address || props.place_formatted || '',
+                    geometry: lat && lng ? { location: { lat, lng } } : undefined,
+                    website: props.metadata?.website || undefined,
+                    international_phone_number: props.metadata?.phone || undefined,
+                };
+                this.applyPlaceDetailsToInputs(result);
+            }
+        }).catch((error) => {
+            console.log(error);
+        });
+    };
+
+    applyPlaceDetailsToInputs = (result) => {
+        if (!result) return;
+
+        const geometry = result?.geometry;
+        const formatted_address = result?.formatted_address;
+        const modifiedInputs = {
+            ...this.state.inputs,
+        };
+        if (formatted_address) {
+            modifiedInputs.addressInputText = formatted_address;
+            modifiedInputs.addressReadable = formatted_address;
+        }
+        if (result?.name) {
+            modifiedInputs.addressNotificationMsg = result.name;
+        }
+        if (geometry?.location) {
+            modifiedInputs.addressLatitude = geometry.location.lat;
+            modifiedInputs.addressLongitude = geometry.location.lng;
+        }
+        if (result?.website) {
+            modifiedInputs.addressWebsite = result?.website;
+        }
+        if (result?.rating) {
+            modifiedInputs.addressRating = {
+                rating: result?.rating,
+                total: result?.user_ratings_total || 0,
+            };
+        }
+        if (result?.opening_hours?.weekday_text) {
+            modifiedInputs.addressOpeningHours = result?.opening_hours?.weekday_text;
+        }
+        if (result?.international_phone_number) {
+            modifiedInputs.addressIntlPhone = result?.international_phone_number.replace(/\s/g, '').replace(/-/g, '');
+        }
+        this.setState({
+            addressInputText: result?.name || formatted_address,
+            inputs: modifiedInputs,
         });
     };
 

--- a/TherrMobile/main/routes/Map/index.tsx
+++ b/TherrMobile/main/routes/Map/index.tsx
@@ -1386,7 +1386,7 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
         this.animateToWithHelp(() => this.mapRef && this.mapRef.animateToRegion(loc, ANIMATE_TO_REGION_DURATION_SLOW));
         this.handleSearchThisLocation(searchRadiusMeters, lat, lng)
             .finally(() => {
-                if (shouldTogglePreview) {
+                if (shouldTogglePreview && this.mapRef) {
                     this.mapRef.props.onPress({
                         nativeEvent: {
                             coordinate: { latitude: lat, longitude: lng },

--- a/TherrMobile/main/routes/Map/index.tsx
+++ b/TherrMobile/main/routes/Map/index.tsx
@@ -1324,44 +1324,76 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
 
         setSearchDropdownVisibility(false);
 
+        if (selection?.provider === 'mapbox' && selection?.mapbox_id) {
+            this.handleMapboxSearchSelect(selection, shouldTogglePreview);
+            return;
+        }
+
         MapsService.getPlaceDetails({
             apiKey: Platform.OS === 'ios' ? GOOGLE_APIS_IOS_KEY : GOOGLE_APIS_ANDROID_KEY,
             placeId: selection?.place_id,
         }).then((response) => {
             const geometry = response.data?.result?.geometry;
             if (geometry) {
-                const latDelta = geometry.viewport.northeast.lat - geometry.viewport.southwest.lat;
-                const lngDelta = geometry.viewport.northeast.lng - geometry.viewport.southwest.lng;
-                const loc = {
-                    latitude: geometry.location.lat,
-                    longitude: geometry.location.lng,
-                    latitudeDelta: Math.max(latDelta, PRIMARY_LATITUDE_DELTA),
-                    longitudeDelta: Math.max(lngDelta, PRIMARY_LONGITUDE_DELTA),
-                };
-                const searchRadiusMeters = this.getSearchRadius(loc, {
-                    longitude: geometry.viewport.northeast.lng,
-                    latitude: geometry.viewport.northeast.lat,
-                });
-                this.animateToWithHelp(() => this.mapRef && this.mapRef.animateToRegion(loc, ANIMATE_TO_REGION_DURATION_SLOW));
-                this.handleSearchThisLocation(searchRadiusMeters, geometry.location.lat, geometry.location.lng)
-                    .finally(() => {
-                        // TODO: Determine if this needs to be canceled when navigating to a new view
-                        // We must wait for search to complete so new spaces are available for rendering the preview overlay
-                        if (shouldTogglePreview) {
-                            this.mapRef.props.onPress({
-                                nativeEvent: {
-                                    coordinate: {
-                                        latitude: geometry.location.lat,
-                                        longitude: geometry.location.lng,
-                                    },
-                                },
-                            }, true);
-                        }
-                    });
+                this.animateToSearchResult(
+                    geometry.location.lat,
+                    geometry.location.lng,
+                    geometry.viewport,
+                    shouldTogglePreview
+                );
             }
         }).catch((error) => {
             console.log(error);
         });
+    };
+
+    handleMapboxSearchSelect = (selection, shouldTogglePreview = false) => {
+        MapsService.getMapboxRetrieve(selection.mapbox_id).then((response) => {
+            const feature = response.data?.features?.[0];
+            if (feature?.geometry?.coordinates) {
+                const [lng, lat] = feature.geometry.coordinates;
+                const bbox = feature.properties?.bbox;
+                const viewport = bbox ? {
+                    northeast: { lat: bbox[3], lng: bbox[2] },
+                    southwest: { lat: bbox[1], lng: bbox[0] },
+                } : undefined;
+                this.animateToSearchResult(lat, lng, viewport, shouldTogglePreview);
+            }
+        }).catch((error) => {
+            console.log(error);
+        });
+    };
+
+    animateToSearchResult = (lat: number, lng: number, viewport: any, shouldTogglePreview = false) => {
+        let latDelta = PRIMARY_LATITUDE_DELTA;
+        let lngDelta = PRIMARY_LONGITUDE_DELTA;
+
+        if (viewport) {
+            latDelta = viewport.northeast.lat - viewport.southwest.lat;
+            lngDelta = viewport.northeast.lng - viewport.southwest.lng;
+        }
+
+        const loc = {
+            latitude: lat,
+            longitude: lng,
+            latitudeDelta: Math.max(latDelta, PRIMARY_LATITUDE_DELTA),
+            longitudeDelta: Math.max(lngDelta, PRIMARY_LONGITUDE_DELTA),
+        };
+        const searchRadiusMeters = viewport
+            ? this.getSearchRadius(loc, { longitude: viewport.northeast.lng, latitude: viewport.northeast.lat })
+            : this.getSearchRadius(loc, { longitude: lng + lngDelta / 2, latitude: lat + latDelta / 2 });
+
+        this.animateToWithHelp(() => this.mapRef && this.mapRef.animateToRegion(loc, ANIMATE_TO_REGION_DURATION_SLOW));
+        this.handleSearchThisLocation(searchRadiusMeters, lat, lng)
+            .finally(() => {
+                if (shouldTogglePreview) {
+                    this.mapRef.props.onPress({
+                        nativeEvent: {
+                            coordinate: { latitude: lat, longitude: lng },
+                        },
+                    }, true);
+                }
+            });
     };
 
     handleQuickFilterSelect = (index: string) => {

--- a/therr-api-gateway/src/services/maps/router.ts
+++ b/therr-api-gateway/src/services/maps/router.ts
@@ -412,6 +412,110 @@ mapsServiceRouter.get('/geocode', geocodeApiLimiter, async (req, res) => {
     }
 });
 
+// External APIs - Mapbox Search proxy with rate limiting and caching
+const MAPBOX_CACHE_PREFIX = 'MAPBOX_CACHE:';
+const MAPBOX_ACCESS_TOKEN = process.env.MAPBOX_ACCESS_TOKEN || '';
+
+mapsServiceRouter.get('/mapbox/search', placesApiLimiter, async (req, res) => {
+    const { q, latitude, longitude, limit: resultLimit, language } = req.query;
+
+    if (!q || typeof q !== 'string' || !q.trim()) {
+        return res.status(400).json({ message: 'Query parameter "q" is required' });
+    }
+
+    if (!MAPBOX_ACCESS_TOKEN) {
+        return res.status(503).json({ message: 'Mapbox search is not configured' });
+    }
+
+    const cacheKey = crypto.createHash('sha256').update(
+        `mapbox:${q.trim().toLowerCase()}:${latitude}:${longitude}:${language || 'en'}`
+    ).digest('hex');
+    const cached = await CacheStore.mapsService.getPlacesResponse(cacheKey);
+
+    if (cached) {
+        return res.status(200).json(cached);
+    }
+
+    try {
+        const params: Record<string, string> = {
+            q: q.trim(),
+            access_token: MAPBOX_ACCESS_TOKEN,
+            limit: String(resultLimit || 5),
+            language: String(language || 'en'),
+        };
+
+        if (latitude && longitude) {
+            params.proximity = `${longitude},${latitude}`;
+        }
+
+        const response = await axios.get('https://api.mapbox.com/search/searchbox/v1/suggest', {
+            params,
+            timeout: 5000,
+        });
+
+        const data = response.data;
+        CacheStore.mapsService.setPlacesResponse(cacheKey, data);
+
+        return res.status(200).json(data);
+    } catch (err) {
+        logSpan({
+            level: 'error',
+            messageOrigin: 'API_GATEWAY_MAPS_ROUTER',
+            messages: ['Mapbox search proxy error'],
+            traceArgs: { 'error.message': err instanceof Error ? err.message : String(err) },
+        });
+        return res.status(502).json({ message: 'Mapbox search service unavailable' });
+    }
+});
+
+mapsServiceRouter.get('/mapbox/retrieve/:mapboxId', placesApiLimiter, async (req, res) => {
+    const { mapboxId } = req.params;
+    const { sessionToken } = req.query;
+
+    if (!mapboxId) {
+        return res.status(400).json({ message: 'mapboxId is required' });
+    }
+
+    if (!MAPBOX_ACCESS_TOKEN) {
+        return res.status(503).json({ message: 'Mapbox search is not configured' });
+    }
+
+    const cacheKey = crypto.createHash('sha256').update(`mapbox-retrieve:${mapboxId}`).digest('hex');
+    const cached = await CacheStore.mapsService.getPlacesResponse(cacheKey);
+
+    if (cached) {
+        return res.status(200).json(cached);
+    }
+
+    try {
+        const params: Record<string, string> = {
+            access_token: MAPBOX_ACCESS_TOKEN,
+        };
+
+        if (sessionToken && typeof sessionToken === 'string') {
+            params.session_token = sessionToken;
+        }
+
+        const response = await axios.get(
+            `https://api.mapbox.com/search/searchbox/v1/retrieve/${encodeURIComponent(mapboxId)}`,
+            { params, timeout: 5000 }
+        );
+
+        const data = response.data;
+        CacheStore.mapsService.setPlacesResponse(cacheKey, data);
+
+        return res.status(200).json(data);
+    } catch (err) {
+        logSpan({
+            level: 'error',
+            messageOrigin: 'API_GATEWAY_MAPS_ROUTER',
+            messages: ['Mapbox retrieve proxy error'],
+            traceArgs: { 'error.message': err instanceof Error ? err.message : String(err) },
+        });
+        return res.status(502).json({ message: 'Mapbox retrieve service unavailable' });
+    }
+});
+
 // External APIs - Google Places proxy with rate limiting and caching
 mapsServiceRouter.get('/place/*', placesApiLimiter, async (req, res, next) => {
     // Cache GET requests (autocomplete, details) using query string as key

--- a/therr-api-gateway/src/services/maps/router.ts
+++ b/therr-api-gateway/src/services/maps/router.ts
@@ -417,7 +417,7 @@ const MAPBOX_CACHE_PREFIX = 'MAPBOX_CACHE:';
 const MAPBOX_ACCESS_TOKEN = process.env.MAPBOX_ACCESS_TOKEN || '';
 
 mapsServiceRouter.get('/mapbox/search', placesApiLimiter, async (req, res) => {
-    const { q, latitude, longitude, limit: resultLimit, language } = req.query;
+    const { q, latitude, longitude, limit: resultLimit, language, sessionToken } = req.query;
 
     if (!q || typeof q !== 'string' || !q.trim()) {
         return res.status(400).json({ message: 'Query parameter "q" is required' });
@@ -446,6 +446,10 @@ mapsServiceRouter.get('/mapbox/search', placesApiLimiter, async (req, res) => {
 
         if (latitude && longitude) {
             params.proximity = `${longitude},${latitude}`;
+        }
+
+        if (sessionToken && typeof sessionToken === 'string') {
+            params.session_token = sessionToken;
         }
 
         const response = await axios.get('https://api.mapbox.com/search/searchbox/v1/suggest', {

--- a/therr-api-gateway/src/services/maps/router.ts
+++ b/therr-api-gateway/src/services/maps/router.ts
@@ -413,7 +413,6 @@ mapsServiceRouter.get('/geocode', geocodeApiLimiter, async (req, res) => {
 });
 
 // External APIs - Mapbox Search proxy with rate limiting and caching
-const MAPBOX_CACHE_PREFIX = 'MAPBOX_CACHE:';
 const MAPBOX_ACCESS_TOKEN = process.env.MAPBOX_ACCESS_TOKEN || '';
 
 mapsServiceRouter.get('/mapbox/search', placesApiLimiter, async (req, res) => {

--- a/therr-public-library/therr-js-utilities/src/constants/enums/FeatureFlags.ts
+++ b/therr-public-library/therr-js-utilities/src/constants/enums/FeatureFlags.ts
@@ -20,6 +20,9 @@ enum FeatureFlags {
     // Groups Features
     ENABLE_FORUMS = 'ENABLE_FORUMS',
     ENABLE_ACTIVITY_SCHEDULER = 'ENABLE_ACTIVITY_SCHEDULER',
+
+    // Search Providers
+    ENABLE_MAPBOX_SEARCH = 'ENABLE_MAPBOX_SEARCH',
 }
 
 export {

--- a/therr-public-library/therr-react/src/redux/actions/Maps.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Maps.ts
@@ -424,12 +424,18 @@ const Maps = {
             return MapsService.getMapboxSearchAutoComplete(mapboxArgs)
                 .then((response) => {
                     const suggestions = response.data?.suggestions || [];
-                    const predictions: ISearchPrediction[] = suggestions.map((s: any) => ({
-                        place_id: s.mapbox_id,
-                        description: s.full_address || s.name || s.place_formatted || '',
-                        provider: 'mapbox',
-                        mapbox_id: s.mapbox_id,
-                    }));
+                    const predictions: ISearchPrediction[] = suggestions.map((s: any) => {
+                        let description = s.full_address || '';
+                        if (!description && s.name) {
+                            description = s.place_formatted ? `${s.name}, ${s.place_formatted}` : s.name;
+                        }
+                        return {
+                            place_id: s.mapbox_id,
+                            description,
+                            provider: 'mapbox' as const,
+                            mapbox_id: s.mapbox_id,
+                        };
+                    });
                     dispatch({
                         type: MapActionTypes.AUTOCOMPLETE_UPDATE,
                         data: { predictions },

--- a/therr-public-library/therr-react/src/redux/actions/Maps.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Maps.ts
@@ -5,8 +5,10 @@ import MapsService, {
     ICreateSpaceCheckInMetricsArgs,
     IGetSpaceEngagementArgs,
     IGetSpaceMetricsArgs,
+    IMapboxSearchArgs,
     IPlacesAutoCompleteArgs,
     ISearchAreasArgs,
+    ISearchPrediction,
 } from '../../services/MapsService';
 import { ContentActionTypes } from '../../types';
 
@@ -406,27 +408,73 @@ const Maps = {
             return response.data;
         }),
 
-    // Google API
-    getPlacesSearchAutoComplete: (args: IPlacesAutoCompleteArgs) => (dispatch: any) => {
+    // Search Autocomplete (supports Google Places and Mapbox providers)
+    getPlacesSearchAutoComplete: (args: IPlacesAutoCompleteArgs, useMapboxSearch = false) => (dispatch: any) => {
         dispatch({
             type: MapActionTypes.AUTOCOMPLETE_SEARCHING,
         });
+
+        if (useMapboxSearch) {
+            const mapboxArgs: IMapboxSearchArgs = {
+                longitude: args.longitude,
+                latitude: args.latitude,
+                input: args.input,
+            };
+
+            return MapsService.getMapboxSearchAutoComplete(mapboxArgs)
+                .then((response) => {
+                    const suggestions = response.data?.suggestions || [];
+                    const predictions: ISearchPrediction[] = suggestions.map((s: any) => ({
+                        place_id: s.mapbox_id,
+                        description: s.full_address || s.name || s.place_formatted || '',
+                        provider: 'mapbox',
+                        mapbox_id: s.mapbox_id,
+                    }));
+                    dispatch({
+                        type: MapActionTypes.AUTOCOMPLETE_UPDATE,
+                        data: { predictions },
+                    });
+                })
+                .catch((error) => {
+                    console.log('Mapbox search failed, falling back to Google Places', error);
+                    // Fallback to Google Places on Mapbox failure
+                    return MapsService.getPlacesSearchAutoComplete(args)
+                        .then((response) => {
+                            const googlePredictions = (response.data?.predictions || []).map((p: any) => ({
+                                ...p,
+                                provider: 'google',
+                            }));
+                            dispatch({
+                                type: MapActionTypes.AUTOCOMPLETE_UPDATE,
+                                data: { predictions: googlePredictions },
+                            });
+                        })
+                        .catch((fallbackError) => {
+                            console.log(fallbackError);
+                            dispatch({
+                                type: MapActionTypes.AUTOCOMPLETE_UPDATE,
+                                data: { predictions: [] },
+                            });
+                        });
+                });
+        }
+
         return MapsService.getPlacesSearchAutoComplete(args)
             .then((response) => {
+                const predictions = (response.data?.predictions || []).map((p: any) => ({
+                    ...p,
+                    provider: 'google',
+                }));
                 dispatch({
                     type: MapActionTypes.AUTOCOMPLETE_UPDATE,
-                    data: {
-                        predictions: response.data?.predictions || [],
-                    },
+                    data: { predictions },
                 });
             })
             .catch((error) => {
                 console.log(error);
                 dispatch({
                     type: MapActionTypes.AUTOCOMPLETE_UPDATE,
-                    data: {
-                        predictions: [],
-                    },
+                    data: { predictions: [] },
                 });
             });
     },

--- a/therr-public-library/therr-react/src/services/MapsService.ts
+++ b/therr-public-library/therr-react/src/services/MapsService.ts
@@ -382,12 +382,9 @@ class MapsService {
         sessiontoken,
     }: IPlacesAutoCompleteArgs) => {
         let url = '/maps-service/place/autocomplete/json?';
+        const searchRadius = radius || 50000;
 
-        url = `${url}input=${input}&location=${latitude},${longitude}&locationbias=circle:radius@lat,lng`;
-
-        if (radius) {
-            url = `${url}&radius=${radius}`;
-        }
+        url = `${url}input=${encodeURIComponent(input)}&location=${latitude},${longitude}&radius=${searchRadius}&locationbias=circle:${searchRadius}@${latitude},${longitude}`;
 
         if (types) {
             url = `${url}&types=${types}`;

--- a/therr-public-library/therr-react/src/services/MapsService.ts
+++ b/therr-public-library/therr-react/src/services/MapsService.ts
@@ -6,6 +6,7 @@ import { IAreaType } from 'therr-js-utilities/types';
 import { ISearchQuery } from '../types';
 
 let googleDynamicSessionToken = uuid.v4(); // This gets stored in the local state of this file/module
+let mapboxSessionToken = uuid.v4(); // Session token for Mapbox Search Box API (groups suggest + retrieve into one billing session)
 
 export interface ISearchAreasArgs {
     distanceOverride?: number;
@@ -113,7 +114,6 @@ export interface IMapboxSearchArgs {
     input: string;
     limit?: number;
     language?: string;
-    sessionToken?: string;
 }
 
 // Normalized prediction format used by both Google and Mapbox providers
@@ -486,13 +486,13 @@ class MapsService {
     };
 
     // Mapbox Search (via server-side proxy)
+    // Session token groups suggest + retrieve calls into one billing session
     getMapboxSearchAutoComplete = ({
         longitude,
         latitude,
         input,
         limit,
         language,
-        sessionToken,
     }: IMapboxSearchArgs) => axios({
         method: 'get',
         url: '/maps-service/mapbox/search',
@@ -502,16 +502,18 @@ class MapsService {
             longitude,
             limit: limit || 5,
             language: language || 'en',
-            sessionToken,
+            sessionToken: mapboxSessionToken,
         },
         headers: {},
     });
 
-    getMapboxRetrieve = (mapboxId: string, sessionToken?: string) => axios({
+    getMapboxRetrieve = (mapboxId: string) => axios({
         method: 'get',
         url: `/maps-service/mapbox/retrieve/${encodeURIComponent(mapboxId)}`,
-        params: sessionToken ? { sessionToken } : {},
+        params: { sessionToken: mapboxSessionToken },
         headers: {},
+    }).finally(() => {
+        mapboxSessionToken = uuid.v4(); // Reset after retrieve to start a new billing session
     });
 
     // Geocoding (Nominatim via server-side proxy)

--- a/therr-public-library/therr-react/src/services/MapsService.ts
+++ b/therr-public-library/therr-react/src/services/MapsService.ts
@@ -103,7 +103,7 @@ export interface IPlacesAutoCompleteArgs {
     latitude: string;
     radius?: number | string;
     types?: string;
-    apiKey: string;
+    apiKey?: string;
     input: string;
     sessiontoken?: string;
 }

--- a/therr-public-library/therr-react/src/services/MapsService.ts
+++ b/therr-public-library/therr-react/src/services/MapsService.ts
@@ -107,6 +107,23 @@ export interface IPlacesAutoCompleteArgs {
     sessiontoken?: string;
 }
 
+export interface IMapboxSearchArgs {
+    longitude: string;
+    latitude: string;
+    input: string;
+    limit?: number;
+    language?: string;
+    sessionToken?: string;
+}
+
+// Normalized prediction format used by both Google and Mapbox providers
+export interface ISearchPrediction {
+    place_id: string;
+    description: string;
+    provider: 'google' | 'mapbox';
+    mapbox_id?: string;
+}
+
 export interface IPlaceDetailsArgs {
     placeId: string;
     sessiontoken?: string;
@@ -467,6 +484,35 @@ class MapsService {
             googleDynamicSessionToken = uuid.v4(); // This must be updated after each call to get place details
         });
     };
+
+    // Mapbox Search (via server-side proxy)
+    getMapboxSearchAutoComplete = ({
+        longitude,
+        latitude,
+        input,
+        limit,
+        language,
+        sessionToken,
+    }: IMapboxSearchArgs) => axios({
+        method: 'get',
+        url: '/maps-service/mapbox/search',
+        params: {
+            q: input,
+            latitude,
+            longitude,
+            limit: limit || 5,
+            language: language || 'en',
+            sessionToken,
+        },
+        headers: {},
+    });
+
+    getMapboxRetrieve = (mapboxId: string, sessionToken?: string) => axios({
+        method: 'get',
+        url: `/maps-service/mapbox/retrieve/${encodeURIComponent(mapboxId)}`,
+        params: sessionToken ? { sessionToken } : {},
+        headers: {},
+    });
 
     // Geocoding (Nominatim via server-side proxy)
     geocodeLocation = (query: string) => axios({


### PR DESCRIPTION
The locationbias parameter was a literal string "circle:radius@lat,lng" instead
of interpolating actual values. This fix:
- Interpolates latitude, longitude, and radius into the locationbias parameter
- Defaults radius to 50km when not provided by caller
- Encodes the search input to handle special characters in queries like
  "pizza by the slice"

https://claude.ai/code/session_018cJpS3kXQ6Mwww5hxbBVTH