### PR TITLE
fix(mobile): restore static map in Recently Activated header

### DIFF
--- a/TherrMobile/main/routes/Areas/AreaCarousel.tsx
+++ b/TherrMobile/main/routes/Areas/AreaCarousel.tsx
@@ -260,7 +260,7 @@ const AreaCarousel = ({
 
     const listHeaderComponent = React.useMemo(
         () => renderHeader(),
-        [renderHeader]
+        [renderHeader, activeData]
     );
 
     const listFooterComponent = React.useMemo(


### PR DESCRIPTION
The carousel memoization refactor (3890f51) wrapped ListHeaderComponent in
a useMemo keyed only on renderHeader. ActivatedAreas passes renderHeader
as a stable class method reference, so the memo ran once at mount — when
activatedData was empty and getMapRegion() returned null — permanently
caching a map-less header. Adding activeData to the dep list mirrors the
footer memo and lets the header recompute once the fetch resolves.