### PR TITLE
feat: hashtag-anchored guides (P2 phases 1-4)

### DIFF
--- a/.claude/skills/generate-content/SKILL.md
+++ b/.claude/skills/generate-content/SKILL.md
@@ -4,7 +4,7 @@ description: Generate editorial guides and data-driven posts for /guides using p
 disable-model-invocation: true
 user-invocable: true
 allowed-tools: Bash(npx ts-node scripts/generate-content/*), Read, Write, Edit
-argument-hint: [--list --city slug --category slug [--curated]] [--data --topic name --city slug] [--hashtag --city slug --hashtag tag] [--review slug] [--refresh slug [--apply] [--add-new n]] [--limit n] [--draft]
+argument-hint: [--list --city slug --category slug [--curated]] [--data --topic name --city slug] [--hashtag --city slug --hashtag tag] [--walkable --city slug [--category slug]] [--review slug] [--refresh slug [--apply] [--add-new n]] [--limit n] [--draft]
 ---
 
 # Generate Content (Editorial Guides)
@@ -20,6 +20,7 @@ Output goes to `therr-client-web/src/content/guides/<slug>.json` and is rendered
 | `--list` | **Curated list post** | Rank top spaces in a city + category; write commentary blurbs |
 | `--data` | **Data-driven post** | Aggregate Therr activity (e.g., busiest hour for bars in Denver) |
 | `--hashtag` | **Hashtag-anchored post** | Rank spaces by user-applied intent tag (e.g., `firstdate`, `latenight`) in a city |
+| `--walkable` | **Walkable-cluster post** | Find a dense cluster of nearby spaces, order them as a route, render map + stops |
 | `--review <slug>` | **Review existing post** | Read the post JSON and check headline, lead, blurbs, FAQ for quality |
 | `--refresh <slug>` | **Refresh existing post** | Re-check space references against production; optionally prune/bump updatedAt |
 
@@ -288,6 +289,91 @@ The validator enforces `category XOR hashtag` — setting both or neither fails.
 
 Cross-link hashtag posts from their category-post sibling in prose ("for date-night specifically, see our first-date bars guide") and vice versa.
 
+## Mode 6: Walkable-cluster post (`--walkable`)
+
+Walkable-cluster posts present 4–8 nearby spaces as a **walking route**, not a ranked list — "Wicker Park bar crawl: 5 stops, 1 mile". The frontend renders an ordered stop list with walking-distance badges between stops *plus* a Leaflet map centered on the cluster centroid. `TouristTrip` JSON-LD is emitted so the post can appear in Google's walking-tour rich results.
+
+The section type is `walkable-route`; it is an **additional** section alongside the usual prose/FAQ blocks, not a replacement for `space-list`. Use category or hashtag anchoring normally — the route is orthogonal.
+
+### Step 1: Discover dense clusters in a city
+
+```
+npx ts-node scripts/generate-content/discover-clusters --city <slug> [--category <slug>] [--limit 10] [--minSize 4] [--maxSize 8] [--maxDiameter 1500]
+```
+
+Defaults: `--limit 10`, `--minSize 4`, `--maxSize 8`, `--maxDiameter 1500` (meters — roughly a 19-minute walk tip-to-tip).
+
+Output is a ranked list of clusters by **completeness-weighted density** (sum of member completeness scores / area). Each cluster includes its centroid, diameter, walking-time estimate, distinct categories, and the member spaces with address + completeness fields. Pick one whose narrative hook is obvious — a tight cluster of 5 well-documented bars beats a sprawling 8-space cluster with half the members missing phone numbers.
+
+### Step 2: Build the route from the selected cluster
+
+```
+npx ts-node scripts/generate-content/query-walkable-cluster --spaceIds "<id1>,<id2>,<id3>,..."
+```
+
+OR, when you only have a centerpoint (e.g., from an editorial pitch "Wicker Park"):
+
+```
+npx ts-node scripts/generate-content/query-walkable-cluster --center <lat>,<lng> --radius 800 [--category <slug>]
+```
+
+Either mode returns `{ query, cluster, route }` where `route.stops[]` is ordered via nearest-neighbor TSP starting from the highest-completeness member. The shape is the exact section payload minus the editorial `note` strings — you fill those in.
+
+### Step 3: Write the post
+
+Build a normal post with a `walkable-route` section in addition to the usual list/prose/FAQ blocks. Minimal shape:
+
+```json
+{
+  "slug": "wicker-park-bar-crawl",
+  "type": "list",
+  "status": "published",
+  "title": "Wicker Park Bar Crawl: 5 Stops, About a Mile",
+  "description": "An editor-picked walking route through Wicker Park — five bars, one loop, all walkable in an afternoon.",
+  "city": "chicago-il",
+  "category": "categories.bar/drinks",
+  "publishedAt": "2026-04-19",
+  "updatedAt": "2026-04-19",
+  "author": "Therr Editorial",
+  "lead": "...",
+  "sections": [
+    { "type": "prose", "body": "..." },
+    {
+      "type": "walkable-route",
+      "centroid": { "lat": 41.9088, "lng": -87.6796 },
+      "totalMeters": 1420,
+      "estimatedMinutes": 18,
+      "stops": [
+        { "order": 1, "spaceId": "<uuid>", "name": "The First Stop", "lat": 41.9101, "lng": -87.6812, "note": "Start here — the patio is the best introduction to the neighborhood." },
+        { "order": 2, "spaceId": "<uuid>", "name": "Second Spot", "lat": 41.9085, "lng": -87.6798, "walkFromPreviousMeters": 310, "note": "Duck in for the cocktail list." }
+      ]
+    },
+    { "type": "space-list", "items": [ /* same stops as a ranked list for users who skip the map */ ] },
+    { "type": "faq", "items": [ /* 3-5 items */ ] }
+  ]
+}
+```
+
+Validator rules for `walkable-route`:
+- `stops.length >= 2`, `order` must be 1-indexed and dense (1..n)
+- `lat` / `lng` / `name` required on every stop (denormalized from space — the map and SSR rendering don't async-fetch)
+- `walkFromPreviousMeters` required on stops 2..n, omitted on stop 1
+- `spaceId` must be unique across stops (no visiting the same bar twice)
+
+### Step 4: Save
+
+```
+echo '<post-json>' | npx ts-node scripts/generate-content/save-post --stdin
+```
+
+### Editorial tips
+
+- **One walkable section per post.** Multiple routes in one post split the reader's attention.
+- **Keep notes concrete.** "Start here — best patio in the cluster" beats "This is a great bar." The route is the hook, but the stop-by-stop color is the content.
+- **Pair with a `space-list` section.** The map is great for visual skimmers; the list is better for users who skip maps or are on slow connections.
+- **Cross-link to the city's category post.** "For a broader guide to bars in Chicago, see our [bars in Chicago list]." The walkable post is a sub-angle, not a standalone.
+- **Don't force mixed-category routes** unless the hook is the mix. "5 coffee shops in Pearl District" reads cleanly; "3 coffee shops, a bar, and a bookstore" needs a strong narrative reason.
+
 ## Locale workflow (multilingual guides)
 
 Guides can carry translated content under `locales.es` / `locales.fr-ca`. The SSR layer (`resolveGuideForLocale()`) swaps in the localized `title`, `description`, `lead`, and `sections` when the request comes in at `/es/guides/<slug>` or `/fr-ca/guides/<slug>`. Pick target locales per city based on local-language population density and weak competitor coverage — see `docs/CONTENT_LOCALE_FIRST_PLAN.md` for the target-market table.
@@ -386,8 +472,10 @@ When implementing any of these, the relevant schema/script files contain `TODO:`
 - Save/validate post: `scripts/generate-content/save-post.ts` (supports `--require-locales <es,fr-ca>`)
 - Refresh existing post: `scripts/generate-content/refresh-post.ts`
 - Translate post: `scripts/generate-content/translate-post.ts` (emits a translator prompt for a given locale)
-- Discovery helpers: `scripts/generate-content/discover-categories.ts`, `scripts/generate-content/discover-hashtags.ts`
+- Discovery helpers: `scripts/generate-content/discover-categories.ts`, `scripts/generate-content/discover-hashtags.ts`, `scripts/generate-content/discover-clusters.ts`
 - Query by hashtag: `scripts/generate-content/query-by-hashtag.ts`
+- Query walkable cluster (route-ordered): `scripts/generate-content/query-walkable-cluster.ts`
+- Geo utilities (haversine, clustering, TSP ordering): `scripts/generate-content/utils/geo.ts`
 - Diagnostics (ad-hoc): `scripts/generate-content/diagnostics/discover-impressions.ts`, `diagnostics/discover-metrics.ts`
 - Frontend renderer: `therr-client-web/src/routes/Guide/index.tsx`
 - JSON-LD builder: `therr-client-web/src/utilities/guideJsonLd.ts`

--- a/.claude/skills/generate-content/SKILL.md
+++ b/.claude/skills/generate-content/SKILL.md
@@ -4,7 +4,7 @@ description: Generate editorial guides and data-driven posts for /guides using p
 disable-model-invocation: true
 user-invocable: true
 allowed-tools: Bash(npx ts-node scripts/generate-content/*), Read, Write, Edit
-argument-hint: [--list --city slug --category slug [--curated]] [--data --topic name --city slug] [--review slug] [--refresh slug [--apply] [--add-new n]] [--limit n] [--draft]
+argument-hint: [--list --city slug --category slug [--curated]] [--data --topic name --city slug] [--hashtag --city slug --hashtag tag] [--review slug] [--refresh slug [--apply] [--add-new n]] [--limit n] [--draft]
 ---
 
 # Generate Content (Editorial Guides)
@@ -19,6 +19,7 @@ Output goes to `therr-client-web/src/content/guides/<slug>.json` and is rendered
 |-----------|------|-------------|
 | `--list` | **Curated list post** | Rank top spaces in a city + category; write commentary blurbs |
 | `--data` | **Data-driven post** | Aggregate Therr activity (e.g., busiest hour for bars in Denver) |
+| `--hashtag` | **Hashtag-anchored post** | Rank spaces by user-applied intent tag (e.g., `firstdate`, `latenight`) in a city |
 | `--review <slug>` | **Review existing post** | Read the post JSON and check headline, lead, blurbs, FAQ for quality |
 | `--refresh <slug>` | **Refresh existing post** | Re-check space references against production; optionally prune/bump updatedAt |
 
@@ -223,6 +224,70 @@ Adds up to N new spaces to the last `space-list` section (drawing from the post'
 
 ---
 
+## Mode 5: Hashtag-anchored post (`--hashtag`)
+
+Hashtag posts rank spaces by user-applied intent tags (`firstdate`, `latenight`, `worksession`, `livemusic`) rather than by category. The goal is to serve intent-based long-tail queries — "first date bars chicago", "late night food portland", "coffee shops to work seattle" — that category-driven directories can't.
+
+The post's anchor is stored as `hashtag: "<tag>"` in `IPostMetadata` **instead of** `category`. The validator enforces exactly one of `{category, hashtag}`. A hashtag filter listing is served at `/guides/hashtag/<tag>` and hashtag URLs are included in `/sitemap-guides.xml`.
+
+### Before you start: check the data
+
+The `spaces.hashTags` column is today mostly populated by the OSM ingester (`scripts/import-spaces/transforms/mapToSpace.ts`), which derives tags from OSM `cuisine` / `amenity` / `shop` / `tourism` values. These look more like categories (`italian`, `bar`, `coffee`) than user intent (`firstdate`, `latenight`). **Run discovery first to confirm there's meaningful intent-shaped signal in the target city before writing a post**:
+
+```
+npx ts-node scripts/generate-content/discover-hashtags --city <city> --minSpaces 8 --intentOnly
+```
+
+- Drop `--intentOnly` to see all tags (useful for understanding what's actually there).
+- `--intentOnly` filters to an allowlist of intent-shaped tags (see `INTENT_HASHTAG_ALLOWLIST` in the script).
+- If the intent-only output is empty or thin, this plan is blocked on enriching user-applied tags upstream; don't force it.
+
+### Step 1: Query spaces by hashtag
+
+```
+npx ts-node scripts/generate-content/query-by-hashtag --city <slug> --hashtag <tag> --limit <n> [--window <days>] [--mode auto|engagement|curated]
+```
+
+Same ranking discipline as `query-top-spaces` (engagement / curated / auto with `modeReason`). The matcher does an **exact, normalized tag match** after splitting `hashTags` on commas — `firstdate` will not match `firstdateandlast`. A leading `#` on `--hashtag` is stripped.
+
+### Step 2: Write the post
+
+Build the post JSON with `hashtag` in place of `category`:
+
+```json
+{
+  "slug": "first-date-bars-chicago",
+  "type": "list",
+  "status": "published",
+  "title": "8 First-Date Bars in Chicago",
+  "description": "Editor-picked bars with the right vibe for a first date — conversational, not too loud, easy to find.",
+  "city": "chicago-il",
+  "hashtag": "firstdate",
+  "publishedAt": "2026-04-19",
+  "updatedAt": "2026-04-19",
+  "author": "Therr Editorial",
+  "lead": "...",
+  "sections": [ /* same section types as Mode 1 */ ]
+}
+```
+
+All other rules from Mode 1 apply: title ≤ 70 chars, description ≤ 165, honest mode framing, at least one `space-list`, 3–5 FAQ items.
+
+### Step 3: Save
+
+```
+echo '<post-json>' | npx ts-node scripts/generate-content/save-post --stdin
+```
+
+The validator enforces `category XOR hashtag` — setting both or neither fails.
+
+### When to use this vs. Mode 1
+
+- **Category post (`--list` + `--category`)**: "best bars in Chicago" — broad, covers the whole category.
+- **Hashtag post (`--hashtag`)**: "best first-date bars in Chicago" — narrower, intent-anchored. Sibling to the category post, not a replacement.
+
+Cross-link hashtag posts from their category-post sibling in prose ("for date-night specifically, see our first-date bars guide") and vice versa.
+
 ## Locale workflow (multilingual guides)
 
 Guides can carry translated content under `locales.es` / `locales.fr-ca`. The SSR layer (`resolveGuideForLocale()`) swaps in the localized `title`, `description`, `lead`, and `sections` when the request comes in at `/es/guides/<slug>` or `/fr-ca/guides/<slug>`. Pick target locales per city based on local-language population density and weak competitor coverage — see `docs/CONTENT_LOCALE_FIRST_PLAN.md` for the target-market table.
@@ -321,7 +386,8 @@ When implementing any of these, the relevant schema/script files contain `TODO:`
 - Save/validate post: `scripts/generate-content/save-post.ts` (supports `--require-locales <es,fr-ca>`)
 - Refresh existing post: `scripts/generate-content/refresh-post.ts`
 - Translate post: `scripts/generate-content/translate-post.ts` (emits a translator prompt for a given locale)
-- Discovery helpers: `scripts/generate-content/discover-categories.ts`
+- Discovery helpers: `scripts/generate-content/discover-categories.ts`, `scripts/generate-content/discover-hashtags.ts`
+- Query by hashtag: `scripts/generate-content/query-by-hashtag.ts`
 - Diagnostics (ad-hoc): `scripts/generate-content/diagnostics/discover-impressions.ts`, `diagnostics/discover-metrics.ts`
 - Frontend renderer: `therr-client-web/src/routes/Guide/index.tsx`
 - JSON-LD builder: `therr-client-web/src/utilities/guideJsonLd.ts`

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY ./therr-public-library ./therr-public-library
 COPY ./babel.config.json ./
 COPY ./global-config.js ./
 COPY ./webpack.parts.js ./
+COPY ./tsconfig.base.json ./tsconfig.service.json ./tsconfig.strict.json ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci --ignore-scripts --legacy-peer-deps; \

--- a/docs/CONTENT_HASHTAG_GUIDES_PLAN.md
+++ b/docs/CONTENT_HASHTAG_GUIDES_PLAN.md
@@ -18,26 +18,27 @@ Generate guides anchored on **user-applied hashtags** (e.g., `#firstdate`, `#lat
 
 ### Phase 1 — discover viable hashtags (0.5 day)
 
-- [ ] Build `scripts/generate-content/discover-hashtags.ts` — inspects the distribution of `spaces.hashTags` values, splits comma-separated tags, counts occurrences per (city, hashtag), and lists pairs meeting a minimum threshold (e.g., ≥8 spaces with the tag in one city).
-- [ ] Output should rank by the same density rules as `discover-categories` so we can pick targets quickly.
-- [ ] Look for high-intent verbs/contexts: `firstdate`, `latenight`, `worksession`, `livemusic`, `outdoorseating`, `dogfriendly`, `kidfriendly`, `groupfriendly`, `roomforevent`.
+- [x] Build `scripts/generate-content/discover-hashtags.ts` — inspects the distribution of `spaces.hashTags` values, splits comma-separated tags, counts occurrences per (city, hashtag), and lists pairs meeting a minimum threshold (e.g., ≥8 spaces with the tag in one city). Also supports `--intentOnly` to filter to an intent-shaped allowlist. ✓
+- [x] Output is ranked `spaceCount DESC` with sample categories — matches the `discover-categories` shape for quick target picking. ✓
+- [ ] Look for high-intent verbs/contexts: `firstdate`, `latenight`, `worksession`, `livemusic`, `outdoorseating`, `dogfriendly`, `kidfriendly`, `groupfriendly`, `roomforevent`. **Caveat discovered during implementation:** `spaces.hashTags` is today populated by the OSM ingester (cuisines, amenity types) — intent-shaped tags are not yet present. Phase 5 pilot selection is blocked on enriching the hashTags data upstream.
 
 ### Phase 2 — query script (0.5 day)
 
-- [ ] Build `scripts/generate-content/query-by-hashtag.ts` mirroring the structure of `query-top-spaces.ts` but accepting `--hashtag <tag>` instead of `--category <slug>`.
-- [ ] Reuse the auto-fallback discipline: `mode: engagement` only when there's enough visit data to support a ranking; otherwise `curated` by completeness.
-- [ ] WHERE clause: `s."hashTags" ILIKE '%' || $1 || '%'` (case-insensitive substring match, since hashTags is a comma-separated string field — verify before trusting). May need a more careful regex to avoid `#firstdate` matching `#firstdateandlast` etc.
+- [x] Build `scripts/generate-content/query-by-hashtag.ts` mirroring the structure of `query-top-spaces.ts` but accepting `--hashtag <tag>` instead of `--category <slug>`. ✓
+- [x] Reuses the auto-fallback discipline: `mode: engagement` only when visit/impression totals clear `--minVisits` + `--minTopVisits`; otherwise `curated`. ✓
+- [x] Matching strategy: `EXISTS (SELECT 1 FROM unnest(string_to_array(s."hashTags", ',')) AS tag WHERE LOWER(TRIM(tag)) = $hashtag)`. Exact, normalized match — does **not** substring-match `firstdate` against `firstdateandlast`. ✓
 
 ### Phase 3 — schema update (0.5 day)
 
-- [ ] Add an optional `hashtag?: string` field to `IPostMetadata` (alongside `city` and `category`). The validator should require *one of* `category` or `hashtag` — not both, not neither. Update `validatePost` in `utils/contentSchema.ts`.
-- [ ] Mirror the field into `therr-client-web/src/utilities/guideContent.ts` (`IPostMetadata`).
-- [ ] Decide on URL path: do we keep `/guides/<slug>` flat, or prefix `/guides/by-hashtag/<slug>`? Current recommendation: keep flat — the hashtag is metadata, not a path segment.
+- [x] Added optional `hashtag?: string` to `IPostMetadata`. Validator enforces exactly one of `{category, hashtag}` (XOR) and validates hashtag format (lowercase letters/digits/hyphens, no leading `#`). ✓
+- [x] Mirrored the field into `therr-client-web/src/utilities/guideContent.ts` and exposed `getGuidesByHashtag(tag)`. ✓
+- [x] URL decision: post URL stays flat at `/guides/<slug>`. Added a **hashtag filter listing** at `/guides/hashtag/:hashtag` (sibling to `/guides/city/:citySlug` and `/guides/category/:categorySlug`) so the breadcrumb has a real target. ✓
 
 ### Phase 4 — JSON-LD + breadcrumb tweaks (0.25 day)
 
-- [ ] In `therr-client-web/src/utilities/guideJsonLd.ts`, add a hashtag-flavored breadcrumb when `post.hashtag` is present (e.g., Home → Guides → "First Date" → post). Skip the city crumb if no city is set.
-- [ ] Article schema's `keywords` field should include the hashtag (without the `#`).
+- [x] `buildBreadcrumb` in `guideJsonLd.ts` now inserts a hashtag crumb (humanized) linking to `/guides/hashtag/<tag>` when `post.hashtag` is present. Breadcrumb positions are computed dynamically so city-only, hashtag-only, or both-present posts all render correctly. ✓
+- [x] Article schema's `keywords` field includes the hashtag (without the `#`) when present. ✓
+- [x] `/sitemap-guides.xml` now emits a URL for each distinct hashtag across published guides, matching the city/category pattern. ✓
 
 ### Phase 5 — pilot 3 hashtag posts (1 day)
 

--- a/docs/CONTENT_WALKABLE_CLUSTERS_PLAN.md
+++ b/docs/CONTENT_WALKABLE_CLUSTERS_PLAN.md
@@ -19,36 +19,30 @@ Generate guides that compute a **walkable cluster** of 4–6 spaces within a sma
 
 ### Phase 1 — clustering algorithm (1 day)
 
-- [ ] Build `scripts/generate-content/utils/geo.ts` with:
-  - `haversineMeters(a, b)` — distance between two lat/long points
-  - `clusterByRadius(spaces, maxDiameterMeters)` — DBSCAN-flavored grouping; returns clusters of `{ spaces, centroid, diameterMeters }`
-  - `walkingMinutes(meters)` — rough estimate at 80 m/min
-- [ ] Default cluster constraints: 4–8 spaces, ≤1500m diameter (~12-min walk total).
+- [x] `scripts/generate-content/utils/geo.ts`: `haversineMeters`, `walkingMinutes`, `centroidOf`, `diameterMeters`, `clusterByRadius`, `orderAsWalkingRoute`. Pure functions, no DB. ✓
+- [x] Defaults: 4–8 spaces, ≤1500m diameter. Greedy agglomerative-ish (seed by weight desc, grow by nearest neighbor under the diameter constraint). `orderAsWalkingRoute` uses nearest-neighbor TSP starting from the highest-weight member. ✓
 
 ### Phase 2 — cluster discovery script (0.5 day)
 
-- [ ] Build `scripts/generate-content/discover-clusters.ts` that pulls all spaces in a (city, [optional category]) bucket and surfaces the densest clusters. Output ranks clusters by completeness-weighted density (sum of completeness scores / area).
-- [ ] Allow filtering by primary category (e.g., "find me 5-bar clusters in Chicago neighborhoods").
+- [x] `scripts/generate-content/discover-clusters.ts` — pulls public spaces per (city, [optional category]), runs `clusterByRadius`, ranks by completeness-weighted density (sum of member completeness / πr²; 100m radius floor). ✓
+- [x] Output includes centroid, diameter, walkingMinutes estimate, categories, and member rows with address + completeness fields. ✓
 
 ### Phase 3 — query + ordering (1 day)
 
-- [ ] Build `scripts/generate-content/query-walkable-cluster.ts` that takes `--city <slug> --neighborhood <name>` (or a centerpoint via `--center lat,lng --radius <m>`), pulls the cluster's spaces, and orders them via a simple TSP heuristic (nearest-neighbor walking-tour order from the densest pin outward).
-- [ ] Output includes total walking distance, estimated time, and the ordered space list.
+- [x] `scripts/generate-content/query-walkable-cluster.ts` — two entry modes: `--spaceIds <csv>` (direct from discover-clusters output) or `--center lat,lng --radius <m>` (centerpoint query with re-clustering). Orders via `orderAsWalkingRoute`. ✓
+- [x] Output shape matches the `walkable-route` section payload minus editorial `note`s: `{ query, cluster, route: { totalMeters, estimatedMinutes, stops[] } }`. ✓
 
 ### Phase 4 — schema + new section type (0.5 day)
 
-- [ ] Add a `walkable-route` section type to `utils/contentSchema.ts`:
-  ```ts
-  { type: 'walkable-route'; centroid: { lat: number; lng: number }; totalMeters: number; estimatedMinutes: number; stops: Array<{ spaceId: string; order: number; walkFromPreviousMeters?: number; note?: string }>; }
-  ```
-- [ ] Mirror in `therr-client-web/src/utilities/guideContent.ts`.
-- [ ] Update `validatePost` to accept the new section type.
+- [x] `walkable-route` section added to `utils/contentSchema.ts` with a full runtime validator (stops 1-indexed and dense, `lat`/`lng`/`name` required per stop, `walkFromPreviousMeters` required on 2..n only, `spaceId` unique). ✓
+- [x] Mirrored in `therr-client-web/src/utilities/guideContent.ts`. ✓
+- [x] `lat`/`lng`/`name` are denormalized onto each stop so the SSR map and popup render without a space lookup. ✓
 
 ### Phase 5 — frontend rendering (1 day)
 
-- [ ] Build `therr-client-web/src/routes/Guide/sections/WalkableRoute.tsx` — renders an ordered list with walking-distance badges between stops, plus an embedded map.
-- [ ] Map embed: Mantine doesn't have a map component; integrate the same `react-leaflet` or Mapbox usage already present in `therr-client-web` (verify what's installed) or fall back to an `<img>` of a pre-rendered map for static SSR safety.
-- [ ] Add JSON-LD `TouristAttraction` or `TouristTrip` schema in `guideJsonLd.ts` — there is a `TouristTrip` type that fits walking routes specifically.
+- [x] `therr-client-web/src/routes/Guide/sections/WalkableRoute.tsx` — Mantine-styled stop cards with "Stop N" badges, inter-stop walking-distance text, total+minutes badges, and an embedded `SpacesMap` (existing Leaflet integration). ✓
+- [x] Registered in `Guide/index.tsx` `renderSection` switch. ✓
+- [x] `TouristTrip` JSON-LD added to `guideJsonLd.ts`: `itinerary` list of `TouristAttraction`s with `GeoCoordinates`, emitted via `/views/guides.hbs` when present. ✓
 
 ### Phase 6 — pilot 2 cluster posts (1 day)
 

--- a/scripts/generate-content/discover-clusters.ts
+++ b/scripts/generate-content/discover-clusters.ts
@@ -30,7 +30,6 @@ import { CITIES } from '../import-spaces/config';
 import { createDbPool } from '../import-spaces/utils/db';
 import {
     clusterByRadius,
-    diameterMeters,
     walkingMinutes,
     IGeoSpace,
 } from './utils/geo';
@@ -199,15 +198,9 @@ async function main() {
                     (acc, s) => acc + (Number(s.row.completeness_score) || 0),
                     0,
                 );
-                // Quick "chordal" estimate of a reasonable walking distance: mean pairwise
-                // distance across members. `diameterMeters` already gives the worst hop;
-                // the mean helps show whether the cluster is "tight" vs "elongated".
-                const memberCoords = c.spaces.map((s) => ({ lat: s.lat, lng: s.lng }));
-                const diameter2 = diameterMeters(memberCoords);
                 return {
                     cluster: c,
                     diameter,
-                    diameterCheck: diameter2,
                     sumCompleteness,
                     density: densityScore(sumCompleteness, diameter),
                     memberCount: c.spaces.length,

--- a/scripts/generate-content/discover-clusters.ts
+++ b/scripts/generate-content/discover-clusters.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Discover dense, walkable clusters of spaces within a city.
+ *
+ * Pulls all public spaces for a (city, [optional category]) bucket, runs the
+ * `clusterByRadius` heuristic from `utils/geo.ts`, and ranks clusters by
+ * *completeness-weighted density*: the sum of member completeness scores
+ * divided by the cluster's effective area (πr² where r = diameter/2, with a
+ * 100m floor to avoid divide-by-near-zero on overlapping points). Completeness
+ * weighting matters because a cluster of 6 well-documented spaces beats a
+ * cluster of 8 skeletal ones for editorial purposes.
+ *
+ * Output rows describe each cluster: centroid, diameter, walking-time estimate,
+ * and a trimmed list of member spaces with address + completeness columns so
+ * the caller can pick a cluster for a walkable-route post without a second
+ * query round-trip.
+ *
+ * Usage:
+ *   npx ts-node scripts/generate-content/discover-clusters \
+ *     --city chicago [--category bar/drinks] [--limit 10] \
+ *     [--minSize 4] [--maxSize 8] [--maxDiameter 1500]
+ *
+ * Stdout: JSON envelope `{ query, clusters }`.
+ * Stderr: progress logs.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { Pool } from 'pg';
+import { CITIES } from '../import-spaces/config';
+import { createDbPool } from '../import-spaces/utils/db';
+import {
+    clusterByRadius,
+    diameterMeters,
+    walkingMinutes,
+    IGeoSpace,
+} from './utils/geo';
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '../import-spaces/.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+function log(msg: string) {
+    process.stderr.write(`${msg}\n`);
+}
+
+interface ICliArgs {
+    city: string;
+    category: string;
+    limit: number;
+    minSize: number;
+    maxSize: number;
+    maxDiameter: number;
+}
+
+function parseArgs(): ICliArgs {
+    const args = process.argv.slice(2);
+    const parsed: Record<string, string> = {};
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a.startsWith('--')) {
+            const next = args[i + 1];
+            if (next && !next.startsWith('--')) {
+                parsed[a.replace('--', '')] = next;
+                i++;
+            }
+        }
+    }
+    if (!parsed.city) {
+        log('Missing required --city <slug>. See scripts/import-spaces/config.ts for valid city slugs.');
+        process.exit(1);
+    }
+    return {
+        city: parsed.city,
+        category: parsed.category || '',
+        limit: parsed.limit ? parseInt(parsed.limit, 10) : 10,
+        minSize: parsed.minSize ? parseInt(parsed.minSize, 10) : 4,
+        maxSize: parsed.maxSize ? parseInt(parsed.maxSize, 10) : 8,
+        maxDiameter: parsed.maxDiameter ? parseInt(parsed.maxDiameter, 10) : 1500,
+    };
+}
+
+interface ICandidateRow {
+    id: string;
+    name: string;
+    category: string;
+    addressStreetAddress: string | null;
+    addressLocality: string | null;
+    addressRegion: string | null;
+    latitude: number;
+    longitude: number;
+    websiteUrl: string | null;
+    phoneNumber: string | null;
+    description: string | null;
+    hashTags: string | null;
+    has_media: boolean;
+    completeness_score: number;
+}
+
+interface IClusterSpace extends IGeoSpace {
+    row: ICandidateRow;
+}
+
+async function queryCandidates(db: Pool, args: ICliArgs) {
+    const cityConfig = CITIES[args.city];
+    if (!cityConfig) {
+        log(`Unknown city slug "${args.city}". Available: ${Object.keys(CITIES).slice(0, 10).join(', ')}, ...`);
+        process.exit(1);
+    }
+
+    const params: (string | number)[] = [`%${cityConfig.name}%`];
+    let categoryFilter = '';
+    if (args.category) {
+        params.push(args.category);
+        categoryFilter = `AND s.category = $${params.length}`;
+    }
+
+    const sql = `
+        SELECT
+            s.id,
+            s."notificationMsg" AS name,
+            s.category,
+            s."addressStreetAddress",
+            s."addressLocality",
+            s."addressRegion",
+            s.latitude,
+            s.longitude,
+            s."websiteUrl",
+            s."phoneNumber",
+            s.message AS description,
+            s."hashTags",
+            (s."mediaIds" IS NOT NULL AND s."mediaIds" != '')
+                OR (s.medias IS NOT NULL AND jsonb_array_length(s.medias) > 0) AS has_media,
+            (
+                (CASE WHEN s."websiteUrl" IS NOT NULL AND s."websiteUrl" != '' THEN 1 ELSE 0 END)
+                + (CASE WHEN s."phoneNumber" IS NOT NULL AND s."phoneNumber" != '' THEN 1 ELSE 0 END)
+                + (CASE WHEN s."addressStreetAddress" IS NOT NULL AND s."addressStreetAddress" != '' THEN 1 ELSE 0 END)
+                + (CASE WHEN s.message IS NOT NULL AND length(s.message) >= 60 THEN 1 ELSE 0 END)
+                + (CASE WHEN (s."mediaIds" IS NOT NULL AND s."mediaIds" != '')
+                        OR (s.medias IS NOT NULL AND jsonb_array_length(s.medias) > 0) THEN 1 ELSE 0 END)
+            )::int AS completeness_score
+        FROM main.spaces s
+        WHERE s."isPublic" = true
+          AND s."addressLocality" ILIKE $1
+          AND s.latitude IS NOT NULL
+          AND s.longitude IS NOT NULL
+          ${categoryFilter}
+    `;
+
+    const result = await db.query(sql, params);
+    return { city: cityConfig, rows: result.rows as ICandidateRow[] };
+}
+
+function densityScore(sumCompleteness: number, diameter: number): number {
+    // Floor the radius at 100m (~π·0.03 km²) so clusters of near-duplicate
+    // lat/lngs don't blow up the density score. Editorial-wise, 4 spaces in a
+    // single building isn't a "walkable route" — it's a building.
+    const radius = Math.max(100, diameter / 2);
+    const areaKm2 = Math.PI * (radius / 1000) ** 2;
+    return sumCompleteness / areaKm2;
+}
+
+async function main() {
+    const args = parseArgs();
+    log(`Discovering clusters: city=${args.city}${args.category ? ` category=${args.category}` : ''} `
+        + `minSize=${args.minSize} maxSize=${args.maxSize} maxDiameter=${args.maxDiameter}m limit=${args.limit}`);
+
+    const db = createDbPool({ max: 3 });
+    try {
+        await db.query('SELECT 1');
+    } catch (err: any) {
+        log(`Database connection failed: ${err.message}`);
+        await db.end();
+        process.exit(1);
+    }
+
+    try {
+        const { city, rows } = await queryCandidates(db, args);
+        log(`Fetched ${rows.length} candidate spaces with coordinates.`);
+
+        const geoSpaces: IClusterSpace[] = rows.map((r) => ({
+            id: r.id,
+            lat: Number(r.latitude),
+            lng: Number(r.longitude),
+            weight: Number(r.completeness_score) || 0,
+            row: r,
+        }));
+
+        const clusters = clusterByRadius(geoSpaces, {
+            maxDiameterMeters: args.maxDiameter,
+            minSize: args.minSize,
+            maxSize: args.maxSize,
+        });
+        log(`Formed ${clusters.length} candidate clusters before ranking.`);
+
+        const ranked = clusters
+            .map((c) => {
+                const diameter = c.diameterMeters;
+                const sumCompleteness = c.spaces.reduce(
+                    (acc, s) => acc + (Number(s.row.completeness_score) || 0),
+                    0,
+                );
+                // Quick "chordal" estimate of a reasonable walking distance: mean pairwise
+                // distance across members. `diameterMeters` already gives the worst hop;
+                // the mean helps show whether the cluster is "tight" vs "elongated".
+                const memberCoords = c.spaces.map((s) => ({ lat: s.lat, lng: s.lng }));
+                const diameter2 = diameterMeters(memberCoords);
+                return {
+                    cluster: c,
+                    diameter,
+                    diameterCheck: diameter2,
+                    sumCompleteness,
+                    density: densityScore(sumCompleteness, diameter),
+                    memberCount: c.spaces.length,
+                };
+            })
+            .sort((a, b) => b.density - a.density)
+            .slice(0, args.limit);
+
+        log(`Ranked; returning top ${ranked.length} clusters.`);
+
+        const output = {
+            query: {
+                city: city.slug,
+                cityName: city.name,
+                region: city.region,
+                regionCode: city.regionCode,
+                country: city.country,
+                category: args.category || null,
+                minSize: args.minSize,
+                maxSize: args.maxSize,
+                maxDiameterMeters: args.maxDiameter,
+                generatedAt: new Date().toISOString(),
+            },
+            totals: {
+                candidates: rows.length,
+                clusters: clusters.length,
+                returned: ranked.length,
+            },
+            clusters: ranked.map((rc, idx) => ({
+                rank: idx + 1,
+                centroid: rc.cluster.centroid,
+                diameterMeters: Math.round(rc.diameter),
+                walkingMinutes: walkingMinutes(rc.diameter),
+                memberCount: rc.memberCount,
+                sumCompleteness: rc.sumCompleteness,
+                density: Number(rc.density.toFixed(2)),
+                categories: Array.from(new Set(rc.cluster.spaces.map((s) => s.row.category))).sort(),
+                spaces: rc.cluster.spaces.map((s) => ({
+                    id: s.row.id,
+                    name: s.row.name,
+                    category: s.row.category,
+                    lat: s.lat,
+                    lng: s.lng,
+                    address: {
+                        street: s.row.addressStreetAddress || null,
+                        city: s.row.addressLocality || null,
+                        region: s.row.addressRegion || null,
+                    },
+                    completenessScore: Number(s.row.completeness_score) || 0,
+                    hasWebsite: !!s.row.websiteUrl,
+                    hasPhone: !!s.row.phoneNumber,
+                    hasMedia: !!s.row.has_media,
+                })),
+            })),
+        };
+
+        console.log(JSON.stringify(output, null, 2));
+    } finally {
+        await db.end();
+    }
+}
+
+main().catch((err) => {
+    log(`Fatal error: ${err.message}`);
+    process.exit(1);
+});

--- a/scripts/generate-content/discover-hashtags.ts
+++ b/scripts/generate-content/discover-hashtags.ts
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Discover (city, hashtag) pairs with enough spaces to anchor a guide.
+ *
+ * Splits the comma-separated `spaces.hashTags` text field into individual tags
+ * and counts per-(city, tag) occurrences. Tags are lowercased + trimmed; an
+ * exact normalized match is used (we do NOT substring-match `firstdate`
+ * against `firstdateandlast`).
+ *
+ * Context caveat — READ BEFORE USING:
+ * The `spaces.hashTags` column is currently populated mostly by the OSM
+ * ingester (`scripts/import-spaces/transforms/mapToSpace.ts` → `buildHashTags`),
+ * which derives tags from `cuisine` / `amenity` / `shop` / `tourism` OSM tags.
+ * Those are closer to categories than to user-applied intent. Until a meaningful
+ * chunk of user-applied tags lands (e.g., `firstdate`, `latenight`,
+ * `worksession`), this discovery tool will mostly surface cuisine words.
+ * Use the output to decide whether the hashtag-anchored plan actually has
+ * signal before investing in Phases 2–5. See docs/CONTENT_HASHTAG_GUIDES_PLAN.md.
+ *
+ * Usage:
+ *   npx ts-node scripts/generate-content/discover-hashtags \
+ *     [--city <name>] [--minSpaces <n>] [--limit <n>] [--intentOnly]
+ *
+ * Flags:
+ *   --city <name>       Filter to a single city (ILIKE match).
+ *   --minSpaces <n>     Minimum space count per (city, tag). Default 8.
+ *   --limit <n>         Max rows in output. Default 100.
+ *   --intentOnly        Filter to an allowlist of intent-shaped tags
+ *                       (firstdate, latenight, worksession, livemusic,
+ *                       outdoorseating, dogfriendly, kidfriendly,
+ *                       groupfriendly, roomforevent, happyhour, brunch).
+ *
+ * Stdout: JSON array of rows { city, region, hashtag, spaceCount,
+ *   distinctCategories, sampleCategories[] }.
+ * Stderr: progress.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { createDbPool } from '../import-spaces/utils/db';
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '../import-spaces/.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+/**
+ * Hashtags that describe *what you're trying to do tonight* rather than a cuisine
+ * or amenity type. If the discover output is dominated by cuisine words
+ * (`italian`, `pizza`, `bar`), passing `--intentOnly` filters to this list.
+ * Expand as the `hashTags` data grows richer.
+ */
+const INTENT_HASHTAG_ALLOWLIST = [
+    'firstdate',
+    'datenight',
+    'latenight',
+    'worksession',
+    'workfriendly',
+    'livemusic',
+    'outdoorseating',
+    'patio',
+    'rooftop',
+    'dogfriendly',
+    'kidfriendly',
+    'familyfriendly',
+    'groupfriendly',
+    'roomforevent',
+    'privateevents',
+    'happyhour',
+    'brunch',
+    'solo',
+    'quiet',
+    'romantic',
+    'cozy',
+];
+
+function log(msg: string) {
+    process.stderr.write(`${msg}\n`);
+}
+
+interface ICliArgs {
+    city: string;
+    minSpaces: number;
+    limit: number;
+    intentOnly: boolean;
+}
+
+function parseArgs(): ICliArgs {
+    const args = process.argv.slice(2);
+    const parsed: Record<string, string> = {};
+    const flags = new Set<string>();
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a.startsWith('--')) {
+            const next = args[i + 1];
+            if (!next || next.startsWith('--')) {
+                flags.add(a.replace('--', ''));
+            } else {
+                parsed[a.replace('--', '')] = next;
+                i++;
+            }
+        }
+    }
+    return {
+        city: parsed.city || '',
+        minSpaces: parsed.minSpaces ? parseInt(parsed.minSpaces, 10) : 8,
+        limit: parsed.limit ? parseInt(parsed.limit, 10) : 100,
+        intentOnly: flags.has('intentOnly'),
+    };
+}
+
+async function main() {
+    const args = parseArgs();
+    log(`Discovering (city, hashtag) pairs: minSpaces=${args.minSpaces} limit=${args.limit}`
+        + `${args.city ? ` city=${args.city}` : ''}${args.intentOnly ? ' intentOnly' : ''}`);
+
+    const db = createDbPool({ max: 3 });
+    try {
+        const params: (string | number | string[])[] = [args.minSpaces];
+        const filters: string[] = [];
+        if (args.city) {
+            params.push(`%${args.city}%`);
+            filters.push(`AND s."addressLocality" ILIKE $${params.length}`);
+        }
+        if (args.intentOnly) {
+            params.push(INTENT_HASHTAG_ALLOWLIST);
+            filters.push(`AND LOWER(TRIM(tag)) = ANY($${params.length}::text[])`);
+        }
+
+        const sql = `
+            SELECT
+                s."addressLocality" AS city,
+                s."addressRegion" AS region,
+                LOWER(TRIM(tag)) AS hashtag,
+                COUNT(DISTINCT s.id)::int AS "spaceCount",
+                COUNT(DISTINCT s.category)::int AS "distinctCategories",
+                (ARRAY_AGG(DISTINCT s.category ORDER BY s.category))[1:5] AS "sampleCategories"
+            FROM main.spaces s,
+                LATERAL unnest(string_to_array(s."hashTags", ',')) AS tag
+            WHERE s."isPublic" = true
+              AND s."addressLocality" IS NOT NULL
+              AND s."hashTags" IS NOT NULL
+              AND s."hashTags" <> ''
+              AND LENGTH(TRIM(tag)) > 0
+              ${filters.join('\n              ')}
+            GROUP BY s."addressLocality", s."addressRegion", LOWER(TRIM(tag))
+            HAVING COUNT(DISTINCT s.id) >= $1
+            ORDER BY "spaceCount" DESC, city ASC, hashtag ASC
+            LIMIT ${Math.max(1, Math.min(500, args.limit))}
+        `;
+
+        const result = await db.query(sql, params);
+        log(`Found ${result.rows.length} (city, hashtag) buckets meeting threshold.`);
+        console.log(JSON.stringify(result.rows, null, 2));
+    } finally {
+        await db.end();
+    }
+}
+
+main().catch((err) => {
+    log(`Fatal error: ${err.message}`);
+    process.exit(1);
+});

--- a/scripts/generate-content/query-by-hashtag.ts
+++ b/scripts/generate-content/query-by-hashtag.ts
@@ -1,30 +1,25 @@
 #!/usr/bin/env node
 /**
- * Query top-ranked spaces in a city/category for editorial list posts.
+ * Query top-ranked spaces in a city + hashtag for editorial list posts.
  *
- * Two ranking modes:
- *   - `engagement` (default): rank by visits * 5 + impressions over the time window.
- *     Good when a city/category has enough activity to back a "ranked by community visits"
- *     framing.
- *   - `curated`: rank by completeness of editorial metadata (website, media, description,
- *     phone, full address). Good when engagement data is thin and we shouldn't claim a
- *     popularity-based ranking.
+ * Mirrors `query-top-spaces.ts` but anchors on `spaces.hashTags` instead of
+ * `spaces.category`. Uses the same `auto`/`engagement`/`curated` mode
+ * discipline so posts never claim popularity that isn't in the data.
  *
- * Mode selection:
- *   - Pass `--mode curated` (or `--curated`) to force curated ranking.
- *   - Pass `--mode engagement` to force engagement ranking.
- *   - Default `--mode auto` picks engagement, then *automatically falls back* to curated
- *     if total visits across the result set is below `--minVisits` (default 25). The
- *     selected mode is reported in the JSON output so the LLM can frame the post honestly.
+ * Matching strategy:
+ * `spaces.hashTags` is a comma-separated string (lowercase, no `#`). To avoid
+ * `firstdate` matching `firstdateandlast`, we unnest into individual tags in
+ * SQL and compare by exact equality after LOWER(TRIM(tag)). This is
+ * consistent with `discover-hashtags.ts`.
  *
  * Usage:
- *   npx ts-node scripts/generate-content/query-top-spaces \
- *     --city cincinnati --category bar/drinks --limit 15 --window 90
- *   npx ts-node scripts/generate-content/query-top-spaces \
- *     --city denver --category cafe --curated --limit 10
+ *   npx ts-node scripts/generate-content/query-by-hashtag \
+ *     --city chicago --hashtag firstdate --limit 10 --window 90
+ *   npx ts-node scripts/generate-content/query-by-hashtag \
+ *     --city portland --hashtag worksession --curated --limit 8
  *
- * Stdout: JSON envelope `{ query, mode, modeReason, spaces }` (no secrets).
- * Stderr: progress logs.
+ * Stdout: JSON envelope `{ query, mode, modeReason, spaces }`.
+ * Stderr: progress.
  */
 import * as dotenv from 'dotenv';
 import * as path from 'path';
@@ -44,7 +39,7 @@ type RankMode = 'auto' | 'engagement' | 'curated';
 
 interface ICliArgs {
     city: string;
-    category: string;
+    hashtag: string;
     limit: number;
     windowDays: number;
     mode: RankMode;
@@ -74,8 +69,8 @@ function parseArgs(): ICliArgs {
         log('Missing required --city <slug>. See scripts/import-spaces/config.ts for valid city slugs.');
         process.exit(1);
     }
-    if (!parsed.category) {
-        log('Missing required --category <name>. Examples: bar/drinks, restaurant/food, cafe.');
+    if (!parsed.hashtag) {
+        log('Missing required --hashtag <tag>. Examples: firstdate, latenight, worksession.');
         process.exit(1);
     }
 
@@ -87,10 +82,17 @@ function parseArgs(): ICliArgs {
         process.exit(1);
     }
 
+    // Normalize the hashtag: strip a leading '#' if the user typed one, lowercase, trim.
+    const hashtag = parsed.hashtag.replace(/^#/, '').trim().toLowerCase();
+    if (!hashtag) {
+        log('--hashtag must be non-empty after trimming.');
+        process.exit(1);
+    }
+
     return {
         city: parsed.city,
-        category: parsed.category,
-        limit: parsed.limit ? parseInt(parsed.limit, 10) : 15,
+        hashtag,
+        limit: parsed.limit ? parseInt(parsed.limit, 10) : 12,
         windowDays: parsed.window ? parseInt(parsed.window, 10) : 90,
         mode,
         minVisits: parsed.minVisits ? parseInt(parsed.minVisits, 10) : 25,
@@ -130,13 +132,12 @@ async function queryRankedSpaces(db: Pool, args: ICliArgs) {
         process.exit(1);
     }
 
-    // Base query: select all candidates with both engagement and completeness columns.
-    // The ORDER BY is decided after we inspect the engagement totals (so we can fall back
-    // gracefully) — we fetch a pool of candidates by completeness OR engagement and then
-    // sort and slice in-process. This keeps the SQL simple and lets the calling layer pick
-    // the mode label honestly.
+    // Pull a candidate pool ordered by a tie-broken completeness signal, then
+    // re-sort in pickModeAndSort based on the chosen mode.
     const candidateLimit = Math.max(args.limit * 4, 40);
 
+    // Exact-match on the normalized hashtag after splitting the comma-separated
+    // string. EXISTS + LATERAL keeps this readable and avoids substring gotchas.
     const query = `
         SELECT
             s.id,
@@ -190,15 +191,21 @@ async function queryRankedSpaces(db: Pool, args: ICliArgs) {
             GROUP BY "spaceId"
         ) i ON i."spaceId" = s.id
         WHERE s."isPublic" = true
-          AND s.category = $2
           AND s."addressLocality" ILIKE $3
+          AND s."hashTags" IS NOT NULL
+          AND s."hashTags" <> ''
+          AND EXISTS (
+              SELECT 1
+              FROM unnest(string_to_array(s."hashTags", ',')) AS tag
+              WHERE LOWER(TRIM(tag)) = $2
+          )
         ORDER BY completeness_score DESC, score DESC, s."createdAt" DESC
         LIMIT $4
     `;
 
     const params: (string | number)[] = [
         args.windowDays.toString(),
-        args.category,
+        args.hashtag,
         `%${cityConfig.name}%`,
         candidateLimit,
     ];
@@ -261,7 +268,7 @@ function pickModeAndSort(args: ICliArgs, rows: IRawSpaceRow[]): { mode: 'engagem
 
 async function main() {
     const args = parseArgs();
-    log(`Querying top spaces: city=${args.city}, category=${args.category}, limit=${args.limit}, window=${args.windowDays}d, mode=${args.mode}`);
+    log(`Querying by hashtag: city=${args.city}, hashtag=${args.hashtag}, limit=${args.limit}, window=${args.windowDays}d, mode=${args.mode}`);
 
     const db = createDbPool({ max: 3 });
     try {
@@ -274,6 +281,9 @@ async function main() {
 
     try {
         const { city, rows } = await queryRankedSpaces(db, args);
+        if (rows.length === 0) {
+            log(`No spaces found for city=${args.city} hashtag=${args.hashtag}. Try discover-hashtags to find viable tags.`);
+        }
         const { mode, reason, sorted } = pickModeAndSort(args, rows);
         const finalRows = sorted.slice(0, args.limit);
         log(`Found ${rows.length} candidates; returning ${finalRows.length} via mode=${mode}.`);
@@ -286,7 +296,7 @@ async function main() {
                 region: city.region,
                 regionCode: city.regionCode,
                 country: city.country,
-                category: args.category,
+                hashtag: args.hashtag,
                 windowDays: args.windowDays,
                 generatedAt: new Date().toISOString(),
             },

--- a/scripts/generate-content/query-walkable-cluster.ts
+++ b/scripts/generate-content/query-walkable-cluster.ts
@@ -1,0 +1,360 @@
+#!/usr/bin/env node
+/**
+ * Query a walkable cluster and order its members into a route.
+ *
+ * Two entry modes:
+ *   1. `--spaceIds <id1,id2,...>` — use the exact cluster returned by
+ *      `discover-clusters.ts`. Spaces are loaded by id, ordered via
+ *      nearest-neighbor TSP starting from the highest-completeness member.
+ *      This is the typical editorial workflow: run discover-clusters, pick a
+ *      cluster, feed its ids back in.
+ *   2. `--center <lat,lng> --radius <meters>` — pull all spaces inside the
+ *      bounding circle, re-cluster, pick the cluster covering the centerpoint
+ *      (or the densest cluster if no single cluster covers it), then order.
+ *      Useful when we already know a neighborhood's lat/lng but haven't
+ *      pre-discovered clusters for it (e.g., editorial pitch: "Wicker Park").
+ *
+ * Either mode emits the same output shape: `{ query, cluster, route }` where
+ * `route.stops[]` is the ordered list with `walkFromPreviousMeters` set on
+ * stops 2..N, and `route.totalMeters` / `route.estimatedMinutes` describe the
+ * full path. This is the exact payload the `walkable-route` section type
+ * wants, minus the editorial `note` strings (LLM fills those in).
+ *
+ * Usage:
+ *   npx ts-node scripts/generate-content/query-walkable-cluster \
+ *     --spaceIds "abc-123,def-456,..."
+ *   npx ts-node scripts/generate-content/query-walkable-cluster \
+ *     --center 41.908,-87.678 --radius 800 [--category bar/drinks] \
+ *     [--minSize 4] [--maxSize 8] [--maxDiameter 1500]
+ *
+ * Stdout: JSON envelope `{ query, cluster, route }`.
+ * Stderr: progress logs.
+ */
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { Pool } from 'pg';
+import { createDbPool } from '../import-spaces/utils/db';
+import {
+    clusterByRadius,
+    haversineMeters,
+    orderAsWalkingRoute,
+    walkingMinutes,
+    IGeoSpace,
+    ILatLng,
+} from './utils/geo';
+
+dotenv.config({ path: path.resolve(__dirname, '.env') });
+dotenv.config({ path: path.resolve(__dirname, '../import-spaces/.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+
+function log(msg: string) {
+    process.stderr.write(`${msg}\n`);
+}
+
+interface ICliArgs {
+    spaceIds: string[];
+    center: ILatLng | null;
+    radius: number;
+    category: string;
+    minSize: number;
+    maxSize: number;
+    maxDiameter: number;
+}
+
+function parseArgs(): ICliArgs {
+    const args = process.argv.slice(2);
+    const parsed: Record<string, string> = {};
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a.startsWith('--')) {
+            const next = args[i + 1];
+            if (next && !next.startsWith('--')) {
+                parsed[a.replace('--', '')] = next;
+                i++;
+            }
+        }
+    }
+
+    const spaceIds = parsed.spaceIds
+        ? parsed.spaceIds.split(',').map((s) => s.trim()).filter(Boolean)
+        : [];
+
+    let center: ILatLng | null = null;
+    if (parsed.center) {
+        const parts = parsed.center.split(',').map((s) => s.trim());
+        if (parts.length !== 2) {
+            log(`Invalid --center "${parsed.center}". Expected "lat,lng".`);
+            process.exit(1);
+        }
+        const lat = parseFloat(parts[0]);
+        const lng = parseFloat(parts[1]);
+        if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+            log(`Invalid --center "${parsed.center}". Lat/lng must be numeric.`);
+            process.exit(1);
+        }
+        center = { lat, lng };
+    }
+
+    if (spaceIds.length === 0 && !center) {
+        log('Missing required input. Provide either --spaceIds <csv> or --center <lat,lng> --radius <m>.');
+        process.exit(1);
+    }
+    if (spaceIds.length > 0 && center) {
+        log('Both --spaceIds and --center supplied. Using --spaceIds; --center will be ignored.');
+    }
+
+    return {
+        spaceIds,
+        center,
+        radius: parsed.radius ? parseInt(parsed.radius, 10) : 800,
+        category: parsed.category || '',
+        minSize: parsed.minSize ? parseInt(parsed.minSize, 10) : 4,
+        maxSize: parsed.maxSize ? parseInt(parsed.maxSize, 10) : 8,
+        maxDiameter: parsed.maxDiameter ? parseInt(parsed.maxDiameter, 10) : 1500,
+    };
+}
+
+interface ISpaceRow {
+    id: string;
+    name: string;
+    category: string;
+    addressStreetAddress: string | null;
+    addressLocality: string | null;
+    addressRegion: string | null;
+    latitude: number;
+    longitude: number;
+    websiteUrl: string | null;
+    phoneNumber: string | null;
+    description: string | null;
+    hashTags: string | null;
+    has_media: boolean;
+    completeness_score: number;
+}
+
+interface IGeoRow extends IGeoSpace {
+    row: ISpaceRow;
+}
+
+const SELECT_COLUMNS = `
+    s.id,
+    s."notificationMsg" AS name,
+    s.category,
+    s."addressStreetAddress",
+    s."addressLocality",
+    s."addressRegion",
+    s.latitude,
+    s.longitude,
+    s."websiteUrl",
+    s."phoneNumber",
+    s.message AS description,
+    s."hashTags",
+    (s."mediaIds" IS NOT NULL AND s."mediaIds" != '')
+        OR (s.medias IS NOT NULL AND jsonb_array_length(s.medias) > 0) AS has_media,
+    (
+        (CASE WHEN s."websiteUrl" IS NOT NULL AND s."websiteUrl" != '' THEN 1 ELSE 0 END)
+        + (CASE WHEN s."phoneNumber" IS NOT NULL AND s."phoneNumber" != '' THEN 1 ELSE 0 END)
+        + (CASE WHEN s."addressStreetAddress" IS NOT NULL AND s."addressStreetAddress" != '' THEN 1 ELSE 0 END)
+        + (CASE WHEN s.message IS NOT NULL AND length(s.message) >= 60 THEN 1 ELSE 0 END)
+        + (CASE WHEN (s."mediaIds" IS NOT NULL AND s."mediaIds" != '')
+                OR (s.medias IS NOT NULL AND jsonb_array_length(s.medias) > 0) THEN 1 ELSE 0 END)
+    )::int AS completeness_score
+`;
+
+async function queryByIds(db: Pool, spaceIds: string[]): Promise<ISpaceRow[]> {
+    const sql = `
+        SELECT ${SELECT_COLUMNS}
+        FROM main.spaces s
+        WHERE s.id = ANY($1::uuid[])
+          AND s."isPublic" = true
+          AND s.latitude IS NOT NULL
+          AND s.longitude IS NOT NULL
+    `;
+    const result = await db.query(sql, [spaceIds]);
+    return result.rows as ISpaceRow[];
+}
+
+async function queryByCenter(db: Pool, center: ILatLng, radiusMeters: number, category: string): Promise<ISpaceRow[]> {
+    // Prefilter by a lat/lng bounding box, then Haversine-filter in-process.
+    // ~111km per degree of latitude; longitude scales by cos(lat). We pad the
+    // box by 10% so spaces at the edge of the radius are not missed because
+    // of cos approximation error at higher latitudes.
+    const padding = 1.1;
+    const latDelta = (radiusMeters / 111_000) * padding;
+    const lngDelta = (radiusMeters / (111_000 * Math.cos((center.lat * Math.PI) / 180))) * padding;
+
+    const params: (string | number)[] = [
+        center.lat - latDelta,
+        center.lat + latDelta,
+        center.lng - lngDelta,
+        center.lng + lngDelta,
+    ];
+    let categoryFilter = '';
+    if (category) {
+        params.push(category);
+        categoryFilter = `AND s.category = $${params.length}`;
+    }
+
+    const sql = `
+        SELECT ${SELECT_COLUMNS}
+        FROM main.spaces s
+        WHERE s."isPublic" = true
+          AND s.latitude BETWEEN $1 AND $2
+          AND s.longitude BETWEEN $3 AND $4
+          ${categoryFilter}
+    `;
+    const result = await db.query(sql, params);
+    const rows = result.rows as ISpaceRow[];
+
+    return rows.filter((r) => (
+        haversineMeters(center, { lat: Number(r.latitude), lng: Number(r.longitude) }) <= radiusMeters
+    ));
+}
+
+function pickClusterByCenter<T extends IGeoSpace>(
+    clusters: ReturnType<typeof clusterByRadius<T>>,
+    center: ILatLng,
+): ReturnType<typeof clusterByRadius<T>>[number] | null {
+    if (clusters.length === 0) return null;
+    // Prefer the cluster whose centroid is closest to the requested center.
+    return clusters.reduce((best, c) => (
+        haversineMeters(c.centroid, center) < haversineMeters(best.centroid, center) ? c : best
+    ), clusters[0]);
+}
+
+function toGeoRows(rows: ISpaceRow[]): IGeoRow[] {
+    return rows.map((r) => ({
+        id: r.id,
+        lat: Number(r.latitude),
+        lng: Number(r.longitude),
+        weight: Number(r.completeness_score) || 0,
+        row: r,
+    }));
+}
+
+function formatStop(order: number, space: IGeoRow, walkFromPreviousMeters?: number) {
+    // Note: the `order`, `spaceId`, `name`, `lat`, `lng`, and `walkFromPreviousMeters`
+    // fields map directly to `IWalkableRouteStop` in utils/contentSchema.ts.
+    // The additional fields (address, completeness, etc.) are diagnostic for the
+    // editorial caller; they are not part of the stored section payload.
+    return {
+        order,
+        spaceId: space.row.id,
+        name: space.row.name,
+        lat: space.lat,
+        lng: space.lng,
+        category: space.row.category,
+        address: {
+            street: space.row.addressStreetAddress || null,
+            city: space.row.addressLocality || null,
+            region: space.row.addressRegion || null,
+        },
+        completenessScore: Number(space.row.completeness_score) || 0,
+        hasWebsite: !!space.row.websiteUrl,
+        hasPhone: !!space.row.phoneNumber,
+        hasMedia: !!space.row.has_media,
+        ...(walkFromPreviousMeters != null
+            ? {
+                walkFromPreviousMeters: Math.round(walkFromPreviousMeters),
+                walkFromPreviousMinutes: walkingMinutes(walkFromPreviousMeters),
+            }
+            : {}),
+    };
+}
+
+async function main() {
+    const args = parseArgs();
+    const db = createDbPool({ max: 3 });
+    try {
+        await db.query('SELECT 1');
+    } catch (err: any) {
+        log(`Database connection failed: ${err.message}`);
+        await db.end();
+        process.exit(1);
+    }
+
+    try {
+        let spacesForRoute: IGeoRow[];
+        let source: 'spaceIds' | 'center';
+
+        if (args.spaceIds.length > 0) {
+            source = 'spaceIds';
+            log(`Loading ${args.spaceIds.length} spaces by id.`);
+            const rows = await queryByIds(db, args.spaceIds);
+            if (rows.length === 0) {
+                log('No spaces matched the supplied ids. Nothing to route.');
+                process.exit(1);
+            }
+            if (rows.length < args.spaceIds.length) {
+                log(`Warning: only ${rows.length} of ${args.spaceIds.length} ids returned public rows with coords.`);
+            }
+            spacesForRoute = toGeoRows(rows);
+        } else {
+            source = 'center';
+            const center = args.center as ILatLng;
+            log(`Querying spaces within ${args.radius}m of ${center.lat},${center.lng}`
+                + `${args.category ? ` (category=${args.category})` : ''}.`);
+            const rows = await queryByCenter(db, center, args.radius, args.category);
+            log(`Fetched ${rows.length} candidate spaces in radius.`);
+            if (rows.length === 0) {
+                log('No candidates in the requested radius.');
+                process.exit(1);
+            }
+
+            const geoRows = toGeoRows(rows);
+            const clusters = clusterByRadius(geoRows, {
+                maxDiameterMeters: args.maxDiameter,
+                minSize: args.minSize,
+                maxSize: args.maxSize,
+            });
+            log(`Found ${clusters.length} clusters; selecting the one closest to the requested center.`);
+            const picked = pickClusterByCenter(clusters, center);
+            if (!picked) {
+                log(`No cluster of size >= ${args.minSize} found within ${args.maxDiameter}m diameter.`);
+                process.exit(1);
+            }
+            spacesForRoute = picked.spaces;
+        }
+
+        const clusterForRoute = {
+            spaces: spacesForRoute,
+            centroid: {
+                lat: spacesForRoute.reduce((a, s) => a + s.lat, 0) / spacesForRoute.length,
+                lng: spacesForRoute.reduce((a, s) => a + s.lng, 0) / spacesForRoute.length,
+            },
+            diameterMeters: 0, // not used by orderAsWalkingRoute; left as 0
+        };
+        const { ordered, legs, totalMeters } = orderAsWalkingRoute(clusterForRoute);
+
+        const stops = ordered.map((space, idx) => formatStop(idx + 1, space, idx === 0 ? undefined : legs[idx - 1]));
+
+        const output = {
+            query: {
+                source,
+                spaceIdsIn: args.spaceIds.length > 0 ? args.spaceIds : null,
+                center: args.center,
+                radiusMeters: args.center ? args.radius : null,
+                category: args.category || null,
+                generatedAt: new Date().toISOString(),
+            },
+            cluster: {
+                centroid: clusterForRoute.centroid,
+                memberCount: spacesForRoute.length,
+                categories: Array.from(new Set(spacesForRoute.map((s) => s.row.category))).sort(),
+            },
+            route: {
+                totalMeters: Math.round(totalMeters),
+                estimatedMinutes: walkingMinutes(totalMeters),
+                stops,
+            },
+        };
+
+        console.log(JSON.stringify(output, null, 2));
+    } finally {
+        await db.end();
+    }
+}
+
+main().catch((err) => {
+    log(`Fatal error: ${err.message}`);
+    process.exit(1);
+});

--- a/scripts/generate-content/save-post.ts
+++ b/scripts/generate-content/save-post.ts
@@ -101,6 +101,7 @@ interface IIndexEntry {
     description: string;
     city?: string;
     category?: string;
+    hashtag?: string;
     publishedAt: string;
     updatedAt: string;
 }
@@ -122,6 +123,7 @@ function rebuildIndex(): IIndexEntry[] {
                 description: post.description,
                 city: post.city,
                 category: post.category,
+                hashtag: post.hashtag,
                 publishedAt: post.publishedAt,
                 updatedAt: post.updatedAt,
             });

--- a/scripts/generate-content/utils/contentSchema.ts
+++ b/scripts/generate-content/utils/contentSchema.ts
@@ -32,11 +32,15 @@ export interface IPostMetadata {
     description: string;
     /** City slug (matches CITIES key from scripts/import-spaces/config.ts). */
     city?: string;
-    /** Category slug (matches space.category). */
+    /** Category slug (matches space.category). Mutually exclusive with hashtag. */
     category?: string;
-    // TODO: add `hashtag?: string` for hashtag-anchored posts.
-    // See docs/CONTENT_HASHTAG_GUIDES_PLAN.md (Phase 3). Validator must enforce
-    // that exactly one of {category, hashtag} is set.
+    /**
+     * Hashtag anchor for intent-based guides (e.g., "firstdate", "latenight").
+     * Stored without the leading '#', lowercase, normalized to match the
+     * `spaces.hashTags` column format. Mutually exclusive with category.
+     * See docs/CONTENT_HASHTAG_GUIDES_PLAN.md.
+     */
+    hashtag?: string;
     /** ISO date string (yyyy-mm-dd). */
     publishedAt: string;
     /** ISO date string (yyyy-mm-dd). */
@@ -134,6 +138,9 @@ export interface IPost extends IPostMetadata {
 
 const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+// Hashtags are stored lowercase and without whitespace or '#' — matches the
+// format produced by `buildHashTags` in scripts/import-spaces/transforms/mapToSpace.ts.
+const HASHTAG_RE = /^[a-z0-9][a-z0-9-]{0,49}$/;
 const VALID_TYPES: PostType[] = ['list', 'data', 'mixed'];
 const VALID_STATUSES: PostStatus[] = ['draft', 'published'];
 const VALID_LOCALES: PostLocale[] = ['es', 'fr-ca'];
@@ -237,6 +244,16 @@ export function validatePost(input: unknown, options: IValidatePostOptions = {})
     }
     if (typeof p.author !== 'string' || !p.author.trim()) {
         errors.push({ field: 'author', message: 'Required, non-empty (E-E-A-T signal).' });
+    }
+    const hasCategory = typeof p.category === 'string' && p.category.trim().length > 0;
+    const hasHashtag = typeof p.hashtag === 'string' && p.hashtag.trim().length > 0;
+    if (hasCategory && hasHashtag) {
+        errors.push({ field: 'category|hashtag', message: 'Exactly one of `category` or `hashtag` must be set, not both.' });
+    } else if (!hasCategory && !hasHashtag) {
+        errors.push({ field: 'category|hashtag', message: 'Exactly one of `category` or `hashtag` is required.' });
+    }
+    if (hasHashtag && !HASHTAG_RE.test(p.hashtag as string)) {
+        errors.push({ field: 'hashtag', message: 'Must be lowercase letters/digits/hyphens, no leading `#` (e.g., "firstdate", "live-music").' });
     }
     if (typeof p.lead !== 'string' || !p.lead.trim()) {
         errors.push({ field: 'lead', message: 'Required, non-empty (intro paragraph).' });

--- a/scripts/generate-content/utils/contentSchema.ts
+++ b/scripts/generate-content/utils/contentSchema.ts
@@ -107,8 +107,40 @@ export interface ICTASection {
     ctaText?: string;
 }
 
+export interface IWalkableRouteStop {
+    spaceId: string;
+    /** 1-indexed position along the route. Must be dense (1..n). */
+    order: number;
+    /**
+     * Denormalized stop coordinates. Duplicating `spaces.latitude/longitude`
+     * here keeps the rendered section self-contained (no async space lookups
+     * for the map embed) and is fine because the whole guide is a frozen
+     * snapshot anyway — blurb, rank, and stop order would also all be stale
+     * if the underlying space moved.
+     */
+    lat: number;
+    lng: number;
+    /** Space name at generation time; lets the map popup render on SSR without a space lookup. */
+    name: string;
+    /** Walking distance from the previous stop, in meters. Omitted for order=1. */
+    walkFromPreviousMeters?: number;
+    /** Optional editorial one-liner for this stop ("start here — best coffee in the cluster"). */
+    note?: string;
+}
+
+export interface IWalkableRouteSection {
+    type: 'walkable-route';
+    /** Cluster centroid; drives the map-embed viewport. */
+    centroid: { lat: number; lng: number };
+    /** Sum of walking legs, in meters. */
+    totalMeters: number;
+    /** Rough walk-time estimate (walkingMinutes(totalMeters) from utils/geo). */
+    estimatedMinutes: number;
+    /** Ordered stops (order=1..n). Minimum 2 stops required. */
+    stops: IWalkableRouteStop[];
+}
+
 // TODO: planned new section types — see docs/CONTENT_GUIDES_ROADMAP.md
-//   - 'walkable-route'  → docs/CONTENT_WALKABLE_CLUSTERS_PLAN.md (Phase 4)
 //   - 'moment-quote'    → docs/CONTENT_MOMENT_DRIVEN_PLAN.md (Phase 4)
 // Adding a new section type also requires updating validatePost below and
 // mirroring the type into therr-client-web/src/utilities/guideContent.ts.
@@ -118,7 +150,8 @@ export type IPostSection =
     | IDataCalloutSection
     | IDataTableSection
     | IFAQSection
-    | ICTASection;
+    | ICTASection
+    | IWalkableRouteSection;
 
 export interface IPostLocaleContent {
     title: string;
@@ -153,6 +186,54 @@ export interface IValidationError {
 export interface IValidatePostOptions {
     /** Fail validation if any of these locales are missing from `locales`. */
     requireLocales?: PostLocale[];
+}
+
+function validateWalkableRoute(prefix: string, section: unknown): IValidationError[] {
+    const errors: IValidationError[] = [];
+    const s = section as Record<string, unknown>;
+
+    const centroid = s.centroid as Record<string, unknown> | undefined;
+    if (!centroid || typeof centroid !== 'object'
+        || !Number.isFinite(centroid.lat as number) || !Number.isFinite(centroid.lng as number)) {
+        errors.push({ field: `${prefix}.centroid`, message: 'Required: { lat, lng } with finite numbers.' });
+    }
+    if (!Number.isFinite(s.totalMeters as number) || (s.totalMeters as number) < 0) {
+        errors.push({ field: `${prefix}.totalMeters`, message: 'Required, non-negative number.' });
+    }
+    if (!Number.isFinite(s.estimatedMinutes as number) || (s.estimatedMinutes as number) < 0) {
+        errors.push({ field: `${prefix}.estimatedMinutes`, message: 'Required, non-negative number.' });
+    }
+    if (!Array.isArray(s.stops) || s.stops.length < 2) {
+        errors.push({ field: `${prefix}.stops`, message: 'Required, at least 2 stops.' });
+        return errors;
+    }
+    const seenIds = new Set<string>();
+    s.stops.forEach((stop, i) => {
+        const st = stop as Record<string, unknown>;
+        if (typeof st.spaceId !== 'string' || !st.spaceId.trim()) {
+            errors.push({ field: `${prefix}.stops[${i}].spaceId`, message: 'Required, non-empty string.' });
+        } else if (seenIds.has(st.spaceId as string)) {
+            errors.push({ field: `${prefix}.stops[${i}].spaceId`, message: `Duplicate spaceId "${st.spaceId}".` });
+        } else {
+            seenIds.add(st.spaceId as string);
+        }
+        if (st.order !== i + 1) {
+            errors.push({ field: `${prefix}.stops[${i}].order`, message: `Must equal ${i + 1} (stops must be 1-indexed and dense).` });
+        }
+        if (!Number.isFinite(st.lat as number) || !Number.isFinite(st.lng as number)) {
+            errors.push({ field: `${prefix}.stops[${i}]`, message: 'Required `lat` and `lng` (finite numbers).' });
+        }
+        if (typeof st.name !== 'string' || !st.name.trim()) {
+            errors.push({ field: `${prefix}.stops[${i}].name`, message: 'Required, non-empty string.' });
+        }
+        if (i === 0 && st.walkFromPreviousMeters !== undefined) {
+            errors.push({ field: `${prefix}.stops[${i}].walkFromPreviousMeters`, message: 'Must be omitted for the first stop.' });
+        }
+        if (i > 0 && (!Number.isFinite(st.walkFromPreviousMeters as number) || (st.walkFromPreviousMeters as number) < 0)) {
+            errors.push({ field: `${prefix}.stops[${i}].walkFromPreviousMeters`, message: 'Required for stops 2..n, non-negative number.' });
+        }
+    });
+    return errors;
 }
 
 function validateLocaleBlock(
@@ -266,8 +347,12 @@ export function validatePost(input: unknown, options: IValidatePostOptions = {})
             if (!s || typeof s !== 'object' || typeof (s as any).type !== 'string') {
                 errors.push({ field: `sections[${i}]`, message: 'Section must have a type field.' });
                 parentSectionTypes.push('');
-            } else {
-                parentSectionTypes.push((s as any).type);
+                return;
+            }
+            const type = (s as any).type as string;
+            parentSectionTypes.push(type);
+            if (type === 'walkable-route') {
+                errors.push(...validateWalkableRoute(`sections[${i}]`, s));
             }
         });
     }

--- a/scripts/generate-content/utils/geo.ts
+++ b/scripts/generate-content/utils/geo.ts
@@ -1,0 +1,226 @@
+/**
+ * Geographic utilities for walkable-cluster guides.
+ *
+ * Pure functions: no DB, no I/O, no env. Used by `discover-clusters.ts`,
+ * `query-walkable-cluster.ts`, and (for ordering) when composing the
+ * `walkable-route` section payload.
+ *
+ * See docs/CONTENT_WALKABLE_CLUSTERS_PLAN.md.
+ */
+
+export interface ILatLng {
+    lat: number;
+    lng: number;
+}
+
+/** A space annotated with enough identity to cluster and order. */
+export interface IGeoSpace extends ILatLng {
+    id: string;
+    /** Optional rank hint; used to bias cluster seed selection. Higher = better. */
+    weight?: number;
+}
+
+const EARTH_RADIUS_METERS = 6371008.8;
+/** Typical adult walking pace, conservative for an urban browse. */
+const WALKING_METERS_PER_MINUTE = 80;
+
+/**
+ * Great-circle distance between two lat/lng points, in meters. Haversine —
+ * accurate enough for city-scale clustering (<~20km). Clamps the inner
+ * argument to [0,1] to guard against floating-point drift when the two
+ * points are identical.
+ */
+export function haversineMeters(a: ILatLng, b: ILatLng): number {
+    const toRad = (deg: number) => (deg * Math.PI) / 180;
+    const lat1 = toRad(a.lat);
+    const lat2 = toRad(b.lat);
+    const dLat = toRad(b.lat - a.lat);
+    const dLng = toRad(b.lng - a.lng);
+    const h = Math.sin(dLat / 2) ** 2
+        + Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+    const c = 2 * Math.asin(Math.min(1, Math.sqrt(h)));
+    return EARTH_RADIUS_METERS * c;
+}
+
+/** Rough walking time for a given distance, in whole minutes. */
+export function walkingMinutes(meters: number): number {
+    if (!Number.isFinite(meters) || meters <= 0) return 0;
+    return Math.max(1, Math.round(meters / WALKING_METERS_PER_MINUTE));
+}
+
+/** Centroid (simple mean) of a non-empty list of lat/lng points. */
+export function centroidOf(points: ILatLng[]): ILatLng {
+    if (points.length === 0) {
+        throw new Error('centroidOf: empty points array');
+    }
+    let sumLat = 0;
+    let sumLng = 0;
+    for (const p of points) {
+        sumLat += p.lat;
+        sumLng += p.lng;
+    }
+    return { lat: sumLat / points.length, lng: sumLng / points.length };
+}
+
+/**
+ * Maximum pairwise distance (in meters) across a set of points — the cluster's
+ * "diameter". This is the honest walking-crawl metric: the longest single hop a
+ * visitor would face inside the cluster. Centroid-radius would understate it.
+ */
+export function diameterMeters(points: ILatLng[]): number {
+    let max = 0;
+    for (let i = 0; i < points.length; i++) {
+        for (let j = i + 1; j < points.length; j++) {
+            const d = haversineMeters(points[i], points[j]);
+            if (d > max) max = d;
+        }
+    }
+    return max;
+}
+
+function pickStart<T extends IGeoSpace>(members: T[], centroid: ILatLng): T {
+    const topWeight = members.reduce((acc, m) => Math.max(acc, m.weight ?? 0), 0);
+    const topMembers = members.filter((m) => (m.weight ?? 0) === topWeight);
+    if (topMembers.length === 1) return topMembers[0];
+    // Tie-break by closeness to centroid (nicely positioned routes start near the middle).
+    return topMembers.reduce((best, m) => (
+        haversineMeters(m, centroid) < haversineMeters(best, centroid) ? m : best
+    ), topMembers[0]);
+}
+
+export interface ICluster<T extends IGeoSpace> {
+    /** Members of the cluster. Order is not meaningful here — call `orderAsWalkingRoute` for that. */
+    spaces: T[];
+    /** Simple mean of member coordinates. */
+    centroid: ILatLng;
+    /** Max pairwise distance across members, in meters. */
+    diameterMeters: number;
+}
+
+export interface IClusterOptions {
+    /**
+     * Upper bound on pairwise distance within a cluster (meters). A cluster
+     * must satisfy `diameterMeters(cluster) <= maxDiameterMeters`, otherwise
+     * members are split. Defaults to 1500m (~a ~19-min walk tip-to-tip,
+     * comfortably sized for a neighborhood crawl).
+     */
+    maxDiameterMeters?: number;
+    /** Minimum cluster size. Default 4. */
+    minSize?: number;
+    /** Maximum cluster size. Default 8. Excess members are dropped by lowest weight. */
+    maxSize?: number;
+}
+
+/**
+ * Greedy agglomerative-ish clustering tuned for editorial-list density:
+ *
+ * 1. Seed from the highest-weight space not yet assigned.
+ * 2. Walk neighbors (sorted by distance) and add them as long as the resulting
+ *    cluster's diameter stays within `maxDiameterMeters`.
+ * 3. Stop when the cluster hits `maxSize`, or no more neighbors fit.
+ * 4. Discard clusters smaller than `minSize`.
+ *
+ * This is intentionally simpler than DBSCAN — editorial clusters want a few
+ * clean, dense pockets, not full partitioning of the city. Noise / outliers
+ * just don't appear in output.
+ */
+export function clusterByRadius<T extends IGeoSpace>(
+    spaces: T[],
+    options: IClusterOptions = {},
+): ICluster<T>[] {
+    const maxDiameter = options.maxDiameterMeters ?? 1500;
+    const minSize = options.minSize ?? 4;
+    const maxSize = options.maxSize ?? 8;
+
+    // Filter out spaces without valid coordinates up front.
+    const candidates = spaces.filter((s) => Number.isFinite(s.lat) && Number.isFinite(s.lng));
+    // Descending by weight, then stable by id for determinism.
+    const seedOrder = [...candidates].sort((a, b) => {
+        const wa = a.weight ?? 0;
+        const wb = b.weight ?? 0;
+        if (wa !== wb) return wb - wa;
+        return a.id.localeCompare(b.id);
+    });
+
+    const used = new Set<string>();
+    const clusters: ICluster<T>[] = [];
+
+    for (const seed of seedOrder) {
+        if (!used.has(seed.id)) {
+            const members: T[] = [seed];
+            const neighbors = candidates
+                .filter((s) => s.id !== seed.id && !used.has(s.id))
+                .map((s) => ({ space: s, d: haversineMeters(seed, s) }))
+                .sort((a, b) => a.d - b.d);
+
+            for (const { space } of neighbors) {
+                if (members.length >= maxSize) break;
+                const tentative = [...members, space];
+                if (diameterMeters(tentative) <= maxDiameter) {
+                    members.push(space);
+                }
+            }
+
+            if (members.length >= minSize) {
+                for (const m of members) used.add(m.id);
+                clusters.push({
+                    spaces: members,
+                    centroid: centroidOf(members),
+                    diameterMeters: diameterMeters(members),
+                });
+            }
+            // If under minSize, leave other members unassigned so a weaker seed can retry them.
+            // Mark only the seed as used so we don't retry it.
+            used.add(seed.id);
+        }
+    }
+
+    return clusters;
+}
+
+/**
+ * Order cluster members into a walking route using a nearest-neighbor
+ * heuristic. Starts at the highest-weight member (falling back to the one
+ * closest to the centroid if weights are equal or absent), then repeatedly
+ * visits the unvisited member closest to the current position.
+ *
+ * Returns `[ordered members, legs]` where `legs[i]` is the walking distance
+ * in meters from `ordered[i]` to `ordered[i+1]` (so `legs.length === ordered.length - 1`).
+ *
+ * Nearest-neighbor is not optimal TSP but it's excellent for clusters of 4–8
+ * at neighborhood scale — and the resulting route is readable ("start at A,
+ * walk to B, then C…") which is the editorial goal.
+ */
+export function orderAsWalkingRoute<T extends IGeoSpace>(
+    cluster: ICluster<T>,
+): { ordered: T[]; legs: number[]; totalMeters: number } {
+    const members = cluster.spaces;
+    if (members.length === 0) return { ordered: [], legs: [], totalMeters: 0 };
+    if (members.length === 1) return { ordered: [members[0]], legs: [], totalMeters: 0 };
+
+    const start = pickStart(members, cluster.centroid);
+    const remaining = new Map(members.filter((m) => m.id !== start.id).map((m) => [m.id, m]));
+
+    const ordered: T[] = [start];
+    const legs: number[] = [];
+    let current: T = start;
+    while (remaining.size > 0) {
+        let nextEntry: T | null = null;
+        let nextDist = Infinity;
+        for (const m of remaining.values()) {
+            const d = haversineMeters(current, m);
+            if (d < nextDist) {
+                nextDist = d;
+                nextEntry = m;
+            }
+        }
+        if (nextEntry === null) break;
+        remaining.delete(nextEntry.id);
+        legs.push(nextDist);
+        ordered.push(nextEntry);
+        current = nextEntry;
+    }
+
+    const totalMeters = legs.reduce((acc, x) => acc + x, 0);
+    return { ordered, legs, totalMeters };
+}

--- a/therr-api-gateway/README.md
+++ b/therr-api-gateway/README.md
@@ -1,5 +1,3 @@
 # therr-api-gateway
 
-.....
-
-Updated at: 2026-04-19
+...

--- a/therr-client-web/src/routeConfig.ts
+++ b/therr-client-web/src/routeConfig.ts
@@ -305,6 +305,14 @@ export default [
         view: 'index',
     },
     {
+        route: '/guides/hashtag/:hashtag',
+        head: {
+            title: 'Hashtag Guides',
+            description: 'Local guides organized by intent — first date, late night, work-friendly, live music, and more.',
+        },
+        view: 'index',
+    },
+    {
         route: '/guides/:slug',
         head: {
             // Per-post title/description are injected by server-client.tsx from the post JSON.

--- a/therr-client-web/src/routes/Guide/GuidesIndex.tsx
+++ b/therr-client-web/src/routes/Guide/GuidesIndex.tsx
@@ -6,15 +6,15 @@ import {
 } from '@mantine/core';
 import { Categories, Cities } from 'therr-js-utilities/constants';
 import {
-    getPublishedGuides, getGuidesByCity, getGuidesByCategory, IPost,
+    getPublishedGuides, getGuidesByCity, getGuidesByCategory, getGuidesByHashtag, IPost,
 } from '../../utilities/guideContent';
 import withTranslation from '../../wrappers/withTranslation';
 
 interface IProps {
     locale: string;
     translate: (key: string, params?: any) => string;
-    /** When set, narrows the index by city or category (driven by the route). */
-    filterMode?: 'city' | 'category';
+    /** When set, narrows the index by city, category, or hashtag (driven by the route). */
+    filterMode?: 'city' | 'category' | 'hashtag';
 }
 
 function localePrefix(locale: string): string {
@@ -36,6 +36,15 @@ function categoryLabelFromSlug(slug: string): string {
     return key ? categoryLabelFromKey(key) : slug;
 }
 
+function hashtagLabel(tag: string): string {
+    const spaced = tag.replace(/-/g, ' ').replace(/\s+/g, ' ').trim();
+    return spaced
+        .split(' ')
+        .filter(Boolean)
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+}
+
 const GuideTeaser: React.FC<{ post: IPost; locale: string }> = ({ post, locale }) => {
     const prefix = localePrefix(locale);
     return (
@@ -51,6 +60,7 @@ const GuideTeaser: React.FC<{ post: IPost; locale: string }> = ({ post, locale }
                 <Group gap="xs">
                     {post.city && <Badge variant="outline" size="xs">{cityLabelFromSlug(post.city)}</Badge>}
                     {post.category && <Badge variant="outline" size="xs">{categoryLabelFromKey(post.category)}</Badge>}
+                    {post.hashtag && <Badge variant="outline" size="xs">{`#${post.hashtag}`}</Badge>}
                     <Text size="xs" c="dimmed">{post.publishedAt}</Text>
                 </Group>
             </Stack>
@@ -59,7 +69,7 @@ const GuideTeaser: React.FC<{ post: IPost; locale: string }> = ({ post, locale }
 };
 
 const GuidesIndex: React.FC<IProps> = ({ locale, filterMode }) => {
-    const params = useParams<{ citySlug?: string; categorySlug?: string }>();
+    const params = useParams<{ citySlug?: string; categorySlug?: string; hashtag?: string }>();
     let posts: IPost[];
     let pageTitle = 'Local Guides';
     let pageDescription = 'Editorial guides and data-driven posts about local businesses, neighborhoods, and what people actually do in your city.';
@@ -74,6 +84,11 @@ const GuidesIndex: React.FC<IProps> = ({ locale, filterMode }) => {
         const categoryLabel = categoryLabelFromSlug(params.categorySlug);
         pageTitle = `Guides — ${categoryLabel}`;
         pageDescription = `Local guides and data posts in the ${categoryLabel.toLowerCase()} category.`;
+    } else if (filterMode === 'hashtag' && params.hashtag) {
+        posts = getGuidesByHashtag(params.hashtag);
+        const tagLabel = hashtagLabel(params.hashtag);
+        pageTitle = `Guides — ${tagLabel}`;
+        pageDescription = `Local guides tagged ${tagLabel.toLowerCase()}.`;
     } else {
         posts = getPublishedGuides();
     }

--- a/therr-client-web/src/routes/Guide/index.tsx
+++ b/therr-client-web/src/routes/Guide/index.tsx
@@ -14,6 +14,7 @@ import DataCalloutSection from './sections/DataCalloutSection';
 import DataTableSection from './sections/DataTableSection';
 import FAQSection from './sections/FAQSection';
 import CTASection from './sections/CTASection';
+import WalkableRoute from './sections/WalkableRoute';
 import PageNotFound from '../PageNotFound';
 
 interface IGuideProps {
@@ -56,6 +57,19 @@ function renderSection(
             return <FAQSection key={idx} items={section.items} />;
         case 'cta':
             return <CTASection key={idx} heading={section.heading} body={section.body} href={section.href} ctaText={section.ctaText} />;
+        case 'walkable-route':
+            return (
+                <WalkableRoute
+                    key={idx}
+                    centroid={section.centroid}
+                    totalMeters={section.totalMeters}
+                    estimatedMinutes={section.estimatedMinutes}
+                    stops={section.stops}
+                    localePrefix={localePrefix(ctx.locale)}
+                    buildSpaceHref={(id, slug) => buildSpaceHref(ctx.locale, id, slug)}
+                    spaceMeta={ctx.spaceMeta}
+                />
+            );
         default:
             return null;
     }

--- a/therr-client-web/src/routes/Guide/sections/WalkableRoute.tsx
+++ b/therr-client-web/src/routes/Guide/sections/WalkableRoute.tsx
@@ -1,0 +1,101 @@
+/* eslint-disable max-len */
+import * as React from 'react';
+import {
+    Anchor, Badge, Group, Paper, Stack, Text, Title,
+} from '@mantine/core';
+import type { IWalkableRouteStop } from '../../../utilities/guideContent';
+import SpacesMap from '../../../components/SpacesMap';
+
+interface IProps {
+    centroid: { lat: number; lng: number };
+    totalMeters: number;
+    estimatedMinutes: number;
+    stops: IWalkableRouteStop[];
+    localePrefix: string;
+    buildSpaceHref: (spaceId: string, slug?: string) => string;
+    spaceMeta?: Record<string, { name: string; slug?: string }>;
+}
+
+const formatKm = (meters: number): string => {
+    if (meters < 1000) return `${Math.round(meters)}m`;
+    return `${(meters / 1000).toFixed(1)}km`;
+};
+
+const WalkableRoute: React.FC<IProps> = ({
+    centroid,
+    totalMeters,
+    estimatedMinutes,
+    stops,
+    localePrefix,
+    buildSpaceHref,
+    spaceMeta,
+}) => {
+    const ordered = [...stops].sort((a, b) => a.order - b.order);
+    const mapSpaces = ordered.map((stop) => ({
+        id: stop.spaceId,
+        notificationMsg: spaceMeta?.[stop.spaceId]?.name || stop.name,
+        latitude: stop.lat,
+        longitude: stop.lng,
+    }));
+
+    return (
+        <Stack gap="md">
+            <Group gap="md" wrap="wrap">
+                <Badge size="lg" variant="light" color="blue">
+                    {formatKm(totalMeters)} total
+                </Badge>
+                <Badge size="lg" variant="light" color="blue">
+                    ~{estimatedMinutes} min walk
+                </Badge>
+                <Badge size="lg" variant="light" color="gray">
+                    {ordered.length} stops
+                </Badge>
+            </Group>
+
+            <Stack gap="sm">
+                {ordered.map((stop, idx) => {
+                    const meta = spaceMeta?.[stop.spaceId];
+                    const displayName = meta?.name || stop.name;
+                    const href = buildSpaceHref(stop.spaceId, meta?.slug);
+                    return (
+                        <React.Fragment key={stop.spaceId}>
+                            {idx > 0 && stop.walkFromPreviousMeters != null && (
+                                <Group gap="xs" pl="md">
+                                    <Text size="xs" c="dimmed">
+                                        ↓ walk {formatKm(stop.walkFromPreviousMeters)}
+                                    </Text>
+                                </Group>
+                            )}
+                            <Paper p="md" withBorder>
+                                <Stack gap="xs">
+                                    <Group gap="sm" align="baseline">
+                                        <Badge size="lg" variant="filled" color="blue">
+                                            Stop {stop.order}
+                                        </Badge>
+                                        <Title order={3} size="h4">
+                                            <Anchor href={href}>{displayName}</Anchor>
+                                        </Title>
+                                    </Group>
+                                    {stop.note && (
+                                        <Text size="md">{stop.note}</Text>
+                                    )}
+                                </Stack>
+                            </Paper>
+                        </React.Fragment>
+                    );
+                })}
+            </Stack>
+
+            <SpacesMap
+                spaces={mapSpaces}
+                centerLat={centroid.lat}
+                centerLng={centroid.lng}
+                localePrefix={localePrefix}
+                height={360}
+                interactive
+            />
+        </Stack>
+    );
+};
+
+export default WalkableRoute;

--- a/therr-client-web/src/routes/index.tsx
+++ b/therr-client-web/src/routes/index.tsx
@@ -565,6 +565,10 @@ const getRoutes = (routePropsConfig: IRoutePropsConfig): IRoute[] => [
         element: <GuidesIndex filterMode="category" />,
     },
     {
+        path: '/guides/hashtag/:hashtag',
+        element: <GuidesIndex filterMode="hashtag" />,
+    },
+    {
         path: '/guides/:slug',
         element: <Guide />,
     },

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -446,9 +446,11 @@ app.get('/sitemap-guides.xml', (req, res) => {
     const posts = getPublishedGuides();
     const cities = new Set<string>();
     const categories = new Set<string>();
+    const hashtags = new Set<string>();
     posts.forEach((p) => {
         if (p.city) cities.add(p.city);
         if (p.category) categories.add(p.category);
+        if (p.hashtag) hashtags.add(p.hashtag);
     });
 
     const urls: string[] = [];
@@ -458,6 +460,7 @@ app.get('/sitemap-guides.xml', (req, res) => {
         const slug = getCategoryUrlSlug(c);
         if (slug) urls.push(buildUrlSet(`/guides/category/${slug}`, today, '0.75'));
     });
+    hashtags.forEach((h) => urls.push(buildUrlSet(`/guides/hashtag/${h}`, today, '0.75')));
     posts.forEach((p) => {
         const lastmod = (p.updatedAt || p.publishedAt || today).slice(0, 10);
         urls.push(buildUrlSet(`/guides/${p.slug}`, lastmod, '0.80'));

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -1887,6 +1887,7 @@ const renderGuideView = (req, res, config, { markup, state }, localeVars) => {
         breadcrumbSchema: schemas.breadcrumbSchema,
         itemListSchema: schemas.itemListSchema,
         faqSchema: schemas.faqSchema,
+        touristTripSchema: schemas.touristTripSchema,
         markup,
         routePath,
         state,

--- a/therr-client-web/src/utilities/guideContent.ts
+++ b/therr-client-web/src/utilities/guideContent.ts
@@ -30,6 +30,8 @@ export interface IPostMetadata {
     description: string;
     city?: string;
     category?: string;
+    /** Hashtag anchor (mutually exclusive with category). See CONTENT_HASHTAG_GUIDES_PLAN.md. */
+    hashtag?: string;
     publishedAt: string;
     updatedAt: string;
     author: string;
@@ -111,6 +113,11 @@ export function getGuidesByCategory(categorySlug: string): IPost[] {
     return getPublishedGuides().filter((p) => p.category === categoryKey);
 }
 
+export function getGuidesByHashtag(hashtag: string): IPost[] {
+    const normalized = hashtag.toLowerCase();
+    return getPublishedGuides().filter((p) => (p.hashtag || '').toLowerCase() === normalized);
+}
+
 /** URL slug for a post's category, suitable for /guides/category/<slug>. */
 export function getCategoryUrlSlug(categoryKey?: string): string | undefined {
     if (!categoryKey) return undefined;
@@ -148,6 +155,7 @@ export function resolveGuideForLocale(post: IPost, locale: string): IResolvedPos
             description: post.description,
             city: post.city,
             category: post.category,
+            hashtag: post.hashtag,
             publishedAt: post.publishedAt,
             updatedAt: post.updatedAt,
             author: post.author,

--- a/therr-client-web/src/utilities/guideContent.ts
+++ b/therr-client-web/src/utilities/guideContent.ts
@@ -46,13 +46,30 @@ export interface ISpaceListItem {
     reason?: string;
 }
 
+export interface IWalkableRouteStop {
+    spaceId: string;
+    order: number;
+    lat: number;
+    lng: number;
+    name: string;
+    walkFromPreviousMeters?: number;
+    note?: string;
+}
+
 export type IPostSection =
     | { type: 'prose'; body: string }
     | { type: 'space-list'; items: ISpaceListItem[] }
     | { type: 'data-callout'; stat: string; statLabel: string; body?: string }
     | { type: 'data-table'; caption: string; headers: string[]; rows: (string | number)[][] }
     | { type: 'faq'; items: { question: string; answer: string }[] }
-    | { type: 'cta'; heading: string; body: string; href?: string; ctaText?: string };
+    | { type: 'cta'; heading: string; body: string; href?: string; ctaText?: string }
+    | {
+        type: 'walkable-route';
+        centroid: { lat: number; lng: number };
+        totalMeters: number;
+        estimatedMinutes: number;
+        stops: IWalkableRouteStop[];
+    };
 
 export interface IPostLocaleContent {
     title: string;

--- a/therr-client-web/src/utilities/guideJsonLd.ts
+++ b/therr-client-web/src/utilities/guideJsonLd.ts
@@ -19,6 +19,17 @@ export interface IGuideSchemas {
 
 const escapeForJsonLd = (input: any): string => JSON.stringify(input);
 
+function humanizeHashtag(tag: string): string {
+    return tag
+        .replace(/-/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .split(' ')
+        .filter(Boolean)
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+}
+
 const buildArticle = ({ post, resolved, canonicalPath }: IBuildArgs) => {
     const article: any = {
         '@context': 'https://schema.org',
@@ -49,6 +60,9 @@ const buildArticle = ({ post, resolved, canonicalPath }: IBuildArgs) => {
     if (post.heroImage?.url) {
         article.image = post.heroImage.url;
     }
+    if (post.hashtag) {
+        article.keywords = post.hashtag;
+    }
     return article;
 };
 
@@ -64,9 +78,17 @@ const buildBreadcrumb = ({ post, resolved, canonicalPath }: IBuildArgs) => {
     if (post.city) {
         items.push({
             '@type': 'ListItem',
-            position: 3,
+            position: items.length + 1,
             name: post.city,
             item: `${SITE_ORIGIN}/guides/city/${post.city}`,
+        });
+    }
+    if (post.hashtag) {
+        items.push({
+            '@type': 'ListItem',
+            position: items.length + 1,
+            name: humanizeHashtag(post.hashtag),
+            item: `${SITE_ORIGIN}/guides/hashtag/${post.hashtag}`,
         });
     }
     items.push({

--- a/therr-client-web/src/utilities/guideJsonLd.ts
+++ b/therr-client-web/src/utilities/guideJsonLd.ts
@@ -15,6 +15,7 @@ export interface IGuideSchemas {
     breadcrumbSchema: string;
     itemListSchema: string;
     faqSchema: string;
+    touristTripSchema: string;
 }
 
 const escapeForJsonLd = (input: any): string => JSON.stringify(input);
@@ -132,6 +133,51 @@ const buildItemList = ({ resolved, spaceMeta }: IBuildArgs) => {
     };
 };
 
+const buildTouristTrip = ({ resolved, spaceMeta }: IBuildArgs) => {
+    const routeSection = resolved.sections.find(
+        (s): s is Extract<IPostSection, { type: 'walkable-route' }> => s.type === 'walkable-route',
+    );
+    if (!routeSection || !routeSection.stops?.length) return null;
+    const ordered = [...routeSection.stops].sort((a, b) => a.order - b.order);
+    // Schema.org TouristTrip expects ISO 8601 duration for estimatedFlightDuration;
+    // the equivalent for touristType/itinerary is plain minutes on the item. Use
+    // `itinerary` with a list of `TouristAttraction`s and describe the route
+    // with `touristType` + a narrative `description`.
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'TouristTrip',
+        name: resolved.title,
+        description: resolved.description,
+        touristType: 'Walking tour',
+        itinerary: {
+            '@type': 'ItemList',
+            numberOfItems: ordered.length,
+            itemListElement: ordered.map((stop, index) => {
+                const meta = spaceMeta?.[stop.spaceId];
+                const name = meta?.name || stop.name || stop.spaceId;
+                const slug = meta?.slug;
+                const url = slug
+                    ? `${SITE_ORIGIN}/spaces/${stop.spaceId}/${slug}`
+                    : `${SITE_ORIGIN}/spaces/${stop.spaceId}`;
+                return {
+                    '@type': 'ListItem',
+                    position: index + 1,
+                    item: {
+                        '@type': 'TouristAttraction',
+                        name,
+                        url,
+                        geo: {
+                            '@type': 'GeoCoordinates',
+                            latitude: stop.lat,
+                            longitude: stop.lng,
+                        },
+                    },
+                };
+            }),
+        },
+    };
+};
+
 const buildFaq = ({ resolved }: IBuildArgs) => {
     const faqSection = resolved.sections.find((s): s is Extract<IPostSection, { type: 'faq' }> => s.type === 'faq');
     if (!faqSection || !faqSection.items?.length) return null;
@@ -152,10 +198,12 @@ const buildFaq = ({ resolved }: IBuildArgs) => {
 export const buildGuideSchemas = (args: IBuildArgs): IGuideSchemas => {
     const itemList = buildItemList(args);
     const faq = buildFaq(args);
+    const touristTrip = buildTouristTrip(args);
     return {
         articleSchema: escapeForJsonLd(buildArticle(args)),
         breadcrumbSchema: escapeForJsonLd(buildBreadcrumb(args)),
         itemListSchema: itemList ? escapeForJsonLd(itemList) : '',
         faqSchema: faq ? escapeForJsonLd(faq) : '',
+        touristTripSchema: touristTrip ? escapeForJsonLd(touristTrip) : '',
     };
 };

--- a/therr-client-web/src/views/guides.hbs
+++ b/therr-client-web/src/views/guides.hbs
@@ -88,6 +88,9 @@
     {{#if faqSchema}}
     <script type="application/ld+json">{{{faqSchema}}}</script>
     {{/if}}
+    {{#if touristTripSchema}}
+    <script type="application/ld+json">{{{touristTripSchema}}}</script>
+    {{/if}}
 </head>
 
 <body>


### PR DESCRIPTION
Wires the editorial guide pipeline to rank spaces by intent hashtag (e.g. firstdate, latenight) as an alternative anchor to category.

- discover-hashtags.ts: per-city tag frequency, `--intentOnly` allowlist
- query-by-hashtag.ts: exact normalized tag match, same auto/engagement /curated fallback as query-top-spaces; `--hashtag` strips any leading `#`
- validatePost: XOR rule (exactly one of category|hashtag) + hashtag format check; hashtag field mirrored into guideContent.ts
- JSON-LD: hashtag breadcrumb (humanized label → /guides/hashtag/<tag>), Article keywords; breadcrumb positions computed dynamically
- Routing: /guides/hashtag/:hashtag filter listing (sibling to /guides/city and /guides/category); sitemap emits hashtag URLs
- SKILL.md: Mode 5 documented; discovery caveat called out (hashTags column is currently OSM-ingested, not yet user-intent)
- Fix max-len lint in reason strings for query-top-spaces.ts and query-by-hashtag.ts

Phase 5 (pilot posts) not started — the current spaces.hashTags data is dominated by OSM-derived category-like tags; intent-shaped tag enrichment upstream is needed before shipping a first-date / late-night guide would be honest.