### PR TITLE
Fix TypeScript strict-mode error in spaces handler catch block

### DIFF
--- a/therr-services/maps-service/src/handlers/spaces.ts
+++ b/therr-services/maps-service/src/handlers/spaces.ts
@@ -1043,7 +1043,7 @@ const updateSpace = async (req, res) => {
                 effectiveFromUserId = existingSpace.fromUserId;
             }
         } catch (err) {
-            return handleHttpError({ err, res, message: 'SQL:SPACES_ROUTES:ERROR' });
+            return handleHttpError({ err: err instanceof Error ? err : undefined, res, message: 'SQL:SPACES_ROUTES:ERROR' });
         }
     }
 


### PR DESCRIPTION
Narrow caught `err` (typed as `unknown`) using `instanceof Error` before
passing it to `handleHttpError`, which expects `Error | undefined`.

https://claude.ai/code/session_01LsM1dZPaWJsR9xkATr1LaJ