### PR TITLE
fix(mobile): overlay loader during TabView initial layout

### DIFF
--- a/TherrMobile/main/components/TabViewLoadingOverlay.tsx
+++ b/TherrMobile/main/components/TabViewLoadingOverlay.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+
+interface ITabViewLoadingOverlayProps {
+    color?: string;
+    backgroundColor?: string;
+}
+
+const TabViewLoadingOverlay = ({ color, backgroundColor }: ITabViewLoadingOverlayProps) => (
+    <View
+        pointerEvents="none"
+        style={[
+            styles.overlay,
+            backgroundColor ? { backgroundColor } : null,
+        ]}
+    >
+        <ActivityIndicator size="large" color={color} />
+    </View>
+);
+
+const styles = StyleSheet.create({
+    overlay: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+});
+
+export default TabViewLoadingOverlay;

--- a/TherrMobile/main/routes/Areas/index.tsx
+++ b/TherrMobile/main/routes/Areas/index.tsx
@@ -36,6 +36,7 @@ import { handleAreaReaction, handleThoughtReaction, loadMorePosts, navToViewCont
 import getDirections from '../../utilities/getDirections';
 import { SELECT_ALL } from '../../utilities/categories';
 import LazyPlaceholder from '../../components/LazyPlaceholder';
+import TabViewLoadingOverlay from '../../components/TabViewLoadingOverlay';
 import AreaCarousel from './AreaCarousel';
 import TherrIcon from '../../components/TherrIcon';
 import requestLocationServiceActivation from '../../utilities/requestLocationServiceActivation';
@@ -122,6 +123,7 @@ interface IAreasState {
     isLoadingThoughts: boolean;
     isLoadingEvents: boolean;
     isLocationUseDisclosureModalVisible: boolean;
+    isTabViewLaidOut: boolean;
     locationDisclosureAreaType: IAreaType;
     tabRoutes: { key: string; title: string }[]
 }
@@ -203,6 +205,7 @@ class Areas extends React.PureComponent<IAreasProps, IAreasState> {
             isLoadingThoughts: false,
             isLoadingEvents: false,
             isLocationUseDisclosureModalVisible: false,
+            isTabViewLaidOut: false,
             locationDisclosureAreaType: 'moments',
             tabRoutes: [
                 { key: CAROUSEL_TABS.DISCOVERIES, title: this.translate('menus.headerTabs.discoveries') },
@@ -561,6 +564,16 @@ class Areas extends React.PureComponent<IAreasProps, IAreasState> {
         });
     };
 
+    handleTabContainerLayout = (e) => {
+        if (this.state.isTabViewLaidOut) {
+            return;
+        }
+        const { width, height } = e.nativeEvent.layout;
+        if (width > 0 && height > 0) {
+            this.setState({ isTabViewLaidOut: true });
+        }
+    };
+
     scrollTop = () => {
         const { activeTabIndex } = this.state;
         switch (tabMap[activeTabIndex]) {
@@ -824,6 +837,7 @@ class Areas extends React.PureComponent<IAreasProps, IAreasState> {
             areCreateActionsVisible,
             activeTabIndex,
             isLocationUseDisclosureModalVisible,
+            isTabViewLaidOut,
             locationDisclosureAreaType,
             tabRoutes,
         } = this.state;
@@ -833,7 +847,11 @@ class Areas extends React.PureComponent<IAreasProps, IAreasState> {
         return (
             <>
                 <BaseStatusBar therrThemeName={this.props.user.settings?.mobileThemeName}/>
-                <SafeAreaView edges={[]} style={[this.theme.styles.safeAreaView, { backgroundColor: this.theme.colorVariations.backgroundNeutral }]}>
+                <SafeAreaView
+                    edges={[]}
+                    style={[this.theme.styles.safeAreaView, { backgroundColor: this.theme.colorVariations.backgroundNeutral }]}
+                    onLayout={this.handleTabContainerLayout}
+                >
                     <TabView
                         lazy
                         lazyPreloadDistance={0}
@@ -858,6 +876,7 @@ class Areas extends React.PureComponent<IAreasProps, IAreasState> {
                         initialLayout={{ width: viewportWidth }}
                         // style={styles.container}
                     />
+                    {!isTabViewLaidOut && <TabViewLoadingOverlay color={this.theme.colors.textWhite} />}
                 </SafeAreaView>
                 {
                     tabName === CAROUSEL_TABS.THOUGHTS

--- a/TherrMobile/main/routes/Connect/index.tsx
+++ b/TherrMobile/main/routes/Connect/index.tsx
@@ -22,6 +22,7 @@ import ConnectionItem from './components/ConnectionItem';
 import CreateConnectionButton from '../../components/CreateConnectionButton';
 import { RefreshControl } from 'react-native-gesture-handler';
 import LazyPlaceholder from '../../components/LazyPlaceholder';
+import TabViewLoadingOverlay from '../../components/TabViewLoadingOverlay';
 import ConfirmModal from '../../components/Modals/ConfirmModal';
 import ListEmpty from '../../components/ListEmpty';
 import UsersActions from '../../redux/actions/UsersActions';
@@ -83,6 +84,7 @@ interface IContactsState {
     isRefreshingConnections: boolean;
     isRefreshingDMsSearch: boolean;
     isRefreshingUserSearch: boolean;
+    isTabViewLaidOut: boolean;
     activeTabIndex: number;
     searchFilters: any;
     tabRoutes: { key: string; title: string }[];
@@ -139,6 +141,7 @@ class Contacts extends React.Component<IContactsProps, IContactsState> {
             isRefreshingConnections: false,
             isRefreshingDMsSearch: false,
             isRefreshingUserSearch: false,
+            isTabViewLaidOut: false,
             tabRoutes: [
                 { key: PEOPLE_CAROUSEL_TABS.PEOPLE, title: this.translate('menus.headerTabs.people') },
                 { key: PEOPLE_CAROUSEL_TABS.MESSAGES, title: this.translate('menus.headerTabs.messages') },
@@ -259,6 +262,16 @@ class Contacts extends React.Component<IContactsProps, IContactsState> {
         navigation.navigate('DirectMessage', {
             connectionDetails,
         });
+    };
+
+    handleTabContainerLayout = (e) => {
+        if (this.state.isTabViewLaidOut) {
+            return;
+        }
+        const { width, height } = e.nativeEvent.layout;
+        if (width > 0 && height > 0) {
+            this.setState({ isTabViewLaidOut: true });
+        }
     };
 
     onTabSelect = (index: number) => {
@@ -614,7 +627,7 @@ class Contacts extends React.Component<IContactsProps, IContactsState> {
     };
 
     render() {
-        const { activeTabIndex, isNameConfirmModalVisible, tabRoutes } = this.state;
+        const { activeTabIndex, isNameConfirmModalVisible, isTabViewLaidOut, tabRoutes } = this.state;
         const { navigation, user } = this.props;
         const createButtonTitle = tabMap[activeTabIndex] === PEOPLE_CAROUSEL_TABS.MESSAGES
             ? this.translate('menus.connections.buttons.invite')
@@ -623,7 +636,7 @@ class Contacts extends React.Component<IContactsProps, IContactsState> {
         return (
             <>
                 <BaseStatusBar therrThemeName={this.props.user.settings?.mobileThemeName}/>
-                <SafeAreaView edges={[]} style={this.theme.styles.safeAreaView}>
+                <SafeAreaView edges={[]} style={this.theme.styles.safeAreaView} onLayout={this.handleTabContainerLayout}>
                     <TabView
                         lazy
                         lazyPreloadDistance={1}
@@ -649,6 +662,7 @@ class Contacts extends React.Component<IContactsProps, IContactsState> {
                         initialLayout={{ width: viewportWidth }}
                         // style={styles.container}
                     />
+                    {!isTabViewLaidOut && <TabViewLoadingOverlay color={this.theme.colors.textWhite} />}
                 </SafeAreaView>
                 <ConfirmModal
                     isVisible={isNameConfirmModalVisible}

--- a/TherrMobile/main/routes/Groups/ViewGroup.tsx
+++ b/TherrMobile/main/routes/Groups/ViewGroup.tsx
@@ -38,6 +38,7 @@ import TherrIcon from '../../components/TherrIcon';
 import ForumMessage from './ForumMessage';
 import ListEmpty from '../../components/ListEmpty';
 import LazyPlaceholder from '../../components/LazyPlaceholder';
+import TabViewLoadingOverlay from '../../components/TabViewLoadingOverlay';
 import UserSearchItem from '../Connect/components/UserSearchItem';
 import UsersActions from '../../redux/actions/UsersActions';
 import AreaDisplay from '../../components/UserContent/AreaDisplay';
@@ -97,6 +98,7 @@ interface IViewGroupState {
     groupEvents: any[];
     groupMembers: any[];
     isSending: boolean;
+    isTabViewLaidOut: boolean;
     isWelcomeDialogVisible: boolean;
     msgInputVal: string;
     isLoading: boolean;
@@ -160,6 +162,7 @@ class ViewGroup extends React.Component<IViewGroupProps, IViewGroupState> {
             groupMembers: [],
             groupEvents: [],
             isSending: false,
+            isTabViewLaidOut: false,
             isWelcomeDialogVisible: !!route.params?.isNewlyCreated,
             msgInputVal: '',
             isLoading: false,
@@ -480,6 +483,16 @@ class ViewGroup extends React.Component<IViewGroupProps, IViewGroupState> {
         });
     };
 
+    handleTabContainerLayout = (e) => {
+        if (this.state.isTabViewLaidOut) {
+            return;
+        }
+        const { width, height } = e.nativeEvent.layout;
+        if (width > 0 && height > 0) {
+            this.setState({ isTabViewLaidOut: true });
+        }
+    };
+
     handleWelcomeDialogDismiss = () => {
         this.setState({ isWelcomeDialogVisible: false });
     };
@@ -672,7 +685,7 @@ class ViewGroup extends React.Component<IViewGroupProps, IViewGroupState> {
     };
 
     render() {
-        const { activeTabIndex, isSending, isWelcomeDialogVisible, tabRoutes, msgInputVal } = this.state;
+        const { activeTabIndex, isSending, isTabViewLaidOut, isWelcomeDialogVisible, tabRoutes, msgInputVal } = this.state;
         const { route, forums } = this.props;
         const { description, subtitle, id: forumId } = route.params;
         const group = forums?.searchResults?.find((g) => g.id === forumId)
@@ -734,7 +747,10 @@ class ViewGroup extends React.Component<IViewGroupProps, IViewGroupState> {
                                 />
                             </View>
                         </View>
-                        <View style={[this.themeAccentLayout.styles.container, this.themeChat.styles.container]}>
+                        <View
+                            style={[this.themeAccentLayout.styles.container, this.themeChat.styles.container]}
+                            onLayout={this.handleTabContainerLayout}
+                        >
                             <TabView
                                 lazy
                                 lazyPreloadDistance={1}
@@ -760,6 +776,7 @@ class ViewGroup extends React.Component<IViewGroupProps, IViewGroupState> {
                                 initialLayout={{ width: viewportWidth }}
                                 // style={styles.container}
                             />
+                            {!isTabViewLaidOut && <TabViewLoadingOverlay color={this.theme.colors.textWhite} />}
                         </View>
                     </View>
                     <KeyboardAvoidingView

--- a/TherrMobile/main/routes/Groups/index.tsx
+++ b/TherrMobile/main/routes/Groups/index.tsx
@@ -22,6 +22,7 @@ import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
 import CreateConnectionButton from '../../components/CreateConnectionButton';
 import { RefreshControl } from 'react-native-gesture-handler';
 import LazyPlaceholder from '../../components/LazyPlaceholder';
+import TabViewLoadingOverlay from '../../components/TabViewLoadingOverlay';
 import ConfirmModal from '../../components/Modals/ConfirmModal';
 import ListEmpty from '../../components/ListEmpty';
 import UsersActions from '../../redux/actions/UsersActions';
@@ -80,6 +81,7 @@ interface IGroupsState {
     isNameConfirmModalVisible: boolean;
     isRefreshing: boolean;
     isMyGroupsRefreshing: boolean;
+    isTabViewLaidOut: boolean;
     activeTabIndex: number;
     searchFilters: any;
     searchText: string;
@@ -147,6 +149,7 @@ class Groups extends React.Component<IGroupsProps, IGroupsState> {
             isNameConfirmModalVisible: false,
             isRefreshing: false,
             isMyGroupsRefreshing: false,
+            isTabViewLaidOut: false,
             tabRoutes: [
                 { key: GROUPS_CAROUSEL_TABS.DISCOVER, title: this.translate('menus.headerTabs.groupsDiscover') },
                 { key: GROUPS_CAROUSEL_TABS.GROUPS, title: this.translate('menus.headerTabs.groupsJoined') },
@@ -227,6 +230,16 @@ class Groups extends React.Component<IGroupsProps, IGroupsState> {
         navigation.setParams({
             activeTab: tabMap[index],
         });
+    };
+
+    handleTabContainerLayout = (e) => {
+        if (this.state.isTabViewLaidOut) {
+            return;
+        }
+        const { width, height } = e.nativeEvent.layout;
+        if (width > 0 && height > 0) {
+            this.setState({ isTabViewLaidOut: true });
+        }
     };
 
     handleRefreshDiscoverSearch = () => {
@@ -612,13 +625,13 @@ class Groups extends React.Component<IGroupsProps, IGroupsState> {
     };
 
     render() {
-        const { activeTabIndex, isNameConfirmModalVisible, tabRoutes } = this.state;
+        const { activeTabIndex, isNameConfirmModalVisible, isTabViewLaidOut, tabRoutes } = this.state;
         const { navigation, user } = this.props;
 
         return (
             <>
                 <BaseStatusBar therrThemeName={this.props.user.settings?.mobileThemeName}/>
-                <SafeAreaView edges={[]} style={this.theme.styles.safeAreaView}>
+                <SafeAreaView edges={[]} style={this.theme.styles.safeAreaView} onLayout={this.handleTabContainerLayout}>
                     <TabView
                         lazy
                         lazyPreloadDistance={1}
@@ -643,6 +656,7 @@ class Groups extends React.Component<IGroupsProps, IGroupsState> {
                         onIndexChange={this.onTabSelect}
                         initialLayout={{ width: viewportWidth }}
                     />
+                    {!isTabViewLaidOut && <TabViewLoadingOverlay color={this.theme.colors.textWhite} />}
                 </SafeAreaView>
                 <ConfirmModal
                     isVisible={isNameConfirmModalVisible}

--- a/TherrMobile/main/routes/ViewUser/index.tsx
+++ b/TherrMobile/main/routes/ViewUser/index.tsx
@@ -40,6 +40,7 @@ import LottieLoader, { ILottieId } from '../../components/LottieLoader';
 import UserDisplayHeader from './UserDisplayHeader';
 import ConfirmModal from '../../components/Modals/ConfirmModal';
 import LazyPlaceholder from '../../components/LazyPlaceholder';
+import TabViewLoadingOverlay from '../../components/TabViewLoadingOverlay';
 import AreaCarousel from '../Areas/AreaCarousel';
 import { isMyContent } from '../../utilities/content';
 import { SheetManager } from 'react-native-actions-sheet';
@@ -95,6 +96,7 @@ interface IViewUserState {
     isRefreshingUserMedia: boolean;
     isRefreshingUserMoments: boolean;
     isRefreshingUserThoughts: boolean;
+    isTabViewLaidOut: boolean;
     tabRoutes: { key: string; title: string }[];
     userInViewsMoments: any[];
     userInViewsThoughts: any[];
@@ -163,6 +165,7 @@ class ViewUser extends React.Component<
             isRefreshingUserMedia: false,
             isRefreshingUserMoments: false,
             isRefreshingUserThoughts: false,
+            isTabViewLaidOut: false,
             tabRoutes,
             userInViewsMoments: [],
             userInViewsThoughts: [],
@@ -591,6 +594,16 @@ class ViewUser extends React.Component<
         });
     };
 
+    handleTabContainerLayout = (e) => {
+        if (this.state.isTabViewLaidOut) {
+            return;
+        }
+        const { width, height } = e.nativeEvent.layout;
+        if (width > 0 && height > 0) {
+            this.setState({ isTabViewLaidOut: true });
+        }
+    };
+
     renderTabBar = props => {
         return (
             <TabBar
@@ -696,6 +709,7 @@ class ViewUser extends React.Component<
             confirmModalText,
             isConfirmProcessing,
             isLoading,
+            isTabViewLaidOut,
             tabRoutes,
         } = this.state;
 
@@ -722,31 +736,34 @@ class ViewUser extends React.Component<
                                     user={user}
                                     userInView={user.userInView || {}}
                                 />
-                                <TabView
-                                    lazy
-                                    lazyPreloadDistance={0}
-                                    navigationState={{
-                                        index: activeTabIndex,
-                                        routes: tabRoutes,
-                                    }}
-                                    renderTabBar={this.renderTabBar}
-                                    renderScene={this.renderSceneMap}
-                                    renderLazyPlaceholder={() => (
-                                        <View style={this.theme.styles.sectionContainer}>
-                                            <LazyPlaceholder lines={[undefined, undefined]} />
-                                            <LazyPlaceholder lines={[undefined, undefined]} />
-                                            <LazyPlaceholder lines={[undefined, undefined]} />
-                                            <LazyPlaceholder lines={[undefined, undefined]} />
-                                            <LazyPlaceholder lines={[undefined, undefined]} />
-                                            <LazyPlaceholder lines={[undefined, undefined]} />
-                                            <LazyPlaceholder lines={[undefined, undefined]} />
-                                            <LazyPlaceholder lines={[undefined, undefined]} />
-                                        </View>
-                                    )}
-                                    onIndexChange={this.onTabSelect}
-                                    initialLayout={{ width: viewportWidth }}
-                                    style={this.theme.styles.tabviewContainer}
-                                />
+                                <View style={this.theme.styles.tabviewContainer} onLayout={this.handleTabContainerLayout}>
+                                    <TabView
+                                        lazy
+                                        lazyPreloadDistance={0}
+                                        navigationState={{
+                                            index: activeTabIndex,
+                                            routes: tabRoutes,
+                                        }}
+                                        renderTabBar={this.renderTabBar}
+                                        renderScene={this.renderSceneMap}
+                                        renderLazyPlaceholder={() => (
+                                            <View style={this.theme.styles.sectionContainer}>
+                                                <LazyPlaceholder lines={[undefined, undefined]} />
+                                                <LazyPlaceholder lines={[undefined, undefined]} />
+                                                <LazyPlaceholder lines={[undefined, undefined]} />
+                                                <LazyPlaceholder lines={[undefined, undefined]} />
+                                                <LazyPlaceholder lines={[undefined, undefined]} />
+                                                <LazyPlaceholder lines={[undefined, undefined]} />
+                                                <LazyPlaceholder lines={[undefined, undefined]} />
+                                                <LazyPlaceholder lines={[undefined, undefined]} />
+                                            </View>
+                                        )}
+                                        onIndexChange={this.onTabSelect}
+                                        initialLayout={{ width: viewportWidth }}
+                                        style={this.theme.styles.tabviewContainer}
+                                    />
+                                    {!isTabViewLaidOut && <TabViewLoadingOverlay color={this.theme.colors.textWhite} />}
+                                </View>
                             </View>
                     }
                 </SafeAreaView>


### PR DESCRIPTION
The prior fixes (3890f51, 0558997) reduced but did not eliminate a brief
empty gap that appears on mount in TabView screens. Between the first
render with initialLayout={width} and the onLayout event that gives the
pager real dimensions, the scene area briefly shows as blank space under
the header — jarring on Connect, Areas, Groups, and the nested TabViews
in ViewGroup and ViewUser.

Add a lightweight TabViewLoadingOverlay (absolutely positioned
ActivityIndicator) and render it over the tab container until the
container's onLayout fires with non-zero dimensions. This covers the
transient gap with a centered spinner so the first frame has something
visible instead of empty space.

https://claude.ai/code/session_01K5Xt6DTZmapu3ZHYjRG12V