### PR TITLE
Add TanStack Query adoption guidance + gatekeeper skill

### DIFF
--- a/.claude/skills/tanstack-query-check/SKILL.md
+++ b/.claude/skills/tanstack-query-check/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: tanstack-query-check
+description: Decide whether TanStack Query (React Query) is appropriate for a proposed feature, and if so, scaffold it correctly per the repo's case-by-case adoption rules. Blocks misuse that would fragment state or duplicate Redux slices.
+user-invocable: true
+allowed-tools: Bash(git branch*), Bash(git status*), Bash(git diff*), Read, Glob, Grep
+argument-hint: [check "<feature description>" | scaffold <app> <feature-name> | explain]
+---
+
+# TanStack Query Check
+
+Gatekeeper skill for introducing TanStack Query (`@tanstack/react-query`) into therr-app. The codebase uses Redux Toolkit as the default data-fetching tool. TanStack Query is permitted **only** for narrow, isolated use cases. This skill enforces the rules documented in root `CLAUDE.md` under "TanStack Query (React Query) — Case-by-Case Adoption".
+
+Always read that section first — this skill operationalizes it.
+
+## Mode Selection
+
+| Argument | Mode |
+|----------|------|
+| `check "<feature description>"` or _(no argument, with a described feature)_ | Decide fit + list precautions |
+| `scaffold <app> <feature-name>` | Scaffold a compliant query file (after check passes) |
+| `explain` | Print the adoption rules in a condensed form |
+
+---
+
+## Mode 1: Check (default)
+
+Given a feature description (from the user or prior conversation), decide whether TanStack Query is appropriate and report a decision.
+
+### Step 1: Collect context
+
+```bash
+git branch --show-current
+```
+
+Read root `CLAUDE.md` (the "TanStack Query — Case-by-Case Adoption" section) so your decision reflects current rules, not stale knowledge.
+
+### Step 2: Run the eligibility checklist
+
+Score the feature against these questions. **Any** No answer in the "Must Be Yes" group disqualifies TanStack Query.
+
+**Must Be Yes (hard requirements):**
+
+1. Is the feature scoped to exactly one app (`therr-client-web`, `therr-client-web-dashboard`, or `TherrMobile`)? — *Must be Yes. Never add to `therr-react`.*
+2. Is the data read-mostly or does it use a pattern TanStack is uniquely good at (infinite scroll, polling, optimistic mutations)? — *Must be Yes, otherwise a Redux thunk is the cheaper choice.*
+3. Will the feature **NOT** overlap with any of these Redux slices: `user`, `notifications`, `messages`, `userConnections`, presence, socket-driven state? — *Must be Yes. If No, TanStack will fight the socket middleware.*
+4. Will the feature **NOT** depend on SSR `__PRELOADED_STATE__` hydration? — *If web SSR is involved, integrating TanStack hydration is a separate architectural decision.*
+5. Is there an existing service in `therr-react/services` that can be called from `queryFn` (or is one not needed)? — *Must be Yes. Do not reimplement the HTTP layer.*
+
+**Nice to Have (signals of fit):**
+
+- Infinite list / paginated feed
+- Polling or background refresh needed
+- Optimistic UI with rollback
+- Multiple components subscribing to the same server state with independent lifecycles
+
+**Red flags (signal NOT to use):**
+
+- Feature touches auth, login/logout, or user profile editing
+- Data is pushed via socket-io events
+- Feature is shared between web and mobile (would belong in `therr-react`)
+- Data is also persisted via `redux-persist`
+- "We might as well use it because it's modern"
+
+### Step 3: Detect existing conflicts
+
+If the user's proposed feature likely overlaps with existing Redux code, surface it:
+
+```bash
+# Find the related Redux action file(s)
+```
+
+Use `Glob` / `Grep` to check:
+- `therr-public-library/therr-react/src/redux/actions/` for an existing action matching the feature area
+- `therr-public-library/therr-react/src/services/` for an existing service
+- `TherrMobile/main/redux/actions/` and `therr-client-web/src/redux/actions/` for app-local actions
+
+If an existing Redux action covers this data, recommend extending it rather than creating a parallel TanStack query.
+
+### Step 4: Report decision
+
+Output one of three verdicts.
+
+**✅ APPROVED**
+```
+✅ TanStack Query is appropriate here.
+
+  Feature: <description>
+  App: therr-client-web-dashboard
+  Why it fits: infinite scroll + dashboard polling; no socket overlap
+
+  Required precautions:
+    1. Add @tanstack/react-query to therr-client-web-dashboard/package.json
+       (NOT to therr-react or the root package.json)
+    2. Use MapsService.searchSpaces as the queryFn — do not re-call axios directly
+    3. Mount QueryClient inside the dashboard feature subtree
+    4. Set staleTime: 30_000 and retry: 1 as defaults
+    5. Add a comment at the top of the query file stating "TanStack used for
+       infinite scroll; Redux pattern would require manual pagination state"
+
+  Next: run `/tanstack-query-check scaffold therr-client-web-dashboard <feature-name>`
+```
+
+**⚠ RECONSIDER**
+```
+⚠ TanStack Query is borderline here. Prefer Redux unless you can justify one of:
+
+  - Infinite scroll (you'd hand-roll pagination state otherwise)
+  - Polling (you'd hand-roll setInterval + cleanup otherwise)
+  - Optimistic mutation with rollback
+
+  If none apply, a thunk in therr-react/redux/actions/ is cheaper and keeps
+  state paradigms consistent.
+
+  Ask: does this feature actually need TanStack, or is it just "nicer"?
+```
+
+**❌ REJECTED**
+```
+❌ TanStack Query is not appropriate here.
+
+  Feature: <description>
+  Blocker(s):
+    - Touches user/auth state (Redux is the source of truth for auth)
+    - Would need to live in therr-react (shared lib) — TanStack is app-scoped only
+    - Overlaps with socket-io-middleware notifications slice
+
+  Use Redux instead:
+    Extend therr-public-library/therr-react/src/redux/actions/<Area>.ts
+    Follow the existing thunk pattern (see ContentActions.ts for reference)
+```
+
+---
+
+## Mode 2: Scaffold
+
+Only run after Mode 1 returns ✅ APPROVED. Generate a compliant query file.
+
+### Step 1: Validate arguments
+
+- `<app>` must be one of: `therr-client-web`, `therr-client-web-dashboard`, `TherrMobile`.
+- If `<app>` is `therr-react` or any package under `therr-public-library/`, **abort**: "TanStack Query must not be added to shared libraries."
+
+### Step 2: Check the dependency
+
+Read the app's `package.json`. If `@tanstack/react-query` is not listed, note that the user needs to add it:
+
+```bash
+# For web/dashboard (from app directory)
+npm install @tanstack/react-query --legacy-peer-deps
+
+# For mobile (from TherrMobile/)
+npm install @tanstack/react-query --legacy-peer-deps
+```
+
+Do NOT install it yourself — the user should run install.
+
+### Step 3: Check for existing QueryClient setup
+
+Search the app for `QueryClientProvider`:
+
+- If present, the new query file just needs to export hooks.
+- If absent, the user needs to mount `QueryClientProvider` at the feature subtree root (not the app root, unless they explicitly want app-wide scope).
+
+### Step 4: Generate the query file
+
+Place under `<app>/src/queries/` (create the directory if needed). File name: `use<FeatureName>Query.ts`.
+
+Template (web/dashboard):
+
+```typescript
+// TanStack Query used here because: <fill in: infinite scroll / polling / optimistic mutation>
+// Approved per CLAUDE.md "TanStack Query — Case-by-Case Adoption" rules.
+// - Scoped to this app only (not therr-react)
+// - Uses therr-react services for HTTP (preserves interceptors + auth headers)
+// - Does not overlap with socket-driven Redux slices
+import { useQuery } from '@tanstack/react-query';
+import { /* ServiceName */ } from 'therr-react/services';
+
+export const use<FeatureName>Query = (params: /* type */) => useQuery({
+    queryKey: ['<feature-name>', params],
+    queryFn: () => /* ServiceName */.method(params).then((res) => res.data),
+    staleTime: 30_000,
+    retry: 1,
+});
+```
+
+Template (mobile) is identical — React Native has no SSR concern.
+
+### Step 5: Remind the user of integration steps
+
+Print a checklist:
+
+```
+Scaffolded <path>
+
+Before merging:
+  [ ] Add @tanstack/react-query to <app>/package.json (use --legacy-peer-deps)
+  [ ] Mount <QueryClientProvider> at the feature subtree (not inside therr-react)
+  [ ] Verify the chosen service in therr-react/services exists and is built (npm run build in therr-public-library)
+  [ ] Add a test for the hook (mock the service, assert the queryKey stays stable)
+  [ ] Run quality-check before committing
+```
+
+---
+
+## Mode 3: Explain
+
+Print a condensed version of the rules:
+
+```
+TanStack Query in therr-app — TL;DR
+
+Default: Redux Toolkit thunks in therr-react/redux/actions/
+TanStack: ONLY for narrow cases in a single app (web, dashboard, or mobile)
+
+Good fit:       Bad fit:
+- Infinite      - Anything auth/user-related
+  scroll        - Socket-driven data (messages, notifications, reactions)
+- Polling       - Shared between web and mobile (goes in therr-react instead)
+- Optimistic    - SSR-hydrated data on therr-client-web
+  mutations     - Data already in redux-persist
+                - "It would be nicer"
+
+If allowed:
+  1. Scope to one app's src/queries/ — never in therr-react
+  2. Call existing therr-react/services from queryFn
+  3. Mount QueryClient at a feature subtree, not globally unless intentional
+  4. Document why TanStack was chosen at the top of each query file
+  5. Never duplicate state — if Redux already has it, don't TanStack it too
+
+Full rules: root CLAUDE.md → "TanStack Query (React Query) — Case-by-Case Adoption"
+```
+
+---
+
+## Rules
+
+- This skill does not install packages or modify `package.json` — it only reads and scaffolds source files.
+- This skill never adds TanStack Query to `therr-public-library/` (shared libraries). That is a hard stop.
+- This skill never replaces existing Redux actions — it only adds new, orthogonal query hooks.
+- If the user pushes back on a ❌ REJECTED verdict, escalate to a human decision — do not silently approve.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,47 @@ Place utility functions in shared libraries only when:
 
 Avoid creating abstractions for hypothetical future reuse.
 
+## TanStack Query (React Query) — Case-by-Case Adoption
+
+TanStack Query is **not** the default data-fetching tool in this codebase — Redux Toolkit with custom action creators is. TanStack Query **may** be introduced for specific, isolated use cases where its features (request deduplication, background refetch, stale-while-revalidate, `useInfiniteQuery`, optimistic mutations) provide clear value over hand-rolled Redux thunks.
+
+Before reaching for it, check the rules below. When in doubt, stay with Redux.
+
+### When it is a good fit
+
+- **New, read-heavy screens** that are self-contained within one app (web, mobile, or dashboard) and do not share state with other features.
+- **Infinite lists / pagination** where `useInfiniteQuery` replaces manual pagination state in Redux.
+- **Mutations with optimistic updates** that don't cascade into other Redux slices.
+- **Polling / background refresh** (`refetchInterval`, `refetchOnReconnect`, `refetchOnWindowFocus`) — especially useful for dashboards.
+
+### When it is NOT appropriate (keep in Redux)
+
+Do not move any of the following to TanStack Query. These slices are tightly coupled to existing infrastructure and splitting them will cause sync bugs:
+
+| Slice / feature | Why it stays in Redux |
+|-----------------|-----------------------|
+| `user`, auth, session | Consumed by axios interceptors, socket middleware, route guards, and redux-persist |
+| `notifications`, `messages`, reactions | Pushed by `socket-io-middleware` directly into Redux — TanStack has no socket story |
+| `userConnections`, presence | Updated by WebSocket events |
+| Anything in `therr-react/redux/actions` | Shared across web, dashboard, and mobile; changing shape breaks all three consumers |
+| SSR-rendered data on `therr-client-web` | Server pre-populates `__PRELOADED_STATE__` into Redux; TanStack SSR hydration is a separate integration |
+| Persisted state (see "Offline-First" in docs) | `redux-persist` already caches key slices; TanStack would need a parallel persister |
+
+### Required precautions before introducing it
+
+If a feature genuinely fits the "good fit" list above, follow these rules:
+
+1. **Scope it to a single app.** Do not add TanStack Query to `therr-react` (the shared library). Add it to `therr-client-web`, `therr-client-web-dashboard`, or `TherrMobile` only, and keep the queries in that app's source.
+2. **Reuse existing API clients.** Call into the singleton services in `therr-react/services` (e.g., `MapsService.searchSpaces`) from inside the `queryFn` — do not reimplement the HTTP layer. This preserves auth headers, brand variation header, and interceptor behavior.
+3. **Do not duplicate state.** If the data you'd put in TanStack is already read from Redux elsewhere, either (a) keep it in Redux, or (b) migrate the other reader too. Never have both.
+4. **Document the decision.** Add a brief comment at the top of the new query file explaining why TanStack was chosen over a Redux action (e.g., "infinite scroll", "needs polling", "optimistic mutation with rollback").
+5. **QueryClient placement.** Provide `QueryClient` at the feature subtree or app root — not inside `therr-react`. Use sensible defaults (`staleTime`, `retry: 1`) so it doesn't thrash on mobile data connections.
+6. **No socket events into the query cache.** If the data is also pushed by WebSocket, pick one: Redux (preferred) or TanStack with manual `queryClient.invalidateQueries` on socket events. Never both.
+
+### Default answer
+
+If you're unsure whether to use TanStack Query for a new feature: **don't**. Use a Redux action in the existing pattern. The cost of two state paradigms in the same app outweighs the ergonomic gains except for the narrow cases listed above.
+
 ## Package-Level Documentation
 
 Each package has its own `CLAUDE.md` with package-specific details:


### PR DESCRIPTION
## Summary

- Adds a "TanStack Query (React Query) — Case-by-Case Adoption" section to root `CLAUDE.md` that documents when TanStack is appropriate (new read-heavy screens, infinite scroll, polling, optimistic mutations) and — more importantly — when it is **not** (auth/user state, socket-driven slices, shared-library placement, SSR-hydrated data, redux-persisted state).
- Adds a `/tanstack-query-check` skill at `.claude/skills/tanstack-query-check/SKILL.md` that operationalizes the rules. It has three modes:
  - `check` — runs the eligibility checklist against a proposed feature and returns ✅ APPROVED / ⚠ RECONSIDER / ❌ REJECTED with reasoning.
  - `scaffold <app> <feature-name>` — generates a compliant query file under the target app's `src/queries/`, reusing `therr-react/services` for the `queryFn` and including a mandatory comment explaining why TanStack was chosen.
  - `explain` — prints a TL;DR of the rules.

## Why

Therr uses Redux Toolkit as the default data layer, with socket-io pushing real-time updates straight into Redux and `redux-persist` caching key slices. Sprinkling TanStack Query in without guardrails would fragment state, duplicate caches, and fight the socket middleware. This PR makes the policy explicit and adds a tool that enforces it at authoring time.

## Test plan

- [ ] Confirm root `CLAUDE.md` renders correctly on GitHub and the new section is easy to find.
- [ ] Invoke `/tanstack-query-check explain` — verify the TL;DR prints.
- [ ] Invoke `/tanstack-query-check check "add real-time chat using TanStack Query"` — verify it REJECTS (socket overlap).
- [ ] Invoke `/tanstack-query-check check "paginated admin space-approval list on the dashboard"` — verify it APPROVES and lists precautions.
- [ ] Invoke `/tanstack-query-check scaffold therr-react some-feature` — verify it aborts (shared library not allowed).
- [ ] Invoke `/tanstack-query-check scaffold therr-client-web-dashboard space-approvals` — verify it generates the expected file under `therr-client-web-dashboard/src/queries/useSpaceApprovalsQuery.ts`.

https://claude.ai/code/session_01CaBzxwcUAgw2Z2LP2cmbXG