### PR TITLE
fix: always redirect /spaces/<uuid> to slug URL regardless of notificationMsg

### DIFF
--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -829,14 +829,14 @@ const renderSpaceView = (req, res, config, {
         });
     }
 
-    // 301 redirect to keyword-rich slug URL if slug is missing or incorrect
-    if (space.notificationMsg) {
-        const expectedSlug = buildSpaceSlug(space.notificationMsg, space.addressLocality, space.addressRegion);
-        const currentSlug = req.params?.spaceSlug || '';
-        if (expectedSlug && currentSlug !== expectedSlug) {
-            const lp = localeVars.localePrefix;
-            return res.redirect(301, `${lp}/spaces/${spaceId}/${expectedSlug}`);
-        }
+    // 301 redirect to keyword-rich slug URL if slug is missing or incorrect.
+    // Build from all available parts — not just notificationMsg — so spaces with only
+    // locality/region data still redirect to a consistent slug URL.
+    const expectedSlug = buildSpaceSlug(space.notificationMsg, space.addressLocality, space.addressRegion);
+    const currentSlug = req.params?.spaceSlug || '';
+    if (expectedSlug && currentSlug !== expectedSlug) {
+        const lp = localeVars.localePrefix;
+        return res.redirect(301, `${lp}/spaces/${spaceId}/${expectedSlug}`);
     }
 
     const spaceNameBase = space.notificationMsg || title;


### PR DESCRIPTION
The 301 redirect from /spaces/<uuid> to /spaces/<uuid>/<slug> was gated
on space.notificationMsg being truthy. However, buildSpaceSlug can build
a valid slug from locality/region alone, and ListSpaces links always
included a slug. This meant spaces with no name but a city/region served
both /spaces/<uuid> (canonical: uuid-only) and /spaces/<uuid>/city-state
(canonical: slug URL) without redirecting, causing Google to index both
as separate pages with different canonicals.

Now the redirect fires whenever buildSpaceSlug can produce any non-empty
slug, consistent with how the sitemap and listing-page links work.

https://claude.ai/code/session_01QrmunoNMJ8KeKXvJ6CmQcy