### PR TITLE
fix(gateway): allow unauthenticated access to city pulse endpoint

### DIFF
--- a/therr-api-gateway/src/index.ts
+++ b/therr-api-gateway/src/index.ts
@@ -110,6 +110,7 @@ app.use(authenticate.unless({
         { url: /\/v1\/maps-service\/spaces\/search/, methods: ['POST'] }, // Optional for public map view
         { url: /\/v1\/maps-service\/spaces\/.*\/pairings$/, methods: ['GET'] }, // Space pairings (optional auth)
         { url: /\/v1\/maps-service\/spaces\/.*\/pairings\/feedback/, methods: ['POST'] }, // Pairing feedback (optional auth)
+        { url: /\/v1\/maps-service\/cities\/[^/]+\/pulse$/, methods: ['GET'] }, // Public city landing page (uses authenticateOptional)
         { url: /\/v1\/messages-service\/forums\/[0-9a-f-]+$/, methods: ['GET'] }, // Public group/forum view (uses authenticateOptional)
         { url: '/v1/messages-service/forums/search', methods: ['POST'] }, // Public forum search (uses authenticateOptional)
     ],


### PR DESCRIPTION
The /maps-service/cities/:slug/pulse endpoint declared authenticateOptional
but was missing from the global authenticate middleware's unless list, so
unauth requests were rejected with 401. The web app's axios interceptor
treats that 401 as a session loss and redirects to /login, breaking public
access to /locations/city/:citySlug pages (e.g. albuquerque-nm).