### PR TITLE
feat(mobile): add safe fallback to escape ManagePreferences redirect …

### DIFF
--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1294,7 +1294,12 @@
       },
       "alertMessages": {
         "preferenceSettingsUpdated": "Your account & content preferences have been updated.",
-        "preferenceSettingsUpdatedError": "Oops! Something went wrong."
+        "preferenceSettingsUpdatedError": "Oops! Something went wrong.",
+        "loadInterestsError": "We couldn't load your interests right now. You can retry or skip for now."
+      },
+      "buttons": {
+        "retry": "Retry",
+        "skipForNow": "Skip for now"
       }
     },
     "requestSpace": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1294,7 +1294,12 @@
       },
       "alertMessages": {
         "preferenceSettingsUpdated": "Tus preferencias de cuenta y contenido han sido actualizadas.",
-        "preferenceSettingsUpdatedError": "¡Ups! Algo salió mal."
+        "preferenceSettingsUpdatedError": "¡Ups! Algo salió mal.",
+        "loadInterestsError": "No pudimos cargar tus intereses ahora. Puedes reintentar u omitir por ahora."
+      },
+      "buttons": {
+        "retry": "Reintentar",
+        "skipForNow": "Omitir por ahora"
       }
     },
     "requestSpace": {

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -1294,7 +1294,12 @@
       },
       "alertMessages": {
         "preferenceSettingsUpdated": "Votre compte et vos préférences de contenu ont été mis à jour.",
-        "preferenceSettingsUpdatedError": "Oups! Une erreur est survenue."
+        "preferenceSettingsUpdatedError": "Oups! Une erreur est survenue.",
+        "loadInterestsError": "Impossible de charger vos intérêts pour le moment. Vous pouvez réessayer ou passer pour l'instant."
+      },
+      "buttons": {
+        "retry": "Réessayer",
+        "skipForNow": "Passer pour l'instant"
       }
     },
     "requestSpace": {

--- a/TherrMobile/main/routes/Areas/index.tsx
+++ b/TherrMobile/main/routes/Areas/index.tsx
@@ -24,6 +24,7 @@ import { buildStyles as buildDisclosureStyles } from '../../styles/modal/locatio
 import { buildStyles as buildMenuStyles } from '../../styles/navigation/buttonMenu';
 import { buildStyles as buildFormStyles } from '../../styles/forms';
 import translator from '../../utilities/translator';
+import { hasBypassedInterestsRedirect } from '../../utilities/interestsRedirectGuard';
 import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
 import BaseStatusBar from '../../components/BaseStatusBar';
 import { SheetManager } from 'react-native-actions-sheet';
@@ -232,9 +233,9 @@ class Areas extends React.PureComponent<IAreasProps, IAreasState> {
             title: this.translate('pages.myDrafts.headerTitle'),
         });
 
-        if (isUserAuthenticated(user)) {
+        if (isUserAuthenticated(user) && !hasBypassedInterestsRedirect()) {
             UsersService.getUserInterests().then((response) => {
-                if (!response?.data?.length) {
+                if (!response?.data?.length && !hasBypassedInterestsRedirect()) {
                     updateTour({
                         isTouring: false,
                         isNavigationTouring: false,

--- a/TherrMobile/main/routes/Settings/ManagePreferences.tsx
+++ b/TherrMobile/main/routes/Settings/ManagePreferences.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import { connect } from 'react-redux';
@@ -8,10 +8,13 @@ import { IUserState } from 'therr-react/types';
 import { UsersService } from 'therr-react/services';
 import { showToast } from '../../utilities/toasts';
 import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
+import { Button } from '../../components/BaseButton';
 import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
 import UsersActions from '../../redux/actions/UsersActions';
 import translator from '../../utilities/translator';
+import { bypassInterestsRedirect } from '../../utilities/interestsRedirectGuard';
 import { buildStyles } from '../../styles';
+import { getTheme } from '../../styles/themes';
 import { buildStyles as buildButtonStyles } from '../../styles/buttons';
 import { buildStyles as buildMenuStyles } from '../../styles/navigation/buttonMenu';
 import { buildStyles as buildFormStyles } from '../../styles/forms';
@@ -42,6 +45,7 @@ interface IManagePreferencesState {
     interests: any;
     isLoading: boolean;
     isSubmitting: boolean;
+    hasLoadError: boolean;
 }
 
 const mapStateToProps = (state) => ({
@@ -73,6 +77,7 @@ export class ManagePreferences extends React.Component<IManagePreferencesProps, 
             interests: {},
             isLoading: true,
             isSubmitting: false,
+            hasLoadError: false,
         };
 
         this.reloadTheme();
@@ -85,8 +90,13 @@ export class ManagePreferences extends React.Component<IManagePreferencesProps, 
             title: this.translate('pages.managePreferences.headerTitle'),
         });
 
+        this.loadInterests();
+    };
+
+    loadInterests = () => {
         this.setState({
             isLoading: true,
+            hasLoadError: false,
         });
 
         Promise.all([
@@ -108,14 +118,27 @@ export class ManagePreferences extends React.Component<IManagePreferencesProps, 
             });
             this.setState({
                 interests: currentInterests,
+                hasLoadError: false,
             });
         }).catch((err) => {
             console.log(err);
+            this.setState({
+                hasLoadError: true,
+            });
         }).finally(() => {
             this.setState({
                 isLoading: false,
             });
         });
+    };
+
+    handleSkipForNow = () => {
+        bypassInterestsRedirect();
+        if (this.props.navigation.canGoBack()) {
+            this.props.navigation.goBack();
+        } else {
+            this.props.navigation.navigate('Settings');
+        }
     };
 
     isFormDisabled() {
@@ -173,9 +196,10 @@ export class ManagePreferences extends React.Component<IManagePreferencesProps, 
 
     render() {
         const { navigation, user } = this.props;
-        const  { interests, isLoading, isSubmitting } = this.state;
+        const  { interests, isLoading, isSubmitting, hasLoadError } = this.state;
         const pageHeaderAdvancedSettings = this.translate('pages.managePreferences.pageHeaderEmailSettings');
         const pageHeaderYourInterests = this.translate('pages.managePreferences.pageSubHeaderInterests');
+        const themeColors = getTheme(user.settings?.mobileThemeName).colors;
 
         return (
             <>
@@ -200,6 +224,30 @@ export class ManagePreferences extends React.Component<IManagePreferencesProps, 
                                     {pageHeaderYourInterests}
                                 </Text>
                             </View>
+                            {hasLoadError && (
+                                <View style={[
+                                    spacingStyles.marginHorizLg,
+                                    spacingStyles.marginTopLg,
+                                ]}>
+                                    <Text style={[
+                                        this.theme.styles.sectionDescriptionCentered,
+                                        { color: themeColors.alertError },
+                                    ]}>
+                                        {this.translate('pages.managePreferences.alertMessages.loadInterestsError')}
+                                    </Text>
+                                    <View style={spacingStyles.marginTopMd}>
+                                        <Button
+                                            buttonStyle={this.themeForms.styles.buttonPrimary}
+                                            disabledStyle={this.themeForms.styles.buttonDisabled}
+                                            titleStyle={this.themeForms.styles.buttonTitle}
+                                            disabledTitleStyle={this.themeForms.styles.buttonTitleDisabled}
+                                            title={this.translate('pages.managePreferences.buttons.retry')}
+                                            onPress={this.loadInterests}
+                                            disabled={isLoading}
+                                        />
+                                    </View>
+                                </View>
+                            )}
                             <CreateProfileInterests
                                 availableInterests={interests}
                                 isDisabled={isSubmitting}
@@ -214,6 +262,29 @@ export class ManagePreferences extends React.Component<IManagePreferencesProps, 
                                     'forms.settings.buttons.submit'
                                 )}
                             />
+                            <View style={[
+                                spacingStyles.marginHorizLg,
+                                spacingStyles.marginTopMd,
+                                spacingStyles.marginBotLg,
+                                { alignItems: 'center' },
+                            ]}>
+                                <TouchableOpacity
+                                    onPress={this.handleSkipForNow}
+                                    disabled={isSubmitting}
+                                    accessibilityRole="button"
+                                >
+                                    <Text style={[
+                                        this.theme.styles.sectionDescription,
+                                        {
+                                            color: themeColors.hyperlink,
+                                            textDecorationLine: 'underline',
+                                            textAlign: 'center',
+                                        },
+                                    ]}>
+                                        {this.translate('pages.managePreferences.buttons.skipForNow')}
+                                    </Text>
+                                </TouchableOpacity>
+                            </View>
                         </View>
                     </KeyboardAwareScrollView>
                 </SafeAreaView>

--- a/TherrMobile/main/utilities/interestsRedirectGuard.ts
+++ b/TherrMobile/main/utilities/interestsRedirectGuard.ts
@@ -1,0 +1,11 @@
+let hasBypassed = false;
+
+export const hasBypassedInterestsRedirect = (): boolean => hasBypassed;
+
+export const bypassInterestsRedirect = (): void => {
+    hasBypassed = true;
+};
+
+export const resetInterestsRedirectBypass = (): void => {
+    hasBypassed = false;
+};


### PR DESCRIPTION
…loop

Areas force-navigates to ManagePreferences whenever the user has no interests. If loading or saving interests fails there, tapping a bottom tab sends the user back through Areas and the redirect fires again — the user is trapped.

Add a session-scoped bypass flag that the Areas redirect respects, surfaced to the user as:
- A "Skip for now" link that's always available on ManagePreferences and sets the bypass before navigating back to Settings
- An inline error state with a Retry button when the initial interests load fails

The bypass is in-memory only (module-level), so it naturally resets on app restart without persisting an opt-out.