### PR TITLE
fix: non-render-blocking CSS + tree-shaking for PageSpeed

### DIFF
--- a/therr-client-web/src/views/events.hbs
+++ b/therr-client-web/src/views/events.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="{{#if organizerName}}{{organizerName}}{{else}}Therr{{/if}}">
@@ -86,8 +86,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/groups.hbs
+++ b/therr-client-web/src/views/groups.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -69,8 +69,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/index.hbs
+++ b/therr-client-web/src/views/index.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -68,8 +68,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/invite.hbs
+++ b/therr-client-web/src/views/invite.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -68,8 +68,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/locations.hbs
+++ b/therr-client-web/src/views/locations.hbs
@@ -26,8 +26,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -79,8 +79,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/moments.hbs
+++ b/therr-client-web/src/views/moments.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="{{#if authorName}}{{authorName}}{{else}}Therr{{/if}}">
@@ -78,8 +78,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/spaces.hbs
+++ b/therr-client-web/src/views/spaces.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -80,8 +80,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/thoughts.hbs
+++ b/therr-client-web/src/views/thoughts.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="{{#if authorName}}{{authorName}}{{else}}Therr{{/if}}">
@@ -77,8 +77,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/users.hbs
+++ b/therr-client-web/src/views/users.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -72,8 +72,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">


### PR DESCRIPTION
## Summary
- Make CSS non-render-blocking using `<link rel="preload" onload>` pattern (filamentgroup/loadCSS) with inline critical CSS to prevent FOUC
- Enable webpack tree-shaking: tsconfig `module: "esnext"`, babel `modules: false`, `usedExports: true`, `sideEffects` field
- Add moment.js IgnorePlugin as safety net against transitive bundle inclusion

## What changed

**9 HBS templates** (`src/views/*.hbs`):
- Preload links now auto-convert to stylesheets via `onload="this.onload=null;this.rel='stylesheet'"`
- Inline `<style>` block (~800B) provides immediate styling for SSR HTML: header, layout, typography, dark mode — no FOUC
- `<noscript>` fallback for no-JS browsers
- Dark mode colors match actual theme values from `css-variables.scss`

**Build config** (4 files):
- `webpack.app.config.js`: `usedExports: true` + moment locale IgnorePlugin
- `tsconfig.json`: `module: "esnext"` (enables tree-shaking for ts-loader output)
- `.babelrc`: `modules: false` in preset-env (preserves ES imports for webpack)
- `package.json`: `sideEffects: ["*.css", "*.scss"]`

## Why preload+onload (not media=print)

Initial approach used `media="print" onload="this.media='all'"` but this failed on both Chrome and Safari mobile — stylesheets never activated. Switched to the more reliable pattern where the `<link rel="preload">` converts itself to a stylesheet on load completion.

## Test plan
- [ ] Verify pages render correctly on mobile Chrome and Safari (no broken styles)
- [ ] Verify dark mode renders correctly with inline critical CSS
- [ ] Verify no white flash or FOUC on initial page load
- [ ] Check PageSpeed Insights score improvement on `/spaces/:id` and `/locations`
- [ ] Verify `update-views.js` correctly replaces CSS hashes in all link tags + noscript fallbacks

https://claude.ai/code/session_01GpwasWT9so31pgFZNXrhTC