### PR TITLE
Fix session-long navigation perf degradation

### DIFF
--- a/TherrMobile/main/components/Layout.tsx
+++ b/TherrMobile/main/components/Layout.tsx
@@ -221,15 +221,11 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
             });
         }
 
-        // Socket reconnection handlers (ensure token is refreshed on reconnect)
-        socketIO.on('reconnect_attempt', () => {
-            updateSocketToken(this.props.user);
-        });
-        socketIO.on('reconnect', () => {
-            if (this.props.user && this.props.user.isAuthenticated) {
-                this.props.refreshConnection(this.props.user);
-            }
-        });
+        // Socket reconnection handlers (ensure token is refreshed on reconnect).
+        // Store references so we can detach them in componentWillUnmount; otherwise
+        // each Layout remount (login/logout cycle) accumulates duplicate handlers.
+        socketIO.on('reconnect_attempt', this.handleSocketReconnectAttempt);
+        socketIO.on('reconnect', this.handleSocketReconnect);
 
         this.subscriptions.push(BackgroundGeolocation.onLocation((/* location */) => {
             logEvent(getAnalytics(),'background_location_on_location', {
@@ -423,9 +419,22 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
             this.authCredentialListener();
         }
 
+        socketIO.off('reconnect_attempt', this.handleSocketReconnectAttempt);
+        socketIO.off('reconnect', this.handleSocketReconnect);
+
         this.unsubscribePushNotifications && this.unsubscribePushNotifications();
         this.subscriptions.forEach((subscription) => subscription.remove());
     }
+
+    handleSocketReconnectAttempt = () => {
+        updateSocketToken(this.props.user);
+    };
+
+    handleSocketReconnect = () => {
+        if (this.props.user && this.props.user.isAuthenticated) {
+            this.props.refreshConnection(this.props.user);
+        }
+    };
 
     // IMPORTANT: This should only be called once per session
     readyAndStartBackgroundGeolocation = () => {
@@ -1527,6 +1536,7 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
 
                         const baseOptions: any = {
                             animation: 'fade',
+                            freezeOnBlur: true,
                             headerLeft: () => headerLeftNode,
                             headerRight: () => headerRightNode,
                             headerTitleStyle: {

--- a/TherrMobile/main/constants/index.tsx
+++ b/TherrMobile/main/constants/index.tsx
@@ -61,6 +61,7 @@ const MIN_LOAD_TIMEOUT = 350;
 const DEFAULT_MOMENT_PROXIMITY = 25;
 const MIN_ZOOM_LEVEL = 1; // Setting this too high may break animation to regions that excede the minimum zoom
 const MOMENTS_REFRESH_THROTTLE_MS = 30 * 1000;
+const MAP_SEARCH_MIN_DISTANCE_METERS = 150; // Skip refetch when user has moved less than this since the last search
 const LOCATION_PROCESSING_THROTTLE_MS = 5 * 1000;
 const MAX_DISTANCE_TO_NEARBY_SPACE = 120; // Distance in meters (roughly 400 feet)
 const EST_US_RADIUS_METERS = 6250000;
@@ -175,6 +176,7 @@ export {
     MAX_LOAD_TIMEOUT,
     MIN_ZOOM_LEVEL,
     MOMENTS_REFRESH_THROTTLE_MS,
+    MAP_SEARCH_MIN_DISTANCE_METERS,
     LOCATION_PROCESSING_THROTTLE_MS,
     MAX_DISTANCE_TO_NEARBY_SPACE,
     EST_US_RADIUS_METERS,

--- a/TherrMobile/main/routes/Map/index.tsx
+++ b/TherrMobile/main/routes/Map/index.tsx
@@ -32,6 +32,7 @@ import {
     PRIMARY_LONGITUDE_DELTA,
     MIN_LOAD_TIMEOUT,
     MOMENTS_REFRESH_THROTTLE_MS,
+    MAP_SEARCH_MIN_DISTANCE_METERS,
     DEFAULT_LONGITUDE,
     DEFAULT_LATITUDE,
     MAX_ANIMATION_LATITUDE_DELTA,
@@ -253,6 +254,10 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
     private initialVisibilityFilters;
     private mapRef: any;
     private mapWatchId;
+    private lastSearchAt?: number;
+    private lastSearchCoords?: { latitude: number, longitude: number };
+    private searchInFlight?: Promise<any>;
+    private searchAbortController?: AbortController;
     private theme = buildStyles();
     private themeAlerts = buildAlertStyles();
     private themeConfirmModal = buildConfirmModalStyles();
@@ -413,6 +418,14 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
 
         this.unsubscribeBlurListener = navigation.addListener('blur', () => {
             this.clearTimeouts();
+            if (this.mapWatchId !== undefined) {
+                Geolocation.clearWatch(this.mapWatchId);
+                this.mapWatchId = undefined;
+            }
+            if (this.searchAbortController) {
+                this.searchAbortController.abort();
+                this.searchAbortController = undefined;
+            }
         });
 
         this.unsubscribeFocusListener = navigation.addListener('focus', () => {
@@ -485,6 +498,10 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
     componentWillUnmount() {
         Geolocation.clearWatch(this.mapWatchId);
         this.clearTimeouts();
+        if (this.searchAbortController) {
+            this.searchAbortController.abort();
+            this.searchAbortController = undefined;
+        }
         if (this.unsubscribeNavigationListener) {
             this.unsubscribeNavigationListener();
         }
@@ -1229,7 +1246,8 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
             itemsPerPage: number,
             meItemsPerPage: number,
         },
-        distanceOverride?: any) => {
+        distanceOverride?: any,
+        options?: { signal?: AbortSignal }) => {
         const {
             findEventReactions,
             findMomentReactions,
@@ -1247,7 +1265,7 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
                 order: 'desc',
                 filterBy: 'fromUserIds',
                 ...longLat,
-            }, distanceOverride),
+            }, distanceOverride, options),
             searchSpaces({
                 query: 'connections',
                 itemsPerPage: conditions.itemsPerPage,
@@ -1255,7 +1273,7 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
                 order: 'desc',
                 filterBy: 'fromUserIds',
                 ...longLat,
-            }, distanceOverride),
+            }, distanceOverride, options),
             searchEvents({
                 query: 'connections',
                 itemsPerPage: conditions.itemsPerPage,
@@ -1263,7 +1281,7 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
                 order: 'desc',
                 filterBy: 'fromUserIds',
                 ...longLat,
-            }, distanceOverride),
+            }, distanceOverride, options),
         ];
 
         if (this.isUserAuthenticated()) {
@@ -1275,7 +1293,7 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
                     order: 'desc',
                     filterBy: 'fromUserIds',
                     ...longLat,
-                }, distanceOverride),
+                }, distanceOverride, options),
                 searchSpaces({
                     query: 'me',
                     itemsPerPage: conditions.meItemsPerPage,
@@ -1283,7 +1301,7 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
                     order: 'desc',
                     filterBy: 'fromUserIds',
                     ...longLat,
-                }, distanceOverride),
+                }, distanceOverride, options),
                 searchEvents({
                     query: 'me',
                     itemsPerPage: conditions.meItemsPerPage,
@@ -1291,7 +1309,7 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
                     order: 'desc',
                     filterBy: 'fromUserIds',
                     ...longLat,
-                }, distanceOverride)
+                }, distanceOverride, options)
             );
         }
 
@@ -1502,7 +1520,7 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
         }
     };
 
-    handleSearchThisLocation = (searchRadius?, latitude?, longitude?): Promise<any> => {
+    handleSearchThisLocation = (searchRadius?, latitude?, longitude?, overrideThrottle = false): Promise<any> => {
         const { region } = this.state;
         const { location } = this.props;
         this.setState({
@@ -1515,6 +1533,27 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
         if (!latitude || !longitude) {
             lat = region.latitude;
             long = region.longitude;
+        }
+
+        // Skip if we searched recently AND haven't moved far enough. Class fields are used
+        // (not state) so these guards don't trigger re-renders.
+        if (!overrideThrottle && lat && long && this.lastSearchAt && this.lastSearchCoords &&
+            (Date.now() - this.lastSearchAt <= MOMENTS_REFRESH_THROTTLE_MS)) {
+            const movedMeters = distanceTo({
+                lon: this.lastSearchCoords.longitude,
+                lat: this.lastSearchCoords.latitude,
+            }, {
+                lon: long,
+                lat,
+            });
+            if (movedMeters < MAP_SEARCH_MIN_DISTANCE_METERS) {
+                return this.searchInFlight || Promise.resolve();
+            }
+        }
+
+        // Collapse focus-event stampedes onto the already-running search.
+        if (!overrideThrottle && this.searchInFlight) {
+            return this.searchInFlight;
         }
 
         let radius = searchRadius || this.getSearchRadius({
@@ -1530,7 +1569,15 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
                 isSearchLoading: true,
             });
 
-            return this.searchMapAreas({
+            // Cancel any prior in-flight search so its stale results don't clobber state.
+            if (this.searchAbortController) {
+                this.searchAbortController.abort();
+            }
+            this.searchAbortController = new AbortController();
+            this.lastSearchAt = Date.now();
+            this.lastSearchCoords = { latitude: lat, longitude: long };
+
+            const promise = this.searchMapAreas({
                 latitude: lat,
                 longitude: long,
             }, {
@@ -1540,11 +1587,19 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
                 distanceOverride: radius,
                 userLatitude: location?.user?.latitude,
                 userLongitude: location?.user?.longitude,
-            }).finally(() =>{
+            }, {
+                signal: this.searchAbortController.signal,
+            }).finally(() => {
                 this.setState({
                     isSearchLoading: false,
                 });
+                if (this.searchInFlight === promise) {
+                    this.searchInFlight = undefined;
+                    this.searchAbortController = undefined;
+                }
             });
+            this.searchInFlight = promise;
+            return promise;
         }
 
         return Promise.resolve();

--- a/therr-public-library/therr-react/src/redux/actions/Maps.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Maps.ts
@@ -6,6 +6,7 @@ import MapsService, {
     IGetSpaceEngagementArgs,
     IGetSpaceMetricsArgs,
     IMapboxSearchArgs,
+    IMapsRequestOptions,
     IPlacesAutoCompleteArgs,
     ISearchAreasArgs,
     ISearchPrediction,
@@ -112,8 +113,8 @@ const Maps = {
 
             return response.data;
         }),
-    searchEvents: (query: any, data: ISearchAreasArgs = {}) => (dispatch: any) => MapsService
-        .searchEvents(query, data).then((response: any) => {
+    searchEvents: (query: any, data: ISearchAreasArgs = {}, options: IMapsRequestOptions = {}) => (dispatch: any) => MapsService
+        .searchEvents(query, data, options).then((response: any) => {
             if (response?.isOfflineFallback) return undefined;
             if (query.query === 'connections') {
                 dispatch({
@@ -232,8 +233,8 @@ const Maps = {
                 },
             });
         }),
-    searchMoments: (query: any, data: ISearchAreasArgs = {}) => (dispatch: any) => MapsService
-        .searchMoments(query, data).then((response: any) => {
+    searchMoments: (query: any, data: ISearchAreasArgs = {}, options: IMapsRequestOptions = {}) => (dispatch: any) => MapsService
+        .searchMoments(query, data, options).then((response: any) => {
             if (response?.isOfflineFallback) return undefined;
             if (query.query === 'connections') {
                 dispatch({
@@ -325,8 +326,8 @@ const Maps = {
             // Return so we can react by searching for associated reactions
             return Promise.resolve(response.data);
         }),
-    searchSpaces: (query: any, data: ISearchAreasArgs = {}) => (dispatch: any) => MapsService
-        .searchSpaces(query, data).then((response: any) => {
+    searchSpaces: (query: any, data: ISearchAreasArgs = {}, options: IMapsRequestOptions = {}) => (dispatch: any) => MapsService
+        .searchSpaces(query, data, options).then((response: any) => {
             if (response?.isOfflineFallback) return undefined;
             if (query.query === 'connections') {
                 dispatch({

--- a/therr-public-library/therr-react/src/redux/reducers/messages.ts
+++ b/therr-public-library/therr-react/src/redux/reducers/messages.ts
@@ -2,6 +2,8 @@ import { produce } from 'immer';
 import { SocketClientActionTypes, SocketServerActionTypes } from 'therr-js-utilities/constants';
 import { IMessagesState, MessageActionTypes } from '../../types/redux/messages';
 
+const MAX_THREAD_MESSAGES = 200;
+
 const initialState: IMessagesState = {
     forums: [],
     dms: {},
@@ -40,6 +42,9 @@ const messages = produce((draft: IMessagesState, action: any) => {
             }
             const prevMsgs = draft.forumMsgs[action.data.roomId] as any[];
             prevMsgs.push(...(action.data.messages || []));
+            if (prevMsgs.length > MAX_THREAD_MESSAGES) {
+                prevMsgs.splice(0, prevMsgs.length - MAX_THREAD_MESSAGES);
+            }
             if (action.data.isLastPage && prevMsgs.length) {
                 prevMsgs[prevMsgs.length - 1].isFirstMessage = true;
             }
@@ -61,6 +66,9 @@ const messages = produce((draft: IMessagesState, action: any) => {
             }
             const prevDMs = draft.dms[action.data.contextUserId] as any[];
             prevDMs.push(...(action.data.messages || []));
+            if (prevDMs.length > MAX_THREAD_MESSAGES) {
+                prevDMs.splice(0, prevDMs.length - MAX_THREAD_MESSAGES);
+            }
             if (action.data.isLastPage && prevDMs.length) {
                 prevDMs[prevDMs.length - 1].isFirstMessage = true;
             }

--- a/therr-public-library/therr-react/src/redux/reducers/userConnections.ts
+++ b/therr-public-library/therr-react/src/redux/reducers/userConnections.ts
@@ -22,11 +22,15 @@ const userConnections = produce((draft: IUserConnectionsState, action: any) => {
             break;
         }
         case SocketServerActionTypes.USER_CONNECTION_CREATED:
-            draft.connections.push(action.data);
+        case SocketServerActionTypes.USER_CONNECTION_UPDATED: {
+            const existingIdx = draft.connections.findIndex((c) => c.id === action.data?.id);
+            if (existingIdx > -1) {
+                draft.connections[existingIdx] = action.data;
+            } else {
+                draft.connections.push(action.data);
+            }
             break;
-        case SocketServerActionTypes.USER_CONNECTION_UPDATED:
-            draft.connections.push(action.data);
-            break;
+        }
         case SocketServerActionTypes.ACTIVE_CONNECTIONS_ADDED:
             draft.activeConnections.unshift(action.data);
             break;

--- a/therr-public-library/therr-react/src/services/MapsService.ts
+++ b/therr-public-library/therr-react/src/services/MapsService.ts
@@ -15,6 +15,10 @@ export interface ISearchAreasArgs {
     userLongitude?: number;
 }
 
+export interface IMapsRequestOptions {
+    signal?: AbortSignal;
+}
+
 interface IGetAreaDetailsArgs {
     withEvents?: boolean;
     withMedia?: boolean;
@@ -177,23 +181,25 @@ class MapsService {
         data: args,
     });
 
-    searchAreas = (areaType: IAreaType, query: ISearchQuery, data: ISearchAreasArgs = {}) => {
+    searchAreas = (areaType: IAreaType, query: ISearchQuery, data: ISearchAreasArgs = {}, options: IMapsRequestOptions = {}) => {
         const queryString = getSearchQueryString(query);
 
         return axios({
             method: 'post',
             url: `/maps-service/${areaType}/search${queryString}`,
             data,
+            signal: options?.signal,
         });
     };
 
-    searchMyAreas = (areaType: IAreaType, query: ISearchQuery, data: ISearchAreasArgs = {}) => {
+    searchMyAreas = (areaType: IAreaType, query: ISearchQuery, data: ISearchAreasArgs = {}, options: IMapsRequestOptions = {}) => {
         const queryString = getSearchQueryString(query);
 
         return axios({
             method: 'post',
             url: `/maps-service/${areaType}/search/me${queryString}`,
             data,
+            signal: options?.signal,
         });
     };
 
@@ -222,7 +228,7 @@ class MapsService {
         });
     };
 
-    searchEvents = (query: ISearchQuery, data: ISearchAreasArgs = {}) => this.searchAreas('events', query, data);
+    searchEvents = (query: ISearchQuery, data: ISearchAreasArgs = {}, options: IMapsRequestOptions = {}) => this.searchAreas('events', query, data, options);
 
     searchMyEvents = (query: ISearchQuery, data: ISearchAreasArgs = {}) => this.searchMyAreas('events', query, data);
 
@@ -263,7 +269,7 @@ class MapsService {
         url: `/maps-service/moments/integrated/${userId}`,
     });
 
-    searchMoments = (query: ISearchQuery, data: ISearchAreasArgs = {}) => this.searchAreas('moments', query, data);
+    searchMoments = (query: ISearchQuery, data: ISearchAreasArgs = {}, options: IMapsRequestOptions = {}) => this.searchAreas('moments', query, data, options);
 
     searchMyMoments = (query: ISearchQuery, data: ISearchAreasArgs = {}) => this.searchMyAreas('moments', query, data);
 
@@ -286,7 +292,7 @@ class MapsService {
         });
     };
 
-    searchSpaces = (query: ISearchQuery, data: ISearchAreasArgs = {}) => this.searchAreas('spaces', query, data);
+    searchSpaces = (query: ISearchQuery, data: ISearchAreasArgs = {}, options: IMapsRequestOptions = {}) => this.searchAreas('spaces', query, data, options);
 
     searchMySpaces = (query: ISearchQuery, data: ISearchAreasArgs = {}) => this.searchMyAreas('spaces', query, data);
 


### PR DESCRIPTION
Under Fabric the app got slower the more the user navigated because
backgrounded screens kept running, the Map refetched 6–9 requests per
focus with no distance/time guard, and socket listeners + message/
connection arrays accumulated monotonically until the process was killed.

- Layout: freezeOnBlur on the root Stack.Navigator pauses React
  reconciliation on blurred screens; add socketIO.off for the reconnect
  handlers so login/logout cycles stop doubling handler counts.
- Map: guard handleSearchThisLocation with a time + distance staleness
  check (reuses MOMENTS_REFRESH_THROTTLE_MS and a new 150m threshold),
  collapse focus-event stampedes onto one in-flight promise, and wire
  an AbortController through searchMapAreas → Maps action →
  MapsService.searchAreas so pending requests are canceled on blur.
- Clear the Map's Geolocation watcher on blur (previously only on
  unmount) so a backgrounded Map stops consuming GPS.
- userConnections reducer: de-dup USER_CONNECTION_CREATED/UPDATED by
  id instead of pushing duplicates.
- messages reducer: cap forumMsgs and dms threads at 200 entries to
  bound persisted AsyncStorage size.

https://claude.ai/code/session_01NYAsRuQ8TC7QYnv473PYrL