### PR TITLE
Strip libconceal.so from Android AAB to unblock Play Store release

### DIFF
--- a/TherrMobile/android/app/build.gradle
+++ b/TherrMobile/android/app/build.gradle
@@ -116,6 +116,9 @@ android {
     packaging {
         jniLibs {
             useLegacyPackaging = false
+            // libconceal.so (archived com.facebook.conceal) is not 16 KB page-aligned
+            // and has no updated release. Strip it so Play Store accepts the AAB.
+            excludes += ["**/libconceal.so"]
         }
     }
     buildTypes {


### PR DESCRIPTION
Google Play now rejects AABs containing .so files that aren't 16 KB
page-aligned. libconceal.so comes from the archived
com.facebook.conceal library (pulled in transitively) and has no
updated release. Exclude it from JNI packaging — it isn't loaded at
runtime in current React Native Fresco versions.

https://claude.ai/code/session_0158eM1NrzqV2zHkYo9NhMby