### PR TITLE
Add City Pulse landing pages for /locations/city/:slug

### DIFF
--- a/therr-api-gateway/src/services/maps/router.ts
+++ b/therr-api-gateway/src/services/maps/router.ts
@@ -348,6 +348,29 @@ mapsServiceRouter.post('/spaces/request-approve/:spaceId', validate, authorize(
     method: 'post',
 }));
 
+// City Pulse — editorial + Therr-data aggregate used by the /locations/city/:slug SSR page.
+// Public endpoint (no auth required); cached in Redis for 15 minutes per (slug, locale).
+mapsServiceRouter.get('/cities/:slug/pulse', authenticateOptional, async (req: any, res, next) => {
+    const { slug } = req.params;
+    const locale = (req.query?.locale as string) || req.headers['x-localecode'] || 'en-us';
+    const cached = await CacheStore.mapsService.getCityPulse(slug, locale);
+
+    if (cached) {
+        return res.status(200).send({ ...cached, cached: true });
+    }
+
+    return next();
+}, handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseMapsServiceRoute}`,
+    method: 'get',
+}, (response, _reqBody) => {
+    if (response?.city?.slug) {
+        const cacheLocale = response.locale || 'en-us';
+        return CacheStore.mapsService.setCityPulse(response.city.slug, cacheLocale, response);
+    }
+    return undefined;
+}));
+
 // External APIs - Nominatim geocoding proxy with rate limiting and caching
 mapsServiceRouter.get('/geocode', geocodeApiLimiter, async (req, res) => {
     const { q } = req.query;

--- a/therr-api-gateway/src/services/maps/router.ts
+++ b/therr-api-gateway/src/services/maps/router.ts
@@ -350,9 +350,21 @@ mapsServiceRouter.post('/spaces/request-approve/:spaceId', validate, authorize(
 
 // City Pulse — editorial + Therr-data aggregate used by the /locations/city/:slug SSR page.
 // Public endpoint (no auth required); cached in Redis for 15 minutes per (slug, locale).
+//
+// Both the gateway and the maps-service handler normalize locale identically
+// (exact-match against the supported set, else fall back to "en-us"), so the
+// key we read from matches `response.locale` we write under.
+const SUPPORTED_PULSE_LOCALES = ['en-us', 'es', 'fr-ca'];
+const normalizePulseLocale = (raw: unknown): string => {
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    const str = typeof value === 'string' ? value : '';
+    return SUPPORTED_PULSE_LOCALES.includes(str) ? str : 'en-us';
+};
+
 mapsServiceRouter.get('/cities/:slug/pulse', authenticateOptional, async (req: any, res, next) => {
     const { slug } = req.params;
-    const locale = (req.query?.locale as string) || req.headers['x-localecode'] || 'en-us';
+    const locale = normalizePulseLocale(req.query?.locale || req.headers['x-localecode']);
+
     const cached = await CacheStore.mapsService.getCityPulse(slug, locale);
 
     if (cached) {
@@ -363,10 +375,20 @@ mapsServiceRouter.get('/cities/:slug/pulse', authenticateOptional, async (req: a
 }, handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseMapsServiceRoute}`,
     method: 'get',
-}, (response, _reqBody) => {
-    if (response?.city?.slug) {
-        const cacheLocale = response.locale || 'en-us';
-        return CacheStore.mapsService.setCityPulse(response.city.slug, cacheLocale, response);
+}, (response) => {
+    // maps-service's response body carries a normalized `locale`. Cache under it.
+    // Use a shorter TTL when wiki content is still empty (cold cache, background
+    // refresh in flight) so users get the editorial layer within minutes, not
+    // at the end of a full 15-minute window.
+    if (response?.city?.slug && response?.locale) {
+        const hasWiki = !!(response.wiki?.summary);
+        const ttl = hasWiki ? 900 : 120; // 15 min normal, 2 min when wiki is still loading
+        return CacheStore.mapsService.setCityPulse(
+            response.city.slug,
+            response.locale,
+            response,
+            ttl,
+        );
     }
     return undefined;
 }));

--- a/therr-api-gateway/src/store/MapsService.ts
+++ b/therr-api-gateway/src/store/MapsService.ts
@@ -6,9 +6,11 @@ import logSpan from 'therr-js-utilities/log-or-update-span';
 const MAPS_STORE_PREFIX = 'MAPS_STORE:';
 const PLACES_CACHE_PREFIX = 'PLACES_CACHE:';
 const GEOCODING_CACHE_PREFIX = 'GEOCODING_CACHE:';
+const CITY_PULSE_CACHE_PREFIX = 'MAPS_STORE:cityPulse:';
 const DEFAULT_TTL_SECONDS = 300;
 const PLACES_TTL_SECONDS = 600; // 10 minutes for Places API responses
 const GEOCODING_TTL_SECONDS = 86400; // 24 hours - locations don't change
+const CITY_PULSE_TTL_SECONDS = 900; // 15 minutes
 
 class MapsServiceCache {
     private cache: Redis;
@@ -90,6 +92,45 @@ class MapsServiceCache {
     public invalidateAreaDetails(areaType: IAreaType, areaId: string): Promise<number | null> {
         return this.cache.del(`${MAPS_STORE_PREFIX}${areaType}:${areaId}`).catch((error) => {
             console.error(`Error invalidating ${areaType} cache`, error);
+            return null;
+        });
+    }
+
+    // City Pulse — one payload per (slug, locale). Short TTL so fresh Therr
+    // content (new spaces/moments/events) surfaces within minutes without
+    // requiring write-path invalidation across every POST handler.
+    public getCityPulse(slug: string, locale: string) {
+        return this.cache.get(`${CITY_PULSE_CACHE_PREFIX}${slug}:${locale}`).then((response) => {
+            if (!response) return undefined;
+            return JSON.parse(response);
+        }).catch((error) => {
+            console.error('Error getting cityPulse from cache', error);
+            return undefined;
+        });
+    }
+
+    public setCityPulse(slug: string, locale: string, data: any, ttl = CITY_PULSE_TTL_SECONDS) {
+        return this.cache
+            .setex(`${CITY_PULSE_CACHE_PREFIX}${slug}:${locale}`, ttl, JSON.stringify(data))
+            .catch((error) => {
+                console.error('Error setting cityPulse in cache', error);
+            });
+    }
+
+    public invalidateCityPulse(slug: string, locale?: string): Promise<number | null> {
+        if (locale) {
+            return this.cache.del(`${CITY_PULSE_CACHE_PREFIX}${slug}:${locale}`).catch((error) => {
+                console.error('Error invalidating cityPulse cache', error);
+                return null;
+            });
+        }
+        // No locale: clear all locale variants via KEYS scan. Small keyspace and
+        // 15-min TTLs mean occasional SCAN work is acceptable.
+        return this.cache.keys(`${CITY_PULSE_CACHE_PREFIX}${slug}:*`).then((keys) => {
+            if (!keys.length) return 0;
+            return this.cache.del(...keys);
+        }).catch((error) => {
+            console.error('Error invalidating cityPulse cache', error);
             return null;
         });
     }

--- a/therr-client-web/src/components/CityPulse/index.tsx
+++ b/therr-client-web/src/components/CityPulse/index.tsx
@@ -1,0 +1,360 @@
+/* eslint-disable max-len */
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import {
+    Stack, Group, Title, Text, Badge, Anchor, Paper, Image, SimpleGrid, Avatar, Button, Divider,
+} from '@mantine/core';
+import { buildSpaceSlug } from 'therr-js-utilities/slugify';
+import getUserContentUri from '../../utilities/getUserContentUri';
+
+// ──────────────────────────────────────────────────────────────────
+// Shared helpers
+
+const formatCategoryLabel = (category: string): string => {
+    if (!category) return '';
+    const label = category.replace('categories.', '').replace('/', ' & ');
+    return label.charAt(0).toUpperCase() + label.slice(1);
+};
+
+const paragraphsFromText = (text: string | null | undefined, limit = 4): string[] => {
+    if (!text) return [];
+    return text.split(/\n\n+/).map((p) => p.trim()).filter(Boolean).slice(0, limit);
+};
+
+export interface ICityPulseCity {
+    slug: string;
+    name: string;
+    state: string;
+    stateAbbr: string;
+    lat: number;
+    lng: number;
+}
+
+export interface ICityPulseWiki {
+    summary: string | null;
+    sections: {
+        understand?: string;
+        districts?: string;
+        getIn?: string;
+        getAround?: string;
+    } | null;
+    heroImageUrl: string | null;
+    attributionUrl: string | null;
+    license: string;
+    localeFallback?: boolean;
+}
+
+export interface ICityPulseData {
+    city: ICityPulseCity;
+    therr: {
+        trendingSpaces: any[];
+        upcomingEvents: any[];
+        recentMoments: any[];
+        topGroups: any[];
+        categoriesWithCounts: { categorySlug: string; count: number }[];
+    };
+    wiki: ICityPulseWiki;
+    nearbyCities: { slug: string; name: string; stateAbbr: string; distanceKm: number }[];
+}
+
+interface ISectionProps {
+    pulse: ICityPulseData;
+    translate: (key: string, params?: any) => string;
+    localePrefix: string;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// CityHero — always renders.
+
+export const CityHero: React.FC<ISectionProps> = ({ pulse, translate }) => {
+    const { city, wiki } = pulse;
+    const displayName = `${city.name}, ${city.stateAbbr}`;
+    const leadParagraph = wiki.summary ? wiki.summary.split(/(?<=[.!?])\s/).slice(0, 2).join(' ') : '';
+
+    return (
+        <Paper withBorder p="lg" radius="md">
+            <Group align="flex-start" wrap="nowrap" gap="md">
+                {wiki.heroImageUrl && (
+                    <Image
+                        src={wiki.heroImageUrl}
+                        alt={displayName}
+                        w={160}
+                        h={120}
+                        radius="md"
+                        fit="cover"
+                        style={{ flexShrink: 0 }}
+                    />
+                )}
+                <Stack gap={6} style={{ flex: 1, minWidth: 0 }}>
+                    <Title order={1} mb={0}>{translate('pages.cityPulse.heroTitle', { city: displayName })}</Title>
+                    {leadParagraph ? (
+                        <Text c="dimmed">{leadParagraph}</Text>
+                    ) : (
+                        <Text c="dimmed">{translate('pages.cityPulse.heroFallback', { city: displayName })}</Text>
+                    )}
+                </Stack>
+            </Group>
+        </Paper>
+    );
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Wiki-sourced sections
+
+export const CityAbout: React.FC<ISectionProps> = ({ pulse, translate }) => {
+    const paragraphs = paragraphsFromText(pulse.wiki.sections?.understand, 4);
+    if (!paragraphs.length) return null;
+    return (
+        <Stack gap="sm">
+            <Title order={2}>{translate('pages.cityPulse.aboutHeading', { city: pulse.city.name })}</Title>
+            {paragraphs.map((p, i) => (<Text key={i}>{p}</Text>))}
+        </Stack>
+    );
+};
+
+export const CityNeighborhoods: React.FC<ISectionProps> = ({ pulse, translate }) => {
+    const paragraphs = paragraphsFromText(pulse.wiki.sections?.districts, 3);
+    if (!paragraphs.length) return null;
+    return (
+        <Stack gap="sm">
+            <Title order={2}>{translate('pages.cityPulse.neighborhoodsHeading')}</Title>
+            {paragraphs.map((p, i) => (<Text key={i}>{p}</Text>))}
+        </Stack>
+    );
+};
+
+export const CityGettingAround: React.FC<ISectionProps> = ({ pulse, translate }) => {
+    const getIn = paragraphsFromText(pulse.wiki.sections?.getIn, 2);
+    const getAround = paragraphsFromText(pulse.wiki.sections?.getAround, 2);
+    if (!getIn.length && !getAround.length) return null;
+    return (
+        <Stack gap="sm">
+            <Title order={2}>{translate('pages.cityPulse.gettingAroundHeading')}</Title>
+            {getIn.length > 0 && (
+                <Stack gap={4}>
+                    <Title order={3}>{translate('pages.cityPulse.getInSubheading')}</Title>
+                    {getIn.map((p, i) => (<Text key={`in-${i}`}>{p}</Text>))}
+                </Stack>
+            )}
+            {getAround.length > 0 && (
+                <Stack gap={4}>
+                    <Title order={3}>{translate('pages.cityPulse.getAroundSubheading')}</Title>
+                    {getAround.map((p, i) => (<Text key={`around-${i}`}>{p}</Text>))}
+                </Stack>
+            )}
+        </Stack>
+    );
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Therr-sourced sections
+
+export const CityTrendingSpaces: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+    const spaces = pulse.therr.trendingSpaces || [];
+    if (spaces.length < 6) return null;
+    return (
+        <Stack gap="sm">
+            <Title order={2}>{translate('pages.cityPulse.trendingSpacesHeading', { city: pulse.city.name })}</Title>
+            <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="sm">
+                {spaces.slice(0, 12).map((space: any) => {
+                    const mediaPath = space.medias?.[0]?.path;
+                    const spaceImage = mediaPath ? getUserContentUri(space.medias[0], 80, 80, true) : null;
+                    const slug = buildSpaceSlug(space.notificationMsg, space.addressLocality, space.addressRegion);
+                    return (
+                        <Paper key={space.id} withBorder p="md" radius="md">
+                            <Group wrap="nowrap" align="flex-start" gap="sm">
+                                {spaceImage ? (
+                                    <Image src={spaceImage} alt={space.notificationMsg} w={56} h={56} radius="md" fit="cover" style={{ flexShrink: 0 }} />
+                                ) : (
+                                    <Avatar size={56} radius="md" color="teal">
+                                        {(space.notificationMsg || '?').charAt(0).toUpperCase()}
+                                    </Avatar>
+                                )}
+                                <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
+                                    <Anchor component={Link} to={`${localePrefix}/spaces/${space.id}/${slug}`} fw={600}>
+                                        {space.notificationMsg}
+                                    </Anchor>
+                                    {space.addressReadable && (
+                                        <Text size="xs" c="dimmed" lineClamp={1}>{space.addressReadable}</Text>
+                                    )}
+                                    {space.category && (
+                                        <Badge variant="outline" size="xs">{formatCategoryLabel(space.category)}</Badge>
+                                    )}
+                                </Stack>
+                            </Group>
+                        </Paper>
+                    );
+                })}
+            </SimpleGrid>
+        </Stack>
+    );
+};
+
+export const CityUpcomingEvents: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+    const events = pulse.therr.upcomingEvents || [];
+    if (events.length < 1) return null;
+    return (
+        <Stack gap="sm">
+            <Title order={2}>{translate('pages.cityPulse.upcomingEventsHeading', { city: pulse.city.name })}</Title>
+            <Stack gap="xs">
+                {events.slice(0, 8).map((event: any) => {
+                    const startDate = event.scheduleStartAt ? new Date(event.scheduleStartAt) : null;
+                    return (
+                        <Paper key={event.id} withBorder p="md" radius="md">
+                            <Anchor component={Link} to={`${localePrefix}/events/${event.id}`} fw={600}>
+                                {event.notificationMsg}
+                            </Anchor>
+                            {startDate && (
+                                <Text size="sm" c="dimmed">{startDate.toLocaleString()}</Text>
+                            )}
+                        </Paper>
+                    );
+                })}
+            </Stack>
+        </Stack>
+    );
+};
+
+export const CityMomentsWall: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+    const moments = pulse.therr.recentMoments || [];
+    if (moments.length < 9) return null;
+    return (
+        <Stack gap="sm">
+            <Title order={2}>{translate('pages.cityPulse.momentsWallHeading', { city: pulse.city.name })}</Title>
+            <SimpleGrid cols={{ base: 2, sm: 3 }} spacing="xs">
+                {moments.slice(0, 18).map((moment: any) => {
+                    const mediaPath = moment.medias?.[0]?.path;
+                    const img = mediaPath ? getUserContentUri(moment.medias[0], 200, 200, true) : null;
+                    return (
+                        <Anchor key={moment.id} component={Link} to={`${localePrefix}/moments/${moment.id}`}>
+                            {img ? (
+                                <Image src={img} alt={moment.notificationMsg || 'moment'} h={120} fit="cover" radius="sm" />
+                            ) : (
+                                <Paper withBorder p="sm" radius="sm" h={120}>
+                                    <Text size="xs" lineClamp={4}>{moment.notificationMsg}</Text>
+                                </Paper>
+                            )}
+                        </Anchor>
+                    );
+                })}
+            </SimpleGrid>
+        </Stack>
+    );
+};
+
+export const CityGroups: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+    const groups = pulse.therr.topGroups || [];
+    if (groups.length < 1) return null;
+    return (
+        <Stack gap="sm">
+            <Title order={2}>{translate('pages.cityPulse.groupsHeading', { city: pulse.city.name })}</Title>
+            <Stack gap="xs">
+                {groups.slice(0, 6).map((group: any) => (
+                    <Paper key={group.id} withBorder p="sm" radius="sm">
+                        <Anchor component={Link} to={`${localePrefix}/groups/${group.id}`}>{group.title}</Anchor>
+                    </Paper>
+                ))}
+            </Stack>
+        </Stack>
+    );
+};
+
+export const CityCategoryTiles: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+    const cats = pulse.therr.categoriesWithCounts || [];
+    if (!cats.length) return null;
+    return (
+        <Stack gap="sm">
+            <Title order={2}>{translate('pages.cityPulse.browseByCategoryHeading', { city: pulse.city.name })}</Title>
+            <Group gap="xs" wrap="wrap">
+                {cats.map((cat) => {
+                    // Category slug mapping in reverse — backend stores categoryKey (e.g. categories.restaurant/food);
+                    // web URL uses /locations/city/:citySlug/:categorySlug. We can only produce a tile when we can
+                    // derive the category URL slug. Fallback: use the raw slug portion after the last `/`.
+                    const urlSlug = cat.categorySlug.replace('categories.', '').replace(/\//g, '-');
+                    return (
+                        <Button
+                            key={cat.categorySlug}
+                            component={Link}
+                            to={`${localePrefix}/locations/city/${pulse.city.slug}/${urlSlug}`}
+                            variant="light"
+                            size="sm"
+                        >
+                            {formatCategoryLabel(cat.categorySlug)} ({cat.count})
+                        </Button>
+                    );
+                })}
+            </Group>
+        </Stack>
+    );
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Computed/static sections
+
+export const CityNearbyCities: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+    const nearby = pulse.nearbyCities || [];
+    if (!nearby.length) return null;
+    return (
+        <Stack gap="sm">
+            <Title order={2}>{translate('pages.cityPulse.nearbyCitiesHeading')}</Title>
+            <Group gap="sm" wrap="wrap">
+                {nearby.map((c) => (
+                    <Anchor
+                        key={c.slug}
+                        component={Link}
+                        to={`${localePrefix}/locations/city/${c.slug}`}
+                    >
+                        {c.name}, {c.stateAbbr}
+                    </Anchor>
+                ))}
+            </Group>
+        </Stack>
+    );
+};
+
+export const CityCTA: React.FC<ISectionProps> = ({ pulse, translate }) => (
+    <Paper withBorder p="lg" radius="md">
+        <Stack gap="sm" align="center">
+            <Title order={3} ta="center">{translate('pages.cityPulse.ctaHeading', { city: pulse.city.name })}</Title>
+            <Text c="dimmed" ta="center" size="sm">{translate('pages.cityPulse.ctaBody')}</Text>
+            <Group gap="xs" wrap="wrap" justify="center">
+                <Anchor href="https://apps.apple.com/us/app/therr/id1569988763?platform=iphone" target="_blank" rel="noreferrer">
+                    <Image maw={120} src="/assets/images/apple-store-download-button.svg" alt="Download Therr on the App Store" />
+                </Anchor>
+                <Anchor href="https://play.google.com/store/apps/details?id=app.therrmobile" target="_blank" rel="noreferrer">
+                    <Image maw={120} src="/assets/images/play-store-download-button.svg" alt="Download Therr on Google Play" />
+                </Anchor>
+            </Group>
+        </Stack>
+    </Paper>
+);
+
+export const CityAttributionFooter: React.FC<ISectionProps> = ({ pulse, translate }) => {
+    const { wiki } = pulse;
+    const hasWikiContent = !!(wiki.summary || wiki.sections);
+    if (!hasWikiContent) return null;
+    return (
+        <Paper p="md" radius="md" mt="md">
+            <Divider mb="sm" />
+            <Stack gap={4}>
+                <Text size="xs" c="dimmed">
+                    {translate('pages.cityPulse.attributionLead')}
+                </Text>
+                {wiki.attributionUrl && (
+                    <Text size="xs" c="dimmed">
+                        {translate('pages.cityPulse.attributionSource')}:
+                        {' '}
+                        <Anchor href={wiki.attributionUrl} target="_blank" rel="noreferrer">{wiki.attributionUrl}</Anchor>
+                        {' '}·{' '}
+                        <Anchor href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank" rel="noreferrer">
+                            CC BY-SA 4.0
+                        </Anchor>
+                    </Text>
+                )}
+                {wiki.localeFallback && (
+                    <Text size="xs" c="dimmed">{translate('pages.cityPulse.attributionLocaleFallback')}</Text>
+                )}
+            </Stack>
+        </Paper>
+    );
+};

--- a/therr-client-web/src/components/CityPulse/index.tsx
+++ b/therr-client-web/src/components/CityPulse/index.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import {
     Stack, Group, Title, Text, Badge, Anchor, Paper, Image, SimpleGrid, Avatar, Button, Divider,
 } from '@mantine/core';
+import { Categories } from 'therr-js-utilities/constants';
 import { buildSpaceSlug } from 'therr-js-utilities/slugify';
 import getUserContentUri from '../../utilities/getUserContentUri';
 
@@ -19,6 +20,21 @@ const formatCategoryLabel = (category: string): string => {
 const paragraphsFromText = (text: string | null | undefined, limit = 4): string[] => {
     if (!text) return [];
     return text.split(/\n\n+/).map((p) => p.trim()).filter(Boolean).slice(0, limit);
+};
+
+// Locale-stable event date formatter. Avoids `toLocaleString()` which produces
+// different output on Node (SSR) vs the browser and triggers React hydration
+// warnings. Format: "Apr 13, 2026 · 7:30 PM".
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const formatEventDate = (iso: string | null | undefined): string => {
+    if (!iso) return '';
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    const hour24 = d.getUTCHours();
+    const hour12 = hour24 % 12 === 0 ? 12 : hour24 % 12;
+    const minutes = String(d.getUTCMinutes()).padStart(2, '0');
+    const ampm = hour24 < 12 ? 'AM' : 'PM';
+    return `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()} · ${hour12}:${minutes} ${ampm}`;
 };
 
 export interface ICityPulseCity {
@@ -60,7 +76,6 @@ export interface ICityPulseData {
 interface ISectionProps {
     pulse: ICityPulseData;
     translate: (key: string, params?: any) => string;
-    localePrefix: string;
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -149,7 +164,11 @@ export const CityGettingAround: React.FC<ISectionProps> = ({ pulse, translate })
 // ──────────────────────────────────────────────────────────────────
 // Therr-sourced sections
 
-export const CityTrendingSpaces: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+export const CityTrendingSpaces: React.FC<ISectionProps> = ({ pulse, translate }) => {
+    // Link `to` values are route-relative; React Router's <StaticRouter> /
+    // <BrowserRouter> basename (set to the locale prefix in Layout) prepends
+    // the locale automatically. Don't prepend localePrefix here — that would
+    // double-prefix client-side navigation.
     const spaces = pulse.therr.trendingSpaces || [];
     if (spaces.length < 6) return null;
     return (
@@ -171,7 +190,7 @@ export const CityTrendingSpaces: React.FC<ISectionProps> = ({ pulse, translate, 
                                     </Avatar>
                                 )}
                                 <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
-                                    <Anchor component={Link} to={`${localePrefix}/spaces/${space.id}/${slug}`} fw={600}>
+                                    <Anchor component={Link} to={`/spaces/${space.id}/${slug}`} fw={600}>
                                         {space.notificationMsg}
                                     </Anchor>
                                     {space.addressReadable && (
@@ -190,7 +209,7 @@ export const CityTrendingSpaces: React.FC<ISectionProps> = ({ pulse, translate, 
     );
 };
 
-export const CityUpcomingEvents: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+export const CityUpcomingEvents: React.FC<ISectionProps> = ({ pulse, translate }) => {
     const events = pulse.therr.upcomingEvents || [];
     if (events.length < 1) return null;
     return (
@@ -198,14 +217,14 @@ export const CityUpcomingEvents: React.FC<ISectionProps> = ({ pulse, translate, 
             <Title order={2}>{translate('pages.cityPulse.upcomingEventsHeading', { city: pulse.city.name })}</Title>
             <Stack gap="xs">
                 {events.slice(0, 8).map((event: any) => {
-                    const startDate = event.scheduleStartAt ? new Date(event.scheduleStartAt) : null;
+                    const dateLabel = formatEventDate(event.scheduleStartAt);
                     return (
                         <Paper key={event.id} withBorder p="md" radius="md">
-                            <Anchor component={Link} to={`${localePrefix}/events/${event.id}`} fw={600}>
+                            <Anchor component={Link} to={`/events/${event.id}`} fw={600}>
                                 {event.notificationMsg}
                             </Anchor>
-                            {startDate && (
-                                <Text size="sm" c="dimmed">{startDate.toLocaleString()}</Text>
+                            {dateLabel && (
+                                <Text size="sm" c="dimmed">{dateLabel}</Text>
                             )}
                         </Paper>
                     );
@@ -215,7 +234,7 @@ export const CityUpcomingEvents: React.FC<ISectionProps> = ({ pulse, translate, 
     );
 };
 
-export const CityMomentsWall: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+export const CityMomentsWall: React.FC<ISectionProps> = ({ pulse, translate }) => {
     const moments = pulse.therr.recentMoments || [];
     if (moments.length < 9) return null;
     return (
@@ -226,7 +245,7 @@ export const CityMomentsWall: React.FC<ISectionProps> = ({ pulse, translate, loc
                     const mediaPath = moment.medias?.[0]?.path;
                     const img = mediaPath ? getUserContentUri(moment.medias[0], 200, 200, true) : null;
                     return (
-                        <Anchor key={moment.id} component={Link} to={`${localePrefix}/moments/${moment.id}`}>
+                        <Anchor key={moment.id} component={Link} to={`/moments/${moment.id}`}>
                             {img ? (
                                 <Image src={img} alt={moment.notificationMsg || 'moment'} h={120} fit="cover" radius="sm" />
                             ) : (
@@ -242,7 +261,7 @@ export const CityMomentsWall: React.FC<ISectionProps> = ({ pulse, translate, loc
     );
 };
 
-export const CityGroups: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+export const CityGroups: React.FC<ISectionProps> = ({ pulse, translate }) => {
     const groups = pulse.therr.topGroups || [];
     if (groups.length < 1) return null;
     return (
@@ -251,7 +270,7 @@ export const CityGroups: React.FC<ISectionProps> = ({ pulse, translate, localePr
             <Stack gap="xs">
                 {groups.slice(0, 6).map((group: any) => (
                     <Paper key={group.id} withBorder p="sm" radius="sm">
-                        <Anchor component={Link} to={`${localePrefix}/groups/${group.id}`}>{group.title}</Anchor>
+                        <Anchor component={Link} to={`/groups/${group.id}`}>{group.title}</Anchor>
                     </Paper>
                 ))}
             </Stack>
@@ -259,30 +278,34 @@ export const CityGroups: React.FC<ISectionProps> = ({ pulse, translate, localePr
     );
 };
 
-export const CityCategoryTiles: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
-    const cats = pulse.therr.categoriesWithCounts || [];
-    if (!cats.length) return null;
+export const CityCategoryTiles: React.FC<ISectionProps> = ({ pulse, translate }) => {
+    // Map backend category keys (e.g. "categories.restaurant/food") to URL slugs
+    // ("restaurants") via the canonical CategorySlugMap. Skip categories without
+    // a URL slug mapping so users never land on a 404 tile.
+    const tiles = (pulse.therr.categoriesWithCounts || [])
+        .map((cat) => ({
+            categoryKey: cat.categorySlug,
+            count: cat.count,
+            urlSlug: Categories.CategorySlugMap[cat.categorySlug],
+        }))
+        .filter((t) => !!t.urlSlug);
+
+    if (!tiles.length) return null;
     return (
         <Stack gap="sm">
             <Title order={2}>{translate('pages.cityPulse.browseByCategoryHeading', { city: pulse.city.name })}</Title>
             <Group gap="xs" wrap="wrap">
-                {cats.map((cat) => {
-                    // Category slug mapping in reverse — backend stores categoryKey (e.g. categories.restaurant/food);
-                    // web URL uses /locations/city/:citySlug/:categorySlug. We can only produce a tile when we can
-                    // derive the category URL slug. Fallback: use the raw slug portion after the last `/`.
-                    const urlSlug = cat.categorySlug.replace('categories.', '').replace(/\//g, '-');
-                    return (
-                        <Button
-                            key={cat.categorySlug}
-                            component={Link}
-                            to={`${localePrefix}/locations/city/${pulse.city.slug}/${urlSlug}`}
-                            variant="light"
-                            size="sm"
-                        >
-                            {formatCategoryLabel(cat.categorySlug)} ({cat.count})
-                        </Button>
-                    );
-                })}
+                {tiles.map((tile) => (
+                    <Button
+                        key={tile.categoryKey}
+                        component={Link}
+                        to={`/locations/city/${pulse.city.slug}/${tile.urlSlug}`}
+                        variant="light"
+                        size="sm"
+                    >
+                        {formatCategoryLabel(tile.categoryKey)} ({tile.count})
+                    </Button>
+                ))}
             </Group>
         </Stack>
     );
@@ -291,7 +314,7 @@ export const CityCategoryTiles: React.FC<ISectionProps> = ({ pulse, translate, l
 // ──────────────────────────────────────────────────────────────────
 // Computed/static sections
 
-export const CityNearbyCities: React.FC<ISectionProps> = ({ pulse, translate, localePrefix }) => {
+export const CityNearbyCities: React.FC<ISectionProps> = ({ pulse, translate }) => {
     const nearby = pulse.nearbyCities || [];
     if (!nearby.length) return null;
     return (
@@ -302,7 +325,7 @@ export const CityNearbyCities: React.FC<ISectionProps> = ({ pulse, translate, lo
                     <Anchor
                         key={c.slug}
                         component={Link}
-                        to={`${localePrefix}/locations/city/${c.slug}`}
+                        to={`/locations/city/${c.slug}`}
                     >
                         {c.name}, {c.stateAbbr}
                     </Anchor>

--- a/therr-client-web/src/locales/en-us/dictionary.json
+++ b/therr-client-web/src/locales/en-us/dictionary.json
@@ -198,6 +198,26 @@
     }
   },
   "pages": {
+    "cityPulse": {
+      "heroTitle": "{city}",
+      "heroFallback": "Explore {city} — local places, events, and community highlights.",
+      "aboutHeading": "About {city}",
+      "neighborhoodsHeading": "Neighborhoods",
+      "gettingAroundHeading": "Getting Around",
+      "getInSubheading": "Getting There",
+      "getAroundSubheading": "Getting Around Town",
+      "trendingSpacesHeading": "Trending places in {city}",
+      "upcomingEventsHeading": "Upcoming events in {city}",
+      "momentsWallHeading": "Recent moments from {city}",
+      "groupsHeading": "Active groups in {city}",
+      "browseByCategoryHeading": "Browse {city} by category",
+      "nearbyCitiesHeading": "Nearby cities",
+      "ctaHeading": "Get the Therr app for {city}",
+      "ctaBody": "Discover more local spots, share moments with the community, and earn rewards.",
+      "attributionLead": "Some content on this page is sourced from Wikipedia and Wikivoyage, licensed under CC BY-SA 4.0. Excerpts have been summarized and reformatted.",
+      "attributionSource": "Source",
+      "attributionLocaleFallback": "Some content is shown in English because a translation was not available."
+    },
     "childSafety": {
       "pageTitle": "Child Safety Standards",
       "intro": "Therr is committed to the safety and protection of all users, especially children. We maintain a zero-tolerance policy toward child sexual abuse and exploitation (CSAE) on our platform.",

--- a/therr-client-web/src/locales/es/dictionary.json
+++ b/therr-client-web/src/locales/es/dictionary.json
@@ -198,6 +198,26 @@
     }
   },
   "pages": {
+    "cityPulse": {
+      "heroTitle": "{city}",
+      "heroFallback": "Explora {city}: lugares locales, eventos y novedades de la comunidad.",
+      "aboutHeading": "Acerca de {city}",
+      "neighborhoodsHeading": "Barrios",
+      "gettingAroundHeading": "Cómo moverse",
+      "getInSubheading": "Cómo llegar",
+      "getAroundSubheading": "Cómo desplazarse",
+      "trendingSpacesHeading": "Lugares populares en {city}",
+      "upcomingEventsHeading": "Próximos eventos en {city}",
+      "momentsWallHeading": "Momentos recientes desde {city}",
+      "groupsHeading": "Grupos activos en {city}",
+      "browseByCategoryHeading": "Explora {city} por categoría",
+      "nearbyCitiesHeading": "Ciudades cercanas",
+      "ctaHeading": "Obtén la aplicación Therr para {city}",
+      "ctaBody": "Descubre más lugares locales, comparte momentos con la comunidad y gana recompensas.",
+      "attributionLead": "Parte del contenido de esta página proviene de Wikipedia y Wikivoyage, bajo licencia CC BY-SA 4.0. Los extractos han sido resumidos y reformateados.",
+      "attributionSource": "Fuente",
+      "attributionLocaleFallback": "Parte del contenido se muestra en inglés porque no hay traducción disponible."
+    },
     "childSafety": {
       "pageTitle": "Estándares de seguridad infantil",
       "intro": "Therr está comprometido con la seguridad y protección de todos los usuarios, especialmente los menores de edad. Mantenemos una política de tolerancia cero hacia el abuso y la explotación sexual infantil (CSAE) en nuestra plataforma.",

--- a/therr-client-web/src/locales/fr-ca/dictionary.json
+++ b/therr-client-web/src/locales/fr-ca/dictionary.json
@@ -198,6 +198,26 @@
     }
   },
   "pages": {
+    "cityPulse": {
+      "heroTitle": "{city}",
+      "heroFallback": "Explorez {city} — lieux locaux, événements et temps forts de la communauté.",
+      "aboutHeading": "À propos de {city}",
+      "neighborhoodsHeading": "Quartiers",
+      "gettingAroundHeading": "Se déplacer",
+      "getInSubheading": "Comment s'y rendre",
+      "getAroundSubheading": "Se déplacer sur place",
+      "trendingSpacesHeading": "Lieux populaires à {city}",
+      "upcomingEventsHeading": "Événements à venir à {city}",
+      "momentsWallHeading": "Moments récents de {city}",
+      "groupsHeading": "Groupes actifs à {city}",
+      "browseByCategoryHeading": "Parcourir {city} par catégorie",
+      "nearbyCitiesHeading": "Villes à proximité",
+      "ctaHeading": "Obtenez l'application Therr pour {city}",
+      "ctaBody": "Découvrez plus de lieux locaux, partagez des moments avec la communauté et gagnez des récompenses.",
+      "attributionLead": "Certains contenus de cette page proviennent de Wikipédia et Wikivoyage, sous licence CC BY-SA 4.0. Les extraits ont été résumés et reformatés.",
+      "attributionSource": "Source",
+      "attributionLocaleFallback": "Certains contenus sont affichés en anglais car aucune traduction n'est disponible."
+    },
     "childSafety": {
       "pageTitle": "Normes de sécurité des enfants",
       "intro": "Therr s'engage à assurer la sécurité et la protection de tous les utilisateurs, en particulier les enfants. Nous maintenons une politique de tolérance zéro envers l'abus et l'exploitation sexuels des enfants (AESE) sur notre plateforme.",

--- a/therr-client-web/src/routeConfig.ts
+++ b/therr-client-web/src/routeConfig.ts
@@ -147,10 +147,10 @@ export default [
     {
         route: '/locations/city/:citySlug',
         head: {
-            title: 'Local Business Directory',
-            description: 'Browse local businesses near you. Read reviews, see hours, and get directions.',
+            title: 'City Guide: Local Businesses, Events & Places',
+            description: 'Discover local businesses, events, and things to do. Read neighborhood guides, transit tips, and community highlights.',
         },
-        view: 'locations',
+        view: 'city-pulse',
     },
     {
         route: '/locations/city/:citySlug/:categorySlug',

--- a/therr-client-web/src/routes/ViewCityPulse.tsx
+++ b/therr-client-web/src/routes/ViewCityPulse.tsx
@@ -42,10 +42,6 @@ interface IViewCityPulseProps extends IViewCityPulseRouterProps, IStoreProps {
     translate: (key: string, params?: any) => string;
 }
 
-interface IViewCityPulseState {
-    isLoading: boolean;
-}
-
 const mapStateToProps = (state: any) => ({
     map: state.map,
 });
@@ -54,14 +50,11 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
     getCityPulse: MapActions.getCityPulse,
 }, dispatch);
 
-export class ViewCityPulseComponent extends React.Component<IViewCityPulseProps, IViewCityPulseState> {
-    constructor(props: IViewCityPulseProps) {
-        super(props);
-        this.state = { isLoading: false };
-    }
-
+export class ViewCityPulseComponent extends React.Component<IViewCityPulseProps> {
     componentDidMount() {
-        const { routeParams, map, locale, getCityPulse, navigation } = this.props;
+        const {
+            routeParams, map, locale, getCityPulse, navigation,
+        } = this.props;
         const city = Cities.CitySlugMap[routeParams.citySlug];
 
         if (!city) {
@@ -69,11 +62,9 @@ export class ViewCityPulseComponent extends React.Component<IViewCityPulseProps,
             return;
         }
 
-        // Use cached state from SSR preload if present; otherwise fetch.
+        // Use SSR preload if present; otherwise fetch client-side.
         if (!map?.cityPulse?.[routeParams.citySlug]) {
-            this.setState({ isLoading: true });
-            getCityPulse(routeParams.citySlug, locale)
-                .finally(() => this.setState({ isLoading: false }));
+            getCityPulse(routeParams.citySlug, locale);
         }
     }
 
@@ -82,6 +73,7 @@ export class ViewCityPulseComponent extends React.Component<IViewCityPulseProps,
      * push Therr above the fold; otherwise lead with the Wiki baseline so the
      * page still feels substantive for thin-data cities.
      */
+    // eslint-disable-next-line class-methods-use-this
     getSectionOrder(pulse: ICityPulseData): 'therrFirst' | 'wikiFirst' {
         const therrSignals = [
             (pulse.therr.trendingSpaces?.length || 0) >= 6,
@@ -94,14 +86,11 @@ export class ViewCityPulseComponent extends React.Component<IViewCityPulseProps,
     }
 
     public render(): JSX.Element | null {
-        const { map, routeParams, locale, translate } = this.props;
+        const { map, routeParams, translate } = this.props;
         const city = Cities.CitySlugMap[routeParams.citySlug];
         if (!city) return null;
 
         const pulse: ICityPulseData | undefined = map?.cityPulse?.[routeParams.citySlug];
-
-        const localePrefixMap: Record<string, string> = { es: '/es', 'fr-ca': '/fr' };
-        const localePrefix = localePrefixMap[locale] || '';
 
         // Fallback "shell" pulse so the page renders while loading
         const effective: ICityPulseData = pulse || {
@@ -130,7 +119,7 @@ export class ViewCityPulseComponent extends React.Component<IViewCityPulseProps,
             nearbyCities: [],
         };
 
-        const sectionProps = { pulse: effective, translate, localePrefix };
+        const sectionProps = { pulse: effective, translate };
         const order = this.getSectionOrder(effective);
 
         const therrBlock = (

--- a/therr-client-web/src/routes/ViewCityPulse.tsx
+++ b/therr-client-web/src/routes/ViewCityPulse.tsx
@@ -1,0 +1,177 @@
+/* eslint-disable max-len */
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { NavigateFunction } from 'react-router-dom';
+import { MapActions } from 'therr-react/redux/actions';
+import { Cities } from 'therr-js-utilities/constants';
+import { Stack } from '@mantine/core';
+import withNavigation from '../wrappers/withNavigation';
+import withTranslation from '../wrappers/withTranslation';
+import {
+    CityHero,
+    CityAbout,
+    CityNeighborhoods,
+    CityTrendingSpaces,
+    CityUpcomingEvents,
+    CityMomentsWall,
+    CityGroups,
+    CityCategoryTiles,
+    CityGettingAround,
+    CityNearbyCities,
+    CityCTA,
+    CityAttributionFooter,
+    ICityPulseData,
+} from '../components/CityPulse';
+
+interface IViewCityPulseRouterProps {
+    navigation: { navigate: NavigateFunction };
+    routeParams: { citySlug: string };
+}
+
+interface IViewCityPulseDispatchProps {
+    getCityPulse: Function;
+}
+
+interface IStoreProps extends IViewCityPulseDispatchProps {
+    map: any;
+}
+
+interface IViewCityPulseProps extends IViewCityPulseRouterProps, IStoreProps {
+    locale: string;
+    translate: (key: string, params?: any) => string;
+}
+
+interface IViewCityPulseState {
+    isLoading: boolean;
+}
+
+const mapStateToProps = (state: any) => ({
+    map: state.map,
+});
+
+const mapDispatchToProps = (dispatch: any) => bindActionCreators({
+    getCityPulse: MapActions.getCityPulse,
+}, dispatch);
+
+export class ViewCityPulseComponent extends React.Component<IViewCityPulseProps, IViewCityPulseState> {
+    constructor(props: IViewCityPulseProps) {
+        super(props);
+        this.state = { isLoading: false };
+    }
+
+    componentDidMount() {
+        const { routeParams, map, locale, getCityPulse, navigation } = this.props;
+        const city = Cities.CitySlugMap[routeParams.citySlug];
+
+        if (!city) {
+            setTimeout(() => navigation.navigate('/locations'));
+            return;
+        }
+
+        // Use cached state from SSR preload if present; otherwise fetch.
+        if (!map?.cityPulse?.[routeParams.citySlug]) {
+            this.setState({ isLoading: true });
+            getCityPulse(routeParams.citySlug, locale)
+                .finally(() => this.setState({ isLoading: false }));
+        }
+    }
+
+    /**
+     * Order sections. When Therr has meaningful content (>= 3 populated sections),
+     * push Therr above the fold; otherwise lead with the Wiki baseline so the
+     * page still feels substantive for thin-data cities.
+     */
+    getSectionOrder(pulse: ICityPulseData): 'therrFirst' | 'wikiFirst' {
+        const therrSignals = [
+            (pulse.therr.trendingSpaces?.length || 0) >= 6,
+            (pulse.therr.upcomingEvents?.length || 0) >= 1,
+            (pulse.therr.recentMoments?.length || 0) >= 9,
+            (pulse.therr.topGroups?.length || 0) >= 1,
+        ].filter(Boolean).length;
+
+        return therrSignals >= 3 ? 'therrFirst' : 'wikiFirst';
+    }
+
+    public render(): JSX.Element | null {
+        const { map, routeParams, locale, translate } = this.props;
+        const city = Cities.CitySlugMap[routeParams.citySlug];
+        if (!city) return null;
+
+        const pulse: ICityPulseData | undefined = map?.cityPulse?.[routeParams.citySlug];
+
+        const localePrefixMap: Record<string, string> = { es: '/es', 'fr-ca': '/fr' };
+        const localePrefix = localePrefixMap[locale] || '';
+
+        // Fallback "shell" pulse so the page renders while loading
+        const effective: ICityPulseData = pulse || {
+            city: {
+                slug: city.slug,
+                name: city.name,
+                state: city.state,
+                stateAbbr: city.stateAbbr,
+                lat: city.lat,
+                lng: city.lng,
+            },
+            therr: {
+                trendingSpaces: [],
+                upcomingEvents: [],
+                recentMoments: [],
+                topGroups: [],
+                categoriesWithCounts: [],
+            },
+            wiki: {
+                summary: null,
+                sections: null,
+                heroImageUrl: null,
+                attributionUrl: null,
+                license: 'CC-BY-SA-4.0',
+            },
+            nearbyCities: [],
+        };
+
+        const sectionProps = { pulse: effective, translate, localePrefix };
+        const order = this.getSectionOrder(effective);
+
+        const therrBlock = (
+            <>
+                <CityTrendingSpaces {...sectionProps} />
+                <CityUpcomingEvents {...sectionProps} />
+                <CityMomentsWall {...sectionProps} />
+                <CityGroups {...sectionProps} />
+                <CityCategoryTiles {...sectionProps} />
+            </>
+        );
+        const wikiBlock = (
+            <>
+                <CityAbout {...sectionProps} />
+                <CityNeighborhoods {...sectionProps} />
+                <CityGettingAround {...sectionProps} />
+            </>
+        );
+
+        return (
+            <div id="page_view_city_pulse">
+                <Stack gap="lg" p={{ base: 'sm', sm: 'xl' }} maw={920} mx="auto">
+                    <CityHero {...sectionProps} />
+                    {order === 'therrFirst' ? (
+                        <>
+                            {therrBlock}
+                            {wikiBlock}
+                        </>
+                    ) : (
+                        <>
+                            {wikiBlock}
+                            {therrBlock}
+                        </>
+                    )}
+                    <CityNearbyCities {...sectionProps} />
+                    <CityCTA {...sectionProps} />
+                    <CityAttributionFooter {...sectionProps} />
+                </Stack>
+            </div>
+        );
+    }
+}
+
+export default withNavigation(withTranslation(connect(mapStateToProps, mapDispatchToProps)(ViewCityPulseComponent)));

--- a/therr-client-web/src/routes/index.tsx
+++ b/therr-client-web/src/routes/index.tsx
@@ -17,6 +17,7 @@ import Home from './Home';
 import ViewSpace from './ViewSpace';
 import Login from './Login';
 import ListSpaces, { DEFAULT_ITEMS_PER_PAGE, DEFAULT_LATITUDE, DEFAULT_LONGITUDE } from './ListSpaces';
+import ViewCityPulse from './ViewCityPulse';
 import ViewEvent from './ViewEvent';
 import ViewMoment from './ViewMoment';
 import ViewThought from './ViewThought';
@@ -348,19 +349,15 @@ const getRoutes = (routePropsConfig: IRoutePropsConfig): IRoute[] => [
         },
     },
     {
+        // City Pulse landing page — SSR-aware, editorial + Therr-data hybrid.
+        // See docs ViewCityPulse.tsx and handlers/cityPulse.ts.
         path: '/locations/city/:citySlug',
-        element: <ListSpaces />,
+        element: <ViewCityPulse />,
         fetchData: (dispatch: any, params: any, query: any = {}) => {
             const city = Cities.CitySlugMap[params.citySlug];
             if (!city) return Promise.resolve();
-            const radius = parseFloat(query.r) || 50000; // 50 km metro radius
-            return MapActions.listSpaces({
-                itemsPerPage: DEFAULT_ITEMS_PER_PAGE,
-                pageNumber: 1,
-                latitude: city.lat,
-                longitude: city.lng,
-                filterBy: 'distance',
-            }, { distanceOverride: radius })(dispatch);
+            const locale = (query.locale as string) || undefined;
+            return MapActions.getCityPulse(params.citySlug, locale)(dispatch);
         },
     },
     {

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -1596,12 +1596,15 @@ const renderCityPulseView = (req, res, config, {
     // Meta description: lead with Therr counts when we have depth, else Wiki lead.
     let description: string;
     if (trendingCount >= 6) {
-        description = `${trendingCount} local spots${eventsCount ? `, ${eventsCount} events this week` : ''} in ${cityDisplayName || 'this city'}. Browse neighborhoods, nearby places, and things to do.`;
+        const eventsFragment = eventsCount ? `, ${eventsCount} events this week` : '';
+        // eslint-disable-next-line max-len
+        description = `${trendingCount} local spots${eventsFragment} in ${cityDisplayName || 'this city'}. Browse neighborhoods, nearby places, and things to do.`;
     } else if (wikiSummary) {
         const firstSentence = wikiSummary.split(/(?<=[.!?])\s/)[0] || wikiSummary;
         description = firstSentence.substring(0, 300);
     } else {
-        description = config.head.description || `Things to do, places to go, and local highlights in ${cityDisplayName || 'this city'}.`;
+        description = config.head.description
+            || `Things to do, places to go, and local highlights in ${cityDisplayName || 'this city'}.`;
     }
 
     const lp = localeVars.localePrefix;
@@ -1625,8 +1628,12 @@ const renderCityPulseView = (req, res, config, {
         '@context': 'https://schema.org',
         '@type': 'BreadcrumbList',
         itemListElement: [
-            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.therr.com/' },
-            { '@type': 'ListItem', position: 2, name: 'Locations', item: 'https://www.therr.com/locations' },
+            {
+                '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.therr.com/',
+            },
+            {
+                '@type': 'ListItem', position: 2, name: 'Locations', item: 'https://www.therr.com/locations',
+            },
             ...(cityDisplayName ? [{
                 '@type': 'ListItem',
                 position: 3,

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -1566,6 +1566,122 @@ const renderLocationsView = (req, res, config, {
     });
 };
 
+/**
+ * City Pulse SSR renderer. Reads the prefetched pulse data from Redux and
+ * builds meta + JSON-LD that match the page's density. Therr-rich cities get a
+ * counts-based description; otherwise we fall back to the Wiki lead paragraph.
+ */
+const renderCityPulseView = (req, res, config, {
+    markup,
+    state,
+}, initialState, localeVars) => {
+    const routePath = config.route;
+    const routeView = config.view;
+
+    const citySlug = req.params?.citySlug || '';
+    const cityEntry = citySlug ? Cities.CitySlugMap[citySlug] : null;
+    const cityDisplayName = cityEntry ? `${cityEntry.name}, ${cityEntry.stateAbbr}` : '';
+
+    const pulse = initialState?.map?.cityPulse?.[citySlug] || null;
+    const trendingCount = pulse?.therr?.trendingSpaces?.length || 0;
+    const eventsCount = pulse?.therr?.upcomingEvents?.length || 0;
+    const wikiSummary = pulse?.wiki?.summary || '';
+    const hasUnderstand = !!pulse?.wiki?.sections?.understand;
+
+    // Meta title: always "{City}, {StateAbbr}: Local Guide, Events & Places | Therr"
+    const title = cityDisplayName
+        ? `${cityDisplayName}: Local Guide, Events & Places`
+        : (config.head.title || 'City Guide');
+
+    // Meta description: lead with Therr counts when we have depth, else Wiki lead.
+    let description: string;
+    if (trendingCount >= 6) {
+        description = `${trendingCount} local spots${eventsCount ? `, ${eventsCount} events this week` : ''} in ${cityDisplayName || 'this city'}. Browse neighborhoods, nearby places, and things to do.`;
+    } else if (wikiSummary) {
+        const firstSentence = wikiSummary.split(/(?<=[.!?])\s/)[0] || wikiSummary;
+        description = firstSentence.substring(0, 300);
+    } else {
+        description = config.head.description || `Things to do, places to go, and local highlights in ${cityDisplayName || 'this city'}.`;
+    }
+
+    const lp = localeVars.localePrefix;
+
+    // schema.org/City — primary entity for the page.
+    const citySchema: any = cityEntry ? {
+        '@context': 'https://schema.org',
+        '@type': 'City',
+        name: cityEntry.name,
+        containedInPlace: { '@type': 'State', name: cityEntry.state },
+        geo: { '@type': 'GeoCoordinates', latitude: cityEntry.lat, longitude: cityEntry.lng },
+        url: `https://www.therr.com${lp}/locations/city/${citySlug}`,
+    } : {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name: title,
+    };
+
+    // Breadcrumb (Home → Locations → {City})
+    const breadcrumbSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://www.therr.com/' },
+            { '@type': 'ListItem', position: 2, name: 'Locations', item: 'https://www.therr.com/locations' },
+            ...(cityDisplayName ? [{
+                '@type': 'ListItem',
+                position: 3,
+                name: cityDisplayName,
+                item: `https://www.therr.com/locations/city/${citySlug}`,
+            }] : []),
+        ],
+    };
+
+    // ItemList of trending spaces (when we have any) — good for rich results.
+    let itemListSchema: any = null;
+    const trendingSpaces = pulse?.therr?.trendingSpaces || [];
+    if (trendingSpaces.length > 0) {
+        itemListSchema = {
+            '@context': 'https://schema.org',
+            '@type': 'ItemList',
+            name: `Trending places in ${cityDisplayName || 'this city'}`,
+            numberOfItems: trendingSpaces.length,
+            itemListElement: trendingSpaces.slice(0, 20).map((space: any, index: number) => {
+                const slug = buildSpaceSlug(space.notificationMsg, space.addressLocality, space.addressRegion);
+                return {
+                    '@type': 'ListItem',
+                    position: index + 1,
+                    url: `https://www.therr.com${lp}/spaces/${space.id}${slug ? `/${slug}` : ''}`,
+                    name: space.notificationMsg || space.id,
+                };
+            }),
+        };
+    }
+
+    // TouristDestination when Wikivoyage provided an Understand section —
+    // signals to search engines this is editorial guide content.
+    const touristDestinationSchema: any = hasUnderstand && cityEntry ? {
+        '@context': 'https://schema.org',
+        '@type': 'TouristDestination',
+        name: cityEntry.name,
+        description,
+        geo: { '@type': 'GeoCoordinates', latitude: cityEntry.lat, longitude: cityEntry.lng },
+    } : null;
+
+    return res.render(routeView, {
+        title,
+        description,
+        cityName: cityEntry?.name || '',
+        citySchema: JSON.stringify(citySchema),
+        breadcrumbSchema: JSON.stringify(breadcrumbSchema),
+        itemListSchema: itemListSchema ? JSON.stringify(itemListSchema) : '',
+        touristDestinationSchema: touristDestinationSchema ? JSON.stringify(touristDestinationSchema) : '',
+        markup,
+        routePath,
+        state,
+        ...localeVars,
+    });
+};
+
 const renderGroupView = (req, res, config, {
     markup,
     state,
@@ -1871,6 +1987,13 @@ routeConfig.forEach((config) => {
 
                 if (routeView === 'locations') {
                     return renderLocationsView(req, res, config, {
+                        markup,
+                        state,
+                    }, initialState, localeVars);
+                }
+
+                if (routeView === 'city-pulse') {
+                    return renderCityPulseView(req, res, config, {
                         markup,
                         state,
                     }, initialState, localeVars);

--- a/therr-client-web/src/views/city-pulse.hbs
+++ b/therr-client-web/src/views/city-pulse.hbs
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="{{htmlLang}}">
+
+<head>
+    <meta charset="utf-8" />
+    <title>Therr | {{title}}</title>
+    <link rel="canonical" href="https://www.therr.com{{canonicalPath}}" />
+    <link rel="alternate" hreflang="en-US" href="https://www.therr.com{{hreflangEn}}" />
+    <link rel="alternate" hreflang="es-MX" href="https://www.therr.com{{hreflangEs}}" />
+    <link rel="alternate" hreflang="fr-CA" href="https://www.therr.com{{hreflangFr}}" />
+    <link rel="alternate" hreflang="x-default" href="https://www.therr.com{{hreflangEn}}" />
+
+    <meta name="msapplication-TileColor" content="#da532c">
+    <meta name="theme-color" content="#ffffff">
+
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="dns-prefetch" href="https://ik.imagekit.io">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://ik.imagekit.io" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@200;400;600;800&display=swap" media="print" id="google-fonts-link">
+    <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@200;400;600;800&display=swap"></noscript>
+    <link rel="preload" as="style" href="/vendor.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.css" onload="this.onload=null;this.rel='stylesheet'">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{{description}}">
+    <meta name="author" content="Therr">
+    <meta name="keywords" content="therr, therr app, {{cityName}}, {{cityName}} guide, things to do in {{cityName}}, local businesses, events, neighborhoods">
+
+    <meta property="og:site_name" content="Therr" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="{{ogLocale}}" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="es_MX" />
+    <meta property="og:locale:alternate" content="fr_CA" />
+    <meta property="og:url" content="https://www.therr.com{{canonicalPath}}" />
+    <meta property="og:title" content="Therr | {{title}}" />
+    <meta property="og:image" content="https://therr.com/assets/images/meta-image-logo.png" />
+    <meta property="og:description" content="{{description}}" />
+    <meta name="twitter:image" content="https://therr.com/assets/images/meta-image-logo.png" />
+    <meta name="twitter:title" content="Therr | {{title}}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@therr_app" />
+
+    {{#if googleSiteVerification}}<meta name="google-site-verification" content="{{googleSiteVerification}}" />{{/if}}
+    {{#if bingSiteVerification}}<meta name="msvalidate.01" content="{{bingSiteVerification}}" />{{/if}}
+    {{#if pinterestVerification}}<meta name="p:domain_verify" content="{{pinterestVerification}}" />{{/if}}
+    <link rel="search" type="application/opensearchdescription+xml" title="Therr" href="/opensearch.xml" />
+    <meta name="apple-itunes-app" content="app-id=1569988763">
+    <link rel="icon" href="/assets/images/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16x16.png">
+    <link rel="mask-icon" href="/assets/images/safari-pinned-tab.svg" color="#5bbad5">
+    <script>document.documentElement.setAttribute('data-mantine-color-scheme', (document.cookie.match(/therr-color-scheme=(light|dark)/)||[])[1]||'light');</script>
+    <style>
+      html{background:#f3f4f6}
+      html,body{color:#1f2937;font-family:'Lexend',sans-serif;font-size:16px;margin:0;padding:0}
+      [data-mantine-color-scheme="dark"]{--mantine-color-body:#1E1E1E;--mantine-color-text:#E0E0E0}
+      [data-mantine-color-scheme="dark"] html{background:#121212}
+      [data-mantine-color-scheme="dark"] html,[data-mantine-color-scheme="dark"] body{color:#E0E0E0}
+      header{z-index:90;align-items:center;background:var(--therr-header-bg,#1C7F8A);display:flex;height:2.8rem;left:0;position:fixed;top:0;width:100%;box-shadow:0 1px 3px rgba(0,0,0,.12)}
+      .content-container,.content-container-home{background:#fff;margin:2.8rem 0;padding:1.5rem 1rem;min-height:calc(100vh - 5.6rem);box-sizing:border-box}
+      [data-mantine-color-scheme="dark"] .content-container,[data-mantine-color-scheme="dark"] .content-container-home{background:#1E1E1E}
+      .view{min-height:100vh}
+      h1{margin:.9rem 0;font-weight:400}
+      @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
+    </style>
+    <noscript>
+        <link rel="stylesheet" href="/vendor.css">
+        <link rel="stylesheet" href="/app.css">
+    </noscript>
+
+    <script type="application/ld+json">{{{citySchema}}}</script>
+    <script type="application/ld+json">{{{breadcrumbSchema}}}</script>
+    {{#if itemListSchema}}
+    <script type="application/ld+json">{{{itemListSchema}}}</script>
+    {{/if}}
+    {{#if touristDestinationSchema}}
+    <script type="application/ld+json">{{{touristDestinationSchema}}}</script>
+    {{/if}}
+</head>
+
+<body>
+    <div id="app" class="view">{{{markup}}}</div>
+    <script>
+        window.__PRELOADED_STATE__ = {{{state}}}
+    </script>
+    <script defer src="/runtime.3f3aa587846de0bb8cf6.js"></script>
+    <script defer src="/vendor.8e197b644a36c40b52ab.js"></script>
+    <script defer src="/app.a85c05b8eaa33ca44d17.js"></script>
+</body>
+
+</html>

--- a/therr-client-web/update-views.js
+++ b/therr-client-web/update-views.js
@@ -12,6 +12,7 @@ const viewFiles = [
     path.join(__dirname, 'src/views/users.hbs'),
     path.join(__dirname, 'src/views/events.hbs'),
     path.join(__dirname, 'src/views/groups.hbs'),
+    path.join(__dirname, 'src/views/city-pulse.hbs'),
 ];
 
 // We need to keep the css/js file paths up to date because we use content hashing in the build compilation

--- a/therr-public-library/therr-react/src/redux/actions/Maps.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Maps.ts
@@ -509,6 +509,21 @@ const Maps = {
             console.log(error);
             return { results: [] };
         }),
+
+    // City Pulse
+    getCityPulse: (slug: string, locale?: string) => (dispatch: any) => MapsService
+        .getCityPulse(slug, locale)
+        .then((response: any) => {
+            dispatch({
+                type: MapActionTypes.GET_CITY_PULSE,
+                data: response.data,
+            });
+            return response.data;
+        })
+        .catch((error: any) => {
+            console.log(error);
+            return null;
+        }),
 };
 
 export default Maps;

--- a/therr-public-library/therr-react/src/redux/reducers/map.ts
+++ b/therr-public-library/therr-react/src/redux/reducers/map.ts
@@ -266,8 +266,10 @@ const map = produce((draft: IMapState, action: any) => {
             break;
         case MapActionTypes.GET_CITY_PULSE:
             if (action.data?.city?.slug) {
+                // Guard: older persisted state (mobile pre-rollout) may rehydrate
+                // without this key. Fall back to {} so the spread is well-defined.
                 draft.cityPulse = {
-                    ...draft.cityPulse,
+                    ...(draft.cityPulse || {}),
                     [action.data.city.slug]: action.data,
                 };
             }

--- a/therr-public-library/therr-react/src/redux/reducers/map.ts
+++ b/therr-public-library/therr-react/src/redux/reducers/map.ts
@@ -6,6 +6,7 @@ import { ContentActionTypes } from '../../types/redux/content';
 const initialState: IMapState = {
     activityGeneration: {},
     activities: {},
+    cityPulse: {},
     events: {},
     moments: {},
     spaces: {},
@@ -262,6 +263,14 @@ const map = produce((draft: IMapState, action: any) => {
                 ...draft.recentEngagements,
                 [action.data.spaceId]: action.data,
             };
+            break;
+        case MapActionTypes.GET_CITY_PULSE:
+            if (action.data?.city?.slug) {
+                draft.cityPulse = {
+                    ...draft.cityPulse,
+                    [action.data.city.slug]: action.data,
+                };
+            }
             break;
         // // // // // // // // // // // //
         case MapActionTypes.UPDATE_MAP_VIEW_COORDS:

--- a/therr-public-library/therr-react/src/services/MapsService.ts
+++ b/therr-public-library/therr-react/src/services/MapsService.ts
@@ -525,6 +525,13 @@ class MapsService {
         headers: {},
     });
 
+    // City Pulse (editorial + Therr-data aggregate for city landing pages)
+    getCityPulse = (slug: string, locale?: string) => axios({
+        method: 'get',
+        url: `/maps-service/cities/${encodeURIComponent(slug)}/pulse${locale ? `?locale=${encodeURIComponent(locale)}` : ''}`,
+        headers: {},
+    });
+
     // Activities
     generateActivity = ({
         distanceMeters,

--- a/therr-public-library/therr-react/src/types/redux/maps.ts
+++ b/therr-public-library/therr-react/src/types/redux/maps.ts
@@ -10,6 +10,7 @@ export interface IMapState {
     prevLatitudeDelta?: number;
     activities: { [id: string]: any };
     activityGeneration: { [id: string]: any };
+    cityPulse: { [slug: string]: any };
     events: { [id: string]: any };
     moments: { [id: string]: any };
     spaces: { [id: string]: any };
@@ -56,6 +57,9 @@ export enum MapActionTypes {
     UPDATE_USER_COORDS = 'UPDATE_USER_COORDS',
     UPDATE_USER_RADIUS = 'UPDATE_USER_RADIUS',
     UPDATE_MAP_VIEW_COORDS = 'UPDATE_MAP_VIEW_COORDS',
+
+    // City Pulse
+    GET_CITY_PULSE = 'GET_CITY_PULSE',
 
     // Filters
     SET_MAP_FILTERS = 'SET_MAP_FILTERS',

--- a/therr-public-library/therr-react/src/types/redux/maps.ts
+++ b/therr-public-library/therr-react/src/types/redux/maps.ts
@@ -10,7 +10,9 @@ export interface IMapState {
     prevLatitudeDelta?: number;
     activities: { [id: string]: any };
     activityGeneration: { [id: string]: any };
-    cityPulse: { [slug: string]: any };
+    // Optional for backwards-compat: the deployed mobile app built before this
+    // field was added may rehydrate persisted state without it.
+    cityPulse?: { [slug: string]: any };
     events: { [id: string]: any };
     moments: { [id: string]: any };
     spaces: { [id: string]: any };

--- a/therr-services/maps-service/src/handlers/cityPulse.ts
+++ b/therr-services/maps-service/src/handlers/cityPulse.ts
@@ -17,8 +17,12 @@ const TRENDING_SPACES_LIMIT = 12;
 const UPCOMING_EVENTS_LIMIT = 12;
 const RECENT_MOMENTS_LIMIT = 18;
 
-const toLocale = (raw: string | undefined): SupportedLocale => {
-    if (raw === 'es' || raw === 'fr-ca') return raw;
+// Must match api-gateway normalizePulseLocale(): exact-match against the
+// supported set, else fall back to "en-us". Handles arrays that Express may
+// produce when a query param is repeated.
+const toLocale = (raw: unknown): SupportedLocale => {
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    if (value === 'es' || value === 'fr-ca' || value === 'en-us') return value;
     return 'en-us';
 };
 
@@ -48,7 +52,7 @@ const getCityPulse: RequestHandler = async (req: any, res: any) => {
     }
 
     const { locale: headerLocale } = parseHeaders(req.headers);
-    const locale = toLocale((req.query?.locale as string) || headerLocale);
+    const locale = toLocale(req.query?.locale || headerLocale);
 
     // Build an auth-optional "headers" object for internal calls. We set
     // isRequestAuthorized=false so stores return the public columns only.

--- a/therr-services/maps-service/src/handlers/cityPulse.ts
+++ b/therr-services/maps-service/src/handlers/cityPulse.ts
@@ -1,0 +1,216 @@
+import { RequestHandler } from 'express';
+import { parseHeaders } from 'therr-js-utilities/http';
+import { Cities } from 'therr-js-utilities/constants';
+import logSpan from 'therr-js-utilities/log-or-update-span';
+import handleHttpError from '../utilities/handleHttpError';
+import Store from '../store';
+import { refreshCityWiki } from '../workers/wikiCacheRefresh';
+import { SupportedLocale } from '../utilities/wikiFetcher';
+
+// City Pulse aggregation endpoint. Fans out to spaces/events/moments in parallel
+// and composes a single response the SSR + client consume directly. Wiki content
+// is served from cache; a cold cache fires a background refresh and returns
+// Therr-only content.
+
+const PULSE_RADIUS_METERS = 50000; // 50 km metro radius (matches ListSpaces).
+const TRENDING_SPACES_LIMIT = 12;
+const UPCOMING_EVENTS_LIMIT = 12;
+const RECENT_MOMENTS_LIMIT = 18;
+
+const toLocale = (raw: string | undefined): SupportedLocale => {
+    if (raw === 'es' || raw === 'fr-ca') return raw;
+    return 'en-us';
+};
+
+const haversineKm = (aLat: number, aLng: number, bLat: number, bLng: number): number => {
+    const R = 6371;
+    const toRad = (d: number) => (d * Math.PI) / 180;
+    const dLat = toRad(bLat - aLat);
+    const dLng = toRad(bLng - aLng);
+    const lat1 = toRad(aLat);
+    const lat2 = toRad(bLat);
+    const h = Math.sin(dLat / 2) ** 2 + Math.sin(dLng / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+    return 2 * R * Math.asin(Math.sqrt(h));
+};
+
+/**
+ * GET /cities/:slug/pulse
+ */
+const getCityPulse: RequestHandler = async (req: any, res: any) => {
+    const { slug } = req.params;
+    const city = Cities.CitySlugMap[slug];
+    if (!city) {
+        return handleHttpError({
+            res,
+            message: 'City not found',
+            statusCode: 404,
+        });
+    }
+
+    const { locale: headerLocale } = parseHeaders(req.headers);
+    const locale = toLocale((req.query?.locale as string) || headerLocale);
+
+    // Build an auth-optional "headers" object for internal calls. We set
+    // isRequestAuthorized=false so stores return the public columns only.
+    const baseConditions: any = {
+        latitude: city.lat,
+        longitude: city.lng,
+        filterBy: 'distance',
+    };
+    const overrides = {
+        distanceOverride: PULSE_RADIUS_METERS,
+        isRequestAuthorized: false,
+        withUser: false,
+    };
+
+    // Fan out. Failures in any one source degrade gracefully to an empty list.
+    const spacesPromise = Store.spaces
+        .searchSpaces(
+            { ...baseConditions, pagination: { itemsPerPage: TRENDING_SPACES_LIMIT, pageNumber: 1 } },
+            null,
+            [],
+            overrides,
+            true,
+        )
+        .catch((err: any) => {
+            logSpan({
+                level: 'error',
+                messageOrigin: 'MAPS_SERVICE',
+                messages: ['cityPulse: spaces fetch failed'],
+                traceArgs: { 'error.message': err?.message, 'city.slug': slug },
+            });
+            return [];
+        });
+
+    const eventsPromise = Store.events
+        .searchEvents(
+            req.headers,
+            { ...baseConditions, pagination: { itemsPerPage: UPCOMING_EVENTS_LIMIT, pageNumber: 1 } },
+            null,
+            [],
+            overrides,
+            true,
+        )
+        .catch((err: any) => {
+            logSpan({
+                level: 'error',
+                messageOrigin: 'MAPS_SERVICE',
+                messages: ['cityPulse: events fetch failed'],
+                traceArgs: { 'error.message': err?.message, 'city.slug': slug },
+            });
+            return [];
+        });
+
+    const momentsPromise = Store.moments
+        .searchMoments(
+            req.headers,
+            { ...baseConditions, pagination: { itemsPerPage: RECENT_MOMENTS_LIMIT, pageNumber: 1 } },
+            null,
+            [],
+            overrides,
+            true,
+        )
+        .catch((err: any) => {
+            logSpan({
+                level: 'error',
+                messageOrigin: 'MAPS_SERVICE',
+                messages: ['cityPulse: moments fetch failed'],
+                traceArgs: { 'error.message': err?.message, 'city.slug': slug },
+            });
+            return [];
+        });
+
+    const wikiPromise = Store.cityWikiCache
+        .get(slug, locale)
+        .then((row) => {
+            // Lazy-fill on miss or expiry. Fire-and-forget — the user gets fast
+            // response now; next crawl/visit gets the enriched page.
+            if (!row || !Store.cityWikiCache.isFresh(row)) {
+                refreshCityWiki(slug, [locale]).catch((err) => {
+                    logSpan({
+                        level: 'warn',
+                        messageOrigin: 'MAPS_SERVICE',
+                        messages: ['cityPulse: background wiki refresh failed'],
+                        traceArgs: {
+                            'error.message': err?.message,
+                            'city.slug': slug,
+                            'city.locale': locale,
+                        },
+                    });
+                });
+            }
+            return row;
+        })
+        .catch(() => null);
+
+    const [spaces, events, moments, wiki] = await Promise.all([
+        spacesPromise,
+        eventsPromise,
+        momentsPromise,
+        wikiPromise,
+    ]);
+
+    // Category counts — only non-empty categories so the UI renders a variable
+    // number of tiles and stays useful for small cities.
+    const categoryCounts: Record<string, number> = {};
+    (spaces || []).forEach((space: any) => {
+        if (space?.category) {
+            categoryCounts[space.category] = (categoryCounts[space.category] || 0) + 1;
+        }
+    });
+    const categoriesWithCounts = Object.entries(categoryCounts)
+        .map(([categorySlug, count]) => ({ categorySlug, count }))
+        .sort((a, b) => b.count - a.count);
+
+    // Nearby cities — pure computation off Cities.CitiesList, no DB round trip.
+    const nearbyCities = Cities.CitiesList
+        .filter((c) => c.slug !== city.slug)
+        .map((c) => ({
+            slug: c.slug,
+            name: c.name,
+            stateAbbr: c.stateAbbr,
+            distanceKm: haversineKm(city.lat, city.lng, c.lat, c.lng),
+        }))
+        .filter((c) => c.distanceKm <= 300)
+        .sort((a, b) => a.distanceKm - b.distanceKm)
+        .slice(0, 3);
+
+    const body = {
+        city: {
+            slug: city.slug,
+            name: city.name,
+            state: city.state,
+            stateAbbr: city.stateAbbr,
+            lat: city.lat,
+            lng: city.lng,
+        },
+        therr: {
+            trendingSpaces: spaces || [],
+            upcomingEvents: events || [],
+            recentMoments: moments || [],
+            topGroups: [], // Forums lack geo tags today; keep the shape for forward compat.
+            categoriesWithCounts,
+        },
+        wiki: wiki && wiki.status === 'ok' ? {
+            summary: wiki.summary,
+            sections: wiki.sections || null,
+            heroImageUrl: wiki.heroImageUrl,
+            attributionUrl: wiki.attributionUrl,
+            license: wiki.license || 'CC-BY-SA-4.0',
+            localeFallback: !!wiki.localeFallback,
+        } : {
+            summary: null,
+            sections: null,
+            heroImageUrl: null,
+            attributionUrl: null,
+            license: 'CC-BY-SA-4.0',
+            localeFallback: false,
+        },
+        nearbyCities,
+        locale,
+    };
+
+    return res.status(200).send(body);
+};
+
+export default getCityPulse;

--- a/therr-services/maps-service/src/routes/cityPulseRouter.ts
+++ b/therr-services/maps-service/src/routes/cityPulseRouter.ts
@@ -1,0 +1,8 @@
+import * as express from 'express';
+import getCityPulse from '../handlers/cityPulse';
+
+const router = express.Router();
+
+router.get('/:slug/pulse', getCityPulse);
+
+export default router;

--- a/therr-services/maps-service/src/routes/index.ts
+++ b/therr-services/maps-service/src/routes/index.ts
@@ -1,5 +1,6 @@
 import * as express from 'express';
 import activitiesRouter from './activitiesRouter';
+import cityPulseRouter from './cityPulseRouter';
 import eventsRouter from './eventsRouter';
 import momentsRouter from './momentsRouter';
 import spacesRouter from './spacesRouter';
@@ -15,6 +16,7 @@ router.delete('/delete-user-data', deleteUserData);
 router.post('/media/signed-urls', createMediaUrls);
 
 router.use('/activities', activitiesRouter);
+router.use('/cities', cityPulseRouter);
 router.use('/events', eventsRouter);
 router.use('/moments', momentsRouter);
 router.use('/spaces', spacesRouter);

--- a/therr-services/maps-service/src/store/CityWikiCacheStore.ts
+++ b/therr-services/maps-service/src/store/CityWikiCacheStore.ts
@@ -80,6 +80,7 @@ class CityWikiCacheStore {
         });
     }
 
+    // eslint-disable-next-line class-methods-use-this
     isFresh(row: ICityWikiCacheRow | null): boolean {
         if (!row) return false;
         if (!row.expiresAt) return true;

--- a/therr-services/maps-service/src/store/CityWikiCacheStore.ts
+++ b/therr-services/maps-service/src/store/CityWikiCacheStore.ts
@@ -1,0 +1,141 @@
+import KnexBuilder, { Knex } from 'knex';
+import { IConnection } from './connection';
+
+const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
+
+export const CITY_WIKI_CACHE_TABLE_NAME = 'main.cityWikiCache';
+
+export interface ICityWikiSections {
+    understand?: string;
+    districts?: string;
+    getIn?: string;
+    getAround?: string;
+}
+
+export interface ICityWikiCacheRow {
+    slug: string;
+    locale: string;
+    resolvedTitle?: string | null;
+    summary?: string | null;
+    sections?: ICityWikiSections | null;
+    heroImageUrl?: string | null;
+    attributionUrl?: string | null;
+    license?: string | null;
+    localeFallback?: boolean;
+    status: 'ok' | 'not_found' | 'error';
+    fetchedAt?: Date;
+    expiresAt?: Date | null;
+}
+
+export interface IUpsertCityWikiCacheParams {
+    slug: string;
+    locale: string;
+    resolvedTitle?: string | null;
+    summary?: string | null;
+    sections?: ICityWikiSections | null;
+    heroImageUrl?: string | null;
+    attributionUrl?: string | null;
+    license?: string | null;
+    localeFallback?: boolean;
+    status: 'ok' | 'not_found' | 'error';
+    ttlDays?: number;
+}
+
+class CityWikiCacheStore {
+    private db: IConnection;
+
+    constructor(dbConnection: IConnection) {
+        this.db = dbConnection;
+    }
+
+    /**
+     * Fetch a single row by slug + locale. Returns null if no row exists.
+     * Callers handle "expired" vs "missing" — both cases may trigger a background refresh.
+     */
+    get(slug: string, locale: string): Promise<ICityWikiCacheRow | null> {
+        const queryString = knexBuilder
+            .select('*')
+            .from(CITY_WIKI_CACHE_TABLE_NAME)
+            .where({ slug, locale })
+            .limit(1)
+            .toString();
+
+        return this.db.read.query(queryString).then((response) => {
+            if (!response.rows.length) return null;
+            const row = response.rows[0];
+            return {
+                slug: row.slug,
+                locale: row.locale,
+                resolvedTitle: row.resolvedTitle,
+                summary: row.summary,
+                sections: row.sections,
+                heroImageUrl: row.heroImageUrl,
+                attributionUrl: row.attributionUrl,
+                license: row.license,
+                localeFallback: row.localeFallback,
+                status: row.status,
+                fetchedAt: row.fetchedAt,
+                expiresAt: row.expiresAt,
+            };
+        });
+    }
+
+    isFresh(row: ICityWikiCacheRow | null): boolean {
+        if (!row) return false;
+        if (!row.expiresAt) return true;
+        return new Date(row.expiresAt).getTime() > Date.now();
+    }
+
+    upsert(params: IUpsertCityWikiCacheParams): Promise<any> {
+        const ttlDays = params.ttlDays ?? 30;
+        const now = new Date();
+        const expiresAt = new Date(now.getTime() + ttlDays * 24 * 60 * 60 * 1000);
+
+        const insertRow: any = {
+            slug: params.slug,
+            locale: params.locale,
+            resolvedTitle: params.resolvedTitle ?? null,
+            summary: params.summary ?? null,
+            sections: params.sections ? JSON.stringify(params.sections) : null,
+            heroImageUrl: params.heroImageUrl ?? null,
+            attributionUrl: params.attributionUrl ?? null,
+            license: params.license ?? 'CC-BY-SA-4.0',
+            localeFallback: params.localeFallback ?? false,
+            status: params.status,
+            fetchedAt: now,
+            expiresAt,
+        };
+
+        const queryString = knexBuilder(CITY_WIKI_CACHE_TABLE_NAME)
+            .insert(insertRow)
+            .onConflict(['slug', 'locale'])
+            .merge({
+                resolvedTitle: insertRow.resolvedTitle,
+                summary: insertRow.summary,
+                sections: insertRow.sections,
+                heroImageUrl: insertRow.heroImageUrl,
+                attributionUrl: insertRow.attributionUrl,
+                license: insertRow.license,
+                localeFallback: insertRow.localeFallback,
+                status: insertRow.status,
+                fetchedAt: insertRow.fetchedAt,
+                expiresAt: insertRow.expiresAt,
+            })
+            .toString();
+
+        return this.db.write.query(queryString);
+    }
+
+    findExpired(limit = 50): Promise<ICityWikiCacheRow[]> {
+        const queryString = knexBuilder
+            .select('*')
+            .from(CITY_WIKI_CACHE_TABLE_NAME)
+            .where('expiresAt', '<=', new Date())
+            .limit(limit)
+            .toString();
+
+        return this.db.read.query(queryString).then((response) => response.rows);
+    }
+}
+
+export default CityWikiCacheStore;

--- a/therr-services/maps-service/src/store/index.ts
+++ b/therr-services/maps-service/src/store/index.ts
@@ -1,4 +1,5 @@
 import connection, { IConnection } from './connection';
+import CityWikiCacheStore from './CityWikiCacheStore';
 import EventsStore from './EventsStore';
 import ExternalMediaIntegrationsStore from './ExternalMediaIntegrationsStore';
 import MediaStore from './MediaStore';
@@ -12,6 +13,8 @@ import SpaceDisplayRequestsStore from './SpaceDisplayRequestsStore';
 
 class Store {
     db: IConnection;
+
+    cityWikiCache: CityWikiCacheStore;
 
     events: EventsStore;
 
@@ -35,6 +38,8 @@ class Store {
 
     constructor(dbConnection) {
         this.db = dbConnection;
+
+        this.cityWikiCache = new CityWikiCacheStore(this.db);
 
         this.externalMediaIntegrations = new ExternalMediaIntegrationsStore(this.db);
 

--- a/therr-services/maps-service/src/store/migrations/20260413000000_main.cityWikiCache.js
+++ b/therr-services/maps-service/src/store/migrations/20260413000000_main.cityWikiCache.js
@@ -1,0 +1,35 @@
+exports.up = (knex) => knex.schema.withSchema('main').createTable('cityWikiCache', (table) => {
+    // (slug, locale) composite primary key
+    table.string('slug', 120).notNullable();
+    table.string('locale', 10).notNullable();
+
+    // Resolved Wikipedia title used for subsequent fetches
+    table.string('resolvedTitle', 200);
+
+    // Editorial content
+    table.text('summary');
+    table.jsonb('sections'); // { understand, districts, getIn, getAround }
+
+    // Lead image
+    table.text('heroImageUrl');
+
+    // Attribution (CC-BY-SA compliance)
+    table.string('attributionUrl', 500);
+    table.string('license', 40).defaultTo('CC-BY-SA-4.0');
+
+    // Fallback indicator when we served English content for a non-en locale request
+    table.boolean('localeFallback').notNullable().defaultTo(false);
+
+    // Status flag — lets us remember "nothing found" and avoid hammering Wikipedia on every request
+    table.string('status', 20).notNullable().defaultTo('ok'); // 'ok' | 'not_found' | 'error'
+
+    // Lifecycle
+    table.timestamp('fetchedAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp('expiresAt', { useTz: true });
+
+    // Indexes
+    table.primary(['slug', 'locale']);
+    table.index('expiresAt');
+});
+
+exports.down = (knex) => knex.schema.withSchema('main').dropTable('cityWikiCache');

--- a/therr-services/maps-service/src/utilities/wikiFetcher.ts
+++ b/therr-services/maps-service/src/utilities/wikiFetcher.ts
@@ -80,8 +80,10 @@ export const fetchCitySummary = async (
         return {
             title: data.title,
             extract: data.extract || null,
-            // Prefer originalimage (higher res) then thumbnail. License check happens elsewhere.
-            thumbnailUrl: data.originalimage?.source || data.thumbnail?.source || null,
+            // Prefer `thumbnail` (Wikipedia's ~320px SSR-friendly variant) over
+            // `originalimage` (can be multi-MB full resolution). License check
+            // happens elsewhere before this URL is surfaced in the UI.
+            thumbnailUrl: data.thumbnail?.source || data.originalimage?.source || null,
             pageUrl: data.content_urls?.desktop?.page || `https://${subdomain}.wikipedia.org/wiki/${encodeURIComponent(title)}`,
         };
     } catch (err) {

--- a/therr-services/maps-service/src/utilities/wikiFetcher.ts
+++ b/therr-services/maps-service/src/utilities/wikiFetcher.ts
@@ -1,0 +1,205 @@
+import axios from 'axios';
+import logSpan from 'therr-js-utilities/log-or-update-span';
+
+// Wikipedia / Wikivoyage fetchers. Both have free public APIs and content is
+// CC-BY-SA 4.0 — attribution is required in the UI.
+//
+// Locale → Wikipedia subdomain mapping. We ship three locales; Wikipedia covers
+// all three. Wikivoyage has en + es + (some) fr.
+export const WIKIPEDIA_USER_AGENT = 'Therr App (https://www.therr.com)';
+
+export type SupportedLocale = 'en-us' | 'es' | 'fr-ca';
+
+const WIKI_SUBDOMAIN: Record<SupportedLocale, string> = {
+    'en-us': 'en',
+    es: 'es',
+    'fr-ca': 'fr',
+};
+
+export interface IWikipediaSummary {
+    title: string;
+    extract: string | null;
+    thumbnailUrl: string | null;
+    pageUrl: string | null;
+}
+
+export interface IWikivoyageSections {
+    understand?: string;
+    districts?: string;
+    getIn?: string;
+    getAround?: string;
+}
+
+/**
+ * Strip wiki markup / HTML noise out of a parse-API section.
+ * Wikivoyage returns HTML via ?prop=text; we flatten it to plain text paragraphs.
+ */
+const stripHtml = (html: string): string => html
+    // Drop script/style blocks entirely (paranoia — unlikely in Wikivoyage output)
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    // Drop edit/see-also navboxes
+    .replace(/<span class="mw-editsection[\s\S]*?<\/span>/gi, '')
+    .replace(/<table[\s\S]*?<\/table>/gi, '')
+    // Convert paragraph/br to newlines
+    .replace(/<\/(p|li|h[1-6])>/gi, '\n\n')
+    .replace(/<br\s*\/?>(?!\n)/gi, '\n')
+    // Strip remaining tags
+    .replace(/<[^>]+>/g, '')
+    // Decode a few common entities
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    // Collapse repeated whitespace
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+/**
+ * Fetch the Wikipedia summary REST endpoint for a given article title.
+ * Returns null if the article doesn't exist or we can't reach Wikipedia.
+ */
+export const fetchCitySummary = async (
+    title: string,
+    locale: SupportedLocale,
+): Promise<IWikipediaSummary | null> => {
+    const subdomain = WIKI_SUBDOMAIN[locale] || 'en';
+    const url = `https://${subdomain}.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`;
+
+    try {
+        const response = await axios.get(url, {
+            headers: { 'User-Agent': WIKIPEDIA_USER_AGENT, accept: 'application/json' },
+            timeout: 5000,
+            validateStatus: (s) => s < 500, // treat 404 as a non-error we handle ourselves
+        });
+
+        if (response.status !== 200) return null;
+        const data = response.data || {};
+        return {
+            title: data.title,
+            extract: data.extract || null,
+            // Prefer originalimage (higher res) then thumbnail. License check happens elsewhere.
+            thumbnailUrl: data.originalimage?.source || data.thumbnail?.source || null,
+            pageUrl: data.content_urls?.desktop?.page || `https://${subdomain}.wikipedia.org/wiki/${encodeURIComponent(title)}`,
+        };
+    } catch (err) {
+        logSpan({
+            level: 'warn',
+            messageOrigin: 'MAPS_SERVICE',
+            messages: ['wikiFetcher: fetchCitySummary error'],
+            traceArgs: {
+                'wiki.title': title,
+                'wiki.locale': locale,
+                'error.message': err instanceof Error ? err.message : String(err),
+            },
+        });
+        return null;
+    }
+};
+
+const SECTION_KEYS: Array<{ key: keyof IWikivoyageSections; aliases: string[] }> = [
+    { key: 'understand', aliases: ['Understand', 'Entender', 'Comprendre'] },
+    { key: 'districts', aliases: ['Districts', 'Neighborhoods', 'Distritos', 'Barrios', 'Quartiers', 'Arrondissements'] },
+    { key: 'getIn', aliases: ['Get in', 'Llegar', 'Cómo llegar', 'Aller'] },
+    { key: 'getAround', aliases: ['Get around', 'Moverse', 'Desplazarse', 'Circuler'] },
+];
+
+/**
+ * Wikivoyage MediaWiki parse API. Returns a list of sections with indexes; we
+ * then fetch specific sections we care about by index. Each section fetch is a
+ * separate call, so we limit ourselves to the four sections that map into the
+ * City Pulse UI.
+ */
+export const fetchWikivoyageSections = async (
+    title: string,
+    locale: SupportedLocale,
+): Promise<IWikivoyageSections | null> => {
+    const subdomain = WIKI_SUBDOMAIN[locale] || 'en';
+    const baseUrl = `https://${subdomain}.wikivoyage.org/w/api.php`;
+
+    try {
+        // Step 1 — list sections so we can map title → index.
+        const sectionsResponse = await axios.get(baseUrl, {
+            params: {
+                action: 'parse',
+                page: title,
+                prop: 'sections',
+                format: 'json',
+                redirects: 1,
+            },
+            headers: { 'User-Agent': WIKIPEDIA_USER_AGENT, accept: 'application/json' },
+            timeout: 5000,
+            validateStatus: (s) => s < 500,
+        });
+
+        if (sectionsResponse.status !== 200) return null;
+        const sectionsList = sectionsResponse.data?.parse?.sections;
+        if (!Array.isArray(sectionsList) || !sectionsList.length) return null;
+
+        // Build a lookup: canonical section key → MediaWiki section index
+        const indexByKey: Partial<Record<keyof IWikivoyageSections, string>> = {};
+        SECTION_KEYS.forEach(({ key, aliases }) => {
+            const match = sectionsList.find((s: any) => aliases.some(
+                (alias) => typeof s.line === 'string' && s.line.trim().toLowerCase() === alias.toLowerCase(),
+            ));
+            if (match?.index) indexByKey[key] = String(match.index);
+        });
+
+        if (!Object.keys(indexByKey).length) return null;
+
+        // Step 2 — fetch each section's HTML content. Run sequentially (Wikivoyage
+        // is lenient but we don't want to DoS ourselves if this ever runs hot).
+        const result: IWikivoyageSections = {};
+        // eslint-disable-next-line no-restricted-syntax
+        for (const [key, sectionIndex] of Object.entries(indexByKey)) {
+            // eslint-disable-next-line no-await-in-loop
+            const sectionResponse = await axios.get(baseUrl, {
+                params: {
+                    action: 'parse',
+                    page: title,
+                    prop: 'text',
+                    section: sectionIndex,
+                    format: 'json',
+                    redirects: 1,
+                },
+                headers: { 'User-Agent': WIKIPEDIA_USER_AGENT, accept: 'application/json' },
+                timeout: 5000,
+                validateStatus: (s) => s < 500,
+            });
+
+            if (sectionResponse.status === 200) {
+                const html = sectionResponse.data?.parse?.text?.['*'];
+                if (typeof html === 'string') {
+                    const text = stripHtml(html);
+                    if (text) result[key as keyof IWikivoyageSections] = text;
+                }
+            }
+        }
+
+        return Object.keys(result).length ? result : null;
+    } catch (err) {
+        logSpan({
+            level: 'warn',
+            messageOrigin: 'MAPS_SERVICE',
+            messages: ['wikiFetcher: fetchWikivoyageSections error'],
+            traceArgs: {
+                'wiki.title': title,
+                'wiki.locale': locale,
+                'error.message': err instanceof Error ? err.message : String(err),
+            },
+        });
+        return null;
+    }
+};
+
+export const buildWikivoyageAttributionUrl = (title: string, locale: SupportedLocale): string => {
+    const subdomain = WIKI_SUBDOMAIN[locale] || 'en';
+    return `https://${subdomain}.wikivoyage.org/wiki/${encodeURIComponent(title)}`;
+};
+
+export const buildWikipediaAttributionUrl = (title: string, locale: SupportedLocale): string => {
+    const subdomain = WIKI_SUBDOMAIN[locale] || 'en';
+    return `https://${subdomain}.wikipedia.org/wiki/${encodeURIComponent(title)}`;
+};

--- a/therr-services/maps-service/src/utilities/wikiResolver.ts
+++ b/therr-services/maps-service/src/utilities/wikiResolver.ts
@@ -31,36 +31,39 @@ export const resolveCityWikipedia = async (
         city.name,
     ];
 
-    // Try the requested locale first.
-    for (const title of candidates) {
-        // eslint-disable-next-line no-await-in-loop
-        const summary = await fetchCitySummary(title, locale);
-        if (summary?.extract && summary.extract.length > 40) {
-            return {
-                title: summary.title,
-                summary: summary.extract,
-                thumbnailUrl: summary.thumbnailUrl,
-                pageUrl: summary.pageUrl || `https://en.wikipedia.org/wiki/${encodeURIComponent(summary.title)}`,
-                localeFallback: false,
-            };
-        }
-    }
-
-    // Fall back to en-us for non-English locales.
-    if (locale !== 'en-us') {
-        for (const title of candidates) {
-            // eslint-disable-next-line no-await-in-loop
-            const summary = await fetchCitySummary(title, 'en-us');
+    // Try candidates sequentially: stop at first successful extract. We want
+    // the short-circuit on success, so this intentionally does not use
+    // Promise.all / array iteration.
+    const tryCandidates = async (
+        tryLocale: SupportedLocale,
+        localeFallback: boolean,
+    ): Promise<IResolvedCity | null> => candidates.reduce<Promise<IResolvedCity | null>>(
+        async (accPromise, title) => {
+            const acc = await accPromise;
+            if (acc) return acc;
+            const summary = await fetchCitySummary(title, tryLocale);
             if (summary?.extract && summary.extract.length > 40) {
                 return {
                     title: summary.title,
                     summary: summary.extract,
                     thumbnailUrl: summary.thumbnailUrl,
-                    pageUrl: summary.pageUrl || `https://en.wikipedia.org/wiki/${encodeURIComponent(summary.title)}`,
-                    localeFallback: true,
+                    pageUrl: summary.pageUrl
+                        || `https://en.wikipedia.org/wiki/${encodeURIComponent(summary.title)}`,
+                    localeFallback,
                 };
             }
-        }
+            return null;
+        },
+        Promise.resolve(null),
+    );
+
+    const primary = await tryCandidates(locale, false);
+    if (primary) return primary;
+
+    // Fall back to en-us for non-English locales.
+    if (locale !== 'en-us') {
+        const fallback = await tryCandidates('en-us', true);
+        if (fallback) return fallback;
     }
 
     return null;

--- a/therr-services/maps-service/src/utilities/wikiResolver.ts
+++ b/therr-services/maps-service/src/utilities/wikiResolver.ts
@@ -1,0 +1,67 @@
+import { Cities } from 'therr-js-utilities/constants';
+import { fetchCitySummary, SupportedLocale } from './wikiFetcher';
+
+// Slug → Wikipedia article title resolution. Cities.ts is the source of truth
+// for lat/lng and display name, but city names collide ("Columbus, OH" vs
+// "Columbus, GA") so we try a couple of strategies in order before giving up.
+
+export interface IResolvedCity {
+    title: string;
+    summary: string;
+    thumbnailUrl: string | null;
+    pageUrl: string;
+    localeFallback: boolean;
+}
+
+/**
+ * Resolve a city slug to a Wikipedia article title. Strategy:
+ *   1) Try "{City}, {State}" — the most reliable canonical form for US cities.
+ *   2) Try bare "{City}" — works for globally unique names (San Francisco, Chicago).
+ *   3) Fall back to en-us if a non-English locale returned nothing.
+ */
+export const resolveCityWikipedia = async (
+    slug: string,
+    locale: SupportedLocale,
+): Promise<IResolvedCity | null> => {
+    const city = Cities.CitySlugMap[slug];
+    if (!city) return null;
+
+    const candidates = [
+        `${city.name}, ${city.state}`,
+        city.name,
+    ];
+
+    // Try the requested locale first.
+    for (const title of candidates) {
+        // eslint-disable-next-line no-await-in-loop
+        const summary = await fetchCitySummary(title, locale);
+        if (summary?.extract && summary.extract.length > 40) {
+            return {
+                title: summary.title,
+                summary: summary.extract,
+                thumbnailUrl: summary.thumbnailUrl,
+                pageUrl: summary.pageUrl || `https://en.wikipedia.org/wiki/${encodeURIComponent(summary.title)}`,
+                localeFallback: false,
+            };
+        }
+    }
+
+    // Fall back to en-us for non-English locales.
+    if (locale !== 'en-us') {
+        for (const title of candidates) {
+            // eslint-disable-next-line no-await-in-loop
+            const summary = await fetchCitySummary(title, 'en-us');
+            if (summary?.extract && summary.extract.length > 40) {
+                return {
+                    title: summary.title,
+                    summary: summary.extract,
+                    thumbnailUrl: summary.thumbnailUrl,
+                    pageUrl: summary.pageUrl || `https://en.wikipedia.org/wiki/${encodeURIComponent(summary.title)}`,
+                    localeFallback: true,
+                };
+            }
+        }
+    }
+
+    return null;
+};

--- a/therr-services/maps-service/src/workers/wikiCacheRefresh.ts
+++ b/therr-services/maps-service/src/workers/wikiCacheRefresh.ts
@@ -1,0 +1,172 @@
+import { Cities } from 'therr-js-utilities/constants';
+import logSpan from 'therr-js-utilities/log-or-update-span';
+import Store from '../store';
+import { resolveCityWikipedia } from '../utilities/wikiResolver';
+import {
+    fetchWikivoyageSections,
+    buildWikivoyageAttributionUrl,
+    buildWikipediaAttributionUrl,
+    SupportedLocale,
+} from '../utilities/wikiFetcher';
+
+const SUPPORTED_LOCALES: SupportedLocale[] = ['en-us', 'es', 'fr-ca'];
+
+// In-flight guard so a burst of SSR requests for the same cold city doesn't
+// fire N parallel resolutions to Wikipedia.
+const inflight = new Set<string>();
+
+const delay = (ms: number) => new Promise<void>((r) => { setTimeout(r, ms); });
+
+/**
+ * Refresh a single slug+locale row. Safe to call on cache-miss as fire-and-forget:
+ * the SSR request returns Therr data immediately and the cache populates for the
+ * next crawl/visit. Always writes a row (even on not_found) so we don't retry
+ * hopeless slugs every page view.
+ */
+export const refreshCityWikiOne = async (
+    slug: string,
+    locale: SupportedLocale,
+): Promise<void> => {
+    const guardKey = `${slug}:${locale}`;
+    if (inflight.has(guardKey)) return;
+    inflight.add(guardKey);
+
+    try {
+        const resolved = await resolveCityWikipedia(slug, locale);
+
+        if (!resolved) {
+            await Store.cityWikiCache.upsert({
+                slug,
+                locale,
+                status: 'not_found',
+                // Shorter TTL for negatives so a newly-created Wikipedia article
+                // starts appearing within a week instead of a month.
+                ttlDays: 7,
+            });
+            return;
+        }
+
+        // Wikivoyage lookup is best-effort. Use resolved title from Wikipedia —
+        // Wikivoyage articles tend to use the same title as Wikipedia.
+        const sections = await fetchWikivoyageSections(
+            resolved.title,
+            resolved.localeFallback ? 'en-us' : locale,
+        );
+
+        // Prefer Wikivoyage attribution when we have Wikivoyage content; otherwise
+        // the user-facing content came from Wikipedia and we attribute that.
+        const attributionLocale = resolved.localeFallback ? 'en-us' : locale;
+        const attributionUrl = sections
+            ? buildWikivoyageAttributionUrl(resolved.title, attributionLocale)
+            : buildWikipediaAttributionUrl(resolved.title, attributionLocale);
+
+        await Store.cityWikiCache.upsert({
+            slug,
+            locale,
+            resolvedTitle: resolved.title,
+            summary: resolved.summary,
+            sections,
+            // heroImageUrl: license-check for Commons images is not implemented in
+            // v1. Leave null until we add Commons API verification.
+            heroImageUrl: null,
+            attributionUrl,
+            license: 'CC-BY-SA-4.0',
+            localeFallback: resolved.localeFallback,
+            status: 'ok',
+        });
+    } catch (err) {
+        logSpan({
+            level: 'error',
+            messageOrigin: 'MAPS_SERVICE',
+            messages: ['wikiCacheRefresh: unexpected error'],
+            traceArgs: {
+                'wiki.slug': slug,
+                'wiki.locale': locale,
+                'error.message': err instanceof Error ? err.message : String(err),
+            },
+        });
+        // Mark as error with short TTL so we retry soon.
+        await Store.cityWikiCache.upsert({
+            slug,
+            locale,
+            status: 'error',
+            ttlDays: 1,
+        });
+    } finally {
+        inflight.delete(guardKey);
+    }
+};
+
+/**
+ * Refresh a single slug across all provided locales. The SSR handler calls this
+ * without awaiting — it returns fast and fills the cache for subsequent crawls.
+ */
+export const refreshCityWiki = (
+    slug: string,
+    locales: SupportedLocale[] = SUPPORTED_LOCALES,
+): Promise<void[]> => Promise.all(locales.map((locale) => refreshCityWikiOne(slug, locale)));
+
+/**
+ * Batch seed entry point. Intended to run out-of-band via:
+ *   node lib/workers/wikiCacheRefresh.js --all
+ *   node lib/workers/wikiCacheRefresh.js --slug=denver-co,new-york-ny
+ *   node lib/workers/wikiCacheRefresh.js --only-expired
+ *
+ * Staggers 2s between cities to stay well under Wikipedia/Wikivoyage courteous
+ * rate limits (≤1 req/sec is a common guideline; we're pulling 1 summary + ≤4
+ * sections, so 2s between cities keeps burst rate reasonable).
+ */
+export const runCli = async (): Promise<void> => {
+    const args = process.argv.slice(2);
+    const slugArg = args.find((a) => a.startsWith('--slug='));
+    const localesArg = args.find((a) => a.startsWith('--locales='));
+    const onlyExpired = args.includes('--only-expired');
+    const all = args.includes('--all');
+
+    const locales: SupportedLocale[] = localesArg
+        ? (localesArg.split('=')[1].split(',') as SupportedLocale[])
+        : SUPPORTED_LOCALES;
+
+    let slugs: string[] = [];
+    if (slugArg) {
+        slugs = slugArg.split('=')[1].split(',').map((s) => s.trim()).filter(Boolean);
+    } else if (onlyExpired) {
+        const expired = await Store.cityWikiCache.findExpired(500);
+        slugs = Array.from(new Set(expired.map((r) => r.slug)));
+    } else if (all) {
+        slugs = Cities.CitiesList.map((c) => c.slug);
+    } else {
+        // eslint-disable-next-line no-console
+        console.log('Usage: wikiCacheRefresh --all | --slug=a,b | --only-expired  [--locales=en-us,es,fr-ca]');
+        process.exit(1);
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(`Refreshing ${slugs.length} cities × ${locales.length} locales`);
+
+    for (let i = 0; i < slugs.length; i += 1) {
+        const slug = slugs[i];
+        // eslint-disable-next-line no-console
+        console.log(`[${i + 1}/${slugs.length}] ${slug}`);
+        // eslint-disable-next-line no-await-in-loop
+        await refreshCityWiki(slug, locales);
+        if (i < slugs.length - 1) {
+            // eslint-disable-next-line no-await-in-loop
+            await delay(2000);
+        }
+    }
+
+    // eslint-disable-next-line no-console
+    console.log('Done.');
+};
+
+// When invoked directly (not imported), run the CLI entrypoint.
+if (require.main === module) {
+    runCli()
+        .then(() => process.exit(0))
+        .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.error(err);
+            process.exit(1);
+        });
+}


### PR DESCRIPTION
Replaces the thin space-list city route with a SSR-aware editorial page that
composes Therr data (trending spaces, upcoming events, recent moments, top
categories, nearby cities) with CC-BY-SA content from Wikipedia + Wikivoyage
so every city page is useful even for thin-data metros.

Backend
- New main.cityWikiCache table + CityWikiCacheStore (30-day TTL, lazy-fill
  on miss, negative cache for not_found).
- wikiResolver + wikiFetcher utilities wrapping Wikipedia summary REST and
  Wikivoyage parse APIs with UA string and locale fallback.
- wikiCacheRefresh worker (lazy fire-and-forget + CLI entrypoint supporting
  --all, --slug=a,b, --only-expired, --locales=...).
- cityPulse handler fans out to SpacesStore/EventsStore/MomentsStore in
  parallel and composes the response; failures degrade to empty lists.
- API gateway GET /cities/:slug/pulse with 15-min Redis cache per (slug, locale).

Frontend
- ViewCityPulse route + CityPulse section components (Hero, About,
  Neighborhoods, TrendingSpaces, UpcomingEvents, MomentsWall, Groups,
  CategoryTiles, GettingAround, NearbyCities, CTA, AttributionFooter).
- Conditional section ordering: Therr-first when >=3 populated sections,
  Wiki-first for thin-data cities.
- New city-pulse.hbs SSR view with City / BreadcrumbList / ItemList /
  TouristDestination JSON-LD, plus hreflang + locale-aware canonical.
- renderCityPulseView in server-client.tsx; dynamic meta title/description
  driven by Therr density or Wiki lead sentence.
- MapActions.getCityPulse thunk + cityPulse slice in the shared map reducer.
- Locale dictionary entries (en-us, es, fr-ca).
- CC-BY-SA 4.0 attribution footer renders whenever Wiki content is shown.

https://claude.ai/code/session_01HMsAeEz5hqgmwpZdC28VmU