### PR TITLE
Improve PageSpeed performance for therr-client-web

### DIFF
--- a/therr-client-web/src/components/SpacesMap.tsx
+++ b/therr-client-web/src/components/SpacesMap.tsx
@@ -35,18 +35,14 @@ const escapeHtml = (str: string): string => {
 
 const ICON_CDN = 'https://unpkg.com/leaflet@1.9.4/dist/images';
 
-// Tile provider configuration
-// To use MapTiler (recommended for better cache headers and performance):
-//   1. Sign up at maptiler.com (free tier: 100K tiles/month)
-//   2. Set tileLayerUrl in global-config.js to:
-//      'https://api.maptiler.com/maps/streets-v2/{z}/{x}/{y}.png?key=YOUR_KEY'
-// Falls back to direct OSM tiles when not configured
+// Tile provider: Carto Voyager (CDN-backed, free, no API key, proper cache headers)
+// Override via tileLayerUrl in global-config.js if needed
 import * as globalConfig from '../../../global-config';
 
 const envConfig = globalConfig[process.env.NODE_ENV || 'production'] || globalConfig.production;
-const TILE_LAYER_URL = envConfig.tileLayerUrl || 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-const TILE_ATTRIBUTION = TILE_LAYER_URL.includes('maptiler')
-    ? '&copy; <a href="https://www.maptiler.com/copyright/">MapTiler</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+const TILE_LAYER_URL = envConfig.tileLayerUrl || 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png';
+const TILE_ATTRIBUTION = TILE_LAYER_URL.includes('cartocdn')
+    ? '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
     : '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
 const SpacesMap: React.FC<ISpacesMapProps> = ({

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -79,8 +79,8 @@ if (process.env.NODE_ENV !== 'development') {
                     'https://*.googletagmanager.com',
                     // Google Sign-In
                     'https://accounts.google.com',
-                    // Map tile providers
-                    'https://api.maptiler.com',
+                    // Map tile providers (Carto CDN)
+                    'https://*.basemaps.cartocdn.com',
                 ],
                 frameSrc: [
                     "'self'",
@@ -117,7 +117,7 @@ if (process.env.NODE_ENV !== 'development') {
                     'https://*.googletagmanager.com',
                     // Leaflet map tiles and marker icons
                     'https://*.tile.openstreetmap.org',
-                    'https://api.maptiler.com',
+                    'https://*.basemaps.cartocdn.com',
                     'https://unpkg.com',
                 ],
                 workerSrc: ["'self'", 'blob:'],

--- a/therr-client-web/src/views/locations.hbs
+++ b/therr-client-web/src/views/locations.hbs
@@ -17,9 +17,9 @@
     <link rel="dns-prefetch" href="https://fonts.gstatic.com">
     <link rel="dns-prefetch" href="https://ik.imagekit.io">
     <link rel="dns-prefetch" href="https://unpkg.com">
-    <link rel="dns-prefetch" href="https://a.tile.openstreetmap.org">
-    <link rel="dns-prefetch" href="https://b.tile.openstreetmap.org">
-    <link rel="dns-prefetch" href="https://c.tile.openstreetmap.org">
+    <link rel="dns-prefetch" href="https://a.basemaps.cartocdn.com">
+    <link rel="dns-prefetch" href="https://b.basemaps.cartocdn.com">
+    <link rel="dns-prefetch" href="https://c.basemaps.cartocdn.com">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://ik.imagekit.io" crossorigin>


### PR DESCRIPTION
## Summary

Improves Google PageSpeed Insights scores for the web client (www.therr.com) targeting the three key mobile metrics: LCP (3.0s), Total Main Thread Work (2.2s), and JS Execution Time (1.7s).

- **Route-level code splitting**: Lazy-load 18 auth-only route components via `React.lazy` with SSR-safe `typeof window` guard, reducing initial `app.js` bundle by ~30-50%
- **Remove render-blocking font loading**: Replace CSS `@import url(...)` in SCSS themes + `<link rel="preload">` in HBS templates with non-blocking `media="print" onload` pattern; drop unused font-weight 200
- **Switch map tiles to Carto Voyager CDN**: Replaces direct OSM tiles (short cache headers) with CDN-backed Carto tiles (`max-age=86400`), no API key required. Resolves PageSpeed "inefficient cache policy" diagnostic
- **Defer map initialization**: IntersectionObserver delays Leaflet + tile loading until the map scrolls into view, preventing tile fetches from impacting initial page load metrics
- **JS content hashing**: Output `[name].[contenthash].js` for proper long-term cache busting; extended `update-views.js` to replace JS filenames in HBS templates
- **Hidden source maps**: Switch from `source-map` to `hidden-source-map` in production
- **Remove server-side analytics**: Remove ReactGA and LogRocket from SSR bundle (analytics should only run client-side), improving TTFB
- **Add ImageKit preconnect**: `<link rel="preconnect">` for `ik.imagekit.io` across all templates for faster LCP image loads
- **Limit theme builds**: Only build active themes (light, dark), with build warning for skipped themes
- **CSP updates**: Add `*.basemaps.cartocdn.com` to `connectSrc` and `imgSrc`; tile provider remains overridable via `tileLayerUrl` in `global-config.js`

## Test plan

- [ ] Run `npm run build` in `therr-client-web` — verify build succeeds with content-hashed JS filenames
- [ ] Verify `update-views.js` correctly replaces JS filenames in all 9 HBS templates post-build
- [ ] Visit `/spaces/:spaceId` — verify map loads with Carto tiles when scrolled into view
- [ ] Visit `/locations` — verify map loads, tiles use Carto CDN, markers render correctly
- [ ] Visit `/` (home) — verify page loads without errors, fonts render correctly (no FOUT)
- [ ] Navigate to auth-protected routes (e.g., `/user/profile`) — verify lazy chunks load on demand
- [ ] Check browser DevTools Network tab: confirm no CSP violations
- [ ] Run PageSpeed Insights on deployed stage URL to measure improvement

https://claude.ai/code/session_01YE6zEYhLy2Qi3n5QpUE8rN