### PR TITLE
fix(mobile): prevent narrow updateUser calls from reverting user settings

### DIFF
--- a/therr-public-library/therr-react/src/redux/actions/Users.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Users.ts
@@ -504,29 +504,39 @@ class UsersActions {
         (this.NativeStorage || sessionStorage).setItem('therrUser', JSON.stringify(userData));
         (this.NativeStorage || sessionStorage).setItem('therrUserSettings', JSON.stringify(userSettingsData));
 
+        // Only sync settings back to Redux when the request actually touched a settings field.
+        // Narrow writes (e.g. deviceMobileFirebaseToken from the FCM registration, hasAgreedToTerms,
+        // lastKnown{Lat,Lng}) race with user-initiated settings saves: their RETURNING * can reflect
+        // pre-commit state of the concurrent settings write and silently revert the Redux slice
+        // (e.g. a theme change that flashes dark and snaps back to light).
+        const requestKeys = Object.keys(data || {});
+        const touchedSettings = requestKeys.some((key) => key.startsWith('settings'));
+        const dispatchData: any = {
+            details: {
+                accessLevels,
+                blockedUsers,
+                email,
+                id,
+                hasAgreedToTerms,
+                isBusinessAccount,
+                isCreatorAccount,
+                isSuperUser,
+                shouldHideMatureContent,
+                firstName,
+                lastName,
+                phoneNumber,
+                userName,
+                media,
+            },
+        };
+        if (touchedSettings) {
+            dispatchData.settings = {
+                ...userSettingsData,
+            };
+        }
         dispatch({
             type: SocketClientActionTypes.UPDATE_USER,
-            data: {
-                details: {
-                    accessLevels,
-                    blockedUsers,
-                    email,
-                    id,
-                    hasAgreedToTerms,
-                    isBusinessAccount,
-                    isCreatorAccount,
-                    isSuperUser,
-                    shouldHideMatureContent,
-                    firstName,
-                    lastName,
-                    phoneNumber,
-                    userName,
-                    media,
-                },
-                settings: {
-                    ...userSettingsData,
-                },
-            },
+            data: dispatchData,
         });
         return {
             email,

--- a/therr-public-library/therr-react/src/redux/actions/__tests__/Users.update.test.ts
+++ b/therr-public-library/therr-react/src/redux/actions/__tests__/Users.update.test.ts
@@ -1,0 +1,106 @@
+jest.mock('therr-js-utilities/constants', () => ({
+    SocketClientActionTypes: {
+        UPDATE_USER: 'CLIENT:UPDATE_USER',
+    },
+}));
+
+jest.mock('../../../services/UsersService', () => ({
+    __esModule: true,
+    default: {
+        update: jest.fn(),
+    },
+}));
+
+// eslint-disable-next-line import/first
+import { SocketClientActionTypes } from 'therr-js-utilities/constants';
+
+// eslint-disable-next-line import/first
+import UsersService from '../../../services/UsersService';
+// eslint-disable-next-line import/first
+import UsersActions from '../Users';
+
+const nativeStorage = {
+    getItem: jest.fn().mockResolvedValue('{}'),
+    setItem: jest.fn(),
+};
+
+const createActions = () => new (UsersActions as any)({}, nativeStorage);
+
+const serverUser = {
+    id: 'u1',
+    email: 'u1@test.com',
+    firstName: 'First',
+    lastName: 'Last',
+    userName: 'user1',
+    phoneNumber: '+10000000000',
+    media: {},
+    accessLevels: [],
+    blockedUsers: [],
+    hasAgreedToTerms: true,
+    isBusinessAccount: false,
+    isCreatorAccount: false,
+    isSuperUser: false,
+    shouldHideMatureContent: false,
+    settingsLocale: 'en-us',
+    // Stale theme — simulates the server response reflecting pre-commit state of a concurrent
+    // settings write (e.g. a theme change racing with this FCM-token update).
+    settingsThemeName: 'light',
+};
+
+describe('UsersActions.update — Redux settings dispatch scoping', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (UsersService.update as jest.Mock).mockResolvedValue({ data: serverUser });
+        nativeStorage.getItem.mockResolvedValue('{}');
+    });
+
+    it('does NOT dispatch settings when the request has no settings* keys', async () => {
+        const dispatch = jest.fn();
+        const actions = createActions();
+        await actions.update('u1', { deviceMobileFirebaseToken: 'new-token' })(dispatch);
+
+        const updateDispatch = dispatch.mock.calls.find(
+            ([action]) => action?.type === SocketClientActionTypes.UPDATE_USER,
+        );
+        expect(updateDispatch).toBeDefined();
+        expect(updateDispatch[0].data.details).toBeDefined();
+        expect(updateDispatch[0].data.settings).toBeUndefined();
+    });
+
+    it('does NOT dispatch settings for hasAgreedToTerms-only updates', async () => {
+        const dispatch = jest.fn();
+        const actions = createActions();
+        await actions.update('u1', { hasAgreedToTerms: true })(dispatch);
+
+        const updateDispatch = dispatch.mock.calls.find(
+            ([action]) => action?.type === SocketClientActionTypes.UPDATE_USER,
+        );
+        expect(updateDispatch[0].data.settings).toBeUndefined();
+    });
+
+    it('dispatches settings when the request includes a settingsThemeName change', async () => {
+        (UsersService.update as jest.Mock).mockResolvedValue({
+            data: { ...serverUser, settingsThemeName: 'dark' },
+        });
+        const dispatch = jest.fn();
+        const actions = createActions();
+        await actions.update('u1', { settingsThemeName: 'dark' })(dispatch);
+
+        const updateDispatch = dispatch.mock.calls.find(
+            ([action]) => action?.type === SocketClientActionTypes.UPDATE_USER,
+        );
+        expect(updateDispatch[0].data.settings).toBeDefined();
+        expect(updateDispatch[0].data.settings.mobileThemeName).toBe('dark');
+    });
+
+    it('dispatches settings when the request includes any settingsEmail* change', async () => {
+        const dispatch = jest.fn();
+        const actions = createActions();
+        await actions.update('u1', { settingsEmailMentions: false })(dispatch);
+
+        const updateDispatch = dispatch.mock.calls.find(
+            ([action]) => action?.type === SocketClientActionTypes.UPDATE_USER,
+        );
+        expect(updateDispatch[0].data.settings).toBeDefined();
+    });
+});


### PR DESCRIPTION
The Settings-screen theme toggle would briefly apply (light -> dark) and then
snap back to light. Root cause: the shared `update` action in therr-react
always dispatched UPDATE_USER with the full `settings` slice reconstructed
from the API response. When narrow updates (FCM `deviceMobileFirebaseToken`,
`hasAgreedToTerms`, background geolocation) fire concurrently with a
user-initiated settings save, their `RETURNING *` can reflect pre-commit
state of the racing write and clobber the fresh Redux value.

Scope the dispatch: only include `settings` when the request body actually
contained a `settings*` field. Persisted storage keeps receiving the full
server state so there's no downstream drift.

https://claude.ai/code/session_01D5QrfF3Svc3bHnCe2STtPZ