### PR TITLE
fix: switch CSS loading to preload+onload pattern

### DIFF
--- a/therr-client-web/src/views/events.hbs
+++ b/therr-client-web/src/views/events.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="{{#if organizerName}}{{organizerName}}{{else}}Therr{{/if}}">
@@ -86,8 +86,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/groups.hbs
+++ b/therr-client-web/src/views/groups.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -69,8 +69,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/index.hbs
+++ b/therr-client-web/src/views/index.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -68,8 +68,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/invite.hbs
+++ b/therr-client-web/src/views/invite.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -68,8 +68,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/locations.hbs
+++ b/therr-client-web/src/views/locations.hbs
@@ -26,8 +26,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -79,8 +79,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/moments.hbs
+++ b/therr-client-web/src/views/moments.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="{{#if authorName}}{{authorName}}{{else}}Therr{{/if}}">
@@ -78,8 +78,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/spaces.hbs
+++ b/therr-client-web/src/views/spaces.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -80,8 +80,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/thoughts.hbs
+++ b/therr-client-web/src/views/thoughts.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="{{#if authorName}}{{authorName}}{{else}}Therr{{/if}}">
@@ -77,8 +77,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">

--- a/therr-client-web/src/views/users.hbs
+++ b/therr-client-web/src/views/users.hbs
@@ -22,8 +22,8 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap" media="print" id="google-fonts-link">
     <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;600;800&display=swap"></noscript>
-    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css">
-    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css">
+    <link rel="preload" as="style" href="/vendor.1c9fd075f123a687e5d3.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.6a888dc918966fbf81ab.css" onload="this.onload=null;this.rel='stylesheet'">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{description}}">
     <meta name="author" content="Therr">
@@ -72,8 +72,6 @@
       h1{margin:.9rem 0;font-weight:400}
       @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
     </style>
-    <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css" media="print" onload="this.media='all'">
-    <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css" media="print" onload="this.media='all'">
     <noscript>
         <link rel="stylesheet" href="/vendor.1c9fd075f123a687e5d3.css">
         <link rel="stylesheet" href="/app.6a888dc918966fbf81ab.css">


### PR DESCRIPTION
## Summary
Fixes broken styling from the previous `media="print"` CSS loading approach, which failed on both Chrome and Safari mobile — stylesheets never activated, leaving pages with only critical inline CSS.

## What changed (9 HBS templates)
- Replace `media="print" onload="this.media='all'"` with the more reliable filamentgroup/loadCSS pattern
- The existing `<link rel="preload">` tags now include `onload="this.onload=null;this.rel='stylesheet'"` which converts the preload to an applied stylesheet once the fetch completes
- Remove the separate `<link rel="stylesheet" media="print">` tags entirely — the preload+onload tag handles both fetching and applying

### New CSS loading flow per template:
1. `<link rel="preload" onload="this.onload=null;this.rel='stylesheet'">` — non-blocking fetch + auto-apply
2. Inline `<style>` with critical CSS — immediate styling for SSR HTML (no FOUC)
3. `<noscript>` fallback — blocking CSS for no-JS browsers

## Test plan
- [ ] Verify pages render correctly on mobile Chrome and Safari
- [ ] Verify no white flash or unstyled content on initial page load
- [ ] Verify dark mode renders correctly
- [ ] Verify `update-views.js` correctly replaces CSS hashes in preload+onload and noscript tags

https://claude.ai/code/session_01GpwasWT9so31pgFZNXrhTC