### PR TITLE
fix: map bottom sheet positioning and nearby list scrolling

### DIFF
--- a/TherrMobile/main/components/BottomSheet/BottomSheetPlus.tsx
+++ b/TherrMobile/main/components/BottomSheet/BottomSheetPlus.tsx
@@ -1,12 +1,14 @@
 import React,{ useRef, useMemo, useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { Easing } from 'react-native-reanimated';
-import BottomSheet, { BottomSheetView, useBottomSheetTimingConfigs } from '@gorhom/bottom-sheet';
+import BottomSheet, { useBottomSheetTimingConfigs } from '@gorhom/bottom-sheet';
 import { BottomSheetMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 import { ITherrThemeColors } from '../../styles/themes';
 import { buttonMenuHeight } from '../../styles/navigation/buttonMenu';
 
-export const defaultSnapPoints = [buttonMenuHeight + 28, '50%', '100%'];
+// bottomInset reserves space for MainButtonMenu, so the first snap only needs
+// the handle visible above it.
+export const defaultSnapPoints = [28, '50%', '100%'];
 
 interface IBottomSheetPlus {
     sheetRef: (sheetRef: React.RefObject<BottomSheetMethods>) => any;
@@ -77,14 +79,13 @@ const BottomSheetPlus = ({
             snapPoints={snapPoints}
             onChange={handleSheetChanges}
             animationConfigs={animationConfigs}
+            bottomInset={buttonMenuHeight}
             containerStyle={localStyles.transparentBackground}
             handleStyle={localStyles.handle}
             handleIndicatorStyle={{}}
             backgroundStyle={backgroundStyle}
         >
-            <BottomSheetView style={localStyles.sheetContent}>
-                { children }
-            </BottomSheetView>
+            { children }
         </BottomSheet>
     );
 };
@@ -95,10 +96,6 @@ const localStyles = StyleSheet.create({
     },
     handle: {
         height: 30,
-    },
-    sheetContent: {
-        flex: 1,
-        width: '100%',
     },
 });
 

--- a/TherrMobile/main/routes/Areas/Nearby/GPSEnableDialog.tsx
+++ b/TherrMobile/main/routes/Areas/Nearby/GPSEnableDialog.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View } from 'react-native';
 import { Button as PaperButton, Text as PaperText } from 'react-native-paper';
 import 'react-native-gesture-handler';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import LottieView from 'lottie-react-native';
 import earthLoader from '../../../assets/earth-loader.json';
 import { ITherrThemeColors } from '../../../styles/themes';
@@ -18,16 +18,14 @@ interface IGpsEnableButtonDialogProps {
 
 const GpsEnableButtonDialog = ({ handleEnableLocationPress, theme, translate }: IGpsEnableButtonDialogProps) => {
     return (
-        <KeyboardAwareScrollView
-            contentInsetAdjustmentBehavior="automatic"
+        <BottomSheetScrollView
             style={theme.styles.bodyFlex}
             contentContainerStyle={theme.styles.bodyScrollTop}
         >
             <View style={[theme.styles.sectionContainer, { marginTop: 0 }]}>
-                <View style={{ flex: 1, height: 100, marginBottom: 30 }}>
+                <View style={{ height: 100, marginBottom: 30 }}>
                     <LottieView
                         source={earthLoader}
-                        // resizeMode="cover"
                         resizeMode="contain"
                         speed={1}
                         autoPlay
@@ -41,9 +39,6 @@ const GpsEnableButtonDialog = ({ handleEnableLocationPress, theme, translate }: 
                 <PaperText variant="bodyMedium" style={theme.styles.sectionDescriptionCentered}>
                     {translate('pages.nearby.locationDescription1')}
                 </PaperText>
-                {/* <PaperText variant="bodyMedium" style={theme.styles.sectionDescriptionCentered}>
-                    {translate('pages.nearby.locationDescription2')}
-                </PaperText> */}
                 <PaperText variant="bodyMedium" style={[theme.styles.sectionDescriptionCentered]} />
                 <PaperButton
                     mode="contained"
@@ -60,7 +55,7 @@ const GpsEnableButtonDialog = ({ handleEnableLocationPress, theme, translate }: 
                     {translate('pages.nearby.locationDescription3')}
                 </PaperText>
             </View>
-        </KeyboardAwareScrollView>
+        </BottomSheetScrollView>
     );
 };
 

--- a/TherrMobile/main/routes/Map/QuickReportSheet.tsx
+++ b/TherrMobile/main/routes/Map/QuickReportSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { ActivityIndicator, Pressable, Text, TextInput, View, StyleSheet } from 'react-native';
+import { BottomSheetView } from '@gorhom/bottom-sheet';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import { Categories, ErrorCodes } from 'therr-js-utilities/constants';
@@ -171,7 +172,7 @@ const QuickReportSheet = ({
     };
 
     return (
-        <View style={styles.container}>
+        <BottomSheetView style={styles.container}>
             <Text style={[styles.title, { color: theme.colors.textWhite }]}>
                 {translate('quickReports.title')}
             </Text>
@@ -220,7 +221,7 @@ const QuickReportSheet = ({
                     <ActivityIndicator size="small" color={theme.colors.primary3} />
                 </View>
             )}
-        </View>
+        </BottomSheetView>
     );
 };
 


### PR DESCRIPTION
Reserve space for MainButtonMenu via bottomInset so the sheet no longer
extends behind the bottom nav. Remove the BottomSheetView wrapper from
BottomSheetPlus so BottomSheetFlatList (nearby list) and
BottomSheetScrollView (GPS enable dialog) can be direct descendants of
BottomSheet, restoring scroll gesture propagation. Swap the GPS dialog's
KeyboardAwareScrollView for BottomSheetScrollView and drop stray flex on
the Lottie container so the earth animation renders at full size.

https://claude.ai/code/session_01VuLQ4tAa7oRpNrxwXFWHmi