### PR TITLE
Localize datetime display and add dateModified to SEO schemas

### DIFF
--- a/therr-client-web/src/components/business-profile/BusinessEventCard.tsx
+++ b/therr-client-web/src/components/business-profile/BusinessEventCard.tsx
@@ -2,27 +2,17 @@ import * as React from 'react';
 import {
     Paper, Text, Group, Badge, Stack,
 } from '@mantine/core';
+import { formatEventDate } from '../../utilities/formatDate';
 
 interface IBusinessEventCardProps {
+    locale: string;
     event: any;
     spaceName?: string;
 }
 
-const formatEventDate = (dateStr: string): string => {
-    if (!dateStr) return '';
-    const date = new Date(dateStr);
-    return date.toLocaleDateString(undefined, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-    });
-};
-
-const BusinessEventCard: React.FC<IBusinessEventCardProps> = ({ event, spaceName }) => {
-    const startDate = formatEventDate(event.scheduleStartAt);
-    const endDate = formatEventDate(event.scheduleStopAt);
+const BusinessEventCard: React.FC<IBusinessEventCardProps> = ({ locale, event, spaceName }) => {
+    const startDate = formatEventDate(event.scheduleStartAt, locale);
+    const endDate = formatEventDate(event.scheduleStopAt, locale);
 
     return (
         <Paper className="business-event-card" shadow="xs" radius="md" withBorder p="sm">

--- a/therr-client-web/src/components/business-profile/ThoughtCard.tsx
+++ b/therr-client-web/src/components/business-profile/ThoughtCard.tsx
@@ -3,23 +3,15 @@ import { Link } from 'react-router-dom';
 import {
     Paper, Text, Group, Badge, Stack, Anchor,
 } from '@mantine/core';
+import { formatDate } from '../../utilities/formatDate';
 
 interface IThoughtCardProps {
+    locale: string;
     thought: any;
     onThoughtClick?: (thoughtId: string) => void;
 }
 
-const formatDate = (dateStr: string): string => {
-    if (!dateStr) return '';
-    const date = new Date(dateStr);
-    return date.toLocaleDateString(undefined, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-    });
-};
-
-const ThoughtCard: React.FC<IThoughtCardProps> = ({ thought, onThoughtClick }) => {
+const ThoughtCard: React.FC<IThoughtCardProps> = ({ locale, thought, onThoughtClick }) => {
     const hashTags = thought.hashTags ? thought.hashTags.split(',').filter(Boolean) : [];
     const thoughtUrl = `/thoughts/${thought.id}`;
 
@@ -50,7 +42,7 @@ const ThoughtCard: React.FC<IThoughtCardProps> = ({ thought, onThoughtClick }) =
                 <Stack gap="xs">
                     <Group justify="space-between" align="center">
                         <Text size="xs" c="dimmed">
-                            {formatDate(thought.createdAt)}
+                            {formatDate(thought.createdAt, locale)}
                         </Text>
                         {thought.category && (
                             <Badge variant="light" size="sm">

--- a/therr-client-web/src/routes/Explore/ExploreThoughts.tsx
+++ b/therr-client-web/src/routes/Explore/ExploreThoughts.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { toIntlLocale } from '../../utilities/formatDate';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 import { ContentActions } from 'therr-react/redux/actions';
@@ -34,8 +35,10 @@ const categoryOptions = Categories.ThoughtCategories.map((cat: string) => {
 const categoryLabelMap: Record<string, string> = {};
 categoryOptions.forEach((opt) => { categoryLabelMap[opt.value] = opt.label; });
 
-const formatTimeAgo = (dateStr: string): string => {
+const formatTimeAgo = (dateStr: string, locale: string): string => {
+    if (!dateStr) return '';
     const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return '';
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMin = Math.floor(diffMs / 60000);
@@ -46,7 +49,7 @@ const formatTimeAgo = (dateStr: string): string => {
     if (diffMin < 60) return `${diffMin}m`;
     if (diffHr < 24) return `${diffHr}h`;
     if (diffDay < 7) return `${diffDay}d`;
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    return date.toLocaleDateString(toIntlLocale(locale), { month: 'short', day: 'numeric' });
 };
 
 interface IThoughtCardProps {
@@ -59,6 +62,7 @@ const ThoughtCard: React.FC<IThoughtCardProps> = ({
     thought, onLike, onBookmark,
 }) => {
     const navigate = useNavigate();
+    const { locale } = useTranslation();
     const isLiked = thought.reaction?.userHasLiked;
     const isBookmarked = thought.reaction?.userBookmarkCategory;
     const hashtags = thought.hashTags ? thought.hashTags.split(',').filter(Boolean) : [];
@@ -85,7 +89,7 @@ const ThoughtCard: React.FC<IThoughtCardProps> = ({
                         {thought.fromUserName}
                     </Text>
                     <Text size="xs" c="dimmed">
-                        {thought.createdAt && formatTimeAgo(thought.createdAt)}
+                        {thought.createdAt && formatTimeAgo(thought.createdAt, locale)}
                     </Text>
                     {thought.category && categoryLabelMap[thought.category] && (
                         <Text size="xs" c="dimmed" className="thought-card-category">

--- a/therr-client-web/src/routes/UserProfile.tsx
+++ b/therr-client-web/src/routes/UserProfile.tsx
@@ -331,6 +331,7 @@ export class UserProfileComponent extends React.Component<IUserProfileProps, IUs
                                             {myEvents.slice(0, 4).map((event: any) => (
                                                 <BusinessEventCard
                                                     key={event.id}
+                                                    locale={this.props.locale}
                                                     event={event}
                                                     spaceName={event.spaceName}
                                                 />
@@ -357,7 +358,7 @@ export class UserProfileComponent extends React.Component<IUserProfileProps, IUs
                                     {!isBusinessDataLoading && (
                                         <Stack gap="sm">
                                             {myThoughts.slice(0, 5).map((thought: any) => (
-                                                <ThoughtCard key={thought.id} thought={thought} onThoughtClick={this.handleThoughtClick} />
+                                                <ThoughtCard key={thought.id} locale={this.props.locale} thought={thought} onThoughtClick={this.handleThoughtClick} />
                                             ))}
                                         </Stack>
                                     )}
@@ -501,7 +502,7 @@ export class UserProfileComponent extends React.Component<IUserProfileProps, IUs
                         {!isThoughtsLoading && myThoughts.length > 0 && (
                             <Stack gap="sm">
                                 {myThoughts.map((thought: any) => (
-                                    <ThoughtCard key={thought.id} thought={thought} onThoughtClick={this.handleThoughtClick} />
+                                    <ThoughtCard key={thought.id} locale={this.props.locale} thought={thought} onThoughtClick={this.handleThoughtClick} />
                                 ))}
                             </Stack>
                         )}

--- a/therr-client-web/src/routes/UserProfile.tsx
+++ b/therr-client-web/src/routes/UserProfile.tsx
@@ -47,6 +47,7 @@ interface IStoreProps extends IUserProfileDispatchProps {
 
 // Regular component props
 interface IUserProfileProps extends IUserProfileRouterProps, IStoreProps {
+    locale: string;
     translate: (key: string, params?: any) => string;
 }
 

--- a/therr-client-web/src/routes/ViewEvent.tsx
+++ b/therr-client-web/src/routes/ViewEvent.tsx
@@ -16,6 +16,7 @@ import {
 import withNavigation from '../wrappers/withNavigation';
 import withTranslation from '../wrappers/withTranslation';
 import getUserContentUri from '../utilities/getUserContentUri';
+import { formatDateTime } from '../utilities/formatDate';
 import ProgressiveImage from '../components/ProgressiveImage';
 
 // Only lazy-load on client (Leaflet requires window/document)
@@ -27,18 +28,6 @@ const formatCategoryLabel = (category: string): string => {
     if (!category) return '';
     const label = category.replace('categories.', '').replace('/', ' & ');
     return label.charAt(0).toUpperCase() + label.slice(1);
-};
-
-const formatDateTime = (dateStr: string): string => {
-    if (!dateStr) return '';
-    return new Date(dateStr).toLocaleDateString('en-US', {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-    });
 };
 
 interface IViewEventRouterProps {
@@ -192,13 +181,13 @@ export class ViewEventComponent extends React.Component<IViewEventProps, IViewEv
                 {event.scheduleStartAt && (
                     <Group gap="xs">
                         <Text fw={600}>{this.props.translate('pages.viewEvent.labels.startDate')}:</Text>
-                        <Text>{formatDateTime(event.scheduleStartAt)}</Text>
+                        <Text>{formatDateTime(event.scheduleStartAt, this.props.locale)}</Text>
                     </Group>
                 )}
                 {event.scheduleStopAt && (
                     <Group gap="xs">
                         <Text fw={600}>{this.props.translate('pages.viewEvent.labels.endDate')}:</Text>
-                        <Text>{formatDateTime(event.scheduleStopAt)}</Text>
+                        <Text>{formatDateTime(event.scheduleStopAt, this.props.locale)}</Text>
                     </Group>
                 )}
             </Paper>

--- a/therr-client-web/src/routes/ViewUser.tsx
+++ b/therr-client-web/src/routes/ViewUser.tsx
@@ -399,6 +399,7 @@ export class ViewUserComponent extends React.Component<IViewUserProps, IViewUser
                                         {userEvents.slice(0, 4).map((event: any) => (
                                             <BusinessEventCard
                                                 key={event.id}
+                                                locale={this.props.locale}
                                                 event={event}
                                                 spaceName={event.spaceName}
                                             />
@@ -427,6 +428,7 @@ export class ViewUserComponent extends React.Component<IViewUserProps, IViewUser
                                         {userThoughts.slice(0, 5).map((thought: any) => (
                                             <ThoughtCard
                                                 key={thought.id}
+                                                locale={this.props.locale}
                                                 thought={thought}
                                                 onThoughtClick={this.handleThoughtClick}
                                             />
@@ -507,6 +509,7 @@ export class ViewUserComponent extends React.Component<IViewUserProps, IViewUser
                                     {userThoughts.slice(0, 5).map((thought: any) => (
                                         <ThoughtCard
                                             key={thought.id}
+                                            locale={this.props.locale}
                                             thought={thought}
                                             onThoughtClick={this.handleThoughtClick}
                                         />

--- a/therr-client-web/src/routes/ViewUser.tsx
+++ b/therr-client-web/src/routes/ViewUser.tsx
@@ -40,6 +40,7 @@ interface IStoreProps extends IViewUserDispatchProps {
 
 // Regular component props
 interface IViewUserProps extends IViewUserRouterProps, IStoreProps {
+    locale: string;
     onInitMessaging?: Function;
     translate: (key: string, params?: any) => string;
 }

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -705,6 +705,7 @@ const renderMomentView = (req, res, config, {
         '@id': `https://www.therr.com${localeVars.canonicalPath}`,
         headline: momentTitle,
         datePublished: moment?.createdAt || '',
+        dateModified: moment?.updatedAt || moment?.createdAt || '',
         image: metaImgUrl || '',
         author: {
             '@type': 'Person',
@@ -1088,6 +1089,9 @@ const renderEventView = (req, res, config, {
     }
     if (eventEndTime) {
         eventSchema.endDate = eventEndTime;
+    }
+    if (event?.updatedAt || event?.createdAt) {
+        eventSchema.dateModified = event?.updatedAt || event?.createdAt;
     }
     if (metaImgUrl) {
         eventSchema.image = metaImgUrl;

--- a/therr-client-web/src/utilities/formatDate.ts
+++ b/therr-client-web/src/utilities/formatDate.ts
@@ -10,7 +10,9 @@ export const toIntlLocale = (appLocale: string): string => LOCALE_MAP[appLocale?
 
 export const formatDate = (dateStr: string, locale: string): string => {
     if (!dateStr) return '';
-    return new Date(dateStr).toLocaleDateString(toIntlLocale(locale), {
+    const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(toIntlLocale(locale), {
         month: 'short',
         day: 'numeric',
         year: 'numeric',
@@ -19,7 +21,9 @@ export const formatDate = (dateStr: string, locale: string): string => {
 
 export const formatDateTime = (dateStr: string, locale: string): string => {
     if (!dateStr) return '';
-    return new Date(dateStr).toLocaleDateString(toIntlLocale(locale), {
+    const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(toIntlLocale(locale), {
         weekday: 'long',
         year: 'numeric',
         month: 'long',
@@ -31,7 +35,9 @@ export const formatDateTime = (dateStr: string, locale: string): string => {
 
 export const formatEventDate = (dateStr: string, locale: string): string => {
     if (!dateStr) return '';
-    return new Date(dateStr).toLocaleDateString(toIntlLocale(locale), {
+    const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(toIntlLocale(locale), {
         month: 'short',
         day: 'numeric',
         year: 'numeric',

--- a/therr-client-web/src/utilities/formatDate.ts
+++ b/therr-client-web/src/utilities/formatDate.ts
@@ -1,0 +1,41 @@
+const LOCALE_MAP: Record<string, string> = {
+    'en-us': 'en-US',
+    en: 'en-US',
+    es: 'es',
+    'fr-ca': 'fr-CA',
+    fr: 'fr-CA',
+};
+
+export const toIntlLocale = (appLocale: string): string => LOCALE_MAP[appLocale?.toLowerCase()] || 'en-US';
+
+export const formatDate = (dateStr: string, locale: string): string => {
+    if (!dateStr) return '';
+    return new Date(dateStr).toLocaleDateString(toIntlLocale(locale), {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+    });
+};
+
+export const formatDateTime = (dateStr: string, locale: string): string => {
+    if (!dateStr) return '';
+    return new Date(dateStr).toLocaleDateString(toIntlLocale(locale), {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+};
+
+export const formatEventDate = (dateStr: string, locale: string): string => {
+    if (!dateStr) return '';
+    return new Date(dateStr).toLocaleDateString(toIntlLocale(locale), {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+};


### PR DESCRIPTION
- Add formatDate/formatDateTime/formatEventDate utilities in
  therr-client-web/src/utilities/formatDate.ts that use
  Intl.DateTimeFormat with the user's app locale (en-us → en-US,
  es → es, fr-ca → fr-CA)
- Update ThoughtCard, BusinessEventCard, and ViewEvent to use the
  new locale-aware utilities instead of hardcoded 'en-US' or
  browser-default formatting
- Pass locale prop from withTranslation HOC down to ThoughtCard and
  BusinessEventCard in ViewUser and UserProfile
- Add dateModified field to SocialMediaPosting (moment) and Event
  JSON-LD schemas in server-client.tsx (falls back to createdAt
  when updatedAt is absent) for improved SEO freshness signals

https://claude.ai/code/session_01Nsjaq1EAUM3eCY3gynyJDW