### PR TITLE
fix(habits-web): keep step-num circles round at desktop breakpoint

### DIFF
--- a/therr-client-web/src/views/habits/landing.hbs
+++ b/therr-client-web/src/views/habits/landing.hbs
@@ -131,7 +131,9 @@
         }
         .step-num {
             flex: 0 0 2.25rem;
+            width: 2.25rem;
             height: 2.25rem;
+            aspect-ratio: 1 / 1;
             border-radius: 50%;
             background: var(--habits-coral);
             color: #fff;


### PR DESCRIPTION
When the .step-list <li> switches to flex-direction: column at min-width:
640px, flex-basis on .step-num constrains the main axis (height) instead
of width, so the circles collapse horizontally into vertical ovals. Add
explicit width and aspect-ratio so the shape stays round regardless of
the parent's flex direction.