### PR TITLE
fix(import-spaces): correct claim-state handling and dedup pipelines

### DIFF
--- a/scripts/import-spaces/clear-pending.ts
+++ b/scripts/import-spaces/clear-pending.ts
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * Bulk-clear lingering `isClaimPending` flags on spaces.
+ *
+ * Mirrors the admin "Approve" button's DB effect at scale, so ops can clear
+ * stale pending claims (e.g., from closed businesses, old test data) from the
+ * admin approval queue in one shot.
+ *
+ * Usage:
+ *   npx ts-node scripts/import-spaces/clear-pending --dry-run
+ *   npx ts-node scripts/import-spaces/clear-pending --city chicago --dry-run
+ *   npx ts-node scripts/import-spaces/clear-pending --ids <id1>,<id2>
+ *   npx ts-node scripts/import-spaces/clear-pending --before-date 2025-01-01 --dry-run
+ *
+ * Default behavior without --yes is equivalent to --dry-run — writes only happen
+ * when you explicitly pass --yes, to protect against accidental mass clears.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { CITIES } from './config';
+import { assertDbConnection, createDbPool } from './utils/db';
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+function printHelp() {
+  const cityList = Object.keys(CITIES).join(', ');
+  console.log(`
+Clear Pending Claims CLI — Bulk-clear stale isClaimPending flags.
+
+Usage:
+  npx ts-node scripts/import-spaces/clear-pending [options]
+
+Options:
+  --city <name>          Filter by addressLocality (default: all)
+                         Available: ${cityList}, all
+  --category <name>      Filter by Therr category (default: all)
+                         e.g. "categories.restaurant/food"
+  --ids <csv>            Only touch these space UUIDs (comma-separated)
+  --before-date <date>   Only rows updated before this date (ISO, YYYY-MM-DD)
+  --limit <n>            Cap the number of rows touched (default: no cap)
+  --dry-run              Print matching rows without writing (default)
+  --yes                  Actually perform the UPDATE (required to write)
+  --help, -h             Show this help message
+
+Effect:
+  UPDATE main.spaces
+     SET "isClaimPending" = false,
+         "updatedAt" = NOW()
+   WHERE "isClaimPending" = true
+     AND (/* filters */);
+
+Examples:
+  # Preview all currently-pending rows
+  npx ts-node scripts/import-spaces/clear-pending --dry-run
+
+  # Preview pending rows in a single city
+  npx ts-node scripts/import-spaces/clear-pending --city chicago --dry-run
+
+  # Actually clear a targeted set
+  npx ts-node scripts/import-spaces/clear-pending --ids abc,def --yes
+`);
+}
+
+interface ICliArgs {
+  city: string;
+  category: string;
+  ids: string[];
+  beforeDate: string | null;
+  limit: number;
+  dryRun: boolean;
+  yes: boolean;
+}
+
+function parseArgs(): ICliArgs {
+  const args = process.argv.slice(2);
+  const parsed: Record<string, string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--help' || args[i] === '-h') {
+      printHelp();
+      process.exit(0);
+    } else if (args[i] === '--dry-run') {
+      parsed.dryRun = 'true';
+    } else if (args[i] === '--yes') {
+      parsed.yes = 'true';
+    } else if (args[i].startsWith('--') && i + 1 < args.length) {
+      parsed[args[i].replace('--', '')] = args[i + 1];
+      i++;
+    }
+  }
+
+  const ids = parsed.ids
+    ? parsed.ids.split(',').map((s) => s.trim()).filter(Boolean)
+    : [];
+
+  return {
+    city: parsed.city || 'all',
+    category: parsed.category || 'all',
+    ids,
+    beforeDate: parsed['before-date'] || null,
+    limit: parsed.limit ? parseInt(parsed.limit, 10) : 0,
+    // If neither --dry-run nor --yes was passed, default to dry-run for safety.
+    dryRun: parsed.dryRun === 'true' || parsed.yes !== 'true',
+    yes: parsed.yes === 'true',
+  };
+}
+
+interface IWhereClause {
+  sql: string;
+  params: (string | number | string[])[];
+}
+
+function buildWhereClause(args: ICliArgs): IWhereClause {
+  const conditions: string[] = [`"isClaimPending" = true`];
+  const params: (string | number | string[])[] = [];
+  let idx = 1;
+
+  if (args.ids.length > 0) {
+    conditions.push(`id = ANY($${idx}::uuid[])`);
+    params.push(args.ids);
+    idx++;
+  }
+
+  if (args.city !== 'all') {
+    const cityConfig = CITIES[args.city];
+    if (cityConfig) {
+      conditions.push(`"addressLocality" ILIKE $${idx}`);
+      params.push(`%${cityConfig.name}%`);
+      idx++;
+    }
+  }
+
+  if (args.category !== 'all') {
+    conditions.push(`category = $${idx}`);
+    params.push(args.category);
+    idx++;
+  }
+
+  if (args.beforeDate) {
+    conditions.push(`"updatedAt" < $${idx}`);
+    params.push(args.beforeDate);
+    idx++;
+  }
+
+  return { sql: conditions.join(' AND '), params };
+}
+
+async function main() {
+  const args = parseArgs();
+
+  console.log('\nClear Pending Claims CLI');
+  console.log(`  City:         ${args.city}`);
+  console.log(`  Category:     ${args.category}`);
+  console.log(`  IDs:          ${args.ids.length || 'none'}`);
+  console.log(`  Before date:  ${args.beforeDate || 'none'}`);
+  console.log(`  Limit:        ${args.limit || 'none'}`);
+  console.log(`  Dry run:      ${args.dryRun}\n`);
+
+  const where = buildWhereClause(args);
+  const db = createDbPool({ max: 3 });
+  await assertDbConnection(db);
+
+  try {
+    let selectSql = `SELECT id, "notificationMsg", "addressLocality", category, "updatedAt"
+        FROM main.spaces
+       WHERE ${where.sql}
+       ORDER BY "updatedAt" DESC`;
+    if (args.limit > 0) {
+      selectSql += ` LIMIT ${args.limit}`;
+    }
+
+    const { rows } = await db.query(selectSql, where.params);
+    console.log(`Matched ${rows.length} row(s) with isClaimPending=true.`);
+    for (const row of rows.slice(0, 20)) {
+      console.log(`  ${row.id}  ${row.addressLocality || '?'}  ${row.category || '?'}  — ${row.notificationMsg}`);
+    }
+    if (rows.length > 20) {
+      console.log(`  …and ${rows.length - 20} more.`);
+    }
+
+    if (args.dryRun) {
+      console.log('\nDry run — no changes made. Re-run with --yes to apply.');
+      return;
+    }
+
+    if (rows.length === 0) {
+      console.log('\nNothing to clear.');
+      return;
+    }
+
+    const ids = rows.map((r: { id: string }) => r.id);
+    const { rowCount } = await db.query(
+      `UPDATE main.spaces
+          SET "isClaimPending" = false,
+              "updatedAt" = NOW()
+        WHERE id = ANY($1::uuid[])`,
+      [ids],
+    );
+
+    console.log(`\nCleared isClaimPending on ${rowCount} row(s).`);
+  } finally {
+    await db.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/import-spaces/clear-pending.ts
+++ b/scripts/import-spaces/clear-pending.ts
@@ -99,7 +99,15 @@ function parseArgs(): ICliArgs {
     category: parsed.category || 'all',
     ids,
     beforeDate: parsed['before-date'] || null,
-    limit: parsed.limit ? parseInt(parsed.limit, 10) : 0,
+    limit: (() => {
+      if (!parsed.limit) return 0;
+      const n = parseInt(parsed.limit, 10);
+      if (!Number.isFinite(n) || n < 0) {
+        console.error(`Error: --limit must be a non-negative integer (got "${parsed.limit}").`);
+        process.exit(1);
+      }
+      return n;
+    })(),
     // If neither --dry-run nor --yes was passed, default to dry-run for safety.
     dryRun: parsed.dryRun === 'true' || parsed.yes !== 'true',
     yes: parsed.yes === 'true',

--- a/scripts/import-spaces/close-spaces.ts
+++ b/scripts/import-spaces/close-spaces.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Batch close (soft-delete) spaces that are no longer operational.
+ *
+ * Parallels `update-space-contact.ts --closed` but operates on many IDs at
+ * once. Sets `isPublic=false` and `isClaimPending=false` so the space
+ * drops out of the public feed AND any admin approval queue.
+ *
+ * Usage:
+ *   npx ts-node scripts/import-spaces/close-spaces --ids <id1>,<id2>[,...]
+ *   npx ts-node scripts/import-spaces/close-spaces --ids-file path/to/ids.txt
+ *   npx ts-node scripts/import-spaces/close-spaces --ids <id1>,<id2> --dry-run
+ *
+ * Reads .env from scripts/import-spaces/.env (preferred) or root .env.
+ */
+import * as dotenv from 'dotenv';
+import * as fs from 'fs';
+import * as path from 'path';
+import { assertDbConnection, createDbPool } from './utils/db';
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+function printHelp() {
+  console.log(`
+Close Spaces CLI — Batch soft-delete spaces that are no longer operational.
+
+Usage:
+  npx ts-node scripts/import-spaces/close-spaces [options]
+
+Options:
+  --ids <csv>          Comma-separated list of space UUIDs to close
+  --ids-file <path>    Path to a file with one space UUID per line
+                       (# and blank lines are ignored)
+  --dry-run            Print matched rows without making changes
+  --help, -h           Show this help message
+
+Effect (per ID):
+  UPDATE main.spaces
+     SET "isPublic" = false,
+         "isClaimPending" = false,
+         "updatedAt" = NOW()
+   WHERE id = ANY($1);
+
+Examples:
+  npx ts-node scripts/import-spaces/close-spaces --ids abc,def --dry-run
+  npx ts-node scripts/import-spaces/close-spaces --ids-file ./to-close.txt
+`);
+}
+
+interface ICliArgs {
+  ids: string[];
+  dryRun: boolean;
+}
+
+function parseIdsFile(filePath: string): string[] {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  return raw
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#'));
+}
+
+function parseArgs(): ICliArgs {
+  const args = process.argv.slice(2);
+  const parsed: Record<string, string> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--help' || args[i] === '-h') {
+      printHelp();
+      process.exit(0);
+    } else if (args[i] === '--dry-run') {
+      parsed.dryRun = 'true';
+    } else if (args[i].startsWith('--') && i + 1 < args.length) {
+      parsed[args[i].replace('--', '')] = args[i + 1];
+      i++;
+    }
+  }
+
+  const ids: string[] = [];
+  if (parsed.ids) {
+    ids.push(...parsed.ids.split(',').map((s) => s.trim()).filter(Boolean));
+  }
+  if (parsed['ids-file']) {
+    ids.push(...parseIdsFile(parsed['ids-file']));
+  }
+
+  const unique = Array.from(new Set(ids));
+  if (unique.length === 0) {
+    console.error('Error: provide --ids or --ids-file with at least one space UUID.');
+    process.exit(1);
+  }
+
+  return { ids: unique, dryRun: parsed.dryRun === 'true' };
+}
+
+async function main() {
+  const args = parseArgs();
+
+  console.log('\nClose Spaces CLI');
+  console.log(`  IDs:     ${args.ids.length}`);
+  console.log(`  Dry run: ${args.dryRun}\n`);
+
+  const db = createDbPool({ max: 3 });
+  await assertDbConnection(db);
+
+  try {
+    const { rows: matched } = await db.query(
+      `SELECT id, "notificationMsg", "isPublic", "isClaimPending"
+         FROM main.spaces
+        WHERE id = ANY($1)`,
+      [args.ids],
+    );
+
+    if (matched.length === 0) {
+      console.log('No matching spaces found.');
+      return;
+    }
+
+    console.log(`Matched ${matched.length} of ${args.ids.length} requested IDs:`);
+    for (const row of matched) {
+      console.log(`  ${row.id}  isPublic=${row.isPublic}  isClaimPending=${row.isClaimPending}  ${row.notificationMsg}`);
+    }
+
+    const missing = args.ids.filter((id) => !matched.some((r: { id: string }) => r.id === id));
+    if (missing.length > 0) {
+      console.log(`\nNot found (${missing.length}):`);
+      for (const id of missing) console.log(`  ${id}`);
+    }
+
+    if (args.dryRun) {
+      console.log('\nDry run — no changes made.');
+      return;
+    }
+
+    const matchedIds = matched.map((r: { id: string }) => r.id);
+    const { rowCount } = await db.query(
+      `UPDATE main.spaces
+          SET "isPublic" = false,
+              "isClaimPending" = false,
+              "updatedAt" = NOW()
+        WHERE id = ANY($1)`,
+      [matchedIds],
+    );
+
+    console.log(`\nClosed ${rowCount} space(s).`);
+  } finally {
+    await db.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/import-spaces/close-spaces.ts
+++ b/scripts/import-spaces/close-spaces.ts
@@ -108,7 +108,7 @@ async function main() {
     const { rows: matched } = await db.query(
       `SELECT id, "notificationMsg", "isPublic", "isClaimPending"
          FROM main.spaces
-        WHERE id = ANY($1)`,
+        WHERE id = ANY($1::uuid[])`,
       [args.ids],
     );
 
@@ -139,7 +139,7 @@ async function main() {
           SET "isPublic" = false,
               "isClaimPending" = false,
               "updatedAt" = NOW()
-        WHERE id = ANY($1)`,
+        WHERE id = ANY($1::uuid[])`,
       [matchedIds],
     );
 

--- a/scripts/import-spaces/index.ts
+++ b/scripts/import-spaces/index.ts
@@ -11,11 +11,13 @@
 import * as dotenv from 'dotenv';
 import * as path from 'path';
 import { Pool } from 'pg';
-import { CITIES, BATCH_SIZE, IMPORT_USER_ID, OSM_CATEGORY_MAP } from './config';
+import { CITIES, IMPORT_USER_ID, OSM_CATEGORY_MAP } from './config';
 import { fetchOsmData } from './sources/osm';
 import { mapOsmToSpace, ISpaceInsertParams } from './transforms/mapToSpace';
 import { findDuplicates, deduplicateWithinBatch } from './utils/deduplicate';
 import { validateSpace } from './utils/validate';
+import { assertDbConnection, createDbPool } from './utils/db';
+import { insertSpacesBatch } from './utils/insertSpaces';
 
 // Load .env from scripts/import-spaces/ first, fall back to root .env
 dotenv.config({ path: path.resolve(__dirname, '.env') });
@@ -98,84 +100,6 @@ function parseArgs(): ICliArgs {
   };
 }
 
-// ── DB connection ────────────────────────────────────────────────────────────
-function createDbPool(): Pool {
-  return new Pool({
-    host: process.env.DB_HOST_MAIN_WRITE,
-    user: process.env.DB_USER_MAIN_WRITE,
-    password: process.env.DB_PASSWORD_MAIN_WRITE,
-    database: process.env.MAPS_SERVICE_DATABASE,
-    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
-    max: 5,
-    idleTimeoutMillis: 10000,
-    connectionTimeoutMillis: 5000,
-  });
-}
-
-// ── Insert spaces ────────────────────────────────────────────────────────────
-async function insertSpaces(db: Pool, spaces: ISpaceInsertParams[]): Promise<number> {
-  let inserted = 0;
-
-  for (let i = 0; i < spaces.length; i += BATCH_SIZE) {
-    const batch = spaces.slice(i, i + BATCH_SIZE);
-
-    for (const space of batch) {
-      try {
-        const result = await db.query(
-          `INSERT INTO main.spaces
-            ("fromUserId", locale, "isPublic", message, "notificationMsg",
-             "mediaIds", "mentionsIds", "hashTags", "maxViews",
-             latitude, longitude, radius, "polygonCoords", "maxProximity",
-             "doesRequireProximityToView", "isMatureContent", "isModeratorApproved",
-             "isForSale", "isHirable", "isPromotional", "isExclusiveToGroups",
-             category, "areaType", valuation, region,
-             "addressReadable", "addressStreetAddress", "addressRegion", "addressLocality", "postalCode",
-             "phoneNumber", "businessEmail", "websiteUrl", "isPointOfInterest", "openingHours",
-             geom, "geomCenter")
-          VALUES
-            ($1, $2, $3, $4, $5,
-             $6, $7, $8, $9,
-             $10::float8, $11::float8, $12::float8, $13::jsonb, $14::float8,
-             $15, $16, $17,
-             $18, $19, $20, $21,
-             $22, $23, $24, $25,
-             $26, $27, $28, $29, $30::integer,
-             $31, $32, $33, $34, $35::jsonb,
-             ST_SetSRID(ST_Buffer(ST_MakePoint($11::float8, $10::float8)::geography, $36::float8)::geometry, 4326),
-             ST_SetSRID(ST_MakePoint($11::float8, $10::float8), 4326))
-          ON CONFLICT DO NOTHING
-          RETURNING id`,
-          [
-            space.fromUserId, space.locale, space.isPublic, space.message, space.notificationMsg,
-            space.mediaIds, space.mentionsIds, space.hashTags, space.maxViews,
-            space.latitude, space.longitude, space.radius, space.polygonCoords, space.maxProximity,
-            space.doesRequireProximityToView, space.isMatureContent, space.isModeratorApproved,
-            space.isForSale, space.isHirable, space.isPromotional, space.isExclusiveToGroups,
-            space.category, space.areaType, space.valuation, space.region,
-            space.addressReadable, space.addressStreetAddress, space.addressRegion, space.addressLocality, space.postalCode,
-            space.phoneNumber, space.businessEmail, space.websiteUrl, space.isPointOfInterest, space.openingHours,
-            space.radius, // $36: separate param for ST_Buffer to avoid type ambiguity
-          ],
-        );
-        if (result.rowCount && result.rowCount > 0) {
-          inserted++;
-        }
-      } catch (err: any) {
-        // Log and continue — overlapping geometries or other constraints may cause failures
-        if (err.message?.includes('no_area_overlaps') || err.message?.includes('exclude')) {
-          // Geometry overlap — expected for nearby businesses
-        } else {
-          console.error(`  Failed to insert "${space.notificationMsg}": ${err.message}`);
-        }
-      }
-    }
-
-    console.log(`  Batch progress: ${Math.min(i + BATCH_SIZE, spaces.length)}/${spaces.length} processed, ${inserted} inserted`);
-  }
-
-  return inserted;
-}
-
 // ── Main ─────────────────────────────────────────────────────────────────────
 async function main() {
   const args = parseArgs();
@@ -202,21 +126,14 @@ async function main() {
   let db: Pool | null = null;
   if (!args.dryRun) {
     db = createDbPool();
-    // Test connection
-    try {
-      await db.query('SELECT 1');
-      console.log('Database connection established.\n');
-    } catch (err: any) {
-      console.error(`Database connection failed: ${err.message}`);
-      console.error('Make sure .env is configured with DB_HOST_MAIN_WRITE, DB_USER_MAIN_WRITE, etc.');
-      process.exit(1);
-    }
+    await assertDbConnection(db);
   }
 
   let totalFetched = 0;
   let totalInserted = 0;
   let totalSkippedValidation = 0;
   let totalSkippedDuplicate = 0;
+  let totalFailed = 0;
   let remaining = args.limit || Infinity;
 
   for (const cityKey of cityKeys) {
@@ -284,10 +201,12 @@ async function main() {
     // Insert
     if (db && spaces.length > 0) {
       console.log(`  Inserting ${spaces.length} spaces...`);
-      const inserted = await insertSpaces(db, spaces);
+      const { inserted, skipped, failed } = await insertSpacesBatch(db, spaces);
       totalInserted += inserted;
+      totalSkippedDuplicate += skipped;
+      totalFailed += failed;
       remaining -= inserted;
-      console.log(`  Inserted: ${inserted}`);
+      console.log(`  Inserted: ${inserted} (skipped ${skipped}, failed ${failed})`);
     }
   }
 
@@ -296,6 +215,7 @@ async function main() {
   console.log(`Total fetched from OSM:   ${totalFetched}`);
   console.log(`Skipped (validation):     ${totalSkippedValidation}`);
   console.log(`Skipped (duplicate):      ${totalSkippedDuplicate}`);
+  console.log(`Failed (DB errors):       ${totalFailed}`);
   console.log(`${args.dryRun ? 'Would insert' : 'Inserted'}:              ${totalInserted}`);
   console.log('══════════════════════════════════════\n');
 

--- a/scripts/import-spaces/manage-space.ts
+++ b/scripts/import-spaces/manage-space.ts
@@ -28,17 +28,14 @@
 import * as dotenv from 'dotenv';
 import * as path from 'path';
 import { Pool } from 'pg';
-import { CITIES, BATCH_SIZE, IMPORT_USER_ID, OSM_CATEGORY_MAP } from './config';
+import { CITIES, IMPORT_USER_ID, OSM_CATEGORY_MAP } from './config';
 import { fetchOsmData } from './sources/osm';
 import { mapOsmToSpace, ISpaceInsertParams } from './transforms/mapToSpace';
 import { findDuplicates, deduplicateWithinBatch } from './utils/deduplicate';
 import { validateSpace } from './utils/validate';
 import { crawlForEmails } from './sources/crawlEmails';
 import { searchForWebsite } from './sources/searchWeb';
-import { crawlForImages } from './sources/crawl';
 import { crawlForDetails, fetchPage } from './sources/crawlDetails';
-import { downloadAndValidateImage } from './utils/imageValidation';
-import { uploadImage } from './utils/gcs';
 import {
   ProcessedType,
   markProcessed,
@@ -46,6 +43,9 @@ import {
   getProcessedStats,
 } from './utils/processedSpaces';
 import { CITY_TIMEZONE_MAP } from './transforms/parseHours';
+import { assertDbConnection, createDbPool } from './utils/db';
+import { insertSpacesBatch } from './utils/insertSpaces';
+import { sourceImageForSpace } from './utils/sourceImage';
 
 // Load .env from scripts/import-spaces/ first, fall back to root .env
 dotenv.config({ path: path.resolve(__dirname, '.env') });
@@ -165,20 +165,6 @@ function parseArgs(): ICliArgs {
   };
 }
 
-// ── DB connection ────────────────────────────────────────────────────────────
-function createDbPool(): Pool {
-  return new Pool({
-    host: process.env.DB_HOST_MAIN_WRITE,
-    user: process.env.DB_USER_MAIN_WRITE,
-    password: process.env.DB_PASSWORD_MAIN_WRITE,
-    database: process.env.MAPS_SERVICE_DATABASE,
-    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
-    max: 5,
-    idleTimeoutMillis: 10000,
-    connectionTimeoutMillis: 10000,
-  });
-}
-
 // ── Sleep helper ─────────────────────────────────────────────────────────────
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => { setTimeout(resolve, ms); });
@@ -213,69 +199,6 @@ function newCounters(): ICounters {
     phonesFound: 0,
     enrichErrors: 0,
   };
-}
-
-// ── Insert spaces ────────────────────────────────────────────────────────────
-async function insertSpaces(db: Pool, spaces: ISpaceInsertParams[]): Promise<{ inserted: number; ids: string[] }> {
-  let inserted = 0;
-  const ids: string[] = [];
-
-  for (let i = 0; i < spaces.length; i += BATCH_SIZE) {
-    const batch = spaces.slice(i, i + BATCH_SIZE);
-
-    for (const space of batch) {
-      try {
-        const result = await db.query(
-          `INSERT INTO main.spaces
-            ("fromUserId", locale, "isPublic", message, "notificationMsg",
-             "mediaIds", "mentionsIds", "hashTags", "maxViews",
-             latitude, longitude, radius, "polygonCoords", "maxProximity",
-             "doesRequireProximityToView", "isMatureContent", "isModeratorApproved",
-             "isForSale", "isHirable", "isPromotional", "isExclusiveToGroups",
-             category, "areaType", valuation, region,
-             "addressReadable", "addressStreetAddress", "addressRegion", "addressLocality", "postalCode",
-             "phoneNumber", "businessEmail", "websiteUrl", "isPointOfInterest", "openingHours",
-             geom, "geomCenter")
-          VALUES
-            ($1, $2, $3, $4, $5,
-             $6, $7, $8, $9,
-             $10::float8, $11::float8, $12::float8, $13::jsonb, $14::float8,
-             $15, $16, $17,
-             $18, $19, $20, $21,
-             $22, $23, $24, $25,
-             $26, $27, $28, $29, $30::integer,
-             $31, $32, $33, $34, $35::jsonb,
-             ST_SetSRID(ST_Buffer(ST_MakePoint($11::float8, $10::float8)::geography, $36::float8)::geometry, 4326),
-             ST_SetSRID(ST_MakePoint($11::float8, $10::float8), 4326))
-          ON CONFLICT DO NOTHING
-          RETURNING id`,
-          [
-            space.fromUserId, space.locale, space.isPublic, space.message, space.notificationMsg,
-            space.mediaIds, space.mentionsIds, space.hashTags, space.maxViews,
-            space.latitude, space.longitude, space.radius, space.polygonCoords, space.maxProximity,
-            space.doesRequireProximityToView, space.isMatureContent, space.isModeratorApproved,
-            space.isForSale, space.isHirable, space.isPromotional, space.isExclusiveToGroups,
-            space.category, space.areaType, space.valuation, space.region,
-            space.addressReadable, space.addressStreetAddress, space.addressRegion, space.addressLocality, space.postalCode,
-            space.phoneNumber, space.businessEmail, space.websiteUrl, space.isPointOfInterest, space.openingHours,
-            space.radius,
-          ],
-        );
-        if (result.rowCount && result.rowCount > 0) {
-          inserted++;
-          ids.push(result.rows[0].id);
-        }
-      } catch (err: any) {
-        if (!err.message?.includes('no_area_overlaps') && !err.message?.includes('exclude')) {
-          console.error(`  Failed to insert "${space.notificationMsg}": ${err.message}`);
-        }
-      }
-    }
-
-    console.log(`  Batch progress: ${Math.min(i + BATCH_SIZE, spaces.length)}/${spaces.length} processed, ${inserted} inserted`);
-  }
-
-  return { inserted, ids };
 }
 
 // ── Space row interface for enrichment ───────────────────────────────────────
@@ -363,50 +286,6 @@ async function querySpacesByIds(db: Pool, ids: string[]): Promise<ISpaceRow[]> {
 // ── Check if a space needs images ────────────────────────────────────────────
 function spaceNeedsImages(space: ISpaceRow): boolean {
   return (!space.mediaIds || space.mediaIds === '') && !space.medias;
-}
-
-// ── Source image for a space ─────────────────────────────────────────────────
-async function sourceImageForSpace(
-  db: Pool,
-  space: ISpaceRow,
-  websiteUrl: string,
-  userId: string,
-  progress: string,
-): Promise<boolean> {
-  const candidates = await crawlForImages(websiteUrl);
-  if (candidates.length === 0) return false;
-
-  for (const candidate of candidates) {
-    const validImage = await downloadAndValidateImage(candidate.imageUrl);
-    if (!validImage) continue;
-
-    console.log(`${progress}   Image found (${candidate.source}): ${validImage.width}x${validImage.height}`);
-
-    const storagePath = await uploadImage(userId, space.id, validImage.buffer, validImage.contentType);
-
-    const mediaResult = await db.query(
-      `INSERT INTO main.media ("fromUserId", "altText", type, path)
-       VALUES ($1, $2, $3, $4)
-       RETURNING id`,
-      [userId, space.notificationMsg, 'user-image-public', storagePath],
-    );
-    const mediaId = mediaResult.rows[0].id;
-
-    const medias = JSON.stringify([{ path: storagePath, type: 'user-image-public' }]);
-    await db.query(
-      `UPDATE main.spaces
-       SET "mediaIds" = $1::text,
-           medias = $2::jsonb,
-           "updatedAt" = NOW()
-       WHERE id = $3`,
-      [String(mediaId), medias, space.id],
-    );
-
-    console.log(`${progress}   Uploaded image: ${storagePath}`);
-    return true;
-  }
-
-  return false;
 }
 
 /**
@@ -556,13 +435,17 @@ async function enrichSpace(
     if (args.dryRun) {
       console.log(`${progress} Would source image from ${websiteUrl}`);
     } else {
-      const imageSourced = await sourceImageForSpace(
-        db, space, websiteUrl, space.fromUserId || args.userId, progress,
+      const outcome = await sourceImageForSpace(
+        db,
+        space,
+        websiteUrl,
+        space.fromUserId || args.userId,
+        { progress },
       );
-      if (imageSourced) {
+      if (outcome.status === 'uploaded') {
         counters.imagesFound++;
         markProcessed(ProcessedType.IMAGE_FOUND, space.id, space.notificationMsg);
-      } else {
+      } else if (outcome.status === 'no-candidates' || outcome.status === 'no-valid-image') {
         markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
       }
     }
@@ -647,11 +530,12 @@ async function runImport(db: Pool, args: ICliArgs, counters: ICounters): Promise
     // Insert
     if (spaces.length > 0) {
       console.log(`  Inserting ${spaces.length} spaces...`);
-      const { inserted, ids } = await insertSpaces(db, spaces);
+      const { inserted, ids, skipped, failed } = await insertSpacesBatch(db, spaces);
       counters.imported += inserted;
+      counters.skippedDuplicate += skipped;
       remaining -= inserted;
       allInsertedIds.push(...ids);
-      console.log(`  Inserted: ${inserted}`);
+      console.log(`  Inserted: ${inserted} (skipped ${skipped}, failed ${failed})`);
     }
   }
 
@@ -721,17 +605,8 @@ async function main() {
   console.log('');
 
   const db = createDbPool();
-
-  // Test connection
-  try {
-    await db.query('SELECT 1');
-    console.log('Database connection established.\n');
-  } catch (err: any) {
-    console.error(`Database connection failed: ${err.message}`);
-    console.error('Make sure .env is configured with DB_HOST_MAIN_WRITE, DB_USER_MAIN_WRITE, etc.');
-    await db.end();
-    process.exit(1);
-  }
+  await assertDbConnection(db);
+  console.log('');
 
   const counters = newCounters();
 

--- a/scripts/import-spaces/query-spaces.ts
+++ b/scripts/import-spaces/query-spaces.ts
@@ -14,6 +14,7 @@ import * as dotenv from 'dotenv';
 import * as path from 'path';
 import { Pool } from 'pg';
 import { CITIES } from './config';
+import { createDbPool } from './utils/db';
 
 dotenv.config({ path: path.resolve(__dirname, '.env') });
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
@@ -52,19 +53,6 @@ function parseArgs(): ICliArgs {
     mode: mode as 'email' | 'website' | 'both',
     limit: parsed.limit ? parseInt(parsed.limit, 10) : 10,
   };
-}
-
-function createDbPool(): Pool {
-  return new Pool({
-    host: process.env.DB_HOST_MAIN_WRITE,
-    user: process.env.DB_USER_MAIN_WRITE,
-    password: process.env.DB_PASSWORD_MAIN_WRITE,
-    database: process.env.MAPS_SERVICE_DATABASE,
-    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
-    max: 3,
-    idleTimeoutMillis: 10000,
-    connectionTimeoutMillis: 10000,
-  });
 }
 
 async function querySpaces(db: Pool, args: ICliArgs) {
@@ -115,7 +103,7 @@ async function main() {
   const args = parseArgs();
   log(`Querying spaces: mode=${args.mode}, city=${args.city}, category=${args.category}, limit=${args.limit}`);
 
-  const db = createDbPool();
+  const db = createDbPool({ max: 3 });
 
   try {
     await db.query('SELECT 1');

--- a/scripts/import-spaces/send-unclaimed-emails.ts
+++ b/scripts/import-spaces/send-unclaimed-emails.ts
@@ -25,6 +25,8 @@ import * as path from 'path';
 import { Pool } from 'pg';
 import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
 import { CITIES } from './config';
+import { createDbPool } from './utils/db';
+import { withRetry, isTransientNetworkError } from './utils/withRetry';
 
 dotenv.config({ path: path.resolve(__dirname, '.env') });
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
@@ -35,6 +37,18 @@ const METRIC_VALUE_TYPE = 'NUMBER';
 const THERR_HOST = process.env.THERR_HOST || 'https://therr.com';
 const FROM_EMAIL = process.env.AWS_SES_FROM_EMAIL || 'info@therr.com';
 const FROM_EMAIL_TITLE = 'Therr App';
+
+// SUPER_ADMIN_ID mirrors therr-services/*/src/constants/index.ts. Imported
+// spaces are inserted with fromUserId = this value; the handler treats such
+// spaces as "unclaimed" when no user has requested to claim them.
+const SUPER_ADMIN_ID_BY_ENV: Record<string, string> = {
+  development: '04e65180-3cff-48b1-988f-4b6e0ab25def',
+  stage: '04e65180-3cff-48b1-988f-4b6e0ab25def',
+  production: '568bf5d2-8595-4fd6-95da-32cc318618d3',
+};
+const SUPER_ADMIN_ID = process.env.SUPER_ADMIN_ID
+  || SUPER_ADMIN_ID_BY_ENV[process.env.NODE_ENV || 'development']
+  || SUPER_ADMIN_ID_BY_ENV.development;
 
 // ── Help ──────────────────────────────────────────────────────────────────────
 function printHelp() {
@@ -101,33 +115,6 @@ function parseArgs(): ICliArgs {
   };
 }
 
-// ── DB helpers ────────────────────────────────────────────────────────────────
-function createMapsPool(): Pool {
-  return new Pool({
-    host: process.env.DB_HOST_MAIN_WRITE,
-    user: process.env.DB_USER_MAIN_WRITE,
-    password: process.env.DB_PASSWORD_MAIN_WRITE,
-    database: process.env.MAPS_SERVICE_DATABASE,
-    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
-    max: 3,
-    idleTimeoutMillis: 10000,
-    connectionTimeoutMillis: 10000,
-  });
-}
-
-function createUsersPool(): Pool {
-  return new Pool({
-    host: process.env.DB_HOST_MAIN_WRITE,
-    user: process.env.DB_USER_MAIN_WRITE,
-    password: process.env.DB_PASSWORD_MAIN_WRITE,
-    database: process.env.USERS_SERVICE_DATABASE || 'therr_dev_users',
-    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
-    max: 3,
-    idleTimeoutMillis: 10000,
-    connectionTimeoutMillis: 10000,
-  });
-}
-
 // ── Space query ───────────────────────────────────────────────────────────────
 interface ISpaceRow {
   id: string;
@@ -139,13 +126,20 @@ interface ISpaceRow {
 }
 
 async function queryUnclaimedSpaces(mapsPool: Pool, args: ICliArgs): Promise<ISpaceRow[]> {
+  // Replicates handlers/spaces.ts:360's computed `isUnclaimed` rule:
+  // fromUserId === SUPER_ADMIN_ID && !requestedByUserId. Also requires the
+  // space is public and has no pending claim so we only email live, unowned
+  // listings.
+  const params: (string | number)[] = [SUPER_ADMIN_ID];
   const conditions = [
     `"businessEmail" IS NOT NULL`,
     `"businessEmail" != ''`,
-    `"isUnclaimed" = true`,
+    `"fromUserId" = $1`,
+    `"requestedByUserId" IS NULL`,
+    `"isClaimPending" = false`,
+    `"isPublic" = true`,
   ];
-  const params: (string | number)[] = [];
-  let paramIdx = 1;
+  let paramIdx = 2;
 
   if (args.city !== 'all') {
     const cityConfig = CITIES[args.city];
@@ -162,7 +156,7 @@ async function queryUnclaimedSpaces(mapsPool: Pool, args: ICliArgs): Promise<ISp
     paramIdx++;
   }
 
-  let query = `SELECT id, "notificationMsg", "businessEmail", "addressLocality", "addressRegion", category
+  const query = `SELECT id, "notificationMsg", "businessEmail", "addressLocality", "addressRegion", category
     FROM main.spaces
     WHERE ${conditions.join(' AND ')}
     ORDER BY RANDOM()
@@ -283,7 +277,13 @@ async function sendEmail(
     },
   });
 
-  await ses.send(command);
+  await withRetry(() => ses.send(command), {
+    retries: 2,
+    baseDelayMs: 2000,
+    shouldRetry: isTransientNetworkError,
+    label: 'ses.send',
+    log: console.warn,
+  });
 }
 
 // ── Metric write ──────────────────────────────────────────────────────────────
@@ -333,8 +333,8 @@ async function main() {
     process.exit(1);
   }
 
-  const mapsPool = createMapsPool();
-  const usersPool = createUsersPool();
+  const mapsPool = createDbPool({ target: 'maps', max: 3 });
+  const usersPool = createDbPool({ target: 'users', max: 3 });
   const ses = createSesClient();
 
   // Test DB connections

--- a/scripts/import-spaces/send-unclaimed-emails.ts
+++ b/scripts/import-spaces/send-unclaimed-emails.ts
@@ -280,10 +280,21 @@ async function sendEmail(
   await withRetry(() => ses.send(command), {
     retries: 2,
     baseDelayMs: 2000,
-    shouldRetry: isTransientNetworkError,
+    shouldRetry: isTransientSesError,
     label: 'ses.send',
     log: console.warn,
   });
+}
+
+// Retry transient SES/AWS errors (throttling, 5xx) as well as generic network blips.
+function isTransientSesError(err: unknown): boolean {
+  if (err && typeof err === 'object') {
+    const name = (err as { name?: string }).name || '';
+    if (/Throttling|TooManyRequests|ServiceUnavailable|RequestTimeout|InternalFailure/i.test(name)) {
+      return true;
+    }
+  }
+  return isTransientNetworkError(err);
 }
 
 // ── Metric write ──────────────────────────────────────────────────────────────
@@ -294,7 +305,7 @@ async function logEmailSentMetric(usersPool: Pool, spaceId: string, businessEmai
      ON CONFLICT DO NOTHING`,
     [
       METRIC_NAME,
-      '', // system-level metric, no user context
+      null, // system-level metric; userMetrics.userId is a nullable uuid FK
       '1',
       METRIC_VALUE_TYPE,
       JSON.stringify({ spaceId, businessEmail }),

--- a/scripts/import-spaces/source-emails-websites.ts
+++ b/scripts/import-spaces/source-emails-websites.ts
@@ -18,15 +18,14 @@ import { Pool } from 'pg';
 import { CITIES, IMPORT_USER_ID } from './config';
 import { crawlForEmails } from './sources/crawlEmails';
 import { searchForWebsite } from './sources/searchWeb';
-import { crawlForImages } from './sources/crawl';
-import { downloadAndValidateImage } from './utils/imageValidation';
-import { uploadImage } from './utils/gcs';
 import {
   ProcessedType,
   markProcessed,
   filterProcessedSpaces,
   getProcessedStats,
 } from './utils/processedSpaces';
+import { assertDbConnection, createDbPool } from './utils/db';
+import { sourceImageForSpace } from './utils/sourceImage';
 
 // Load .env from scripts/import-spaces/ first, fall back to root .env
 dotenv.config({ path: path.resolve(__dirname, '.env') });
@@ -119,20 +118,6 @@ function parseArgs(): ICliArgs {
   };
 }
 
-// ── DB connection ────────────────────────────────────────────────────────────
-function createDbPool(): Pool {
-  return new Pool({
-    host: process.env.DB_HOST_MAIN_WRITE,
-    user: process.env.DB_USER_MAIN_WRITE,
-    password: process.env.DB_PASSWORD_MAIN_WRITE,
-    database: process.env.MAPS_SERVICE_DATABASE,
-    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
-    max: 5,
-    idleTimeoutMillis: 10000,
-    connectionTimeoutMillis: 10000,
-  });
-}
-
 interface ISpaceRow {
   id: string;
   notificationMsg: string;
@@ -206,53 +191,6 @@ function spaceNeedsImages(space: ISpaceRow): boolean {
   return (!space.mediaIds || space.mediaIds === '') && !space.medias;
 }
 
-// ── Image sourcing (reuses existing pipeline) ────────────────────────────────
-async function sourceImageForSpace(
-  db: Pool,
-  space: ISpaceRow,
-  websiteUrl: string,
-  userId: string,
-  progress: string,
-): Promise<boolean> {
-  const candidates = await crawlForImages(websiteUrl);
-  if (candidates.length === 0) return false;
-
-  // Try each candidate until one validates
-  for (const candidate of candidates) {
-    const validImage = await downloadAndValidateImage(candidate.imageUrl);
-    if (!validImage) continue;
-
-    console.log(`${progress}   Image found (${candidate.source}): ${validImage.width}x${validImage.height}`);
-
-    const storagePath = await uploadImage(userId, space.id, validImage.buffer, validImage.contentType);
-
-    // Insert media record
-    const mediaResult = await db.query(
-      `INSERT INTO main.media ("fromUserId", "altText", type, path)
-       VALUES ($1, $2, $3, $4)
-       RETURNING id`,
-      [userId, space.notificationMsg, 'user-image-public', storagePath],
-    );
-    const mediaId = mediaResult.rows[0].id;
-
-    // Update space with media references
-    const medias = JSON.stringify([{ path: storagePath, type: 'user-image-public' }]);
-    await db.query(
-      `UPDATE main.spaces
-       SET "mediaIds" = $1::text,
-           medias = $2::jsonb,
-           "updatedAt" = NOW()
-       WHERE id = $3`,
-      [String(mediaId), medias, space.id],
-    );
-
-    console.log(`${progress}   Uploaded image: ${storagePath}`);
-    return true;
-  }
-
-  return false;
-}
-
 // ── Process spaces that need emails ──────────────────────────────────────────
 async function processEmailSpaces(db: Pool, args: ICliArgs, counters: ICounters) {
   let spaces = await querySpacesForEmails(db, args);
@@ -309,11 +247,17 @@ async function processEmailSpaces(db: Pool, args: ICliArgs, counters: ICounters)
         if (args.dryRun) {
           console.log(`${progress}   Would also source image from ${space.websiteUrl}`);
         } else {
-          const imageSourced = await sourceImageForSpace(db, space, space.websiteUrl, space.fromUserId || args.userId, progress);
-          if (imageSourced) {
+          const outcome = await sourceImageForSpace(
+            db,
+            space,
+            space.websiteUrl!,
+            space.fromUserId || args.userId,
+            { progress },
+          );
+          if (outcome.status === 'uploaded') {
             counters.imagesFound++;
             markProcessed(ProcessedType.IMAGE_FOUND, space.id, space.notificationMsg);
-          } else {
+          } else if (outcome.status === 'no-candidates' || outcome.status === 'no-valid-image') {
             markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
           }
         }
@@ -404,13 +348,17 @@ async function processWebsiteSpaces(db: Pool, args: ICliArgs, counters: ICounter
         if (args.dryRun) {
           console.log(`${progress}   Would also source image from ${searchResult.websiteUrl}`);
         } else {
-          const imageSourced = await sourceImageForSpace(
-            db, space, searchResult.websiteUrl, space.fromUserId || args.userId, progress,
+          const outcome = await sourceImageForSpace(
+            db,
+            space,
+            searchResult.websiteUrl,
+            space.fromUserId || args.userId,
+            { progress },
           );
-          if (imageSourced) {
+          if (outcome.status === 'uploaded') {
             counters.imagesFound++;
             markProcessed(ProcessedType.IMAGE_FOUND, space.id, space.notificationMsg);
-          } else {
+          } else if (outcome.status === 'no-candidates' || outcome.status === 'no-valid-image') {
             markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
           }
         }
@@ -450,16 +398,8 @@ async function main() {
   console.log('');
 
   const db = createDbPool();
-
-  // Test connection
-  try {
-    await db.query('SELECT 1');
-    console.log('Database connection established.\n');
-  } catch (err: any) {
-    console.error(`Database connection failed: ${err.message}`);
-    console.error('Make sure .env is configured with DB_HOST_MAIN_WRITE, DB_USER_MAIN_WRITE, etc.');
-    process.exit(1);
-  }
+  await assertDbConnection(db);
+  console.log('');
 
   const counters: ICounters = {
     emailsFound: 0,

--- a/scripts/import-spaces/source-images.ts
+++ b/scripts/import-spaces/source-images.ts
@@ -12,15 +12,14 @@ import * as dotenv from 'dotenv';
 import * as path from 'path';
 import { Pool } from 'pg';
 import { CITIES, IMPORT_USER_ID } from './config';
-import { crawlForImages, ICrawlResult } from './sources/crawl';
-import { downloadAndValidateImage } from './utils/imageValidation';
-import { uploadImage } from './utils/gcs';
 import {
   ProcessedType,
   markProcessed,
   filterProcessedSpaces,
   getProcessedStats,
 } from './utils/processedSpaces';
+import { assertDbConnection, createDbPool } from './utils/db';
+import { sourceImageForSpace } from './utils/sourceImage';
 
 // Load .env from scripts/import-spaces/ first, fall back to root .env
 dotenv.config({ path: path.resolve(__dirname, '.env') });
@@ -94,20 +93,6 @@ function parseArgs(): ICliArgs {
   };
 }
 
-// ── DB connection ────────────────────────────────────────────────────────────
-function createDbPool(): Pool {
-  return new Pool({
-    host: process.env.DB_HOST_MAIN_WRITE,
-    user: process.env.DB_USER_MAIN_WRITE,
-    password: process.env.DB_PASSWORD_MAIN_WRITE,
-    database: process.env.MAPS_SERVICE_DATABASE,
-    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
-    max: 5,
-    idleTimeoutMillis: 10000,
-    connectionTimeoutMillis: 10000,
-  });
-}
-
 interface ISpaceRow {
   id: string;
   notificationMsg: string;
@@ -174,16 +159,8 @@ async function main() {
   console.log('');
 
   const db = createDbPool();
-
-  // Test connection
-  try {
-    await db.query('SELECT 1');
-    console.log('Database connection established.\n');
-  } catch (err: any) {
-    console.error(`Database connection failed: ${err.message}`);
-    console.error('Make sure .env is configured with DB_HOST_MAIN_WRITE, DB_USER_MAIN_WRITE, etc.');
-    process.exit(1);
-  }
+  await assertDbConnection(db);
+  console.log('');
 
   let spaces = await querySpaces(db, args);
 
@@ -217,77 +194,49 @@ async function main() {
     const progress = `[${i + 1}/${spaces.length}]`;
 
     try {
-      // Step 1: Crawl website for image candidates
-      const candidates = await crawlForImages(space.websiteUrl);
-      if (candidates.length === 0) {
-        console.log(`${progress} SKIP (no image found): ${space.notificationMsg} — ${space.websiteUrl}`);
-        if (!args.dryRun) {
-          markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
+      const userId = space.fromUserId || args.userId;
+      const outcome = await sourceImageForSpace(
+        db,
+        space,
+        space.websiteUrl,
+        userId,
+        { dryRun: args.dryRun, progress },
+      );
+
+      switch (outcome.status) {
+        case 'no-candidates': {
+          console.log(`${progress} SKIP (no image found): ${space.notificationMsg} — ${space.websiteUrl}`);
+          if (!args.dryRun) {
+            markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
+          }
+          skippedNoImage++;
+          break;
         }
-        skippedNoImage++;
-        if (i < spaces.length - 1) await sleep(args.delay);
-        continue;
-      }
-
-      console.log(`${progress} Found ${candidates.length} candidate(s) for: ${space.notificationMsg}`);
-
-      if (args.dryRun) {
-        const best = candidates[0];
-        console.log(`  DRY RUN — best candidate: ${best.source} ${best.imageUrl.substring(0, 80)}...`);
-        dryRunFound++;
-        if (i < spaces.length - 1) await sleep(args.delay);
-        continue;
-      }
-
-      // Step 2: Try each candidate until one validates
-      let validImage = null;
-      let matchedCandidate = candidates[0];
-      for (const candidate of candidates) {
-        validImage = await downloadAndValidateImage(candidate.imageUrl);
-        if (validImage) {
-          matchedCandidate = candidate;
+        case 'dry-run': {
+          console.log(`${progress} DRY RUN — ${outcome.candidateCount} candidate(s) for: ${space.notificationMsg}`);
+          dryRunFound++;
+          break;
+        }
+        case 'no-valid-image': {
+          console.log(`${progress}  SKIP (all candidates invalid/too small): ${space.notificationMsg}`);
+          markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
+          skippedTooSmall++;
+          break;
+        }
+        case 'uploaded': {
+          markProcessed(ProcessedType.IMAGE_FOUND, space.id, space.notificationMsg);
+          updated++;
+          break;
+        }
+        case 'skipped-has-media': {
+          // Space already has media — nothing to do.
+          break;
+        }
+        default: {
+          // exhaustive
           break;
         }
       }
-
-      if (!validImage) {
-        console.log(`  SKIP (all candidates invalid/too small): ${space.notificationMsg}`);
-        markProcessed(ProcessedType.NO_IMAGE_FOUND, space.id, space.notificationMsg);
-        skippedTooSmall++;
-        if (i < spaces.length - 1) await sleep(args.delay);
-        continue;
-      }
-
-      console.log(`  Image validated (${matchedCandidate.source}): ${validImage.width}x${validImage.height} ${validImage.contentType}`);
-
-      // Step 3: Upload to GCS
-      const userId = space.fromUserId || args.userId;
-      const storagePath = await uploadImage(userId, space.id, validImage.buffer, validImage.contentType);
-      console.log(`  Uploaded to GCS: ${storagePath}`);
-
-      // Step 4: Insert media record
-      const mediaResult = await db.query(
-        `INSERT INTO main.media ("fromUserId", "altText", type, path)
-         VALUES ($1, $2, $3, $4)
-         RETURNING id`,
-        [userId, space.notificationMsg, 'user-image-public', storagePath],
-      );
-      const mediaId = mediaResult.rows[0].id;
-
-      // Step 5: Update space with media references
-      const medias = JSON.stringify([{ path: storagePath, type: 'user-image-public' }]);
-      await db.query(
-        `UPDATE main.spaces
-         SET "mediaIds" = $1::text,
-             medias = $2::jsonb,
-             "updatedAt" = NOW()
-         WHERE id = $3`,
-        [String(mediaId), medias, space.id],
-      );
-
-      console.log(`  Updated space ${space.id} with media ${mediaId}`);
-      markProcessed(ProcessedType.IMAGE_FOUND, space.id, space.notificationMsg);
-      updated++;
     } catch (err: any) {
       console.error(`${progress} ERROR: ${space.notificationMsg} — ${err.message}`);
       errors++;

--- a/scripts/import-spaces/sources/crawl.ts
+++ b/scripts/import-spaces/sources/crawl.ts
@@ -2,6 +2,7 @@
  * Website crawling for image extraction.
  * Extracts the best representative image from a business website.
  */
+import { withRetry, isTransientNetworkError } from '../utils/withRetry';
 
 export interface ICrawlResult {
   imageUrl: string;
@@ -109,15 +110,24 @@ export async function crawlForImages(url: string): Promise<ICrawlResult[]> {
       normalizedUrl = `https://${normalizedUrl}`;
     }
 
-    const response = await fetch(normalizedUrl, {
-      signal: AbortSignal.timeout(10000),
-      redirect: 'follow',
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.9',
+    const response = await withRetry(
+      () => fetch(normalizedUrl, {
+        signal: AbortSignal.timeout(10000),
+        redirect: 'follow',
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.9',
+        },
+      }),
+      {
+        retries: 1,
+        baseDelayMs: 2000,
+        shouldRetry: isTransientNetworkError,
+        label: `crawlImages ${normalizedUrl}`,
+        log: console.warn,
       },
-    });
+    );
 
     if (!response.ok) {
       console.warn(`  [crawlImages] HTTP ${response.status} for ${normalizedUrl}`);

--- a/scripts/import-spaces/sources/crawlEmails.ts
+++ b/scripts/import-spaces/sources/crawlEmails.ts
@@ -3,6 +3,7 @@
  * Extracts business email addresses from a website by checking mailto links,
  * plaintext patterns, and optionally following a contact page.
  */
+import { withRetry, isTransientNetworkError } from '../utils/withRetry';
 
 export interface IEmailCrawlResult {
   email: string;
@@ -144,15 +145,24 @@ function findContactPageUrl(html: string, baseUrl: string): string | null {
  */
 async function fetchPage(url: string): Promise<string | null> {
   try {
-    const response = await fetch(url, {
-      signal: AbortSignal.timeout(10000),
-      redirect: 'follow',
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.9',
+    const response = await withRetry(
+      () => fetch(url, {
+        signal: AbortSignal.timeout(10000),
+        redirect: 'follow',
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.9',
+        },
+      }),
+      {
+        retries: 1,
+        baseDelayMs: 2000,
+        shouldRetry: isTransientNetworkError,
+        label: `crawlEmails ${url}`,
+        log: console.warn,
       },
-    });
+    );
 
     if (!response.ok) {
       console.warn(`  [crawlEmails] HTTP ${response.status} for ${url}`);

--- a/scripts/import-spaces/sources/searchWeb.ts
+++ b/scripts/import-spaces/sources/searchWeb.ts
@@ -251,45 +251,43 @@ async function webSearch(query: string): Promise<ISearchResult[]> {
     console.warn(`  [searchWeb] Bing error: ${err.message}`);
   }
 
-  // Fallback to DuckDuckGo with retry + backoff
+  // Fallback to DuckDuckGo with retry + backoff. DDG returns 403 when
+  // rate-limited; treat that as a retryable signal alongside network blips.
   const ddgUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;
-  const maxRetries = 2;
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    if (attempt > 0) {
-      const backoff = 2000 * Math.pow(2, attempt - 1) + Math.random() * 1000;
-      console.warn(`  [searchWeb] DDG retry ${attempt}/${maxRetries}, waiting ${Math.round(backoff)}ms...`);
-      await new Promise((resolve) => { setTimeout(resolve, backoff); });
-    }
-
-    try {
-      const response = await fetch(ddgUrl, {
-        signal: AbortSignal.timeout(10000),
-        redirect: 'follow',
-        headers: {
-          'User-Agent': randomUserAgent(),
-          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-          'Accept-Language': 'en-US,en;q=0.9',
-        },
-      });
-
-      if (response.ok) {
-        const html = await response.text();
-        return extractDdgResults(html);
-      }
-
-      if (response.status !== 403) {
+  try {
+    return await withRetry(
+      async () => {
+        const response = await fetch(ddgUrl, {
+          signal: AbortSignal.timeout(10000),
+          redirect: 'follow',
+          headers: {
+            'User-Agent': randomUserAgent(),
+            Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.9',
+          },
+        });
+        if (response.ok) {
+          return extractDdgResults(await response.text());
+        }
+        if (response.status === 403) {
+          throw new Error('DDG rate limited (HTTP 403)');
+        }
         console.warn(`  [searchWeb] DuckDuckGo returned HTTP ${response.status}`);
         return [];
-      }
-      // 403 = rate limited, retry
-    } catch (err: any) {
-      console.warn(`  [searchWeb] DDG error: ${err.message}`);
-      return [];
-    }
+      },
+      {
+        retries: 2,
+        baseDelayMs: 2000,
+        shouldRetry: (err) => (err instanceof Error && err.message.includes('403'))
+          || isTransientNetworkError(err),
+        label: 'searchWeb ddg',
+        log: console.warn,
+      },
+    );
+  } catch (err: any) {
+    console.warn(`  [searchWeb] DDG error: ${err.message}`);
+    return [];
   }
-
-  console.warn('  [searchWeb] All search engines exhausted');
-  return [];
 }
 
 /**

--- a/scripts/import-spaces/sources/searchWeb.ts
+++ b/scripts/import-spaces/sources/searchWeb.ts
@@ -6,6 +6,7 @@
  * domain must clearly match the business name, so we don't associate the wrong
  * website with a space.
  */
+import { withRetry, isTransientNetworkError } from '../utils/withRetry';
 
 // Social media, directory, and review sites that are never a business's own website
 const REJECT_DOMAINS = [
@@ -220,15 +221,24 @@ async function webSearch(query: string): Promise<ISearchResult[]> {
   // Try Bing first (more tolerant of programmatic access)
   const bingUrl = `https://www.bing.com/search?q=${encodeURIComponent(query)}&setlang=en`;
   try {
-    const response = await fetch(bingUrl, {
-      signal: AbortSignal.timeout(10000),
-      redirect: 'follow',
-      headers: {
-        'User-Agent': randomUserAgent(),
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'en-US,en;q=0.9',
+    const response = await withRetry(
+      () => fetch(bingUrl, {
+        signal: AbortSignal.timeout(10000),
+        redirect: 'follow',
+        headers: {
+          'User-Agent': randomUserAgent(),
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+          'Accept-Language': 'en-US,en;q=0.9',
+        },
+      }),
+      {
+        retries: 1,
+        baseDelayMs: 2000,
+        shouldRetry: isTransientNetworkError,
+        label: 'searchWeb bing',
+        log: console.warn,
       },
-    });
+    );
 
     if (response.ok) {
       const html = await response.text();

--- a/scripts/import-spaces/update-space-contact.ts
+++ b/scripts/import-spaces/update-space-contact.ts
@@ -16,11 +16,9 @@
  */
 import * as dotenv from 'dotenv';
 import * as path from 'path';
-import { Pool } from 'pg';
 import { IMPORT_USER_ID } from './config';
-import { crawlForImages } from './sources/crawl';
-import { downloadAndValidateImage } from './utils/imageValidation';
-import { uploadImage } from './utils/gcs';
+import { createDbPool } from './utils/db';
+import { sourceImageForSpace } from './utils/sourceImage';
 
 dotenv.config({ path: path.resolve(__dirname, '.env') });
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
@@ -73,19 +71,6 @@ function parseArgs(): ICliArgs {
   };
 }
 
-function createDbPool(): Pool {
-  return new Pool({
-    host: process.env.DB_HOST_MAIN_WRITE,
-    user: process.env.DB_USER_MAIN_WRITE,
-    password: process.env.DB_PASSWORD_MAIN_WRITE,
-    database: process.env.MAPS_SERVICE_DATABASE,
-    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
-    max: 3,
-    idleTimeoutMillis: 10000,
-    connectionTimeoutMillis: 10000,
-  });
-}
-
 interface IUpdateResult {
   spaceId: string;
   emailUpdated: boolean;
@@ -97,7 +82,7 @@ interface IUpdateResult {
 
 async function main() {
   const args = parseArgs();
-  const db = createDbPool();
+  const db = createDbPool({ max: 3 });
 
   try {
     await db.query('SELECT 1');
@@ -152,64 +137,53 @@ async function main() {
       log(`Updated website: ${args.website}`);
     }
 
-    // Mark as closed/defunct
+    // Mark as closed/defunct. Also clears any lingering pending-claim flag so
+    // the space drops out of the admin approval queue — a closed business
+    // should never appear as "awaiting approval".
     if (args.closed) {
       await db.query(
-        `UPDATE main.spaces SET "isPublic" = false, "updatedAt" = NOW() WHERE id = $1`,
+        `UPDATE main.spaces
+            SET "isPublic" = false,
+                "isClaimPending" = false,
+                "updatedAt" = NOW()
+          WHERE id = $1`,
         [args.id],
       );
       result.closedMarked = true;
-      log(`Marked space as closed (isPublic=false): ${args.id}`);
+      log(`Marked space as closed (isPublic=false, isClaimPending=false): ${args.id}`);
     }
 
     // Source image
     if (args.sourceImage) {
       const websiteUrl = args.website || space.websiteUrl;
-      const hasMedia = (space.mediaIds && space.mediaIds !== '') || (space.medias && space.medias.length > 0);
 
       if (!websiteUrl) {
         log('Skipping image sourcing: no website URL available.');
-      } else if (hasMedia) {
-        log('Skipping image sourcing: space already has media.');
       } else {
         log(`Sourcing image from: ${websiteUrl}`);
-        const candidates = await crawlForImages(websiteUrl);
+        const userId = space.fromUserId || args.userId;
+        const outcome = await sourceImageForSpace(
+          db,
+          { id: args.id, notificationMsg: space.notificationMsg, mediaIds: space.mediaIds, medias: space.medias },
+          websiteUrl,
+          userId,
+          { log },
+        );
 
-        for (const candidate of candidates) {
-          const validImage = await downloadAndValidateImage(candidate.imageUrl);
-          if (!validImage) continue;
-
-          const userId = space.fromUserId || args.userId;
-          const storagePath = await uploadImage(userId, args.id, validImage.buffer, validImage.contentType);
-
-          // Insert media record
-          const mediaResult = await db.query(
-            `INSERT INTO main.media ("fromUserId", "altText", type, path)
-             VALUES ($1, $2, $3, $4)
-             RETURNING id`,
-            [userId, space.notificationMsg, 'user-image-public', storagePath],
-          );
-          const mediaId = mediaResult.rows[0].id;
-
-          // Update space with media references
-          const medias = JSON.stringify([{ path: storagePath, type: 'user-image-public' }]);
-          await db.query(
-            `UPDATE main.spaces
-             SET "mediaIds" = $1::text,
-                 medias = $2::jsonb,
-                 "updatedAt" = NOW()
-             WHERE id = $3`,
-            [String(mediaId), medias, args.id],
-          );
-
-          result.imageSourced = true;
-          result.imagePath = storagePath;
-          log(`Uploaded image: ${storagePath}`);
-          break;
-        }
-
-        if (!result.imageSourced) {
-          log('No valid image found on website.');
+        switch (outcome.status) {
+          case 'uploaded':
+            result.imageSourced = true;
+            result.imagePath = outcome.imagePath;
+            break;
+          case 'skipped-has-media':
+            log('Skipping image sourcing: space already has media.');
+            break;
+          case 'no-candidates':
+          case 'no-valid-image':
+            log('No valid image found on website.');
+            break;
+          default:
+            break;
         }
       }
     }

--- a/scripts/import-spaces/utils/db.ts
+++ b/scripts/import-spaces/utils/db.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared Postgres pool factory for import-space CLI scripts.
+ *
+ * Centralizes the per-script `new Pool({...})` boilerplate so connection
+ * settings and env-var names stay consistent across every script.
+ */
+import { Pool, PoolConfig } from 'pg';
+
+export type DbTarget = 'maps' | 'users';
+
+export interface ICreatePoolOptions {
+  /** Which service's database to connect to (default: 'maps'). */
+  target?: DbTarget;
+  /** Max pool size (default: 5). */
+  max?: number;
+  /** Idle timeout in ms (default: 10000). */
+  idleTimeoutMillis?: number;
+  /** Connection timeout in ms (default: 10000). */
+  connectionTimeoutMillis?: number;
+}
+
+function resolveDatabase(target: DbTarget): string {
+  if (target === 'users') {
+    return process.env.USERS_SERVICE_DATABASE || 'therr_dev_users';
+  }
+  return process.env.MAPS_SERVICE_DATABASE || 'therr_dev_maps';
+}
+
+/**
+ * Create a Postgres connection pool pointed at the maps-service or
+ * users-service database, using the standard write-replica env vars.
+ */
+export function createDbPool(options: ICreatePoolOptions = {}): Pool {
+  const {
+    target = 'maps',
+    max = 5,
+    idleTimeoutMillis = 10000,
+    connectionTimeoutMillis = 10000,
+  } = options;
+
+  const config: PoolConfig = {
+    host: process.env.DB_HOST_MAIN_WRITE,
+    user: process.env.DB_USER_MAIN_WRITE,
+    password: process.env.DB_PASSWORD_MAIN_WRITE,
+    database: resolveDatabase(target),
+    port: Number(process.env.DB_PORT_MAIN_WRITE) || 5432,
+    max,
+    idleTimeoutMillis,
+    connectionTimeoutMillis,
+  };
+
+  return new Pool(config);
+}
+
+/**
+ * Attempt a trivial query to verify the pool can reach the database.
+ * Exits the process with a helpful message on failure; returns silently on success.
+ */
+export async function assertDbConnection(db: Pool, logFn: (msg: string) => void = console.log): Promise<void> {
+  try {
+    await db.query('SELECT 1');
+    logFn('Database connection established.');
+  } catch (err: any) {
+    console.error(`Database connection failed: ${err.message}`);
+    console.error('Make sure .env is configured with DB_HOST_MAIN_WRITE, DB_USER_MAIN_WRITE, etc.');
+    await db.end().catch(() => undefined);
+    process.exit(1);
+  }
+}

--- a/scripts/import-spaces/utils/insertSpaces.ts
+++ b/scripts/import-spaces/utils/insertSpaces.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared INSERT helper for `main.spaces` used by import scripts.
+ *
+ * Centralizes the 35-line INSERT statement that `index.ts` and `manage-space.ts`
+ * had duplicated verbatim. Returns granular counts so callers can distinguish
+ * real failures from benign ON CONFLICT skips.
+ */
+import { Pool } from 'pg';
+import { BATCH_SIZE } from '../config';
+import { ISpaceInsertParams } from '../transforms/mapToSpace';
+
+const INSERT_SQL = `INSERT INTO main.spaces
+    ("fromUserId", locale, "isPublic", message, "notificationMsg",
+     "mediaIds", "mentionsIds", "hashTags", "maxViews",
+     latitude, longitude, radius, "polygonCoords", "maxProximity",
+     "doesRequireProximityToView", "isMatureContent", "isModeratorApproved",
+     "isForSale", "isHirable", "isPromotional", "isExclusiveToGroups",
+     category, "areaType", valuation, region,
+     "addressReadable", "addressStreetAddress", "addressRegion", "addressLocality", "postalCode",
+     "phoneNumber", "businessEmail", "websiteUrl", "isPointOfInterest", "openingHours",
+     geom, "geomCenter")
+  VALUES
+    ($1, $2, $3, $4, $5,
+     $6, $7, $8, $9,
+     $10::float8, $11::float8, $12::float8, $13::jsonb, $14::float8,
+     $15, $16, $17,
+     $18, $19, $20, $21,
+     $22, $23, $24, $25,
+     $26, $27, $28, $29, $30::integer,
+     $31, $32, $33, $34, $35::jsonb,
+     ST_SetSRID(ST_Buffer(ST_MakePoint($11::float8, $10::float8)::geography, $36::float8)::geometry, 4326),
+     ST_SetSRID(ST_MakePoint($11::float8, $10::float8), 4326))
+  ON CONFLICT DO NOTHING
+  RETURNING id`;
+
+export interface IInsertSpacesResult {
+  /** Number of rows actually inserted. */
+  inserted: number;
+  /** IDs of inserted rows, in insertion order. */
+  ids: string[];
+  /**
+   * Rows the database rejected via ON CONFLICT (including the exclude_geom
+   * overlap constraint) — not a real error, just a duplicate/neighbor hit.
+   */
+  skipped: number;
+  /** Rows that raised a non-conflict DB error. */
+  failed: number;
+}
+
+export interface IInsertSpacesOptions {
+  /** Per-row max before a progress line is logged. Defaults to `BATCH_SIZE`. */
+  batchSize?: number;
+  /** Logger for progress/error lines. Defaults to `console`. */
+  log?: (msg: string) => void;
+  errorLog?: (msg: string) => void;
+}
+
+/**
+ * Determines whether an INSERT error should be treated as a benign conflict
+ * (duplicate, geom overlap) vs a true failure worth logging.
+ */
+function isBenignConflict(err: { message?: string }): boolean {
+  const msg = err.message || '';
+  return msg.includes('no_area_overlaps') || msg.includes('exclude');
+}
+
+/**
+ * Insert a batch of spaces with ON CONFLICT DO NOTHING. Returns
+ * `{inserted, ids, skipped, failed}` so callers can tell true errors from
+ * benign duplicates — something the old in-file versions lost.
+ */
+export async function insertSpacesBatch(
+  db: Pool,
+  spaces: ISpaceInsertParams[],
+  options: IInsertSpacesOptions = {},
+): Promise<IInsertSpacesResult> {
+  const {
+    batchSize = BATCH_SIZE,
+    log = (m: string) => console.log(m),
+    errorLog = (m: string) => console.error(m),
+  } = options;
+
+  const result: IInsertSpacesResult = {
+    inserted: 0,
+    ids: [],
+    skipped: 0,
+    failed: 0,
+  };
+
+  for (let i = 0; i < spaces.length; i += batchSize) {
+    const batch = spaces.slice(i, i + batchSize);
+
+    for (const space of batch) {
+      try {
+        const r = await db.query(INSERT_SQL, [
+          space.fromUserId, space.locale, space.isPublic, space.message, space.notificationMsg,
+          space.mediaIds, space.mentionsIds, space.hashTags, space.maxViews,
+          space.latitude, space.longitude, space.radius, space.polygonCoords, space.maxProximity,
+          space.doesRequireProximityToView, space.isMatureContent, space.isModeratorApproved,
+          space.isForSale, space.isHirable, space.isPromotional, space.isExclusiveToGroups,
+          space.category, space.areaType, space.valuation, space.region,
+          space.addressReadable, space.addressStreetAddress, space.addressRegion, space.addressLocality, space.postalCode,
+          space.phoneNumber, space.businessEmail, space.websiteUrl, space.isPointOfInterest, space.openingHours,
+          space.radius,
+        ]);
+
+        if (r.rowCount && r.rowCount > 0) {
+          result.inserted += 1;
+          result.ids.push(r.rows[0].id);
+        } else {
+          result.skipped += 1;
+        }
+      } catch (err: any) {
+        if (isBenignConflict(err)) {
+          result.skipped += 1;
+        } else {
+          result.failed += 1;
+          errorLog(`  Failed to insert "${space.notificationMsg}": ${err.message}`);
+        }
+      }
+    }
+
+    log(`  Batch progress: ${Math.min(i + batchSize, spaces.length)}/${spaces.length} processed, ${result.inserted} inserted`);
+  }
+
+  return result;
+}

--- a/scripts/import-spaces/utils/sourceImage.ts
+++ b/scripts/import-spaces/utils/sourceImage.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared image-sourcing pipeline for import scripts.
+ *
+ * Handles the full crawl → validate → GCS upload → media INSERT → spaces UPDATE
+ * flow that was duplicated across `manage-space.ts`, `source-emails-websites.ts`,
+ * `source-images.ts`, and `update-space-contact.ts`.
+ *
+ * Includes an idempotency guard: if the space already has a `mediaIds` or
+ * `medias` value, the upload is skipped so we don't orphan old files in GCS
+ * on re-runs.
+ */
+import { Pool } from 'pg';
+import { crawlForImages } from '../sources/crawl';
+import { downloadAndValidateImage } from './imageValidation';
+import { uploadImage } from './gcs';
+
+export interface ISourceImageInput {
+  id: string;
+  notificationMsg: string;
+  mediaIds?: string | null;
+  medias?: unknown;
+}
+
+export interface ISourceImageOptions {
+  /** If true, skip GCS upload and DB writes. */
+  dryRun?: boolean;
+  /** Optional log prefix (e.g. "[3/50]"). */
+  progress?: string;
+  /** Logger; defaults to console.log. */
+  log?: (msg: string) => void;
+}
+
+export type SourceImageOutcome =
+  | { status: 'skipped-has-media' }
+  | { status: 'no-candidates' }
+  | { status: 'no-valid-image' }
+  | { status: 'dry-run'; candidateCount: number }
+  | { status: 'uploaded'; imagePath: string; width: number; height: number; contentType: string };
+
+/**
+ * Source an image for a space. Returns a tagged outcome so callers can
+ * update their own counters / processed-spaces files as needed.
+ */
+export async function sourceImageForSpace(
+  db: Pool,
+  space: ISourceImageInput,
+  websiteUrl: string,
+  userId: string,
+  options: ISourceImageOptions = {},
+): Promise<SourceImageOutcome> {
+  const { dryRun = false, progress, log = (m: string) => console.log(m) } = options;
+  const prefix = progress ? `${progress} ` : '';
+
+  // Idempotency: don't re-upload if this space already has media.
+  const hasMedia = Boolean(
+    (space.mediaIds && space.mediaIds !== '')
+    || (Array.isArray(space.medias) && space.medias.length > 0)
+    || (space.medias && typeof space.medias === 'object' && !Array.isArray(space.medias)),
+  );
+  if (hasMedia) {
+    return { status: 'skipped-has-media' };
+  }
+
+  const candidates = await crawlForImages(websiteUrl);
+  if (candidates.length === 0) {
+    return { status: 'no-candidates' };
+  }
+
+  if (dryRun) {
+    return { status: 'dry-run', candidateCount: candidates.length };
+  }
+
+  for (const candidate of candidates) {
+    const validImage = await downloadAndValidateImage(candidate.imageUrl);
+    if (!validImage) continue;
+
+    log(`${prefix}  Image found (${candidate.source}): ${validImage.width}x${validImage.height}`);
+
+    const storagePath = await uploadImage(userId, space.id, validImage.buffer, validImage.contentType);
+
+    const mediaResult = await db.query(
+      `INSERT INTO main.media ("fromUserId", "altText", type, path)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id`,
+      [userId, space.notificationMsg, 'user-image-public', storagePath],
+    );
+    const mediaId = mediaResult.rows[0].id;
+
+    const medias = JSON.stringify([{ path: storagePath, type: 'user-image-public' }]);
+    await db.query(
+      `UPDATE main.spaces
+         SET "mediaIds" = $1::text,
+             medias = $2::jsonb,
+             "updatedAt" = NOW()
+       WHERE id = $3`,
+      [String(mediaId), medias, space.id],
+    );
+
+    log(`${prefix}  Uploaded image: ${storagePath}`);
+    return {
+      status: 'uploaded',
+      imagePath: storagePath,
+      width: validImage.width,
+      height: validImage.height,
+      contentType: validImage.contentType,
+    };
+  }
+
+  return { status: 'no-valid-image' };
+}

--- a/scripts/import-spaces/utils/sourceImage.ts
+++ b/scripts/import-spaces/utils/sourceImage.ts
@@ -52,12 +52,11 @@ export async function sourceImageForSpace(
   const prefix = progress ? `${progress} ` : '';
 
   // Idempotency: don't re-upload if this space already has media.
-  const hasMedia = Boolean(
-    (space.mediaIds && space.mediaIds !== '')
-    || (Array.isArray(space.medias) && space.medias.length > 0)
-    || (space.medias && typeof space.medias === 'object' && !Array.isArray(space.medias)),
-  );
-  if (hasMedia) {
+  // `mediaIds` is a legacy text column; `medias` is jsonb. Treat empty string,
+  // empty array, and empty object all as "no media".
+  const hasMediaIds = typeof space.mediaIds === 'string' && space.mediaIds !== '';
+  const hasMediasArray = Array.isArray(space.medias) && space.medias.length > 0;
+  if (hasMediaIds || hasMediasArray) {
     return { status: 'skipped-has-media' };
   }
 

--- a/scripts/import-spaces/utils/withRetry.ts
+++ b/scripts/import-spaces/utils/withRetry.ts
@@ -79,6 +79,9 @@ export function isTransientNetworkError(err: unknown): boolean {
     || msg.includes('enotfound')
     || msg.includes('socket hang up')
     || msg.includes('eai_again')
-    || /\b5\d\d\b/.test(msg)
+    // Match HTTP 5xx only when clearly framed as a status, not any 3-digit number.
+    || /\bhttp\s*5\d\d\b/.test(msg)
+    || /\bstatus(?:\s*(?:code)?)?[:\s]+5\d\d\b/.test(msg)
+    || /\b5\d\d\s+(?:server|bad gateway|service unavailable|gateway timeout|internal server error)\b/.test(msg)
   );
 }

--- a/scripts/import-spaces/utils/withRetry.ts
+++ b/scripts/import-spaces/utils/withRetry.ts
@@ -1,0 +1,84 @@
+/**
+ * Generalized exponential-backoff retry wrapper for transient network failures.
+ *
+ * Extracted from `sources/osm.ts` so crawl/search/SES calls can opt into the
+ * same behavior. Default is no retries — wrap call sites explicitly.
+ */
+
+export interface IWithRetryOptions {
+  /** Total attempts beyond the first (default: 0 → no retry). */
+  retries?: number;
+  /** Initial backoff in ms; doubled each attempt. */
+  baseDelayMs?: number;
+  /** Cap on any single backoff. */
+  maxDelayMs?: number;
+  /** Predicate to decide whether an error is worth retrying. Defaults to all errors. */
+  shouldRetry?: (err: unknown, attempt: number) => boolean;
+  /** Optional logger; no-op by default. */
+  log?: (msg: string) => void;
+  /** Label used in log messages (e.g. "crawl"). */
+  label?: string;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/**
+ * Run `fn` up to `retries + 1` times with exponential backoff between attempts.
+ * The final error is re-thrown when all attempts are exhausted.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: IWithRetryOptions = {},
+): Promise<T> {
+  const {
+    retries = 0,
+    baseDelayMs = 1000,
+    maxDelayMs = 30000,
+    shouldRetry = () => true,
+    log,
+    label,
+  } = options;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (attempt >= retries || !shouldRetry(err, attempt)) {
+        throw err;
+      }
+      const delay = Math.min(baseDelayMs * Math.pow(2, attempt), maxDelayMs);
+      if (log) {
+        const prefix = label ? `[${label}] ` : '';
+        const message = err instanceof Error ? err.message : String(err);
+        log(`${prefix}attempt ${attempt + 1}/${retries + 1} failed: ${message}. Retrying in ${delay}ms…`);
+      }
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Default predicate: retry on network errors and 5xx-ish fetch failures, not on 4xx.
+ * Callers pass it explicitly via `shouldRetry` when useful.
+ */
+export function isTransientNetworkError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes('network')
+    || msg.includes('timeout')
+    || msg.includes('econnreset')
+    || msg.includes('etimedout')
+    || msg.includes('enotfound')
+    || msg.includes('socket hang up')
+    || msg.includes('eai_again')
+    || /\b5\d\d\b/.test(msg)
+  );
+}


### PR DESCRIPTION
Fixes a runtime bug in send-unclaimed-emails.ts that queried a
nonexistent "isUnclaimed" column, closes a gap where --closed spaces
lingered in the admin approval queue, and dedups ~260 LOC of copy-pasted
image-sourcing and insert pipelines into shared utilities with
idempotency guards and retry/backoff.

Also adds close-spaces.ts (batch soft-delete) and clear-pending.ts
(bulk-clear stale isClaimPending rows) as operational tooling.