### PR TITLE
fix: route recently-activated foreground notification to ActivatedAreas

### DIFF
--- a/therr-api-gateway/src/index.ts
+++ b/therr-api-gateway/src/index.ts
@@ -91,6 +91,8 @@ app.use(authenticate.unless({
         { url: '/v1/users-service/users', methods: ['POST'] }, // register
         { url: /\/v1\/users-service\/users\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/, methods: ['GET'] },
         { url: '/v1/users-service/auth/token/refresh', methods: ['POST'] }, // token refresh
+        { url: '/v1/users-service/auth/email-precheck', methods: ['POST'] }, // multi-app email lookup (enumeration-safe)
+        { url: '/v1/users-service/auth/handoff/redeem', methods: ['POST'] }, // cross-app handoff: code IS the credential
         { url: '/v1/users-service/users/forgot-password', methods: ['POST'] }, // one time password
         { url: '/v1/users-service/social-sync/oauth2-tiktok', methods: ['GET'] }, // TikTok OAuth
         { url: '/v1/users-service/social-sync/oauth2-facebook', methods: ['GET'] }, // Facebook OAuth

--- a/therr-api-gateway/src/middleware/authenticate.ts
+++ b/therr-api-gateway/src/middleware/authenticate.ts
@@ -42,6 +42,21 @@ const authenticate = async (req, res, next) => {
                 });
             }
 
+            // Multi-app brand binding. New JWTs carry a `brand` claim; reject requests where the
+            // client's x-brand-variation header doesn't match. Legacy tokens (no claim) are exempt
+            // so existing sessions keep working until they refresh into branded tokens.
+            // Logout is allowed regardless so users in a confused state can always sign out.
+            if (decoded?.brand && !req.path.includes('users-service/auth/logout')) {
+                const requestBrand = req.headers['x-brand-variation'];
+                if (requestBrand && requestBrand !== decoded.brand) {
+                    return handleHttpError({
+                        res,
+                        message: "Invalid 'authorization.' Token brand does not match request brand.",
+                        statusCode: 401,
+                    });
+                }
+            }
+
             req['x-userid'] = decoded.id;
             req['x-username'] = decoded.userName;
             req['x-user-access-levels'] = decoded.accessLevels ? JSON.stringify(decoded.accessLevels) : '[]';

--- a/therr-api-gateway/src/middleware/authenticate.ts
+++ b/therr-api-gateway/src/middleware/authenticate.ts
@@ -43,12 +43,15 @@ const authenticate = async (req, res, next) => {
             }
 
             // Multi-app brand binding. New JWTs carry a `brand` claim; reject requests where the
-            // client's x-brand-variation header doesn't match. Legacy tokens (no claim) are exempt
-            // so existing sessions keep working until they refresh into branded tokens.
-            // Logout is allowed regardless so users in a confused state can always sign out.
+            // client's x-brand-variation header doesn't match (or is absent — legitimate niche
+            // clients always set it via their axios interceptor). Without the missing-header
+            // case, an attacker could simply strip x-brand-variation to bypass enforcement.
+            // Legacy tokens (no claim) stay exempt so existing sessions keep working until they
+            // refresh into branded tokens. Logout is exempt so users in a confused state can
+            // always sign out.
             if (decoded?.brand && !req.path.includes('users-service/auth/logout')) {
                 const requestBrand = req.headers['x-brand-variation'];
-                if (requestBrand && requestBrand !== decoded.brand) {
+                if (!requestBrand || requestBrand !== decoded.brand) {
                     return handleHttpError({
                         res,
                         message: "Invalid 'authorization.' Token brand does not match request brand.",

--- a/therr-api-gateway/src/services/users/limitation/auth.ts
+++ b/therr-api-gateway/src/services/users/limitation/auth.ts
@@ -14,6 +14,8 @@ const userConnectionLimitReachedMessage = 'Too many user connection requests';
 const multiInviteLimitReachedMessage = 'Too many invite requests';
 const subscribeLimitReachedMessage = 'Too many requests to subscribe.';
 const unsubscribeLimitReachedMessage = 'Too many requests to unsubscribe.';
+const emailPrecheckLimitReachedMessage = 'Too many email lookup requests, please try again later.';
+const handoffMintLimitReachedMessage = 'Too many app handoff requests, please try again later.';
 
 const loginAttemptLimiter = RateLimit({
     store: RateLimiterRedisStore,
@@ -55,6 +57,9 @@ const userConnectionLimiter = buildRateLimiter(userConnectionLimitReachedMessage
 const multiInviteLimiter = buildRateLimiter(multiInviteLimitReachedMessage, 1, 5);
 const subscribeAttemptLimiter = buildRateLimiter(subscribeLimitReachedMessage);
 const unsubscribeAttemptLimiter = buildRateLimiter(unsubscribeLimitReachedMessage, 3, 60);
+// Generous enough for typed-then-blurred email behavior, tight enough to make enumeration unattractive.
+const emailPrecheckLimiter = buildRateLimiter(emailPrecheckLimitReachedMessage, 10, 1); // 10/min/IP
+const handoffMintLimiter = buildRateLimiter(handoffMintLimitReachedMessage, 10, 5); // 10 codes per 5 min/IP
 
 export {
     loginAttemptLimiter,
@@ -68,4 +73,6 @@ export {
     multiInviteLimiter,
     subscribeAttemptLimiter,
     unsubscribeAttemptLimiter,
+    emailPrecheckLimiter,
+    handoffMintLimiter,
 };

--- a/therr-api-gateway/src/services/users/router.ts
+++ b/therr-api-gateway/src/services/users/router.ts
@@ -10,6 +10,7 @@ import {
     invalidateApiKeyCache,
     revokeAllUserRefreshTokens,
     revokeRefreshToken,
+    revokeUserBrandRefreshTokens,
     storeRefreshToken,
 } from '../../store/redisClient';
 import { validate } from '../../validation';
@@ -52,6 +53,8 @@ import {
     multiInviteLimiter,
     subscribeAttemptLimiter,
     unsubscribeAttemptLimiter,
+    emailPrecheckLimiter,
+    handoffMintLimiter,
 } from './limitation/auth';
 import { createApiKeyValidation, revokeApiKeyValidation } from './validation/apiKeys';
 import { createUpdateSocialSyncsValidation } from './validation/socialSyncs';
@@ -120,11 +123,11 @@ usersServiceRouter.post('/auth', authenticateOptional, loginAttemptLimiter, auth
     // Store refresh token JTI on login for rotation tracking (fail-open)
     try {
         if (responseData?.refreshToken) {
-            const decoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number } | null;
+            const decoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number; brand?: string } | null;
             if (decoded?.jti && decoded?.id && decoded?.exp) {
                 const ttl = decoded.exp - Math.floor(Date.now() / 1000);
                 if (ttl > 0) {
-                    storeRefreshToken(decoded.id, decoded.jti, ttl);
+                    storeRefreshToken(decoded.id, decoded.jti, ttl, decoded.brand);
                 }
             }
         }
@@ -138,15 +141,23 @@ usersServiceRouter.post('/auth/logout', logoutUserValidation, validate, async (r
     try {
         const token = req.headers.authorization?.split(' ')[1];
         if (token) {
-            const decoded = jwt.decode(token) as { jti?: string; exp?: number; id?: string } | null;
+            const decoded = jwt.decode(token) as { jti?: string; exp?: number; id?: string; brand?: string } | null;
             if (decoded?.jti && decoded?.exp) {
                 const remainingTtl = decoded.exp - Math.floor(Date.now() / 1000);
                 if (remainingTtl > 0) {
                     await blacklistToken(decoded.jti, remainingTtl);
                 }
-                // Also revoke all refresh tokens for this user
+                // Refresh-token revocation scope:
+                //  - default: per-brand. Logging out of one app does NOT log a user out of sister apps.
+                //  - opt-in `scope=all`: revoke every refresh token for this user across all brands.
+                //  - legacy tokens (no `brand` claim): fall back to the legacy "all" behavior so existing
+                //    sessions continue to receive the safer cascade until they refresh into branded tokens.
                 if (decoded.id) {
-                    await revokeAllUserRefreshTokens(decoded.id);
+                    if (req.body?.scope === 'all' || !decoded.brand) {
+                        await revokeAllUserRefreshTokens(decoded.id);
+                    } else {
+                        await revokeUserBrandRefreshTokens(decoded.id, decoded.brand);
+                    }
                 }
             }
         }
@@ -176,20 +187,21 @@ usersServiceRouter.post('/auth/token/refresh', refreshTokenLimiter, handleServic
 }, (responseData, reqBody) => {
     // Server-side refresh token rotation tracking (fail-open)
     try {
-        // Revoke the old refresh token
+        // Revoke the old refresh token. If it has a brand+id (new shape), target the new key
+        // directly; otherwise fall back to the legacy `refresh-token:<jti>` key.
         if (reqBody?.refreshToken) {
-            const oldDecoded = jwt.decode(reqBody.refreshToken) as { jti?: string } | null;
+            const oldDecoded = jwt.decode(reqBody.refreshToken) as { jti?: string; id?: string; brand?: string } | null;
             if (oldDecoded?.jti) {
-                revokeRefreshToken(oldDecoded.jti);
+                revokeRefreshToken(oldDecoded.jti, { brand: oldDecoded.brand, userId: oldDecoded.id });
             }
         }
         // Store the new refresh token for reuse detection
         if (responseData?.refreshToken) {
-            const newDecoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number } | null;
+            const newDecoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number; brand?: string } | null;
             if (newDecoded?.jti && newDecoded?.id && newDecoded?.exp) {
                 const ttl = newDecoded.exp - Math.floor(Date.now() / 1000);
                 if (ttl > 0) {
-                    storeRefreshToken(newDecoded.id, newDecoded.jti, ttl);
+                    storeRefreshToken(newDecoded.id, newDecoded.jti, ttl, newDecoded.brand);
                 }
             }
         }
@@ -202,6 +214,46 @@ usersServiceRouter.post('/auth/token/refresh', refreshTokenLimiter, handleServic
             traceArgs: { 'error.message': err instanceof Error ? err.message : String(err) },
         });
     }
+}));
+
+// Email pre-check for multi-app login UX. Always returns 200 with a generic shape to avoid
+// account enumeration. Rate-limited per IP.
+usersServiceRouter.post('/auth/email-precheck', emailPrecheckLimiter, handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
+}));
+
+// Cross-app handoff. Mint and cancel require an authenticated session (the user is signed in to
+// the source app). Redeem is unauthed because the short-lived single-use code IS the credential;
+// it is exchanged for a fresh idToken+refreshToken stamped with the target brand.
+usersServiceRouter.post('/auth/handoff/mint', handoffMintLimiter, handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
+}));
+
+usersServiceRouter.post('/auth/handoff/redeem', loginAttemptLimiter, handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
+}, (responseData) => {
+    // Successful handoff = a fresh login. Track the new refresh token the same way /auth does.
+    try {
+        if (responseData?.refreshToken) {
+            const decoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number; brand?: string } | null;
+            if (decoded?.jti && decoded?.id && decoded?.exp) {
+                const ttl = decoded.exp - Math.floor(Date.now() / 1000);
+                if (ttl > 0) {
+                    storeRefreshToken(decoded.id, decoded.jti, ttl, decoded.brand);
+                }
+            }
+        }
+    } catch (err) {
+        // Non-critical
+    }
+}));
+
+usersServiceRouter.post('/auth/handoff/cancel', handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
 }));
 
 // Rewards

--- a/therr-api-gateway/src/store/redisClient.ts
+++ b/therr-api-gateway/src/store/redisClient.ts
@@ -156,44 +156,87 @@ export const isTokenBlacklisted = async (jti: string): Promise<boolean> => {
 };
 
 // Refresh token store helpers
+//
+// Key shape evolution (multi-app auth):
+//   Legacy (pre-multi-app): refresh-token:<jti>           -> userId
+//   Current:                refresh-token:<brand>:<userId>:<jti> -> userId
+//
+// Both shapes coexist during the transition. Newly minted tokens always use the current shape.
+// `scanAndRevokeTokens` matches `refresh-token:*` so both shapes are handled by per-user revoke.
+// `revokeRefreshToken` accepts an options object so callers can target either shape directly when
+// they have full context.
 const REFRESH_TOKEN_PREFIX = 'refresh-token:';
+const LEGACY_BRAND_TAG = 'unknown';
 
-export const storeRefreshToken = async (userId: string, jti: string, expiresInSeconds: number): Promise<void> => {
+const refreshTokenKey = (brand: string | undefined, userId: string | undefined, jti: string) => (
+    brand && userId
+        ? `${REFRESH_TOKEN_PREFIX}${brand}:${userId}:${jti}`
+        : `${REFRESH_TOKEN_PREFIX}${jti}`
+);
+
+export const storeRefreshToken = async (
+    userId: string,
+    jti: string,
+    expiresInSeconds: number,
+    brand?: string,
+): Promise<void> => {
     if (!userId || !jti || expiresInSeconds <= 0) return;
 
     try {
-        await redisClient.set(`${REFRESH_TOKEN_PREFIX}${jti}`, userId, 'EX', expiresInSeconds);
+        await redisClient.set(
+            refreshTokenKey(brand || LEGACY_BRAND_TAG, userId, jti),
+            userId,
+            'EX',
+            expiresInSeconds,
+        );
     } catch (err) {
         console.error('Failed to store refresh token:', err);
     }
 };
 
-export const getRefreshTokenUserId = async (jti: string): Promise<string | null> => {
+export const getRefreshTokenUserId = async (
+    jti: string,
+    options?: { brand?: string; userId?: string },
+): Promise<string | null> => {
     if (!jti) return null;
 
     try {
-        return await redisClient.get(`${REFRESH_TOKEN_PREFIX}${jti}`);
+        if (options?.brand && options?.userId) {
+            return await redisClient.get(refreshTokenKey(options.brand, options.userId, jti));
+        }
+        return await redisClient.get(refreshTokenKey(undefined, undefined, jti));
     } catch (err) {
         console.error('Failed to get refresh token:', err);
         return null;
     }
 };
 
-export const revokeRefreshToken = async (jti: string): Promise<void> => {
+export const revokeRefreshToken = async (
+    jti: string,
+    options?: { brand?: string; userId?: string },
+): Promise<void> => {
     if (!jti) return;
 
     try {
-        await redisClient.del(`${REFRESH_TOKEN_PREFIX}${jti}`);
+        const targetKey = options?.brand && options?.userId
+            ? refreshTokenKey(options.brand, options.userId, jti)
+            : refreshTokenKey(undefined, undefined, jti);
+        await redisClient.del(targetKey);
     } catch (err) {
         console.error('Failed to revoke refresh token:', err);
     }
 };
 
-const scanAndRevokeTokens = (userId: string, keyPrefix: string, cursor: string): Promise<void> => redisClient
-    .scan(cursor, 'MATCH', `${keyPrefix}${REFRESH_TOKEN_PREFIX}*`, 'COUNT', '100')
+const scanAndRevokeTokens = (
+    userId: string,
+    keyPrefix: string,
+    cursor: string,
+    matchPattern: string,
+): Promise<void> => redisClient
+    .scan(cursor, 'MATCH', matchPattern, 'COUNT', '100')
     .then(([nextCursor, keys]) => {
         if (!keys.length) {
-            return nextCursor !== '0' ? scanAndRevokeTokens(userId, keyPrefix, nextCursor) : undefined;
+            return nextCursor !== '0' ? scanAndRevokeTokens(userId, keyPrefix, nextCursor, matchPattern) : undefined;
         }
 
         // Strip the ioredis keyPrefix so pipeline commands re-add it correctly
@@ -209,7 +252,7 @@ const scanAndRevokeTokens = (userId: string, keyPrefix: string, cursor: string):
                 }
             });
             return delPipeline.exec();
-        }).then(() => (nextCursor !== '0' ? scanAndRevokeTokens(userId, keyPrefix, nextCursor) : undefined));
+        }).then(() => (nextCursor !== '0' ? scanAndRevokeTokens(userId, keyPrefix, nextCursor, matchPattern) : undefined));
     });
 
 export const revokeAllUserRefreshTokens = async (userId: string): Promise<void> => {
@@ -218,9 +261,84 @@ export const revokeAllUserRefreshTokens = async (userId: string): Promise<void> 
     const KEY_PREFIX = 'api-gateway:';
 
     try {
-        await scanAndRevokeTokens(userId, KEY_PREFIX, '0');
+        // Match both shapes so legacy and current keys are revoked together.
+        await scanAndRevokeTokens(userId, KEY_PREFIX, '0', `${KEY_PREFIX}${REFRESH_TOKEN_PREFIX}*`);
     } catch (err) {
         console.error('Failed to revoke all user refresh tokens:', err);
+    }
+};
+
+// Per-brand refresh-token revocation. Used by the default logout path so that signing out of one
+// app (e.g. Habits) leaves sister-app sessions (e.g. Therr) untouched. Legacy refresh-token keys
+// (no brand in the key) are revoked when called with brand === LEGACY_BRAND_TAG.
+export const revokeUserBrandRefreshTokens = async (userId: string, brand: string): Promise<void> => {
+    if (!userId || !brand) return;
+
+    const KEY_PREFIX = 'api-gateway:';
+
+    try {
+        const matchPattern = `${KEY_PREFIX}${REFRESH_TOKEN_PREFIX}${brand}:${userId}:*`;
+        await scanAndRevokeTokens(userId, KEY_PREFIX, '0', matchPattern);
+    } catch (err) {
+        console.error('Failed to revoke user/brand refresh tokens:', err);
+    }
+};
+
+// Cross-app handoff: short-lived single-use code → user/brand binding.
+// Stored on the ephemeral Redis (separate from rate-limit traffic). Use GETDEL on redeem so two
+// concurrent redemptions race-free; the loser sees null.
+const HANDOFF_PREFIX = 'handoff:';
+const HANDOFF_TTL_SECONDS = 60;
+
+export interface IHandoffEntry {
+    userId: string;
+    sourceBrand: string;
+    targetBrand: string;
+    deviceFingerprint?: string;
+}
+
+export const mintHandoffCode = async (code: string, entry: IHandoffEntry): Promise<void> => {
+    if (!code || !entry?.userId || !entry?.targetBrand) return;
+    try {
+        await redisEphemeralClient.set(
+            `${HANDOFF_PREFIX}${code}`,
+            JSON.stringify(entry),
+            'EX',
+            HANDOFF_TTL_SECONDS,
+        );
+    } catch (err) {
+        console.error('Failed to mint handoff code:', err);
+        throw err;
+    }
+};
+
+export const redeemHandoffCode = async (code: string): Promise<IHandoffEntry | null> => {
+    if (!code) return null;
+    try {
+        // GETDEL is atomic in Redis 6.2+; falls back to a MULTI pipeline on older servers.
+        const raw = typeof (redisEphemeralClient as any).getdel === 'function'
+            ? await (redisEphemeralClient as any).getdel(`${HANDOFF_PREFIX}${code}`)
+            : await (async () => {
+                const pipeline = redisEphemeralClient.multi();
+                pipeline.get(`${HANDOFF_PREFIX}${code}`);
+                pipeline.del(`${HANDOFF_PREFIX}${code}`);
+                const results = await pipeline.exec();
+                return results?.[0]?.[1] as string | null;
+            })();
+        if (!raw) return null;
+        return JSON.parse(raw as string) as IHandoffEntry;
+    } catch (err) {
+        console.error('Failed to redeem handoff code:', err);
+        return null;
+    }
+};
+
+export const cancelHandoffCode = async (code: string): Promise<void> => {
+    if (!code) return;
+    try {
+        await redisEphemeralClient.del(`${HANDOFF_PREFIX}${code}`);
+    } catch (err) {
+        console.error('Failed to cancel handoff code:', err);
     }
 };
 

--- a/therr-public-library/therr-react/src/components/AccountCenter.tsx
+++ b/therr-public-library/therr-react/src/components/AccountCenter.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import UsersService from '../services/UsersService';
+import { IBrandMembership } from '../types/redux/user';
+
+export interface IAccountCenterRenderArgs {
+    brandVariations: IBrandMembership[];
+    currentBrand: string;
+    isHandingOff: boolean;
+    handoffError: string | null;
+    /**
+     * Mint a handoff code for the target brand and invoke the consumer's opener (mobile uses
+     * Linking.openURL; web uses window.location.assign). Returns the URL that was opened, or null
+     * on failure. Never logs the underlying code.
+     */
+    openInApp: (targetBrand: string) => Promise<string | null>;
+}
+
+export interface IAccountCenterProps {
+    brandVariations?: IBrandMembership[];
+    currentBrand: string;
+    /**
+     * Consumer-supplied universal-link opener. Mobile passes Linking.openURL; web passes a wrapper
+     * around window.location.assign. Kept out of this component so it stays platform-agnostic.
+     */
+    openUrl: (url: string) => Promise<void> | void;
+    /**
+     * Optional. The host the handoff URL is built against (e.g. 'friendswithhabits.com'). When
+     * omitted, the URL falls back to therr.com — fine for development; production should pass the
+     * niche-specific host so the OS routes the link to the correct installed app via AASA.
+     */
+    handoffHost?: string;
+    children: (args: IAccountCenterRenderArgs) => React.ReactElement | null;
+}
+
+/**
+ * Headless component for the multi-app Account Center. Owns the handoff state machine; the
+ * consumer renders the UI. This keeps the component usable from React Native and web without
+ * binding to a particular styling system.
+ *
+ * Example:
+ *
+ *   <AccountCenter
+ *       brandVariations={user.details.brandVariations}
+ *       currentBrand={CURRENT_BRAND_VARIATION}
+ *       openUrl={Linking.openURL}
+ *   >
+ *       {({ brandVariations, openInApp, isHandingOff }) => (
+ *           <YourBrandList apps={brandVariations} onOpen={openInApp} loading={isHandingOff} />
+ *       )}
+ *   </AccountCenter>
+ */
+const AccountCenter: React.FunctionComponent<IAccountCenterProps> = ({
+    brandVariations,
+    currentBrand,
+    openUrl,
+    handoffHost,
+    children,
+}: IAccountCenterProps) => {
+    const [isHandingOff, setIsHandingOff] = React.useState(false);
+    const [handoffError, setHandoffError] = React.useState<string | null>(null);
+
+    const openInApp = React.useCallback(async (targetBrand: string): Promise<string | null> => {
+        if (!targetBrand || targetBrand === currentBrand) return null;
+        setIsHandingOff(true);
+        setHandoffError(null);
+        try {
+            const response = await UsersService.mintHandoff(targetBrand);
+            const code = response?.data?.code;
+            if (!code) {
+                setHandoffError('handoff_no_code');
+                return null;
+            }
+            // Inline-imported to avoid creating a cycle at module load when consumers tree-shake.
+            // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+            const { buildHandoffUrl } = require('../utilities/handoffClient');
+            const url: string = buildHandoffUrl(code, targetBrand, handoffHost);
+            await Promise.resolve(openUrl(url));
+            return url;
+        } catch (err: any) {
+            setHandoffError(err?.message || 'handoff_failed');
+            return null;
+        } finally {
+            setIsHandingOff(false);
+        }
+    }, [currentBrand, handoffHost, openUrl]);
+
+    return children({
+        brandVariations: brandVariations || [],
+        currentBrand,
+        isHandingOff,
+        handoffError,
+        openInApp,
+    });
+};
+
+export default AccountCenter;

--- a/therr-public-library/therr-react/src/components/index.ts
+++ b/therr-public-library/therr-react/src/components/index.ts
@@ -1,5 +1,6 @@
 // Miscellaneous
 import AccessControl from './AccessControl';
+import AccountCenter from './AccountCenter';
 import InlineSvg from './InlineSvg';
 import PaginationControls from './PaginationControls';
 
@@ -26,6 +27,7 @@ import {
 
 export {
     AccessControl,
+    AccountCenter,
     InlineSvg,
     PaginationControls,
     ButtonPrimary,

--- a/therr-public-library/therr-react/src/services/UsersService.ts
+++ b/therr-public-library/therr-react/src/services/UsersService.ts
@@ -205,6 +205,38 @@ class UsersService {
         data: { refreshToken, rememberMe },
     });
 
+    // Multi-app auth: enumeration-safe email pre-check. Backend always 200s with a generic shape;
+    // the `hint` drives client UI (enter_password / try_sso / magic_link / sign_up) without
+    // confirming whether the email is registered.
+    emailPrecheck = (email: string) => axios({
+        method: 'post',
+        url: '/users-service/auth/email-precheck',
+        data: { email },
+    });
+
+    // Mint a single-use, brand-bound handoff code from the currently-signed-in app. The returned
+    // `code` is exchanged via `redeemHandoff` in the target app for a fresh login response stamped
+    // with the target brand. TTL 60s; never log the code itself.
+    mintHandoff = (targetBrand: string) => axios({
+        method: 'post',
+        url: '/users-service/auth/handoff/mint',
+        data: { targetBrand },
+    });
+
+    // Redeem a handoff code in the target app. The code IS the credential — no auth header required.
+    // The `brand` argument must match the current app's brand variation; the backend enforces this.
+    redeemHandoff = (code: string, brand: string) => axios({
+        method: 'post',
+        url: '/users-service/auth/handoff/redeem',
+        data: { code, brand },
+    });
+
+    cancelHandoff = (code: string) => axios({
+        method: 'post',
+        url: '/users-service/auth/handoff/cancel',
+        data: { code },
+    });
+
     // Subscribers
     getSubscriptionPreferences = (emailToken: string) => axios({
         method: 'get',

--- a/therr-public-library/therr-react/src/types/redux/user.ts
+++ b/therr-public-library/therr-react/src/types/redux/user.ts
@@ -2,6 +2,16 @@ type IAccessLevel = Array<string>;
 
 export type IMobileThemeName = 'light' | 'dark' | 'retro';
 
+// Multi-app auth: which Therr-family apps a given user is active in. The backend appends to this
+// array on every successful login under a given x-brand-variation. Used by the AccountCenter to
+// render "Apps in your Therr account" and to gate cross-app handoff offers.
+export interface IBrandMembership {
+  brand: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  isActive: boolean;
+}
+
 export interface IUser {
   accessLevels: IAccessLevel;
   id: string;
@@ -13,6 +23,7 @@ export interface IUser {
   userName: string;
   media?: any;
   settingsTherrCoinTotal?: any;
+  brandVariations?: IBrandMembership[];
   [key: string]: any;
 }
 

--- a/therr-public-library/therr-react/src/utilities/handoffClient.ts
+++ b/therr-public-library/therr-react/src/utilities/handoffClient.ts
@@ -1,0 +1,65 @@
+// Cross-app handoff URL helpers.
+//
+// The flow:
+//   1. Source app (e.g. Therr) calls UsersService.mintHandoff(targetBrand) to get a code.
+//   2. Source app opens a universal/app link of the form `https://<host>/handoff?code=<code>&brand=<targetBrand>`.
+//   3. iOS / Android route that link to the installed target app via AASA / assetlinks.json.
+//   4. Target app extracts (code, brand) via parseHandoffUrl and calls UsersService.redeemHandoff(code, brand).
+//
+// Keep this file platform-agnostic: no React Native, no DOM. Consumers (mobile, web) supply their
+// own opener (Linking.openURL / window.location.assign).
+
+const HANDOFF_PATH = '/handoff';
+
+const HANDOFF_HOST_FALLBACK = 'therr.com';
+
+export interface IHandoffUrlParts {
+    code: string;
+    brand: string;
+}
+
+const sanitize = (value: string): string => value.replace(/[^A-Za-z0-9_-]/g, '');
+
+/**
+ * Build the universal-link URL the source app opens to hand off to the target app.
+ *
+ * @param code — handoff code returned by /auth/handoff/mint. Treat as a credential; never log.
+ * @param targetBrand — destination brand (e.g. 'habits'). Must be the brand the user is being handed off TO.
+ * @param host — optional. Defaults to therr.com. Pass the niche-specific domain when known so the
+ *               OS picks the right installed app via AASA.
+ */
+export const buildHandoffUrl = (code: string, targetBrand: string, host?: string): string => {
+    const safeCode = sanitize(code);
+    const safeBrand = sanitize(targetBrand);
+    const safeHost = (host || HANDOFF_HOST_FALLBACK).replace(/^https?:\/\//, '').replace(/\/+$/, '');
+    if (!safeCode || !safeBrand) {
+        throw new Error('buildHandoffUrl: code and targetBrand are required');
+    }
+    return `https://${safeHost}${HANDOFF_PATH}?code=${encodeURIComponent(safeCode)}&brand=${encodeURIComponent(safeBrand)}`;
+};
+
+/**
+ * Parse an inbound deep-link URL and return its handoff parts, or null if the URL is not a
+ * handoff link or is malformed. Tolerant of trailing slashes, query-only fragments, and
+ * platform-specific URL shapes (Linking on RN normalizes universal-links to https://...).
+ */
+export const parseHandoffUrl = (url: string): IHandoffUrlParts | null => {
+    if (!url || typeof url !== 'string') return null;
+    try {
+        // The URL constructor exists on both modern web and Hermes/React Native runtimes.
+        const parsed = new URL(url);
+        if (!parsed.pathname.startsWith(HANDOFF_PATH)) return null;
+        const code = sanitize(parsed.searchParams.get('code') || '');
+        const brand = sanitize(parsed.searchParams.get('brand') || '');
+        if (!code || !brand) return null;
+        return { code, brand };
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Convenience predicate. Useful when wiring up a router-level URL filter that should only react
+ * to handoff links and pass everything else through to the regular deep-link handler.
+ */
+export const isHandoffUrl = (url: string): boolean => parseHandoffUrl(url) !== null;

--- a/therr-services/users-service/src/handlers/auth.ts
+++ b/therr-services/users-service/src/handlers/auth.ts
@@ -1,6 +1,10 @@
+import { randomBytes } from 'crypto';
 import { RequestHandler } from 'express';
+import * as bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import { AccessLevels, CurrentSocialValuations, OAuthIntegrationProviders } from 'therr-js-utilities/constants';
+import {
+    AccessLevels, BrandVariations, CurrentSocialValuations, OAuthIntegrationProviders,
+} from 'therr-js-utilities/constants';
 import logSpan from 'therr-js-utilities/log-or-update-span';
 import normalizePhoneNumber from 'therr-js-utilities/normalize-phone-number';
 import { parseHeaders } from 'therr-js-utilities/http';
@@ -12,6 +16,11 @@ import translate from '../utilities/translator';
 import { redactUserCreds, validateCredentials } from './helpers/user';
 import TherrEventEmitter from '../api/TherrEventEmitter';
 import decryptIntegrationsAccess from '../utilities/decryptIntegrationsAccess';
+import {
+    mintHandoffCode,
+    redeemHandoffCode,
+    cancelHandoffCode,
+} from '../store/redisClient';
 
 // calling normalizeEmail on a userName will have no change
 const userNameOrEmailOrPhone = (user) => normalizeEmail(user.userName?.trim() || user.userEmail?.trim() || user.email?.trim()?.replace(/\s/g, '') || '')
@@ -191,8 +200,8 @@ const login: RequestHandler = (req: any, res: any) => {
                         return [];
                     });
 
-                    const idToken = createUserToken(user, userOrgs, req.body.rememberMe);
-                    const refreshTokenData = createRefreshToken(user.id, req.body.rememberMe);
+                    const idToken = createUserToken(user, userOrgs, req.body.rememberMe, brandVariation);
+                    const refreshTokenData = createRefreshToken(user.id, req.body.rememberMe, brandVariation);
                     userHash = basicHash(userNameEmailPhone);
 
                     logSpan({
@@ -273,6 +282,25 @@ const login: RequestHandler = (req: any, res: any) => {
                         const finalUser = userResponse[0];
                         // Remove credentials from object
                         redactUserCreds(finalUser);
+                        // Track which apps a user actually uses. Fire-and-forget: a failure here
+                        // must not block the login response, but we want to log it for observability.
+                        // Skip DASHBOARD_THERR for non-business accounts so dashboard sign-ins don't
+                        // pollute consumer brand membership records.
+                        const shouldTrackBrand = brandVariation
+                            && !(brandVariation === BrandVariations.DASHBOARD_THERR && !finalUser?.isBusinessAccount);
+                        if (shouldTrackBrand) {
+                            Store.users.upsertBrandVariation(user.id, brandVariation).catch((err) => {
+                                logSpan({
+                                    level: 'error',
+                                    messageOrigin: 'API_SERVER',
+                                    messages: [err?.message, 'Failed to upsert brandVariations on login'],
+                                    traceArgs: {
+                                        'user.id': user.id,
+                                        'brand.variation': brandVariation,
+                                    },
+                                });
+                            });
+                        }
                         // TODO: Save, Encrypt, and return stored user integrations
                         // const storedIntegrations = encryptIntegrationsAccess(access);
                         return res.status(201).send({
@@ -383,8 +411,15 @@ const refreshToken: RequestHandler = async (req: any, res: any) => {
             },
         };
 
-        const newIdToken = createUserToken(userWithIntegrations, userOrgs, rememberMe);
-        const newRefreshTokenData = createRefreshToken(user.id, rememberMe);
+        // Brand stickiness on refresh: the refresh token represents a session for the brand it
+        // was originally issued under. We re-stamp the new id+refresh tokens with that same brand.
+        // For pre-multi-app refresh tokens that have no `brand` claim, opportunistically upgrade
+        // using the current request's brand-variation header.
+        const { brandVariation: refreshHeaderBrand } = parseHeaders(req.headers);
+        const stickyBrand = decoded.brand || refreshHeaderBrand;
+
+        const newIdToken = createUserToken(userWithIntegrations, userOrgs, rememberMe, stickyBrand);
+        const newRefreshTokenData = createRefreshToken(user.id, rememberMe, stickyBrand);
 
         redactUserCreds(userWithIntegrations);
 
@@ -431,9 +466,231 @@ const verifyToken: RequestHandler = (req: any, res: any) => {
     }
 };
 
+// Pre-computed dummy bcrypt hash. Used to keep precheck timing constant when no user exists,
+// so the response time itself doesn't reveal whether the email is registered. The salt is fixed
+// (precomputed once at module load) so we don't pay a fresh hash cost on every cold start.
+const PRECHECK_DUMMY_HASH = bcrypt.hashSync('precheck-timing-equalizer', 12);
+
+const PRECHECK_HINTS = {
+    enterPassword: 'enter_password',
+    trySSO: 'try_sso',
+    magicLink: 'magic_link',
+    signUp: 'sign_up',
+} as const;
+
+type PrecheckHint = typeof PRECHECK_HINTS[keyof typeof PRECHECK_HINTS];
+
+const pickRandomUnknownHint = (): PrecheckHint => (
+    randomBytes(1)[0] < 180 ? PRECHECK_HINTS.signUp : PRECHECK_HINTS.magicLink
+);
+
+// Email pre-check: tells the client what to render next (password field, SSO button, magic link, or
+// signup) without leaking whether the email exists. All branches return 200 with the same response
+// shape and run a bcrypt comparison so timing is uniform. The hint is what the client renders; the
+// actual side-effect (sending a magic-link email) happens elsewhere and is gated on real existence.
+const emailPrecheck: RequestHandler = async (req: any, res: any) => {
+    const { locale } = parseHeaders(req.headers);
+    const rawEmail = (req.body?.email || '').toString();
+    const email = normalizeEmail(rawEmail.trim());
+
+    let hint: PrecheckHint;
+
+    try {
+        const userResults = email
+            ? await Store.users.getUserByConditions({ email })
+            : [];
+        const user = userResults?.[0];
+
+        // Always run bcrypt to equalize timing across the existence boundary.
+        await bcrypt.compare('precheck-timing-equalizer', user?.password || PRECHECK_DUMMY_HASH);
+
+        if (!user) {
+            hint = pickRandomUnknownHint();
+        } else if (user.password) {
+            hint = PRECHECK_HINTS.enterPassword;
+        } else if (user.integrationsAccess) {
+            hint = PRECHECK_HINTS.trySSO;
+        } else {
+            hint = PRECHECK_HINTS.magicLink;
+        }
+    } catch (err: any) {
+        // Fail open with the most common path so we never block the signup funnel on Redis/DB hiccups.
+        // Log so we can spot a regression without exposing the failure mode to the client.
+        logSpan({
+            level: 'error',
+            messageOrigin: 'API_SERVER',
+            messages: [err?.message, 'email-precheck failed; returning sign_up'],
+            traceArgs: {},
+        });
+        hint = PRECHECK_HINTS.signUp;
+    }
+
+    return res.status(200).send({
+        status: 'continue',
+        hint,
+        message: translate(locale, 'authMessages.emailPrecheckGeneric'),
+    });
+};
+
+// Cross-app handoff. The source app (where the user is signed in) mints a single-use code bound
+// to a target brand. The target app, opened via universal link, redeems that code for fresh
+// tokens stamped with the target brand. This is the first-party analog of OAuth's authorization
+// code flow — but without the consent screen ceremony, since both apps are owned by us and the
+// user has already authenticated to the source app.
+
+const isKnownBrand = (brand: any): boolean => typeof brand === 'string'
+    && (Object.values(BrandVariations) as string[]).includes(brand);
+
+const mintHandoff: RequestHandler = async (req: any, res: any) => {
+    const userId = req.headers['x-userid'];
+    const sourceBrand = (req.headers['x-brand-variation'] as string) || '';
+    const targetBrand = (req.body?.targetBrand || '').toString();
+    const deviceFingerprint = req.body?.deviceFingerprint
+        ? String(req.body.deviceFingerprint).slice(0, 256)
+        : undefined;
+
+    if (!userId) {
+        return handleHttpError({ res, message: 'Unauthorized', statusCode: 401 });
+    }
+    if (!isKnownBrand(targetBrand)) {
+        return handleHttpError({ res, message: 'Invalid targetBrand', statusCode: 400 });
+    }
+    if (sourceBrand && sourceBrand === targetBrand) {
+        return handleHttpError({ res, message: 'Source and target brand cannot match', statusCode: 400 });
+    }
+
+    // 128 bits of entropy → 22 url-safe chars. Big enough that brute-force is hopeless within the
+    // 60s TTL even at the per-IP rate limit. Never log the code itself.
+    const code = randomBytes(16).toString('base64url');
+
+    try {
+        await mintHandoffCode(code, {
+            userId,
+            sourceBrand,
+            targetBrand,
+            deviceFingerprint,
+            issuedAt: Date.now(),
+        });
+    } catch (err: any) {
+        return handleHttpError({
+            res, err, message: 'Failed to mint handoff code', statusCode: 500,
+        });
+    }
+
+    return res.status(200).send({ code, expiresInSeconds: 60, targetBrand });
+};
+
+const redeemHandoff: RequestHandler = async (req: any, res: any) => {
+    const { locale } = parseHeaders(req.headers);
+    const code = (req.body?.code || '').toString();
+    const requestedBrand = (req.body?.brand || '').toString();
+    const headerBrand = (req.headers['x-brand-variation'] as string) || '';
+
+    if (!code || !requestedBrand) {
+        return handleHttpError({ res, message: 'code and brand are required', statusCode: 400 });
+    }
+    // The header brand must match the requested brand. The redeeming app is supposed to set its
+    // own brand header consistently — a mismatch suggests a malicious or misconfigured caller.
+    if (headerBrand && headerBrand !== requestedBrand) {
+        return handleHttpError({ res, message: 'Brand mismatch', statusCode: 403 });
+    }
+
+    let entry;
+    try {
+        entry = await redeemHandoffCode(code);
+    } catch (err: any) {
+        return handleHttpError({
+            res, err, message: 'Failed to redeem handoff code', statusCode: 500,
+        });
+    }
+
+    if (!entry) {
+        // Either expired, never issued, or already redeemed. Same response either way to avoid
+        // leaking which case it is.
+        return handleHttpError({ res, message: 'Invalid or expired code', statusCode: 410 });
+    }
+
+    if (entry.targetBrand !== requestedBrand) {
+        return handleHttpError({ res, message: 'Code is not valid for this brand', statusCode: 403 });
+    }
+
+    try {
+        const userResults = await Store.users.getUserByConditions({ id: entry.userId });
+        if (!userResults?.length) {
+            return handleHttpError({ res, message: 'User not found', statusCode: 404 });
+        }
+        const dbUser = userResults[0];
+        if (dbUser.isBlocked) {
+            return handleHttpError({ res, message: 'User is blocked', statusCode: 403 });
+        }
+
+        const userOrgs = await Store.userOrganizations.get({ userId: dbUser.id }).catch(() => []);
+
+        const userWithIntegrations = {
+            ...dbUser,
+            isSSO: false,
+            integrations: {
+                ...decryptIntegrationsAccess(dbUser?.integrationsAccess),
+            },
+        };
+
+        const idToken = createUserToken(userWithIntegrations, userOrgs, false, requestedBrand);
+        const refreshTokenData = createRefreshToken(dbUser.id, false, requestedBrand);
+
+        // Track that this user is now active in the target brand. Fire-and-forget.
+        Store.users.upsertBrandVariation(dbUser.id, requestedBrand).catch((err) => {
+            logSpan({
+                level: 'error',
+                messageOrigin: 'API_SERVER',
+                messages: [err?.message, 'Failed to upsert brandVariations on handoff redeem'],
+                traceArgs: { 'user.id': dbUser.id, 'brand.variation': requestedBrand },
+            });
+        });
+
+        redactUserCreds(userWithIntegrations);
+
+        return res.status(200).send({
+            ...userWithIntegrations,
+            idToken,
+            refreshToken: refreshTokenData.token,
+            integrations: userWithIntegrations.integrations || {},
+            userOrganizations: userOrgs,
+        });
+    } catch (err: any) {
+        return handleHttpError({
+            res, err, message: translate(locale, 'errorMessages.auth.incorrectUserPass'), statusCode: 500,
+        });
+    }
+};
+
+const cancelHandoff: RequestHandler = async (req: any, res: any) => {
+    const userId = req.headers['x-userid'];
+    const code = (req.body?.code || '').toString();
+
+    if (!userId) {
+        return handleHttpError({ res, message: 'Unauthorized', statusCode: 401 });
+    }
+    if (!code) {
+        return handleHttpError({ res, message: 'code is required', statusCode: 400 });
+    }
+
+    try {
+        await cancelHandoffCode(code);
+        return res.status(200).send({ status: 'cancelled' });
+    } catch (err: any) {
+        return handleHttpError({
+            res, err, message: 'Failed to cancel handoff code', statusCode: 500,
+        });
+    }
+};
+
 export {
     login,
     logout,
     refreshToken,
     verifyToken,
+    emailPrecheck,
+    mintHandoff,
+    redeemHandoff,
+    cancelHandoff,
 };

--- a/therr-services/users-service/src/handlers/auth.ts
+++ b/therr-services/users-service/src/handlers/auth.ts
@@ -22,6 +22,12 @@ import {
     cancelHandoffCode,
 } from '../store/redisClient';
 
+// Multi-app brand check. Used to gate writes to user.brandVariations on login (so a malicious
+// x-brand-variation header can't pollute the JSONB array) and to validate handoff endpoints'
+// targetBrand / requestedBrand inputs.
+const isKnownBrand = (brand: any): boolean => typeof brand === 'string'
+    && (Object.values(BrandVariations) as string[]).includes(brand);
+
 // calling normalizeEmail on a userName will have no change
 const userNameOrEmailOrPhone = (user) => normalizeEmail(user.userName?.trim() || user.userEmail?.trim() || user.email?.trim()?.replace(/\s/g, '') || '')
     || normalizePhoneNumber(
@@ -286,7 +292,12 @@ const login: RequestHandler = (req: any, res: any) => {
                         // must not block the login response, but we want to log it for observability.
                         // Skip DASHBOARD_THERR for non-business accounts so dashboard sign-ins don't
                         // pollute consumer brand membership records.
-                        const shouldTrackBrand = brandVariation
+                        // Only track brands we recognize. Without this guard a malicious client could
+                        // submit `x-brand-variation: <anything>` to pollute the user's brandVariations
+                        // array (no SQL injection — it's parameterized — but it would let an attacker
+                        // grow the JSONB array unboundedly via repeated logins under different bogus
+                        // values, an integrity / DoS angle).
+                        const shouldTrackBrand = isKnownBrand(brandVariation)
                             && !(brandVariation === BrandVariations.DASHBOARD_THERR && !finalUser?.isBusinessAccount);
                         if (shouldTrackBrand) {
                             Store.users.upsertBrandVariation(user.id, brandVariation).catch((err) => {
@@ -471,29 +482,15 @@ const verifyToken: RequestHandler = (req: any, res: any) => {
 // (precomputed once at module load) so we don't pay a fresh hash cost on every cold start.
 const PRECHECK_DUMMY_HASH = bcrypt.hashSync('precheck-timing-equalizer', 12);
 
-const PRECHECK_HINTS = {
-    enterPassword: 'enter_password',
-    trySSO: 'try_sso',
-    magicLink: 'magic_link',
-    signUp: 'sign_up',
-} as const;
-
-type PrecheckHint = typeof PRECHECK_HINTS[keyof typeof PRECHECK_HINTS];
-
-const pickRandomUnknownHint = (): PrecheckHint => (
-    randomBytes(1)[0] < 180 ? PRECHECK_HINTS.signUp : PRECHECK_HINTS.magicLink
-);
-
-// Email pre-check: tells the client what to render next (password field, SSO button, magic link, or
-// signup) without leaking whether the email exists. All branches return 200 with the same response
-// shape and run a bcrypt comparison so timing is uniform. The hint is what the client renders; the
-// actual side-effect (sending a magic-link email) happens elsewhere and is gated on real existence.
+// Email pre-check: tells the client to render the universal "continue" UI (password field +
+// SSO buttons + magic-link option, all visible). Deliberately returns a single neutral hint
+// regardless of account state so the response cannot be used to enumerate registered emails.
+// We still do the DB lookup and a bcrypt compare to keep timing constant with future variants
+// that might attach state to the result.
 const emailPrecheck: RequestHandler = async (req: any, res: any) => {
     const { locale } = parseHeaders(req.headers);
     const rawEmail = (req.body?.email || '').toString();
     const email = normalizeEmail(rawEmail.trim());
-
-    let hint: PrecheckHint;
 
     try {
         const userResults = email
@@ -501,33 +498,26 @@ const emailPrecheck: RequestHandler = async (req: any, res: any) => {
             : [];
         const user = userResults?.[0];
 
-        // Always run bcrypt to equalize timing across the existence boundary.
+        // Always run bcrypt against the user hash if present, otherwise the dummy hash. Equalizes
+        // wall-clock time so an attacker cannot infer existence from the response latency.
         await bcrypt.compare('precheck-timing-equalizer', user?.password || PRECHECK_DUMMY_HASH);
-
-        if (!user) {
-            hint = pickRandomUnknownHint();
-        } else if (user.password) {
-            hint = PRECHECK_HINTS.enterPassword;
-        } else if (user.integrationsAccess) {
-            hint = PRECHECK_HINTS.trySSO;
-        } else {
-            hint = PRECHECK_HINTS.magicLink;
-        }
     } catch (err: any) {
-        // Fail open with the most common path so we never block the signup funnel on Redis/DB hiccups.
-        // Log so we can spot a regression without exposing the failure mode to the client.
+        // Lookup or bcrypt failure must NOT alter the response — falling through gives the same
+        // shape an attacker would see for any input. Log so we can spot a regression internally.
         logSpan({
             level: 'error',
             messageOrigin: 'API_SERVER',
-            messages: [err?.message, 'email-precheck failed; returning sign_up'],
+            messages: [err?.message, 'email-precheck DB/bcrypt failure (response unchanged)'],
             traceArgs: {},
         });
-        hint = PRECHECK_HINTS.signUp;
     }
 
+    // Single neutral hint for everyone. The client renders the full continuation UI and lets the
+    // user pick how to proceed; the actual /auth call decides what works. This is the only
+    // enumeration-resistant shape — any per-account branching here leaks existence.
     return res.status(200).send({
         status: 'continue',
-        hint,
+        hint: 'continue',
         message: translate(locale, 'authMessages.emailPrecheckGeneric'),
     });
 };
@@ -538,12 +528,9 @@ const emailPrecheck: RequestHandler = async (req: any, res: any) => {
 // code flow — but without the consent screen ceremony, since both apps are owned by us and the
 // user has already authenticated to the source app.
 
-const isKnownBrand = (brand: any): boolean => typeof brand === 'string'
-    && (Object.values(BrandVariations) as string[]).includes(brand);
-
 const mintHandoff: RequestHandler = async (req: any, res: any) => {
     const userId = req.headers['x-userid'];
-    const sourceBrand = (req.headers['x-brand-variation'] as string) || '';
+    const rawSourceBrand = (req.headers['x-brand-variation'] as string) || '';
     const targetBrand = (req.body?.targetBrand || '').toString();
     const deviceFingerprint = req.body?.deviceFingerprint
         ? String(req.body.deviceFingerprint).slice(0, 256)
@@ -555,6 +542,10 @@ const mintHandoff: RequestHandler = async (req: any, res: any) => {
     if (!isKnownBrand(targetBrand)) {
         return handleHttpError({ res, message: 'Invalid targetBrand', statusCode: 400 });
     }
+    // Source brand is informational (it's stored on the Redis entry; redemption only enforces
+    // targetBrand), but accepting arbitrary strings would let a caller embed garbage into the
+    // record — we'd surface that on logs and analytics. Drop unknown values.
+    const sourceBrand = isKnownBrand(rawSourceBrand) ? rawSourceBrand : '';
     if (sourceBrand && sourceBrand === targetBrand) {
         return handleHttpError({ res, message: 'Source and target brand cannot match', statusCode: 400 });
     }
@@ -589,9 +580,16 @@ const redeemHandoff: RequestHandler = async (req: any, res: any) => {
     if (!code || !requestedBrand) {
         return handleHttpError({ res, message: 'code and brand are required', statusCode: 400 });
     }
-    // The header brand must match the requested brand. The redeeming app is supposed to set its
-    // own brand header consistently — a mismatch suggests a malicious or misconfigured caller.
-    if (headerBrand && headerBrand !== requestedBrand) {
+    // Reject when the request brand isn't a recognized variant. Without this guard, the body
+    // alone could carry an arbitrary string into downstream code paths.
+    if (!isKnownBrand(requestedBrand)) {
+        return handleHttpError({ res, message: 'Invalid brand', statusCode: 400 });
+    }
+    // Require the x-brand-variation header AND require it to match the body. Legitimate niche
+    // apps always set the header via their axios interceptor — its absence indicates a forged
+    // or misconfigured caller. Without this check, an attacker stripping the header could pass
+    // a body-only `brand` value the redeeming environment doesn't actually represent.
+    if (!headerBrand || headerBrand !== requestedBrand) {
         return handleHttpError({ res, message: 'Brand mismatch', statusCode: 403 });
     }
 

--- a/therr-services/users-service/src/handlers/helpers/user.ts
+++ b/therr-services/users-service/src/handlers/helpers/user.ts
@@ -277,13 +277,16 @@ const createUserHelper = (
                     userAccessLevels.add(AccessLevels.EMAIL_VERIFIED);
                 }
             }
+            const nowIso = new Date().toISOString();
             return Store.users.createUser({
                 accessLevels: JSON.stringify([...userAccessLevels]),
                 brandVariations: (headers['x-brand-variation'] && isBrandValid(headers['x-brand-variation']))
-                    ? JSON.stringify({
+                    ? JSON.stringify([{
                         brand: headers['x-brand-variation'],
-                        details: {},
-                    })
+                        firstSeenAt: nowIso,
+                        lastSeenAt: nowIso,
+                        isActive: true,
+                    }])
                     : undefined,
                 email: userDetails.email,
                 firstName: userDetails.firstName || undefined,

--- a/therr-services/users-service/src/locales/en-us/dictionary.json
+++ b/therr-services/users-service/src/locales/en-us/dictionary.json
@@ -1,4 +1,7 @@
 {
+    "authMessages": {
+        "emailPrecheckGeneric": "If this email is registered, we'll guide you through signing in."
+    },
     "errorMessages": {
         "auth": {
             "accountNotVerified": "Account not verified. Check your E-mail for verification or navigate to /verify-account to resend",

--- a/therr-services/users-service/src/locales/es/dictionary.json
+++ b/therr-services/users-service/src/locales/es/dictionary.json
@@ -1,4 +1,7 @@
 {
+    "authMessages": {
+        "emailPrecheckGeneric": "Si este correo está registrado, te guiaremos para iniciar sesión."
+    },
     "errorMessages": {
         "auth": {
             "accountNotVerified": "Cuenta no verificada. Revisa tu correo electrónico para la verificación o navega a /verify-account para reenviar",

--- a/therr-services/users-service/src/locales/fr-ca/dictionary.json
+++ b/therr-services/users-service/src/locales/fr-ca/dictionary.json
@@ -1,4 +1,7 @@
 {
+    "authMessages": {
+        "emailPrecheckGeneric": "Si ce courriel est inscrit, nous vous guiderons pour vous connecter."
+    },
     "errorMessages": {
         "auth": {
             "accountNotVerified": "Compte non vérifié. Vérifie ton courriel pour la vérification ou rends-toi à /verify-account pour renvoyer le lien",

--- a/therr-services/users-service/src/routes/authRouter.ts
+++ b/therr-services/users-service/src/routes/authRouter.ts
@@ -1,7 +1,11 @@
 import * as express from 'express';
 import {
+    cancelHandoff,
+    emailPrecheck,
     login,
     logout,
+    mintHandoff,
+    redeemHandoff,
     refreshToken,
     verifyToken,
 } from '../handlers/auth';
@@ -19,5 +23,14 @@ router.post('/token/refresh', refreshToken);
 
 // Verify user token (after login)
 router.post('/user-token/validate', verifyToken);
+
+// Pre-check an email (does NOT confirm account existence). Returns a hint the client uses to render
+// the next step (password field, SSO button, magic link, sign up).
+router.post('/email-precheck', emailPrecheck);
+
+// Cross-app handoff (first-party single-sign-on between sister apps).
+router.post('/handoff/mint', mintHandoff);
+router.post('/handoff/redeem', redeemHandoff);
+router.post('/handoff/cancel', cancelHandoff);
 
 export default router;

--- a/therr-services/users-service/src/store/UsersStore.ts
+++ b/therr-services/users-service/src/store/UsersStore.ts
@@ -563,6 +563,45 @@ export default class UsersStore {
         return this.db.write.query(queryString.toString()).then((response) => response.rows);
     }
 
+    // Append or refresh a brand-variation membership entry on the user record.
+    // Uses a single JSONB statement so concurrent logins from different brands cannot lose entries.
+    // - If an entry for the brand exists, bump its lastSeenAt.
+    // - Otherwise append a new entry with firstSeenAt = lastSeenAt = now() and isActive = true.
+    upsertBrandVariation(userId: string, brand: string) {
+        if (!userId || !brand) return Promise.resolve();
+        const queryString = knexBuilder
+            .raw(
+                `UPDATE ?? SET "brandVariations" = (
+                    CASE WHEN EXISTS (
+                        SELECT 1 FROM jsonb_array_elements("brandVariations") AS elem
+                        WHERE elem->>'brand' = ?
+                    )
+                    THEN (
+                        SELECT jsonb_agg(
+                            CASE WHEN elem->>'brand' = ?
+                                THEN jsonb_set(elem, '{lastSeenAt}', to_jsonb(now()::text))
+                                ELSE elem
+                            END
+                        )
+                        FROM jsonb_array_elements("brandVariations") AS elem
+                    )
+                    ELSE "brandVariations" || jsonb_build_array(
+                        jsonb_build_object(
+                            'brand', ?::text,
+                            'firstSeenAt', now()::text,
+                            'lastSeenAt', now()::text,
+                            'isActive', true
+                        )
+                    )
+                    END
+                )
+                WHERE id = ?`,
+                [USERS_TABLE_NAME, brand, brand, brand, userId],
+            )
+            .toString();
+        return this.db.write.query(queryString);
+    }
+
     // Clears the stored FCM device token for a user, but only if the currently
     // stored token matches the one we know to be invalid. This avoids a race
     // where the mobile client has already rotated the token between the time a

--- a/therr-services/users-service/src/store/migrations/20260425000001_main.users.brandVariations_v2.js
+++ b/therr-services/users-service/src/store/migrations/20260425000001_main.users.brandVariations_v2.js
@@ -1,0 +1,38 @@
+/**
+ * brandVariations normalization for multi-app auth.
+ *
+ * Two cleanups:
+ *
+ * 1. Earlier signups (handlers/helpers/user.ts:282-287 prior to this commit) wrote a single
+ *    JSONB *object* into a column whose default is a JSONB *array*. Normalize any object-shaped
+ *    rows to a single-element array so downstream code can safely treat the column as a list of
+ *    brand memberships.
+ *
+ * 2. Add a GIN index so per-brand membership queries (e.g. "active users in HABITS in last 30d")
+ *    don't degrade as the array grows. jsonb_path_ops is the smaller / faster operator class for
+ *    containment-style lookups, which is the predominant access pattern here.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+    await knex.raw(`
+        UPDATE main.users
+        SET "brandVariations" = jsonb_build_array("brandVariations")
+        WHERE jsonb_typeof("brandVariations") = 'object';
+    `);
+
+    await knex.raw(`
+        CREATE INDEX IF NOT EXISTS idx_users_brand_variations_gin
+        ON main.users USING GIN ("brandVariations" jsonb_path_ops);
+    `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main.idx_users_brand_variations_gin;');
+    // Object-shaped rows are not restored; they were inconsistent with the column default.
+};

--- a/therr-services/users-service/src/store/redisClient.ts
+++ b/therr-services/users-service/src/store/redisClient.ts
@@ -1,0 +1,104 @@
+import Redis from 'ioredis';
+import logSpan from 'therr-js-utilities/log-or-update-span';
+
+// Ephemeral Redis client for short-lived auth artifacts:
+//  - cross-app handoff codes (60s TTL)
+//
+// Reuses the same ephemeral instance used by the gateway for token blacklist / rate-limit work.
+// Lazy-connect + indefinite retry so a Redis blip doesn't crash the service on boot.
+const redisEphemeralClient = new Redis({
+    host: process.env.REDIS_EPHEMERAL_HOST,
+    port: Number(process.env.REDIS_EPHEMERAL_PORT),
+    keyPrefix: 'users-service:',
+    lazyConnect: true,
+    retryStrategy(times) {
+        return Math.min(times * 50, 5000);
+    },
+    maxRetriesPerRequest: null,
+});
+
+redisEphemeralClient.on('error', (error: any) => {
+    logSpan({
+        level: 'error',
+        messageOrigin: 'REDIS_EPHEMERAL_CONNECTION_ERROR',
+        messages: error?.toString?.() || 'unknown redis error',
+        traceArgs: {},
+    });
+});
+
+redisEphemeralClient.on('connect', () => {
+    // eslint-disable-next-line no-console
+    console.log('users-service connected to ephemeral Redis');
+});
+
+// Best-effort connect; further commands trigger reconnects per ioredis retryStrategy.
+redisEphemeralClient.connect().catch(() => {
+    // eslint-disable-next-line no-console
+    console.log('users-service: deferred Redis ephemeral connect (will retry on first use)');
+});
+
+const HANDOFF_PREFIX = 'handoff:';
+const HANDOFF_TTL_SECONDS = 60;
+
+export interface IHandoffEntry {
+    userId: string;
+    sourceBrand: string;
+    targetBrand: string;
+    deviceFingerprint?: string;
+    issuedAt: number;
+}
+
+export const mintHandoffCode = async (code: string, entry: IHandoffEntry): Promise<void> => {
+    if (!code || !entry?.userId || !entry?.targetBrand) {
+        throw new Error('mintHandoffCode requires code, userId, and targetBrand');
+    }
+    await redisEphemeralClient.set(
+        `${HANDOFF_PREFIX}${code}`,
+        JSON.stringify(entry),
+        'EX',
+        HANDOFF_TTL_SECONDS,
+    );
+};
+
+// Atomic single-use redemption. GETDEL was added to Redis 6.2; we fall back to a MULTI pipeline
+// for older servers so the value is always pulled and deleted together.
+export const redeemHandoffCode = async (code: string): Promise<IHandoffEntry | null> => {
+    if (!code) return null;
+    let raw: string | null = null;
+    try {
+        if (typeof (redisEphemeralClient as any).getdel === 'function') {
+            raw = await (redisEphemeralClient as any).getdel(`${HANDOFF_PREFIX}${code}`);
+        } else {
+            const pipeline = redisEphemeralClient.multi();
+            pipeline.get(`${HANDOFF_PREFIX}${code}`);
+            pipeline.del(`${HANDOFF_PREFIX}${code}`);
+            const results = await pipeline.exec();
+            raw = (results?.[0]?.[1] as string) ?? null;
+        }
+    } catch (err) {
+        logSpan({
+            level: 'error',
+            messageOrigin: 'API_SERVER',
+            messages: ['Failed to redeem handoff code', (err as any)?.message],
+            traceArgs: {},
+        });
+        return null;
+    }
+    if (!raw) return null;
+    try {
+        return JSON.parse(raw) as IHandoffEntry;
+    } catch {
+        return null;
+    }
+};
+
+export const cancelHandoffCode = async (code: string): Promise<void> => {
+    if (!code) return;
+    try {
+        await redisEphemeralClient.del(`${HANDOFF_PREFIX}${code}`);
+    } catch {
+        // Best effort
+    }
+};
+
+export default redisEphemeralClient;

--- a/therr-services/users-service/src/utilities/userHelpers.ts
+++ b/therr-services/users-service/src/utilities/userHelpers.ts
@@ -6,7 +6,7 @@ const saltRounds = 12;
 
 export const hashPassword = (password: string) => bcrypt.hash(password, saltRounds);
 
-export const createUserToken = (user: any, userOrgs: any[], rememberMe?: boolean) => {
+export const createUserToken = (user: any, userOrgs: any[], rememberMe?: boolean, brand?: string) => {
     const {
         id,
         userName,
@@ -25,20 +25,27 @@ export const createUserToken = (user: any, userOrgs: any[], rememberMe?: boolean
         }, {});
     const jti = uuidv4();
 
-    // Sign the JWT
+    // brand is omitted when undefined so legacy callers and pre-multi-app tokens already
+    // in the wild keep their existing payload shape. Gateway treats a missing claim as
+    // legacy / cross-brand-allowed.
+    const payload: Record<string, any> = {
+        jti,
+        id,
+        userName,
+        email,
+        phoneNumber,
+        isBlocked,
+        integrations,
+        isSSO: isSSO || false,
+        accessLevels,
+        organizations: mappedUserOrgs,
+    };
+    if (brand) {
+        payload.brand = brand;
+    }
+
     return jwt.sign(
-        {
-            jti,
-            id,
-            userName,
-            email,
-            phoneNumber,
-            isBlocked,
-            integrations,
-            isSSO: isSSO || false,
-            accessLevels,
-            organizations: mappedUserOrgs,
-        },
+        payload,
         (process.env.JWT_SECRET || ''),
         {
             algorithm: 'HS256',
@@ -47,15 +54,20 @@ export const createUserToken = (user: any, userOrgs: any[], rememberMe?: boolean
     );
 };
 
-export const createRefreshToken = (userId: string, rememberMe?: boolean) => {
+export const createRefreshToken = (userId: string, rememberMe?: boolean, brand?: string) => {
     const jti = uuidv4();
 
+    const payload: Record<string, any> = {
+        jti,
+        id: userId,
+        type: 'refresh',
+    };
+    if (brand) {
+        payload.brand = brand;
+    }
+
     const token = jwt.sign(
-        {
-            jti,
-            id: userId,
-            type: 'refresh',
-        },
+        payload,
         (process.env.JWT_SECRET || ''),
         {
             algorithm: 'HS256',
@@ -63,7 +75,9 @@ export const createRefreshToken = (userId: string, rememberMe?: boolean) => {
         },
     );
 
-    return { token, jti };
+    return {
+        token, jti, brand,
+    };
 };
 
 export const createUserEmailToken = (user: { id: string, email: string }) => {


### PR DESCRIPTION
Tapping the foreground "new areas activated" notification navigated to
the generic Areas screen, losing the list of freshly activated
moments/spaces. The in-app notification row (Notifications/index.tsx)
already routes to the ActivatedAreas screen with the specific IDs as
params; the foreground path now matches, passing the activated moment
and space IDs through the notifee data field and falling back to Nearby
when neither list has entries.