### PR TITLE
fix(mobile): prevent moments bottom sheet content from hiding behind header

### DIFF
--- a/TherrMobile/main/components/BottomSheet/BottomSheetPlus.tsx
+++ b/TherrMobile/main/components/BottomSheet/BottomSheetPlus.tsx
@@ -5,6 +5,10 @@ import BottomSheet, { BottomSheetView, useBottomSheetTimingConfigs } from '@gorh
 import { BottomSheetMethods } from '@gorhom/bottom-sheet/lib/typescript/types';
 import { ITherrThemeColors } from '../../styles/themes';
 import { buttonMenuHeight } from '../../styles/navigation/buttonMenu';
+import { getHeaderTopInset } from '../../styles';
+
+// Header content height (mirrors Layout.tsx custom header inner row).
+const HEADER_CONTENT_HEIGHT = 52;
 
 export const defaultSnapPoints = [buttonMenuHeight + 28, '50%', '100%'];
 
@@ -15,6 +19,7 @@ interface IBottomSheetPlus {
     onClose: () => any;
     children: React.ReactNode;
     overrideSnapPoints?: (string | number)[];
+    topInset?: number;
     themeBottomSheet: {
         colors: ITherrThemeColors;
         styles: any;
@@ -28,6 +33,7 @@ const BottomSheetPlus = ({
     isTransparent,
     onClose,
     overrideSnapPoints,
+    topInset,
     themeBottomSheet,
 }: IBottomSheetPlus) => {
     // ref
@@ -38,6 +44,14 @@ const BottomSheetPlus = ({
     const defaultBorderRadius = themeBottomSheet.styles.backgroundStyle.borderRadius;
     const initialSnapPoints = overrideSnapPoints || defaultSnapPoints;
     const snapPoints = useMemo(() => initialSnapPoints, [initialSnapPoints]);
+    // Offset the sheet by the custom header height so percentage snap points
+    // ('50%', '100%') are measured against the visible screen area. Without
+    // this, the fully expanded sheet's top content (handle, section title,
+    // first list item header) slides behind the opaque route header.
+    const resolvedTopInset = useMemo(
+        () => (topInset != null ? topInset : getHeaderTopInset() + HEADER_CONTENT_HEIGHT),
+        [topInset]
+    );
 
     const [borderRadius, setBorderRadius] = useState(defaultBorderRadius);
 
@@ -75,6 +89,7 @@ const BottomSheetPlus = ({
             index={initialIndex || 0}
             enablePanDownToClose
             snapPoints={snapPoints}
+            topInset={resolvedTopInset}
             onChange={handleSheetChanges}
             animationConfigs={animationConfigs}
             containerStyle={localStyles.transparentBackground}


### PR DESCRIPTION
Percentage snap points ('50%', '100%') in @gorhom/bottom-sheet v5 are measured
against the full window height, so the fully expanded Map bottom sheet's top
(handle, "Moments & Events Near You" title, first list item's author row) was
sliding behind the opaque custom route header.

Pass topInset to the BottomSheet so percentage snap points are measured against
the visible screen area below the header.