### PR TITLE
fix(mobile): render header search placeholder on first paint

### DIFF
--- a/TherrMobile/main/components/Input/HeaderSearchInput.tsx
+++ b/TherrMobile/main/components/Input/HeaderSearchInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform, StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, TextInput as RNTextInput, View } from 'react-native';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Badge } from 'react-native-paper';
@@ -172,6 +172,13 @@ export class HeaderSearchInput extends React.Component<IHeaderSearchInputProps, 
                     onFocus={() => this.handlePress('onfocus')}
                     placeholder={placeholderText}
                     placeholderTextColor={theme.colorVariations.textGrayFade}
+                    render={(inputProps) => (
+                        <RNTextInput
+                            {...inputProps}
+                            placeholder={placeholderText}
+                            placeholderTextColor={theme.colorVariations.textGrayFade}
+                        />
+                    )}
                     underlineColor="transparent"
                     activeUnderlineColor="transparent"
                     dense

--- a/TherrMobile/main/components/Input/HeaderSearchUsersInput.tsx
+++ b/TherrMobile/main/components/Input/HeaderSearchUsersInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform, StyleSheet, TextInputProps } from 'react-native';
+import { Platform, StyleSheet, TextInput as RNTextInput, TextInputProps } from 'react-native';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import 'react-native-gesture-handler';
@@ -99,6 +99,7 @@ export class HeaderSearchUsersInput extends React.Component<IHeaderSearchUsersIn
         const textStyle = !inputText?.length
             ? [themeForms.styles.placeholderText, { fontSize: 16 }]
             : [themeForms.styles.inputText, { fontSize: 16 }];
+        const placeholderText = this.translate('components.header.searchUsersInput.placeholder');
         return (
             <>
                 <RoundInput
@@ -118,8 +119,15 @@ export class HeaderSearchUsersInput extends React.Component<IHeaderSearchUsersIn
                     inputContainerStyle={[themeForms.styles.inputContainerRound, theme.styles.headerSearchInputContainer]}
                     roundness={18}
                     onChangeText={this.onInputChange}
-                    placeholder={this.translate('components.header.searchUsersInput.placeholder')}
+                    placeholder={placeholderText}
                     placeholderTextColor={theme.colorVariations.textGrayFade}
+                    render={(inputProps) => (
+                        <RNTextInput
+                            {...inputProps}
+                            placeholder={placeholderText}
+                            placeholderTextColor={theme.colorVariations.textGrayFade}
+                        />
+                    )}
                     underlineColor="transparent"
                     activeUnderlineColor="transparent"
                     rightIcon={

--- a/TherrMobile/main/components/Input/index.tsx
+++ b/TherrMobile/main/components/Input/index.tsx
@@ -36,6 +36,11 @@ export interface IBaseInputProps extends TextInputProps {
     underlineStyle?: any;
     dense?: boolean;
     roundness?: number;
+    // Paper TextInput render override. Useful to bypass Paper's deferred
+    // placeholder state (which is initialized to ' ' and only swapped to
+    // the real value via a 50ms timer that races with native-stack header
+    // animations, leaving headers blank on first render).
+    render?: (props: any) => React.ReactNode;
 }
 
 // BaseInput wrapping react-native-paper TextInput.


### PR DESCRIPTION
Paper's TextInput holds `placeholder` in internal state initialized to
' ' and only swaps in the real value via a 50ms setTimeout inside a
useEffect — a race that loses against native-stack header animations,
leaving the Map/Areas/Connect search inputs blank until first focus.

Pass a `render` override that drops the real placeholder onto RN's
TextInput directly, bypassing Paper's deferred placeholder state.

https://claude.ai/code/session_011q3k9AUg8pzESHy3ZyTxKs