### PR TITLE
fix(mobile): refresh own profile when tapping Profile after viewing another user

### DIFF
--- a/TherrMobile/main/components/ButtonMenu/MainButtonMenu.tsx
+++ b/TherrMobile/main/components/ButtonMenu/MainButtonMenu.tsx
@@ -162,7 +162,6 @@ class MainButtonMenuAlt extends ButtonMenu {
 
     goToMyProfile = () => {
         const { navigation, user } = this.props;
-        const currentScreen = this.getCurrentScreen();
 
         // ReactNativeHapticFeedback.trigger(HAPTIC_FEEDBACK_TYPE, hapticFeedbackOptions);
 
@@ -178,13 +177,11 @@ class MainButtonMenuAlt extends ButtonMenu {
                     },
                 ],
             });
-        } else if (currentScreen === 'ViewUser') {
-            navigation.setParams({
-                userInView: {
-                    id: user.details.id,
-                },
-            });
         } else {
+            // native-stack v6 merges params when navigating to the currently
+            // focused screen and pushes ViewUser otherwise. Unifying both
+            // branches ensures componentDidUpdate fires consistently so the
+            // screen swaps from the previously-viewed user back to self.
             navigation.navigate('ViewUser', {
                 userInView: {
                     id: user.details.id,

--- a/TherrMobile/main/routes/ViewUser/index.tsx
+++ b/TherrMobile/main/routes/ViewUser/index.tsx
@@ -191,8 +191,20 @@ class ViewUser extends React.Component<
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.route?.params?.userInView?.id !== this.props.route?.params?.userInView?.id) {
-            const isMe = this.props.route?.params?.userInView?.id === this.props.user.details.id;
+        const prevRouteUserId = prevProps.route?.params?.userInView?.id;
+        const currentRouteUserId = this.props.route?.params?.userInView?.id;
+        const reduxUserInViewId = this.props.user.userInView?.id;
+        const routeParamChanged = prevRouteUserId !== currentRouteUserId;
+        // Fallback: if Redux userInView is stale relative to the route param
+        // (e.g. after returning to this screen via setParams/navigate where
+        // the diff was missed), force a refetch so the UI never keeps the
+        // previous user's data visible.
+        const reduxOutOfSync = !!currentRouteUserId
+            && reduxUserInViewId !== currentRouteUserId
+            && !this.state.isLoading;
+
+        if (routeParamChanged || reduxOutOfSync) {
+            const isMe = currentRouteUserId === this.props.user.details.id;
             const tabRoutes = [
                 { key: PROFILE_CAROUSEL_TABS.THOUGHTS, title: this.translate('menus.headerTabs.thoughts') },
             ];


### PR DESCRIPTION
ViewUser shared the same screen instance for both self and other-user profiles,
so tapping Profile after viewing another user relied on setParams to mutate
the current route's params. When the shallow id diff check in componentDidUpdate
missed that transition, the screen kept rendering the prior user's Redux data.

- Unify goToMyProfile to always use navigation.navigate so native-stack v6
  consistently merges params on the focused ViewUser screen (pushing only
  when not already there).
- Harden ViewUser.componentDidUpdate with a fallback that refetches whenever
  Redux userInView.id is stale relative to route.params.userInView.id,
  guaranteeing the profile swaps back to self.

https://claude.ai/code/session_01SbN5B5oG5kR7n79G1cXXHf