### PR TITLE
feat: public shareable lists (Phase 1)

### DIFF
--- a/TherrMobile/main/components/Layout.tsx
+++ b/TherrMobile/main/components/Layout.tsx
@@ -1223,6 +1223,7 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
         const viewUserFromDesktopRegex = RegExp('users/([0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})', 'i');
         const viewEventRegex = RegExp('events/([0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})', 'i');
         const viewGroupRegex = RegExp('groups/([0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})', 'i');
+        const viewPublicListRegex = RegExp('lists/([0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12})/([a-z0-9-]+)', 'i');
         const isUserLoggedIn = isUserAuthenticated(user);
         const isUserMissingProps = UsersService.isAuthorized(
             {
@@ -1379,6 +1380,18 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
                     targetRouteView: 'ViewGroup',
                     targetRouteParams,
                 });
+            }
+        } else if (url?.match(viewPublicListRegex)) {
+            // Public shareable list. For the owner, open MyLists so they can
+            // navigate into their own editable list. For other viewers the
+            // web page at this URL is the read-only experience; we don't yet
+            // render other users' lists inside the app, so fall back to
+            // opening MyLists for authed users / the Home route otherwise.
+            // A dedicated in-app viewer is intentionally deferred to Phase 2.
+            if (isUserLoggedIn && !isUserMissingProps) {
+                RootNavigation.navigate('MyLists');
+            } else {
+                this.setState({ targetRouteView: 'MyLists' });
             }
         } else if (Platform.OS !== 'ios') {
             // IOS will use the notifee foreground listener instead

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1729,7 +1729,15 @@
         "spaceUnavailable": "Space unavailable",
         "createFailedTitle": "Couldn't create list",
         "createFailedBody": "Something went wrong. Check your connection and try again.",
-        "nameTakenBody": "A list with that name already exists."
+        "nameTakenBody": "A list with that name already exists.",
+        "makePublic": "Make public",
+        "publicHintOn": "Anyone with the link can view this list.",
+        "publicHintOff": "Only you can see this list.",
+        "publicBadge": "Public",
+        "shareList": "Share list",
+        "shareMessage": "Check out my list \"{listName}\" on Therr: {url}",
+        "publicToggleErrorTitle": "Couldn't update list",
+        "publicToggleErrorBody": "Something went wrong. Please try again."
       }
     },
     "myQRCodes": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1729,7 +1729,15 @@
         "spaceUnavailable": "Espacio no disponible",
         "createFailedTitle": "No se pudo crear la lista",
         "createFailedBody": "Algo salió mal. Revisa tu conexión e inténtalo de nuevo.",
-        "nameTakenBody": "Ya existe una lista con ese nombre."
+        "nameTakenBody": "Ya existe una lista con ese nombre.",
+        "makePublic": "Hacer pública",
+        "publicHintOn": "Cualquiera con el enlace puede ver esta lista.",
+        "publicHintOff": "Solo tú puedes ver esta lista.",
+        "publicBadge": "Pública",
+        "shareList": "Compartir lista",
+        "shareMessage": "Mira mi lista \"{listName}\" en Therr: {url}",
+        "publicToggleErrorTitle": "No se pudo actualizar la lista",
+        "publicToggleErrorBody": "Algo salió mal. Inténtalo de nuevo."
       }
     },
     "myQRCodes": {

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -1729,7 +1729,15 @@
         "spaceUnavailable": "Espace indisponible",
         "createFailedTitle": "Impossible de créer la liste",
         "createFailedBody": "Un problème est survenu. Vérifiez votre connexion et réessayez.",
-        "nameTakenBody": "Une liste portant ce nom existe déjà."
+        "nameTakenBody": "Une liste portant ce nom existe déjà.",
+        "makePublic": "Rendre publique",
+        "publicHintOn": "Toute personne ayant le lien peut voir cette liste.",
+        "publicHintOff": "Vous seul pouvez voir cette liste.",
+        "publicBadge": "Publique",
+        "shareList": "Partager la liste",
+        "shareMessage": "Découvrez ma liste « {listName} » sur Therr : {url}",
+        "publicToggleErrorTitle": "Impossible de mettre à jour la liste",
+        "publicToggleErrorBody": "Un problème est survenu. Veuillez réessayer."
       }
     },
     "myQRCodes": {

--- a/TherrMobile/main/routes/Areas/BookmarkListDetail.tsx
+++ b/TherrMobile/main/routes/Areas/BookmarkListDetail.tsx
@@ -4,22 +4,27 @@ import {
     Alert,
     FlatList,
     RefreshControl,
+    Share,
     StyleSheet,
+    Switch,
     Text,
     TouchableOpacity,
     View} from 'react-native';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ContentActions } from 'therr-react/redux/actions';
+import { slugify } from 'therr-js-utilities/slugify';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import BaseStatusBar from '../../components/BaseStatusBar';
 import translator from '../../utilities/translator';
 import { buildStyles } from '../../styles';
 import { navToViewContent } from '../../utilities/postViewHelpers';
+import { buildPublicListUrl } from '../../utilities/shareUrls';
 
 interface IListDetailDispatchProps {
     fetchUserList: Function;
     deleteUserList: Function;
+    updateUserList: Function;
 }
 
 interface IStoreProps extends IListDetailDispatchProps {
@@ -34,6 +39,7 @@ interface IListDetailProps extends IStoreProps {
 
 interface IListDetailState {
     isLoading: boolean;
+    isTogglingPublic: boolean;
 }
 
 const mapStateToProps = (state: any) => ({
@@ -46,6 +52,7 @@ const mapDispatchToProps = (dispatch: any) =>
         {
             fetchUserList: ContentActions.fetchUserList,
             deleteUserList: ContentActions.deleteUserList,
+            updateUserList: ContentActions.updateUserList,
         },
         dispatch,
     );
@@ -57,7 +64,7 @@ class BookmarkListDetail extends React.Component<IListDetailProps, IListDetailSt
     constructor(props: IListDetailProps) {
         super(props);
 
-        this.state = { isLoading: true };
+        this.state = { isLoading: true, isTogglingPublic: false };
 
         this.theme = buildStyles(props.user.settings?.mobileThemeName);
         this.translate = (key: string, params?: any) =>
@@ -96,6 +103,36 @@ class BookmarkListDetail extends React.Component<IListDetailProps, IListDetailSt
         navToViewContent({ ...space, areaType: 'spaces' }, user, navigation.navigate);
     };
 
+    handleTogglePublic = (nextValue: boolean) => {
+        const { content, route, updateUserList } = this.props;
+        const list = content?.activeUserList;
+        if (!list || list.id !== route.params.listId) return;
+        this.setState({ isTogglingPublic: true });
+        updateUserList(list.id, { isPublic: nextValue })
+            .catch((err: any) => {
+                Alert.alert(
+                    this.translate('pages.bookmarks.lists.publicToggleErrorTitle'),
+                    err?.response?.data?.message || this.translate('pages.bookmarks.lists.publicToggleErrorBody'),
+                );
+            })
+            .finally(() => this.setState({ isTogglingPublic: false }));
+    };
+
+    handleShare = async () => {
+        const { content, user } = this.props;
+        const list = content?.activeUserList;
+        if (!list) return;
+        const locale = user?.settings?.locale || 'en-us';
+        const url = buildPublicListUrl(locale, list.userId, slugify(list.name));
+        try {
+            await Share.share({
+                message: this.translate('pages.bookmarks.lists.shareMessage', { listName: list.name, url }),
+                url, // iOS only
+                title: list.name, // Android only
+            });
+        } catch { /* noop */ }
+    };
+
     handleDelete = () => {
         const { route, deleteUserList, navigation } = this.props;
         Alert.alert(
@@ -118,11 +155,12 @@ class BookmarkListDetail extends React.Component<IListDetailProps, IListDetailSt
     };
 
     render() {
-        const { content } = this.props;
+        const { content, user } = this.props;
         const activeUserList = content?.activeUserList;
-        const { isLoading } = this.state;
+        const { isLoading, isTogglingPublic } = this.state;
         const spaces = activeUserList?.spaces || [];
         const items = activeUserList?.items || [];
+        const isOwner = !!(activeUserList && user?.details?.id && activeUserList.userId === user.details.id);
         // Fall back to junction rows if the space lookup came back empty —
         // this surfaces that the list has content even when maps-service is
         // unreachable or a space was deleted.
@@ -142,12 +180,40 @@ class BookmarkListDetail extends React.Component<IListDetailProps, IListDetailSt
                         <Text style={styles.headerTitle}>
                             {activeUserList?.name || this.translate('pages.bookmarks.lists.loading')}
                         </Text>
-                        {activeUserList && !activeUserList.isDefault && (
-                            <TouchableOpacity onPress={this.handleDelete} style={styles.deleteBtn}>
+                        {activeUserList && isOwner && activeUserList.isPublic && (
+                            <TouchableOpacity
+                                onPress={this.handleShare}
+                                style={styles.iconBtn}
+                                accessibilityLabel={this.translate('pages.bookmarks.lists.shareList')}
+                            >
+                                <MaterialIcon name="share" size={22} color="#1C7F8A" />
+                            </TouchableOpacity>
+                        )}
+                        {activeUserList && isOwner && !activeUserList.isDefault && (
+                            <TouchableOpacity onPress={this.handleDelete} style={styles.iconBtn}>
                                 <MaterialIcon name="delete-outline" size={22} color="#d32f2f" />
                             </TouchableOpacity>
                         )}
                     </View>
+                    {activeUserList && isOwner && (
+                        <View style={styles.publicRow}>
+                            <View style={styles.publicLabelWrap}>
+                                <Text style={styles.publicLabel}>
+                                    {this.translate('pages.bookmarks.lists.makePublic')}
+                                </Text>
+                                <Text style={styles.publicHint}>
+                                    {activeUserList.isPublic
+                                        ? this.translate('pages.bookmarks.lists.publicHintOn')
+                                        : this.translate('pages.bookmarks.lists.publicHintOff')}
+                                </Text>
+                            </View>
+                            <Switch
+                                value={!!activeUserList.isPublic}
+                                disabled={isTogglingPublic}
+                                onValueChange={this.handleTogglePublic}
+                            />
+                        </View>
+                    )}
                     <FlatList
                         data={rows}
                         keyExtractor={(item: any, index: number) => `${item.id}-${index}`}
@@ -203,8 +269,31 @@ const styles = StyleSheet.create({
         fontSize: 18,
         fontWeight: '700',
     },
-    deleteBtn: {
+    iconBtn: {
         padding: 6,
+        marginLeft: 4,
+    },
+    publicRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingHorizontal: 14,
+        paddingVertical: 8,
+        backgroundColor: '#f5f7f8',
+    },
+    publicLabelWrap: {
+        flex: 1,
+        paddingRight: 12,
+    },
+    publicLabel: {
+        fontSize: 14,
+        fontWeight: '600',
+        color: '#222',
+    },
+    publicHint: {
+        marginTop: 2,
+        fontSize: 12,
+        color: '#666',
     },
     card: {
         flexDirection: 'row',

--- a/TherrMobile/main/routes/Areas/MyLists.tsx
+++ b/TherrMobile/main/routes/Areas/MyLists.tsx
@@ -112,6 +112,7 @@ class MyLists extends React.Component<IMyListsProps, IMyListsState> {
                                     <Text style={styles.meta}>
                                         {this.translate('pages.bookmarks.lists.itemCount', { count: item.itemCount ?? 0 })}
                                         {item.isDefault ? ` · ${this.translate('pages.bookmarks.lists.default')}` : ''}
+                                        {item.isPublic ? ` · ${this.translate('pages.bookmarks.lists.publicBadge')}` : ''}
                                     </Text>
                                 </View>
                                 <MaterialIcon name="chevron-right" size={24} color="#aaa" />

--- a/TherrMobile/main/utilities/shareUrls.ts
+++ b/TherrMobile/main/utilities/shareUrls.ts
@@ -16,6 +16,8 @@ export const buildEventUrl = (locale: string, id: string) => buildShareUrl(local
 export const buildInviteUrl = (locale: string, userName: string) => buildShareUrl(locale, `/invite/${userName}`);
 export const buildUserUrl = (locale: string, id: string) => buildShareUrl(locale, `/users/${id}`);
 export const buildGroupUrl = (locale: string, id: string) => buildShareUrl(locale, `/groups/${id}`);
+export const buildPublicListUrl = (locale: string, ownerUserId: string, listSlug: string) =>
+    buildShareUrl(locale, `/lists/${ownerUserId}/${listSlug}`);
 
 export type ShareableEntityType = 'user' | 'space' | 'event' | 'group';
 

--- a/therr-api-gateway/src/index.ts
+++ b/therr-api-gateway/src/index.ts
@@ -113,6 +113,7 @@ app.use(authenticate.unless({
         { url: /\/v1\/maps-service\/cities\/[^/]+\/pulse$/, methods: ['GET'] }, // Public city landing page (uses authenticateOptional)
         { url: /\/v1\/messages-service\/forums\/[0-9a-f-]+$/, methods: ['GET'] }, // Public group/forum view (uses authenticateOptional)
         { url: '/v1/messages-service/forums/search', methods: ['POST'] }, // Public forum search (uses authenticateOptional)
+        { url: /\/v1\/reactions-service\/user-lists\/public\/[0-9a-f-]+\/[a-z0-9-]+$/, methods: ['GET'] }, // Public shareable list page
     ],
 }));
 

--- a/therr-api-gateway/src/services/reactions/router.ts
+++ b/therr-api-gateway/src/services/reactions/router.ts
@@ -33,6 +33,7 @@ import {
     createUserListValidation,
     getUserListsValidation,
     getUserListByIdValidation,
+    getPublicUserListValidation,
     updateUserListValidation,
     deleteUserListValidation,
     addSpaceToListValidation,
@@ -203,6 +204,15 @@ reactionsServiceRouter.get('/user-lists', getUserListsValidation, validate, hand
 }));
 
 reactionsServiceRouter.get('/user-lists/for-space/:spaceId', getListsForSpaceValidation, validate, handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseReactionsServiceRoute}`,
+    method: 'get',
+}));
+
+// Public shareable list fetch — registered BEFORE the `/user-lists/:listId`
+// route so the more specific `/user-lists/public/...` path wins matching.
+// Auth is optional: the `.unless` block in api-gateway/src/index.ts exempts
+// this URL from the JWT middleware.
+reactionsServiceRouter.get('/user-lists/public/:ownerUserId/:listSlug', getPublicUserListValidation, validate, handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseReactionsServiceRoute}`,
     method: 'get',
 }));

--- a/therr-api-gateway/src/services/reactions/validation/userLists.ts
+++ b/therr-api-gateway/src/services/reactions/validation/userLists.ts
@@ -59,3 +59,12 @@ export const getListsForSpaceValidation = [
     header('x-userid').exists(),
     param('spaceId').isUUID(),
 ];
+
+// Public list lookup — x-userid is NOT required (auth-optional).
+// Slug is URL-friendly lowercase with hyphens, max 100 chars (see slugify util).
+export const getPublicUserListValidation = [
+    param('ownerUserId').isUUID(),
+    param('listSlug').isString().isLength({ min: 1, max: 100 }).matches(/^[a-z0-9-]+$/),
+    query('limit').optional().isNumeric(),
+    query('offset').optional().isNumeric(),
+];

--- a/therr-client-web/src/locales/en-us/dictionary.json
+++ b/therr-client-web/src/locales/en-us/dictionary.json
@@ -321,6 +321,14 @@
         "back": "Back"
       }
     },
+    "publicList": {
+      "loadingTitle": "Loading list...",
+      "itemCount": "{count} places",
+      "openInApp": "Open in app",
+      "emptyList": "This list has no places yet.",
+      "notFoundTitle": "List not available",
+      "notFoundBody": "This list is private or no longer exists."
+    },
     "discovered": {
       "pageTitle": "Discovered",
       "subtitle": "Recently shared moments and spaces from the community",

--- a/therr-client-web/src/locales/es/dictionary.json
+++ b/therr-client-web/src/locales/es/dictionary.json
@@ -321,6 +321,14 @@
         "back": "Atrás"
       }
     },
+    "publicList": {
+      "loadingTitle": "Cargando lista...",
+      "itemCount": "{count} lugares",
+      "openInApp": "Abrir en la app",
+      "emptyList": "Esta lista aún no tiene lugares.",
+      "notFoundTitle": "Lista no disponible",
+      "notFoundBody": "Esta lista es privada o ya no existe."
+    },
     "discovered": {
       "pageTitle": "Descubierto",
       "subtitle": "Momentos y espacios compartidos recientemente por la comunidad",

--- a/therr-client-web/src/locales/fr-ca/dictionary.json
+++ b/therr-client-web/src/locales/fr-ca/dictionary.json
@@ -321,6 +321,14 @@
         "back": "Retour"
       }
     },
+    "publicList": {
+      "loadingTitle": "Chargement de la liste...",
+      "itemCount": "{count} endroits",
+      "openInApp": "Ouvrir dans l'application",
+      "emptyList": "Cette liste ne contient encore aucun endroit.",
+      "notFoundTitle": "Liste indisponible",
+      "notFoundBody": "Cette liste est privée ou n'existe plus."
+    },
     "discovered": {
       "pageTitle": "Découvertes",
       "subtitle": "Moments et espaces récemment partagés par la communauté",

--- a/therr-client-web/src/routeConfig.ts
+++ b/therr-client-web/src/routeConfig.ts
@@ -273,6 +273,16 @@ export default [
         view: 'index',
     },
     {
+        route: '/lists/:ownerUserId/:listSlug',
+        head: {
+            // Per-list title/description are injected by server-client.tsx
+            // `renderPublicListView` from the fetched list data.
+            title: 'Public List',
+            description: 'A public list of places on Therr.',
+        },
+        view: 'public-list',
+    },
+    {
         route: '/go-mobile',
         head: {
             title: 'Your Local Hub',

--- a/therr-client-web/src/routes/Bookmarks/PublicListView.tsx
+++ b/therr-client-web/src/routes/Bookmarks/PublicListView.tsx
@@ -1,0 +1,125 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ContentActions } from 'therr-react/redux/actions';
+import {
+    Alert,
+    Button,
+    Container,
+    Group,
+    Paper,
+    SimpleGrid,
+    Skeleton,
+    Stack,
+    Text,
+    Title,
+} from '@mantine/core';
+import useTranslation from '../../hooks/useTranslation';
+import Tile from '../Discovered/Tile';
+
+// Read-only public list page. Fetched via the auth-optional
+// /user-lists/public/:ownerUserId/:listSlug endpoint; populates the shared
+// `activeUserList` Redux slice so SSR preload and client render match.
+const PublicListView: React.FC = () => {
+    const { t: translate } = useTranslation();
+    const { ownerUserId, listSlug } = useParams();
+    const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const activeUserList = useSelector((state: any) => state.content?.activeUserList);
+    const user = useSelector((state: any) => state.user);
+    const [isLoading, setIsLoading] = useState(() => {
+        // If SSR already populated the matching list, render immediately.
+        if (typeof window === 'undefined') return false;
+        return !(activeUserList
+            && activeUserList.isPublic
+            && activeUserList.userId === ownerUserId);
+    });
+    const [notFound, setNotFound] = useState(false);
+
+    const load = useCallback(() => {
+        if (!ownerUserId || !listSlug) return;
+        setIsLoading(true);
+        setNotFound(false);
+        dispatch(ContentActions.fetchPublicUserList(ownerUserId, listSlug) as any)
+            .catch(() => { setNotFound(true); })
+            .finally(() => setIsLoading(false));
+    }, [dispatch, ownerUserId, listSlug]);
+
+    useEffect(() => {
+        const alreadyHydrated = activeUserList
+            && activeUserList.isPublic
+            && activeUserList.userId === ownerUserId;
+        if (!alreadyHydrated) {
+            load();
+        }
+    }, [load]); // eslint-disable-line
+
+    const list = (activeUserList && activeUserList.userId === ownerUserId) ? activeUserList : null;
+    const spaces = (list && list.spaces) || [];
+    const hasContent = spaces.length > 0;
+    const isAuthed = !!user?.isAuthenticated;
+
+    return (
+        <Container id="page_public_list_view" size="lg" py="xl">
+            <Stack gap="lg">
+                <Group justify="space-between" align="flex-start" wrap="wrap">
+                    <Stack gap={4} style={{ flex: 1, minWidth: 240 }}>
+                        <Title order={1} size="h2">
+                            {list?.name || translate('pages.publicList.loadingTitle')}
+                        </Title>
+                        {list && (
+                            <Text size="sm" c="dimmed">
+                                {translate('pages.publicList.itemCount', { count: list.itemCount ?? spaces.length })}
+                            </Text>
+                        )}
+                        {list?.description && (
+                            <Text size="sm" style={{ maxWidth: 720 }}>{list.description}</Text>
+                        )}
+                    </Stack>
+                    {!isAuthed && (
+                        <Button variant="filled" onClick={() => navigate('/go-mobile')}>
+                            {translate('pages.publicList.openInApp')}
+                        </Button>
+                    )}
+                </Group>
+
+                {notFound && (
+                    <Alert color="red" variant="light" title={translate('pages.publicList.notFoundTitle')}>
+                        {translate('pages.publicList.notFoundBody')}
+                    </Alert>
+                )}
+
+                {isLoading && !notFound && (
+                    <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
+                        {[1, 2, 3, 4, 5, 6].map((i) => (
+                            <Skeleton key={i} height={280} radius="md" />
+                        ))}
+                    </SimpleGrid>
+                )}
+
+                {!isLoading && !notFound && !hasContent && (
+                    <Paper withBorder p="xl" radius="md">
+                        <Stack align="center" gap="md">
+                            <Text ta="center" c="dimmed">{translate('pages.publicList.emptyList')}</Text>
+                        </Stack>
+                    </Paper>
+                )}
+
+                {!isLoading && !notFound && hasContent && (
+                    <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
+                        {spaces.map((space: any) => (
+                            <Tile
+                                key={space.id}
+                                area={{ ...space, areaType: 'spaces' }}
+                                areaType="spaces"
+                                userDetails={user.details}
+                            />
+                        ))}
+                    </SimpleGrid>
+                )}
+            </Stack>
+        </Container>
+    );
+};
+
+export default PublicListView;

--- a/therr-client-web/src/routes/index.tsx
+++ b/therr-client-web/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { RouteObject } from 'react-router-dom';
 import { AccessCheckType, IAccess } from 'therr-react/types';
 import { AccessLevels, Categories, Cities } from 'therr-js-utilities/constants';
 import { AuthRoute } from 'therr-react/components';
-import { ForumActions, MapActions } from 'therr-react/redux/actions';
+import { ContentActions, ForumActions, MapActions } from 'therr-react/redux/actions';
 import UsersActions from '../redux/actions/UsersActions';
 
 // SSR-rendered / public routes — keep statically imported for renderToString compatibility
@@ -30,6 +30,7 @@ import DeleteAccount from './DeleteAccount';
 import InviteLanding from './InviteLanding';
 import Guide from './Guide';
 import GuidesIndex from './Guide/GuidesIndex';
+import PublicListView from './Bookmarks/PublicListView';
 import { getGuide, IPostSection } from '../utilities/guideContent';
 
 // Auth-only routes — lazy-loaded client-side to reduce initial bundle size.
@@ -591,6 +592,19 @@ const getRoutes = (routePropsConfig: IRoutePropsConfig): IRoute[] => [
                 withMedia: true,
             })(dispatch).catch(() => undefined)));
         },
+    },
+
+    {
+        // Public shareable list page — SSR-rendered for SEO.
+        // Data is fetched via the auth-optional
+        // /user-lists/public/:ownerUserId/:listSlug endpoint and populates
+        // the `activeUserList` Redux slice.
+        path: '/lists/:ownerUserId/:listSlug',
+        element: <PublicListView />,
+        fetchData: (dispatch: any, params: any) => ContentActions.fetchPublicUserList(
+            params.ownerUserId,
+            params.listSlug,
+        )(dispatch).catch(() => undefined),
     },
 
     // If no route matches, return NotFound component

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -1902,6 +1902,96 @@ const renderGuideView = (req, res, config, { markup, state }, initialState, loca
     });
 };
 
+// Public shareable list page. Injects per-list title/description, OG tags,
+// and a schema.org ItemList. Emits <meta name="robots" content="noindex,follow">
+// for thin lists (fewer than 3 items OR no description) so Google doesn't
+// index low-quality UGC pages.
+const renderPublicListView = (req, res, config, { markup, state }, initialState, localeVars) => {
+    const routePath = config.route;
+    const routeView = config.view;
+    const fallbackTitle = config.head.title;
+    const fallbackDescription = config.head.description;
+
+    const list = initialState?.content?.activeUserList;
+    const ownerUserId = req.params?.ownerUserId;
+
+    if (!list || !list.isPublic || list.userId !== ownerUserId) {
+        res.status(404);
+        return res.render(routeView, {
+            title: fallbackTitle,
+            description: fallbackDescription,
+            listName: '',
+            robotsNoindex: true,
+            markup,
+            routePath,
+            state,
+            ...localeVars,
+        });
+    }
+
+    const spaces: any[] = list.spaces || [];
+    const itemCount = typeof list.itemCount === 'number' ? list.itemCount : spaces.length;
+
+    // Title: "<List name> — a Therr list of places"
+    const title = `${list.name} — a Therr list of places`;
+    // Description: prefer the owner's description; otherwise synthesize from
+    // the first few space names so the snippet is meaningful even for thin lists.
+    const truncate = (str: string, max: number) => (str.length > max ? `${str.slice(0, max - 1)}…` : str);
+    const listDescription = (list.description || '').toString().trim();
+    const fallbackFromSpaces = spaces.slice(0, 6).map((s: any) => s.notificationMsg).filter(Boolean).join(', ');
+    const description = truncate(listDescription || fallbackFromSpaces || fallbackDescription, 300);
+
+    // Thin-content gate. Keep these pages out of Google's index until they
+    // accumulate real content; `follow` still lets Google follow outbound links
+    // to the canonical space pages.
+    const robotsNoindex = itemCount < 3 || !listDescription;
+
+    const itemListSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'ItemList',
+        name: list.name,
+        numberOfItems: itemCount,
+        itemListElement: spaces.slice(0, 50).map((space: any, index: number) => {
+            const slug = buildSpaceSlug(space.notificationMsg, space.addressLocality, space.addressRegion);
+            return {
+                '@type': 'ListItem',
+                position: index + 1,
+                url: `https://www.therr.com${localeVars.localePrefix || ''}/spaces/${space.id}${slug ? `/${slug}` : ''}`,
+                name: space.notificationMsg || space.id,
+            };
+        }),
+    };
+
+    const breadcrumbSchema = {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+            {
+                '@type': 'ListItem', position: 1, name: 'Therr', item: 'https://www.therr.com/',
+            },
+            {
+                '@type': 'ListItem',
+                position: 2,
+                name: list.name,
+                item: `https://www.therr.com${localeVars.canonicalPath}`,
+            },
+        ],
+    };
+
+    return res.render(routeView, {
+        title,
+        description,
+        listName: list.name,
+        robotsNoindex,
+        itemListSchema: JSON.stringify(itemListSchema),
+        breadcrumbSchema: JSON.stringify(breadcrumbSchema),
+        markup,
+        routePath,
+        state,
+        ...localeVars,
+    });
+};
+
 const renderGroupView = (req, res, config, {
     markup,
     state,
@@ -2215,6 +2305,7 @@ const publicRoutePatterns = [
     /^\/thoughts\/[^/]+$/,
     /^\/users\/[^/]+$/,
     /^\/invite\/[^/]+$/,
+    /^\/lists\/[^/]+\/[a-z0-9-]+$/,
     /^\/child-safety$/,
     /^\/go-mobile$/,
     /^\/app-feedback$/,
@@ -2418,6 +2509,10 @@ routeConfig.forEach((config) => {
 
                 if (routeView === 'guides') {
                     return renderGuideView(req, res, config, { markup, state }, initialState, localeVars);
+                }
+
+                if (routeView === 'public-list') {
+                    return renderPublicListView(req, res, config, { markup, state }, initialState, localeVars);
                 }
 
                 return res.render(routeView, {

--- a/therr-client-web/src/views/public-list.hbs
+++ b/therr-client-web/src/views/public-list.hbs
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="{{htmlLang}}">
+
+<head>
+    <meta charset="utf-8" />
+    <title>Therr | {{title}}</title>
+    <link rel="canonical" href="https://www.therr.com{{canonicalPath}}" />
+    <link rel="alternate" hreflang="en-US" href="https://www.therr.com{{hreflangEn}}" />
+    <link rel="alternate" hreflang="es-MX" href="https://www.therr.com{{hreflangEs}}" />
+    <link rel="alternate" hreflang="fr-CA" href="https://www.therr.com{{hreflangFr}}" />
+    <link rel="alternate" hreflang="x-default" href="https://www.therr.com{{hreflangEn}}" />
+
+    <meta name="msapplication-TileColor" content="#da532c">
+    <meta name="theme-color" content="#ffffff">
+
+    <link rel="dns-prefetch" href="https://fonts.googleapis.com">
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link rel="dns-prefetch" href="https://ik.imagekit.io">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://ik.imagekit.io" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@200;400;600;800&display=swap" media="print" id="google-fonts-link">
+    <script>document.getElementById('google-fonts-link').addEventListener('load',function(){this.media='all'});</script>
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lexend:wght@200;400;600;800&display=swap"></noscript>
+    <link rel="preload" as="style" href="/vendor.css" onload="this.onload=null;this.rel='stylesheet'">
+    <link rel="preload" as="style" href="/app.css" onload="this.onload=null;this.rel='stylesheet'">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="{{description}}">
+    {{#if robotsNoindex}}<meta name="robots" content="noindex,follow">{{/if}}
+    <meta name="keywords" content="therr, therr app, local list, places to visit, {{listName}}, things to do">
+
+    <meta property="og:site_name" content="Therr" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="{{ogLocale}}" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="es_MX" />
+    <meta property="og:locale:alternate" content="fr_CA" />
+    <meta property="og:url" content="https://www.therr.com{{canonicalPath}}" />
+    <meta property="og:title" content="Therr | {{title}}" />
+    <meta property="og:image" content="https://therr.com/assets/images/meta-image-logo.png" />
+    <meta property="og:description" content="{{description}}" />
+    <meta name="twitter:image" content="https://therr.com/assets/images/meta-image-logo.png" />
+    <meta name="twitter:title" content="Therr | {{title}}" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@therr_app" />
+
+    {{#if googleSiteVerification}}<meta name="google-site-verification" content="{{googleSiteVerification}}" />{{/if}}
+    {{#if bingSiteVerification}}<meta name="msvalidate.01" content="{{bingSiteVerification}}" />{{/if}}
+    {{#if pinterestVerification}}<meta name="p:domain_verify" content="{{pinterestVerification}}" />{{/if}}
+    <link rel="search" type="application/opensearchdescription+xml" title="Therr" href="/opensearch.xml" />
+    <meta name="apple-itunes-app" content="app-id=1569988763">
+    <link rel="icon" href="/assets/images/favicon.ico">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/images/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/images/favicon-16x16.png">
+    <link rel="mask-icon" href="/assets/images/safari-pinned-tab.svg" color="#5bbad5">
+    <script>document.documentElement.setAttribute('data-mantine-color-scheme', (document.cookie.match(/therr-color-scheme=(light|dark)/)||[])[1]||'light');</script>
+    <style>
+      html{background:#f3f4f6}
+      html,body{color:#1f2937;font-family:'Lexend',sans-serif;font-size:16px;margin:0;padding:0}
+      [data-mantine-color-scheme="dark"]{--mantine-color-body:#1E1E1E;--mantine-color-text:#E0E0E0}
+      [data-mantine-color-scheme="dark"] html{background:#121212}
+      [data-mantine-color-scheme="dark"] html,[data-mantine-color-scheme="dark"] body{color:#E0E0E0}
+      header{z-index:90;align-items:center;background:var(--therr-header-bg,#1C7F8A);display:flex;height:2.8rem;left:0;position:fixed;top:0;width:100%;box-shadow:0 1px 3px rgba(0,0,0,.12)}
+      .content-container,.content-container-home{background:#fff;margin:2.8rem 0;padding:1.5rem 1rem;min-height:calc(100vh - 5.6rem);box-sizing:border-box}
+      [data-mantine-color-scheme="dark"] .content-container,[data-mantine-color-scheme="dark"] .content-container-home{background:#1E1E1E}
+      .view{min-height:100vh}
+      h1{margin:.9rem 0;font-weight:400}
+      @media(min-width:540px){header{height:3rem}.content-container,.content-container-home{margin:3rem 0}}
+    </style>
+    <noscript>
+        <link rel="stylesheet" href="/vendor.css">
+        <link rel="stylesheet" href="/app.css">
+    </noscript>
+
+    {{#if itemListSchema}}
+    <script type="application/ld+json">{{{itemListSchema}}}</script>
+    {{/if}}
+    {{#if breadcrumbSchema}}
+    <script type="application/ld+json">{{{breadcrumbSchema}}}</script>
+    {{/if}}
+</head>
+
+<body>
+    <div id="app" class="view">{{{markup}}}</div>
+    <script>
+        window.__PRELOADED_STATE__ = {{{state}}}
+    </script>
+    <script defer src="/runtime.3f3aa587846de0bb8cf6.js"></script>
+    <script defer src="/vendor.8e197b644a36c40b52ab.js"></script>
+    <script defer src="/app.01cb71cac15106317ed1.js"></script>
+</body>
+
+</html>

--- a/therr-client-web/update-views.js
+++ b/therr-client-web/update-views.js
@@ -15,6 +15,7 @@ const viewFiles = [
     path.join(__dirname, 'src/views/hub.hbs'),
     path.join(__dirname, 'src/views/city-pulse.hbs'),
     path.join(__dirname, 'src/views/guides.hbs'),
+    path.join(__dirname, 'src/views/public-list.hbs'),
 ];
 
 // We need to keep the css/js file paths up to date because we use content hashing in the build compilation

--- a/therr-public-library/therr-react/src/redux/actions/Content.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Content.ts
@@ -369,6 +369,19 @@ const Content = {
             return response?.data;
         })
         .catch((err) => { console.log(err); throw err; }),
+    // Public shareable list fetch — auth-optional. Populates `activeUserList`
+    // via the same reducer case so the read-only web page and SSR can reuse
+    // the existing rendering path.
+    fetchPublicUserList: (ownerUserId: string, listSlug: string, limit = 100, offset = 0) => (dispatch: any) => ReactionsService
+        .fetchPublicUserList(ownerUserId, listSlug, limit, offset)
+        .then((response: any) => {
+            dispatch({
+                type: ContentActionTypes.FETCH_USER_LIST_DETAILS,
+                data: response?.data,
+            });
+            return response?.data;
+        })
+        .catch((err) => { console.log(err); throw err; }),
     createUserList: (params: {
         name: string;
         description?: string;

--- a/therr-public-library/therr-react/src/services/ReactionsService.ts
+++ b/therr-public-library/therr-react/src/services/ReactionsService.ts
@@ -414,6 +414,13 @@ class ReactionsService {
         url: `/reactions-service/user-lists/${listId}?limit=${limit}&offset=${offset}`,
     });
 
+    // Public shareable list — auth-optional. `listSlug` is the lowercase
+    // hyphenated form of the list name (see therr-js-utilities/slugify).
+    fetchPublicUserList = (ownerUserId: string, listSlug: string, limit = 100, offset = 0) => axios({
+        method: 'get',
+        url: `/reactions-service/user-lists/public/${ownerUserId}/${listSlug}?limit=${limit}&offset=${offset}`,
+    });
+
     createUserList = (data: {
         name: string;
         description?: string;

--- a/therr-services/reactions-service/src/handlers/userLists.ts
+++ b/therr-services/reactions-service/src/handlers/userLists.ts
@@ -1,6 +1,7 @@
 import { internalRestRequest } from 'therr-js-utilities/internal-rest-request';
 import { parseHeaders } from 'therr-js-utilities/http';
 import logSpan from 'therr-js-utilities/log-or-update-span';
+import { slugify } from 'therr-js-utilities/slugify';
 import handleHttpError from '../utilities/handleHttpError';
 // Handlers without custom error branching are wrapped at the router with
 // `asyncHandler` (see ../routes/userListsRouter.ts). Keeping try/catch here
@@ -126,6 +127,61 @@ const getUserLists = async (req, res) => {
     return res.status(200).send({ lists: enriched });
 };
 
+// Hydrate list items into full space objects via maps-service. Returns spaces
+// plus any media payload. Failures are non-fatal — returns empty spaces so the
+// list still renders with placeholder rows.
+const hydrateListSpaces = async (items: any[], reqHeaders: any, listIdForLog: string) => {
+    const spaceIds = items
+        .filter((item) => item.contentType === 'space')
+        .map((item) => item.contentId);
+
+    logSpan({
+        level: 'info',
+        messageOrigin: 'API_SERVER',
+        messages: [`hydrateListSpaces: items=${items.length} spaceIds=${spaceIds.length} contentTypes=${items.map((i: any) => i.contentType).join(',')}`],
+        traceArgs: { listId: listIdForLog },
+    });
+
+    if (!spaceIds.length) {
+        return { spaces: [], media: undefined, spaceIds };
+    }
+
+    try {
+        const response = await internalRestRequest({
+            headers: reqHeaders,
+        }, {
+            method: 'post',
+            url: `${globalConfig[process.env.NODE_ENV].baseMapsServiceRoute}/spaces/find`,
+            data: {
+                spaceIds,
+                limit: spaceIds.length,
+                withMedia: true,
+                withUser: true,
+                isDraft: false,
+            },
+        });
+        const spaces = response?.data?.spaces || [];
+        const media = response?.data?.media;
+        if (!spaces.length) {
+            logSpan({
+                level: 'warn',
+                messageOrigin: 'API_SERVER',
+                messages: ['hydrateListSpaces: maps-service returned 0 spaces for non-empty spaceIds'],
+                traceArgs: { listId: listIdForLog, spaceIdsCount: spaceIds.length },
+            });
+        }
+        return { spaces, media, spaceIds };
+    } catch (err: any) {
+        logSpan({
+            level: 'error',
+            messageOrigin: 'API_SERVER',
+            messages: [`hydrateListSpaces: maps-service lookup failed: ${err?.message || err}`],
+            traceArgs: { listId: listIdForLog, spaceIdsCount: spaceIds.length },
+        });
+        return { spaces: [], media: undefined, spaceIds };
+    }
+};
+
 // Get a single list with its spaces
 const getUserListById = async (req, res) => {
     const { userId } = parseHeaders(req.headers);
@@ -146,55 +202,7 @@ const getUserListById = async (req, res) => {
         offset: parseInt(req.query.offset, 10) || 0,
     });
 
-    const spaceIds = items
-        .filter((item) => item.contentType === 'space')
-        .map((item) => item.contentId);
-
-    logSpan({
-        level: 'info',
-        messageOrigin: 'API_SERVER',
-        messages: [`getUserListById: items=${items.length} spaceIds=${spaceIds.length} contentTypes=${items.map((i: any) => i.contentType).join(',')}`],
-        traceArgs: { listId },
-    });
-
-    let spaces: any[] = [];
-    let media: any;
-
-    if (spaceIds.length) {
-        try {
-            const response = await internalRestRequest({
-                headers: req.headers,
-            }, {
-                method: 'post',
-                url: `${globalConfig[process.env.NODE_ENV].baseMapsServiceRoute}/spaces/find`,
-                data: {
-                    spaceIds,
-                    limit: spaceIds.length,
-                    withMedia: true,
-                    withUser: true,
-                    isDraft: false,
-                },
-            });
-            spaces = response?.data?.spaces || [];
-            media = response?.data?.media;
-            if (!spaces.length) {
-                logSpan({
-                    level: 'warn',
-                    messageOrigin: 'API_SERVER',
-                    messages: ['getUserListById: maps-service returned 0 spaces for non-empty spaceIds'],
-                    traceArgs: { listId, spaceIdsCount: spaceIds.length },
-                });
-            }
-        } catch (err: any) {
-            logSpan({
-                level: 'error',
-                messageOrigin: 'API_SERVER',
-                messages: [`getUserListById: maps-service lookup failed: ${err?.message || err}`],
-                traceArgs: { listId, spaceIdsCount: spaceIds.length },
-            });
-            spaces = [];
-        }
-    }
+    const { spaces: hydratedSpaces, media, spaceIds } = await hydrateListSpaces(items, req.headers, listId);
 
     // Attach the reaction for each space (bookmark state, etc.)
     const reactions = spaceIds.length
@@ -204,7 +212,42 @@ const getUserListById = async (req, res) => {
         acc[cur.spaceId] = cur;
         return acc;
     }, {});
-    spaces = spaces.map((s) => ({ ...s, reaction: reactionBySpaceId[s.id] || {} }));
+    const spaces = hydratedSpaces.map((s) => ({ ...s, reaction: reactionBySpaceId[s.id] || {} }));
+
+    return res.status(200).send({
+        list: {
+            ...list,
+            items,
+            spaces,
+        },
+        media,
+    });
+};
+
+// Get a list by (ownerUserId, listSlug) for the public shareable URL.
+// Returns 404 unless the list is marked isPublic=true. Does not require
+// the viewer to be authenticated and does not attach viewer-specific
+// reactions — this response is SSR- and CDN-cache-friendly.
+const getPublicUserListBySlug = async (req, res) => {
+    const { ownerUserId, listSlug } = req.params;
+
+    // Find candidate lists for this owner and match by computed slug. Scanning
+    // the owner's lists is cheap (typically < 20 per user) and avoids storing
+    // a denormalized slug column. The per-owner name uniqueness index guarantees
+    // at most one match.
+    const ownersLists = await Store.userLists.get({ userId: ownerUserId });
+    const list = ownersLists.find((l) => slugify(l.name) === listSlug);
+
+    if (!list || !list.isPublic) {
+        return handleHttpError({ res, message: 'List not found', statusCode: 404 });
+    }
+
+    const items = await Store.userListItems.getByList(list.id, {
+        limit: parseInt(req.query.limit, 10) || 100,
+        offset: parseInt(req.query.offset, 10) || 0,
+    });
+
+    const { spaces, media } = await hydrateListSpaces(items, req.headers, list.id);
 
     return res.status(200).send({
         list: {
@@ -436,6 +479,7 @@ export {
     createUserList,
     getUserLists,
     getUserListById,
+    getPublicUserListBySlug,
     updateUserList,
     deleteUserList,
     addSpaceToList,

--- a/therr-services/reactions-service/src/routes/userListsRouter.ts
+++ b/therr-services/reactions-service/src/routes/userListsRouter.ts
@@ -4,6 +4,7 @@ import {
     createUserList,
     getUserLists,
     getUserListById,
+    getPublicUserListBySlug,
     updateUserList,
     deleteUserList,
     addSpaceToList,
@@ -19,6 +20,11 @@ const router = express.Router();
 // with a grep-able context label.
 router.post('/', createUserList);
 router.get('/', asyncHandler('SQL:USER_LISTS_ROUTES:GET', getUserLists));
+
+// Public shareable list (auth-optional at the gateway; does not require the
+// viewer to be the owner). Must be registered BEFORE `/:listId` so the more
+// specific path matches first.
+router.get('/public/:ownerUserId/:listSlug', asyncHandler('SQL:USER_LISTS_ROUTES:GET_PUBLIC', getPublicUserListBySlug));
 
 // Lookup: which of the user's lists contain a given space (used by the picker)
 router.get('/for-space/:spaceId', asyncHandler('SQL:USER_LISTS_ROUTES:FOR_SPACE', getListsForSpace));


### PR DESCRIPTION
Adds an opt-in "public" flag to bookmark lists so owners can share a
crawlable URL at /lists/:ownerUserId/:listSlug. The `isPublic` column
already existed on main.userLists; this wire-up exposes it end-to-end.

Backend (reactions-service):
- New `getPublicUserListBySlug` handler — auth-optional lookup by
  (ownerUserId, slugified name). Reuses findByUserAndName and a new
  `hydrateListSpaces` helper factored out of getUserListById.
- Internal route mounted before `/:listId` so path ordering matches.

API Gateway:
- New `/user-lists/public/:ownerUserId/:listSlug` route, exempted from
  JWT auth via the existing `.unless` list.
- `getPublicUserListValidation` enforces UUID owner + slug regex.

Shared lib (therr-react):
- `ReactionsService.fetchPublicUserList`.
- `ContentActions.fetchPublicUserList` — dispatches the existing
  FETCH_USER_LIST_DETAILS so `activeUserList` is reused for SSR hydration.

Web (therr-client-web):
- `/lists/:ownerUserId/:listSlug` route registered in routeConfig + routes
  with SSR `fetchData` populating `activeUserList`.
- `PublicListView.tsx` — read-only page, "Open in app" CTA for unauthed.
- `renderPublicListView` in server-client.tsx injects per-list title,
  meta description (falls back to space names), OG tags, ItemList +
  BreadcrumbList JSON-LD, and `<meta name="robots" content="noindex,follow">`
  when itemCount < 3 or description is empty — prevents thin UGC from
  being indexed.
- New `public-list.hbs` view, registered in update-views.js.
- `/lists/[^/]+/[a-z0-9-]+` added to `publicRoutePatterns` (CDN-cacheable).
- Locale strings in en-us, es, fr-ca.

Mobile (TherrMobile):
- BookmarkListDetail: "Make public" Switch + Share icon (owner-only).
  Share uses RN's Share API with a slugified list URL.
- MyLists: "Public" badge on list cards.
- Universal-link handler in Layout.tsx matches `/lists/:uuid/:slug`
  and navigates to MyLists for the owner (in-app viewer for non-owners
  is deferred — the SSR web page is the Phase 1 experience).
- buildPublicListUrl helper in shareUrls.ts.
- Locale strings in en-us, es, fr-ca.

Not included (Phase 2, data-gated):
- Follow a list, collaborator contributors, notification types,
  dynamic sitemap, moderation surface. See plan for re-evaluation gates.

https://claude.ai/code/session_01YP1gBwWMbB2ynytDqsPeSn