### PR TITLE
fix(mobile): use fromUserId for DM sender check instead of fragile 'you' substring match

### DIFF
--- a/TherrMobile/main/components/TextMessage.tsx
+++ b/TherrMobile/main/components/TextMessage.tsx
@@ -16,7 +16,9 @@ export default ({
     themeMessage,
     translate,
 }) => {
-    const isYou = () => message.fromUserName?.toLowerCase().includes('you');
+    const isYou = () => (message.fromUserId
+        ? message.fromUserId === userDetails?.id
+        : !!message.fromUserName?.toLowerCase().includes('you'));
     const getName = () => {
         if (isYou()) {
             return 'You';

--- a/TherrMobile/main/routes/DirectMessage/index.tsx
+++ b/TherrMobile/main/routes/DirectMessage/index.tsx
@@ -177,7 +177,12 @@ class DirectMessage extends React.Component<
     isFirstOfMessage = (messages, index) => {
         if (!messages[index + 1]) { return true; }
 
-        return messages[index].fromUserName !== messages[index + 1].fromUserName;
+        const curr = messages[index];
+        const next = messages[index + 1];
+        if (curr.fromUserId && next.fromUserId) {
+            return curr.fromUserId !== next.fromUserId;
+        }
+        return curr.fromUserName?.toLowerCase() !== next.fromUserName?.toLowerCase();
     };
 
     tryLoadMore = () => {
@@ -225,19 +230,27 @@ class DirectMessage extends React.Component<
                                     data={dms}
                                     inverted
                                     keyExtractor={(item) => String(item.id || item.key)}
-                                    renderItem={({ item, index }) => (
-                                        <TextMessage
-                                            connectionDetails={connectionDetails}
-                                            goToUser={this.goToUser}
-                                            userDetails={user.details}
-                                            message={item}
-                                            isLeft={!item.fromUserName?.toLowerCase().includes('you')}
-                                            isFirstOfMessage={this.isFirstOfMessage(dms, index)}
-                                            theme={this.theme}
-                                            themeMessage={this.themeMessage}
-                                            translate={this.translate}
-                                        />
-                                    )}
+                                    renderItem={({ item, index }) => {
+                                        // Prefer fromUserId when available (authoritative); fall back
+                                        // to the 'you' name convention for messages cached before
+                                        // fromUserId started being persisted.
+                                        const isFromMe = item.fromUserId
+                                            ? item.fromUserId === user.details?.id
+                                            : !!item.fromUserName?.toLowerCase().includes('you');
+                                        return (
+                                            <TextMessage
+                                                connectionDetails={connectionDetails}
+                                                goToUser={this.goToUser}
+                                                userDetails={user.details}
+                                                message={item}
+                                                isLeft={!isFromMe}
+                                                isFirstOfMessage={this.isFirstOfMessage(dms, index)}
+                                                theme={this.theme}
+                                                themeMessage={this.themeMessage}
+                                                translate={this.translate}
+                                            />
+                                        );
+                                    }}
                                     ref={(component) => (this.flatListRef = component)}
                                     style={this.theme.styles.stretch}
                                     // onContentSizeChange={() => dms.length && this.flatListRef.scrollToEnd({ animated: true })}

--- a/therr-public-library/therr-react/src/redux/actions/Messages.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Messages.ts
@@ -6,7 +6,9 @@ const Messages = {
         if (response?.isOfflineFallback) return;
         const data = { // TODO: Consider doing this mapping on the server side
             messages: response.data.results.map((directMessage) => ({
+                id: directMessage.id,
                 key: directMessage.id,
+                fromUserId: directMessage.fromUserId,
                 fromUserName: directMessage.fromUserId === contextUserDetails.id
                     ? contextUserDetails.userName
                     : 'You',

--- a/therr-services/websocket-service/src/handlers/messages.ts
+++ b/therr-services/websocket-service/src/handlers/messages.ts
@@ -33,6 +33,7 @@ const sendDirectMessage = (internalConfig: IInternalConfig, socket: socketio.Soc
                 contextUserId: data.to.id,
                 message: {
                     id: message.id,
+                    fromUserId: data.userId,
                     fromUserName: 'you',
                     fromUserImgSrc: data.userImgSrc,
                     time: timeFormatted,
@@ -47,6 +48,7 @@ const sendDirectMessage = (internalConfig: IInternalConfig, socket: socketio.Soc
                     contextUserId: data.userId,
                     message: {
                         id: message.id,
+                        fromUserId: data.userId,
                         fromUserName: data.userName,
                         fromUserImgSrc: data.userImgSrc,
                         time: timeFormatted,


### PR DESCRIPTION
Mobile DMs decided which side of the chat to render each message by
calling `fromUserName?.toLowerCase().includes('you')`. Any user whose
handle contained "you" as a substring (Young, Youssef, joeyoung, etc.)
had their messages rendered on the wrong side, making the conversation
unreadable.

Thread the message's fromUserId end-to-end so the client can compare
against the current user's id authoritatively:

- Preserve fromUserId (and id) when mapping REST history responses in
  therr-react's searchDMs action.
- Include fromUserId in the socket-emitted SEND_DIRECT_MESSAGE payload
  for both the sender echo and the recipient broadcast.
- Use fromUserId === userDetails.id in DirectMessage renderItem and
  in TextMessage's isYou helper, with the old fromUserName check as a
  fallback so messages cached before this change still render.
- Group consecutive messages by fromUserId (falling back to case-
  insensitive fromUserName) so socket-echoed 'you' and history-fetched
  'You' no longer break grouping.