### PR TITLE
Remove LogRocket from web clients

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,8 +235,6 @@
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.0.0",
     "leaflet": "^1.9.4",
-    "logrocket": "^3.0.1",
-    "logrocket-react": "^5.0.1",
     "lottie-react": "^2.4.0",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.43",

--- a/therr-client-web-dashboard/src/index.tsx
+++ b/therr-client-web-dashboard/src/index.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import LogRocket from 'logrocket';
-import setupLogRocketReact from 'logrocket-react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
@@ -29,9 +27,6 @@ const RootComponent = () => (
     </Provider>
 );
 
-LogRocket.init('pibaqj/business-dashboard-web-app');
-// after calling LogRocket.init()
-setupLogRocketReact(LogRocket);
 if (process.env.NODE_ENV === 'development') {
     createRoot(rootEl).render(<RootComponent />);
 } else {

--- a/therr-client-web-dashboard/src/routes/Login/index.tsx
+++ b/therr-client-web-dashboard/src/routes/Login/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Location, NavigateFunction, Link } from 'react-router-dom';
-import LogRocket from 'logrocket';
 import { IUserState } from 'therr-react/types';
 import {
     Col,
@@ -74,11 +73,6 @@ export class LoginComponent extends React.Component<ILoginProps, ILoginState> {
     static getDerivedStateFromProps(nextProps: ILoginProps) {
         // TODO: Choose route based on accessLevels
         if (!shouldRenderLoginForm(nextProps)) {
-            LogRocket.identify(nextProps.user.details.id, {
-                name: `${nextProps.user.details.firstName} ${nextProps.user.details.lastName}`,
-                email: nextProps.user.details.email,
-                // Add your own custom user variables below:
-            });
             // TODO: This doesn't seem to work with react-router-dom v6 after a newly created user tries to login
             // Causes a flicker / Need to investigate further
             setTimeout(() => nextProps.navigation.navigate(routeAfterLogin));

--- a/therr-client-web-dashboard/src/routes/OAuth2Landing.tsx
+++ b/therr-client-web-dashboard/src/routes/OAuth2Landing.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Location, NavigateFunction, Link } from 'react-router-dom';
-import LogRocket from 'logrocket';
 import { IUserState } from 'therr-react/types';
 import {
     Col,
@@ -73,11 +72,6 @@ export class OAuth2LandingComponent extends React.Component<IOAuth2LandingProps,
     static getDerivedStateFromProps(nextProps: IOAuth2LandingProps) {
         // TODO: Choose route based on accessLevels
         if (!shouldRenderLoginForm(nextProps)) {
-            LogRocket.identify(nextProps.user.details.id, {
-                name: `${nextProps.user.details.firstName} ${nextProps.user.details.lastName}`,
-                email: nextProps.user.details.email,
-                // Add your own custom user variables below:
-            });
             // TODO: This doesn't seem to work with react-router-dom v6 after a newly created user tries to login
             // Causes a flicker / Need to investigate further
             setTimeout(() => {

--- a/therr-client-web-dashboard/src/routes/Register/index.tsx
+++ b/therr-client-web-dashboard/src/routes/Register/index.tsx
@@ -10,7 +10,6 @@ import {
     ToastContainer,
     Button,
 } from 'react-bootstrap';
-import LogRocket from 'logrocket';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faFacebookF } from '@fortawesome/free-brands-svg-icons';
 import Toast from 'react-bootstrap/Toast';
@@ -67,11 +66,6 @@ export class RegisterComponent extends React.Component<IRegisterProps, IRegister
     static getDerivedStateFromProps(nextProps: IRegisterProps) {
         // TODO: Choose route based on accessLevels
         if (!shouldRenderLoginForm(nextProps)) {
-            LogRocket.identify(nextProps.user.details.id, {
-                name: `${nextProps.user.details.firstName} ${nextProps.user.details.lastName}`,
-                email: nextProps.user.details.email,
-                // Add your own custom user variables below:
-            });
             // TODO: This doesn't seem to work with react-router-dom v6 after a newly created user tries to login
             // Causes a flicker / Need to investigate further
             setTimeout(() => nextProps.navigation.navigate(routeAfterLogin));

--- a/therr-client-web-dashboard/src/server-client.tsx
+++ b/therr-client-web-dashboard/src/server-client.tsx
@@ -10,7 +10,6 @@ import * as ReactDOMServer from 'react-dom/server'; // eslint-disable-line impor
 import { matchPath } from 'react-router-dom';
 import { StaticRouter } from 'react-router-dom/server';
 import ReactGA from 'react-ga4';
-import LogRocket from 'logrocket';
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import printLogs from 'therr-js-utilities/print-logs';
@@ -56,11 +55,6 @@ if (process.env.NODE_ENV !== 'development') {
                     "'self'",
                     'https://*.therr.com',
                     'wss://*.therr.com',
-                    // LogRocket
-                    'https://*.lr-in-prod.com',
-                    'https://*.lr-ingest.com',
-                    'https://*.logrocket.io',
-                    'https://*.logrocket.com',
                     // Google Analytics
                     'https://*.google-analytics.com',
                     'https://*.analytics.google.com',
@@ -71,8 +65,6 @@ if (process.env.NODE_ENV !== 'development') {
                     "'unsafe-inline'",
                     'https://*.googletagmanager.com',
                     'https://*.google-analytics.com',
-                    'https://cdn.lr-in-prod.com',
-                    'https://cdn.lr-ingest.com',
                 ],
                 styleSrc: [
                     "'self'",
@@ -144,7 +136,7 @@ routeConfig.forEach((config) => {
         const store = configureStore({
             reducer: rootReducer,
             preloadedState: initialState,
-            middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(socketIOMiddleWare).concat(LogRocket.reduxMiddleware()),
+            middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(socketIOMiddleWare),
         });
 
         getRoutes({

--- a/therr-client-web-dashboard/src/store.tsx
+++ b/therr-client-web-dashboard/src/store.tsx
@@ -1,4 +1,3 @@
-import LogRocket from 'logrocket';
 import logger from 'redux-logger';
 import { configureStore, Middleware } from '@reduxjs/toolkit';
 import rootReducer from './redux/reducers';
@@ -53,10 +52,10 @@ if (typeof (Storage) !== 'undefined' && typeof (window) !== 'undefined') {
 
 const getMiddleware = (getDefaultMiddleware: any) => {
     if (process.env.NODE_ENV === 'development') {
-        return getDefaultMiddleware().concat(socketIOMiddleWare).concat(LogRocket.reduxMiddleware()).concat(logger as Middleware);
+        return getDefaultMiddleware().concat(socketIOMiddleWare).concat(logger as Middleware);
     }
 
-    return getDefaultMiddleware().concat(socketIOMiddleWare).concat(LogRocket.reduxMiddleware());
+    return getDefaultMiddleware().concat(socketIOMiddleWare);
 };
 
 const store: any = configureStore( // Create Store (Production)

--- a/therr-client-web/src/index.tsx
+++ b/therr-client-web/src/index.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import LogRocket from 'logrocket';
-import setupLogRocketReact from 'logrocket-react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
@@ -63,9 +61,3 @@ if (process.env.NODE_ENV === 'development') {
         <RootComponent />,
     );
 }
-
-// Defer LogRocket initialization to reduce main thread blocking during page load
-requestIdleCallback(() => {
-    LogRocket.init('pibaqj/therr-web-app');
-    setupLogRocketReact(LogRocket);
-}, { timeout: 5000 });

--- a/therr-client-web/src/routes/Login.tsx
+++ b/therr-client-web/src/routes/Login.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import LogRocket from 'logrocket';
 import qs from 'qs';
 import { IUserState } from 'therr-react/types';
 import { AccessLevels } from 'therr-js-utilities/constants';
@@ -80,10 +79,6 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
 export class LoginComponent extends React.Component<ILoginProps, ILoginState> {
     static getDerivedStateFromProps(nextProps: ILoginProps) {
         if (!shouldRenderLoginForm(nextProps)) {
-            LogRocket.identify(nextProps.user.details.id, {
-                name: `${nextProps.user.details.firstName} ${nextProps.user.details.lastName}`,
-                email: nextProps.user.details.email,
-            });
             const returnTo = getReturnTo(nextProps.location?.search);
             const destination = getRouteAfterLogin(nextProps.user, returnTo);
             setTimeout(() => nextProps.navigation.navigate(destination));

--- a/therr-client-web/src/routes/Register.tsx
+++ b/therr-client-web/src/routes/Register.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Location, NavigateFunction } from 'react-router-dom';
-import LogRocket from 'logrocket';
 import qs from 'qs';
 import { IUserState } from 'therr-react/types';
 import RegisterForm from '../components/forms/RegisterForm';
@@ -53,10 +52,6 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
 export class RegisterComponent extends React.Component<IRegisterProps, IRegisterState> {
     static getDerivedStateFromProps(nextProps: IRegisterProps) {
         if (!shouldRenderLoginForm(nextProps as any)) {
-            LogRocket.identify(nextProps.user.details.id, {
-                name: `${nextProps.user.details.firstName} ${nextProps.user.details.lastName}`,
-                email: nextProps.user.details.email,
-            });
             const returnTo = getReturnTo(nextProps.location?.search);
             const destination = getRouteAfterLogin(nextProps.user, returnTo);
             setTimeout(() => nextProps.navigation.navigate(destination));

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -10,7 +10,6 @@ import * as ReactDOMServer from 'react-dom/server'; // eslint-disable-line impor
 import { matchPath } from 'react-router-dom';
 import { StaticRouter } from 'react-router-dom/server';
 // ReactGA removed from server — analytics should only run client-side
-// LogRocket removed from server — session replay only runs client-side
 import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 import { MantineProvider } from '@mantine/core';
@@ -82,11 +81,6 @@ if (process.env.NODE_ENV !== 'development') {
                     "'self'",
                     'https://*.therr.com',
                     'wss://*.therr.com',
-                    // LogRocket
-                    'https://*.lr-in-prod.com',
-                    'https://*.lr-ingest.com',
-                    'https://*.logrocket.io',
-                    'https://*.logrocket.com',
                     // Google Analytics
                     'https://*.google-analytics.com',
                     'https://*.analytics.google.com',
@@ -107,8 +101,6 @@ if (process.env.NODE_ENV !== 'development') {
                     "'unsafe-inline'",
                     'https://*.googletagmanager.com',
                     'https://*.google-analytics.com',
-                    'https://cdn.lr-in-prod.com',
-                    'https://cdn.lr-ingest.com',
                     // Google Sign-In
                     'https://accounts.google.com',
                     // Cloudflare Insights / Web Analytics

--- a/therr-client-web/src/store.tsx
+++ b/therr-client-web/src/store.tsx
@@ -1,4 +1,3 @@
-import LogRocket from 'logrocket';
 import logger from 'redux-logger';
 import { configureStore, Middleware } from '@reduxjs/toolkit';
 import { persistStore, persistReducer } from 'redux-persist';
@@ -93,10 +92,10 @@ const getMiddleware = (getDefaultMiddleware: any) => {
     });
 
     if (process.env.NODE_ENV === 'development') {
-        return middleware.concat(socketIOMiddleWare).concat(LogRocket.reduxMiddleware()).concat(logger as Middleware);
+        return middleware.concat(socketIOMiddleWare).concat(logger as Middleware);
     }
 
-    return middleware.concat(socketIOMiddleWare).concat(LogRocket.reduxMiddleware());
+    return middleware.concat(socketIOMiddleWare);
 };
 
 const store: any = configureStore(


### PR DESCRIPTION
LogRocket is no longer used. Removing its SDK from both web apps to
eliminate the third-party script/session-replay overhead that hurts
pagespeed. Dropped imports, init, identify, and redux middleware calls
from therr-client-web and therr-client-web-dashboard, trimmed the
related CSP allowlist entries, and removed logrocket + logrocket-react
from root dependencies. TherrMobile is untouched.

https://claude.ai/code/session_01SwrpLww5AKkm9Mz7MRondq