### PR TITLE
mobile: surface ListPickerSheet create-list errors

### DIFF
--- a/TherrMobile/main/components/ActionSheet/ListPickerSheet.tsx
+++ b/TherrMobile/main/components/ActionSheet/ListPickerSheet.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
     ActivityIndicator,
+    Alert,
     FlatList,
     Pressable,
     StyleSheet,
@@ -88,6 +89,7 @@ const ListPickerSheet = (props: SheetProps<'list-picker-sheet'>) => {
     const handleCreate = useCallback(async () => {
         const name = newName.trim();
         if (!name) return;
+        const translateFn = payload?.translate || ((k: string) => k);
         try {
             const created: any = await dispatch(ContentActions.createUserList({ name }) as any);
             if (created?.id) {
@@ -95,10 +97,18 @@ const ListPickerSheet = (props: SheetProps<'list-picker-sheet'>) => {
             }
             setNewName('');
             setIsCreating(false);
-        } catch {
-            // noop
+        } catch (err: any) {
+            if (__DEV__) {
+                // eslint-disable-next-line no-console
+                console.warn('[ListPickerSheet] createUserList failed', err?.response?.status, err?.response?.data || err?.message);
+            }
+            const isConflict = Number(err?.response?.status) === 409;
+            Alert.alert(
+                translateFn('pages.bookmarks.lists.createFailedTitle'),
+                translateFn(isConflict ? 'pages.bookmarks.lists.nameTakenBody' : 'pages.bookmarks.lists.createFailedBody'),
+            );
         }
-    }, [newName, dispatch, handleToggle]);
+    }, [newName, dispatch, handleToggle, payload?.translate]);
 
     const translate = payload?.translate || ((k: string) => k);
     const themeStyles = payload?.themeForms?.styles || {};

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1726,7 +1726,10 @@
         "deleteConfirm": "Delete this list? Saved spaces will be removed from it.",
         "loading": "Loading list...",
         "done": "Done",
-        "spaceUnavailable": "Space unavailable"
+        "spaceUnavailable": "Space unavailable",
+        "createFailedTitle": "Couldn't create list",
+        "createFailedBody": "Something went wrong. Check your connection and try again.",
+        "nameTakenBody": "A list with that name already exists."
       }
     },
     "myQRCodes": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1726,7 +1726,10 @@
         "deleteConfirm": "¿Eliminar esta lista? Los espacios guardados serán removidos.",
         "loading": "Cargando lista...",
         "done": "Listo",
-        "spaceUnavailable": "Espacio no disponible"
+        "spaceUnavailable": "Espacio no disponible",
+        "createFailedTitle": "No se pudo crear la lista",
+        "createFailedBody": "Algo salió mal. Revisa tu conexión e inténtalo de nuevo.",
+        "nameTakenBody": "Ya existe una lista con ese nombre."
       }
     },
     "myQRCodes": {

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -1726,7 +1726,10 @@
         "deleteConfirm": "Supprimer cette liste? Les espaces enregistrés en seront retirés.",
         "loading": "Chargement de la liste...",
         "done": "Terminé",
-        "spaceUnavailable": "Espace indisponible"
+        "spaceUnavailable": "Espace indisponible",
+        "createFailedTitle": "Impossible de créer la liste",
+        "createFailedBody": "Un problème est survenu. Vérifiez votre connexion et réessayez.",
+        "nameTakenBody": "Une liste portant ce nom existe déjà."
       }
     },
     "myQRCodes": {


### PR DESCRIPTION
The Create button on the Save-to-list sheet silently swallowed
failures (including the common "migration not run" 500), so a
broken create looked like the button did nothing.

- Log the failure in __DEV__ with status + body.
- Show an Alert with a distinct message for 409 (name taken) vs
  generic failure.
- Add createFailedTitle / createFailedBody / nameTakenBody strings
  to en-us, es, and fr-ca dictionaries.