### PR TITLE
fix: route recently-activated foreground notification to ActivatedAreas

### DIFF
--- a/TherrMobile/main/components/Layout.tsx
+++ b/TherrMobile/main/components/Layout.tsx
@@ -28,7 +28,7 @@ import DeviceInfo from 'react-native-device-info';
 import { MessagesService, UsersService } from 'therr-react/services';
 import { AccessCheckType, IContentState, IForumsState, INotificationsState, IUserState } from 'therr-react/types';
 import { ContentActions, ForumActions, NotificationActions, SocketActions, UserConnectionsActions } from 'therr-react/redux/actions';
-import { AccessLevels, FeatureFlags, GroupMemberRoles, PushNotifications, UserConnectionTypes } from 'therr-js-utilities/constants';
+import { AccessLevels, BrandVariations, FeatureFlags, GroupMemberRoles, PushNotifications, UserConnectionTypes } from 'therr-js-utilities/constants';
 import { CURRENT_BRAND_VARIATION } from '../config/brandConfig';
 import { SheetManager, Sheets } from 'react-native-actions-sheet';
 import { NavigationContainer, type ParamListBase } from '@react-navigation/native';
@@ -831,23 +831,68 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
         let targetRouteView = '';
         let targetRouteParams: any = {};
         if (data && !Array.isArray(data) && typeof (data) === 'object') {
-            if (data.action === PushNotifications.AndroidIntentActions.Therr.ACHIEVEMENT_COMPLETED
-                || data.action === PushNotifications.AndroidIntentActions.Therr.UNCLAIMED_ACHIEVEMENTS_REMINDER) {
+            // Each native build only declares its own brand's intent filters,
+            // so the action string we receive will already be brand-scoped.
+            // Pick the matching enum so Teem/Habits taps route correctly when
+            // running on those brand binaries.
+            const brandIntents = CURRENT_BRAND_VARIATION === BrandVariations.HABITS
+                ? PushNotifications.AndroidIntentActions.Habits
+                : CURRENT_BRAND_VARIATION === BrandVariations.TEEM
+                    ? PushNotifications.AndroidIntentActions.Teem
+                    : PushNotifications.AndroidIntentActions.Therr;
+
+            if (data.action === brandIntents.ACHIEVEMENT_COMPLETED
+                || data.action === brandIntents.UNCLAIMED_ACHIEVEMENTS_REMINDER) {
                 targetRouteView = 'Achievements';
-            } else if (data.action === PushNotifications.AndroidIntentActions.Therr.CREATE_A_MOMENT_REMINDER) {
+            } else if (data.action === brandIntents.CREATE_A_MOMENT_REMINDER) {
                 targetRouteView = 'Map';
-            } else if (data.action === PushNotifications.AndroidIntentActions.Therr.LATEST_POST_LIKES_STATS) {
+            } else if (data.action === brandIntents.CREATE_YOUR_PROFILE_REMINDER) {
+                targetRouteView = 'ManageAccount';
+            } else if (data.action === brandIntents.COMPLETE_DRAFT_REMINDER) {
+                targetRouteView = 'MyDrafts';
+            } else if (data.action === brandIntents.LATEST_POST_LIKES_STATS
+                || data.action === brandIntents.LATEST_POST_VIEWCOUNT_STATS) {
+                // Author's own post stats — open their profile so they can
+                // see the affected post in the user's content carousel.
                 targetRouteView = 'ViewUser';
-            } else if (data.action === PushNotifications.AndroidIntentActions.Therr.UNREAD_NOTIFICATIONS_REMINDER) {
+                if (user?.details?.id) {
+                    targetRouteParams = { userInView: { id: user.details.id } };
+                }
+            } else if (data.action === brandIntents.UNREAD_NOTIFICATIONS_REMINDER) {
                 targetRouteView = 'Notifications';
-            } else if (data.action === PushNotifications.AndroidIntentActions.Therr.INVITE_FRIENDS_REMINDER) {
+            } else if (data.action === brandIntents.INVITE_FRIENDS_REMINDER) {
                 targetRouteView = 'Invite';
-            } else if (data.action === PushNotifications.AndroidIntentActions.Therr.NEW_GROUP_INVITE
-                || data.action === PushNotifications.AndroidIntentActions.Therr.NEW_GROUP_MEMBERS) {
+            } else if (data.action === brandIntents.NEW_AREAS_ACTIVATED) {
+                targetRouteView = 'Areas';
+            } else if (data.action === brandIntents.NEW_GROUP_INVITE
+                || data.action === brandIntents.NEW_GROUP_MEMBERS) {
                 targetRouteView = 'Groups';
                 targetRouteParams = {
                     activeTab: GROUPS_CAROUSEL_TABS.GROUPS,
                 };
+            } else if (data.action === brandIntents.NEW_GROUP_MESSAGE) {
+                targetRouteView = 'Groups';
+                targetRouteParams = {
+                    activeTab: GROUPS_CAROUSEL_TABS.GROUPS,
+                };
+            } else if (data.action === brandIntents.NEW_DIRECT_MESSAGE) {
+                // Without the conversation's other-user-id we can only land
+                // on the messaging hub; the per-thread navigation happens via
+                // the data-only path on Notifee/handleRemoteMessageTap.
+                targetRouteView = 'Notifications';
+            } else if (data.action === brandIntents.NEW_CONNECTION
+                || data.action === brandIntents.NEW_CONNECTION_REQUEST) {
+                targetRouteView = 'Connect';
+            } else if (data.action === brandIntents.NEW_LIKE_RECEIVED
+                || data.action === brandIntents.NEW_SUPER_LIKE_RECEIVED
+                || data.action === brandIntents.NEW_THOUGHT_REPLY_RECEIVED) {
+                targetRouteView = 'Notifications';
+            } else if (data.action === brandIntents.NUDGE_SPACE_ENGAGEMENT) {
+                targetRouteView = 'Areas';
+            } else if (data.action === brandIntents.POST_VISIT_REVIEW_REMINDER) {
+                targetRouteView = 'BookMarked';
+            } else if (data.action === brandIntents.REPORT_CONFIRMED) {
+                targetRouteView = 'Notifications';
             }
         }
 
@@ -859,6 +904,202 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
             RootNavigation.navigate('Login');
         } else if (targetRouteView) {
             RootNavigation.navigate(targetRouteView, targetRouteParams);
+        }
+    };
+
+    /**
+     * Maps a PushNotifications.Types value (carried in `data.type` on every
+     * FCM payload — see push-notifications-service createMessage) to a route.
+     *
+     * Used as the universal fallback in handleNotifeeNotificationEvent so
+     * notifications that lack a notificationPressActionId still land on a
+     * sensible screen instead of dropping the user on the launch view. This
+     * matters most for:
+     *  - iOS APNs alert taps (createNotificationMessage payloads have no
+     *    notificationPressActionId, so handleRemoteMessageTap synthesizes
+     *    `default` and falls through every press-action branch).
+     *  - Android FCM-rendered notifications with no clickAction / unmatched
+     *    intent action.
+     *  - Brand variants whose intent strings don't match the legacy
+     *    handleFirebasePushNotificationEvent checks.
+     */
+    getRouteFromNotificationType = (
+        notificationType: string | undefined,
+        data: { [key: string]: any } | undefined,
+    ): { targetRouteView: string; targetRouteParams: any } | null => {
+        if (!notificationType) {
+            return null;
+        }
+
+        const { user } = this.props;
+        const currentUserId = user?.details?.id;
+
+        // Object payloads are JSON-stringified by the backend
+        // (push-notifications-service firebaseAdmin.ts createMessage), so
+        // parse here defensively rather than assuming a type.
+        const parseObject = (key: string): any => {
+            const value = data?.[key];
+            if (typeof value === 'string') {
+                try {
+                    return JSON.parse(value);
+                } catch (e) {
+                    return null;
+                }
+            }
+            if (typeof value === 'object' && value !== null) {
+                return value;
+            }
+            return null;
+        };
+
+        const area = parseObject('area');
+        const fromUser = parseObject('fromUser');
+        const thought = parseObject('thought');
+        const groupId = typeof data?.groupId === 'string' ? data.groupId : undefined;
+        const postType = typeof data?.postType === 'string' ? data.postType : undefined;
+
+        const buildMomentRoute = (m: any) => ({
+            targetRouteView: 'ViewMoment',
+            targetRouteParams: {
+                isMyContent: m?.fromUserId === currentUserId,
+                previousView: 'Map',
+                moment: { id: m.id },
+                momentDetails: m,
+            },
+        });
+        const buildSpaceRoute = (s: any) => ({
+            targetRouteView: 'ViewSpace',
+            targetRouteParams: {
+                isMyContent: s?.fromUserId === currentUserId,
+                previousView: 'Map',
+                space: { id: s.id },
+                spaceDetails: s,
+            },
+        });
+        const buildThoughtRoute = (t: any) => ({
+            targetRouteView: 'ViewThought',
+            targetRouteParams: {
+                isMyContent: t?.fromUserId === currentUserId,
+                previousView: 'Map',
+                thought: { id: t.id },
+                thoughtDetails: t,
+            },
+        });
+
+        switch (notificationType) {
+            // Automation reminders
+            case PushNotifications.Types.createYourProfileReminder:
+                return { targetRouteView: 'ManageAccount', targetRouteParams: {} };
+            case PushNotifications.Types.createAMomentReminder:
+                return { targetRouteView: 'Map', targetRouteParams: {} };
+            case PushNotifications.Types.completeDraftReminder:
+                return { targetRouteView: 'MyDrafts', targetRouteParams: {} };
+            case PushNotifications.Types.latestPostLikesStats:
+                if (currentUserId) {
+                    return { targetRouteView: 'ViewUser', targetRouteParams: { userInView: { id: currentUserId } } };
+                }
+                return { targetRouteView: 'Notifications', targetRouteParams: {} };
+            case PushNotifications.Types.latestPostViewcountStats:
+                if (area?.id) return buildMomentRoute(area);
+                if (currentUserId) {
+                    return { targetRouteView: 'ViewUser', targetRouteParams: { userInView: { id: currentUserId } } };
+                }
+                return { targetRouteView: 'Notifications', targetRouteParams: {} };
+            case PushNotifications.Types.unreadNotificationsReminder:
+                return { targetRouteView: 'Notifications', targetRouteParams: {} };
+            case PushNotifications.Types.unclaimedAchievementsReminder:
+                return { targetRouteView: 'Achievements', targetRouteParams: {} };
+            case PushNotifications.Types.inviteFriendsReminder:
+                return { targetRouteView: 'Invite', targetRouteParams: {} };
+
+            // Event-driven
+            case PushNotifications.Types.achievementCompleted:
+                return { targetRouteView: 'Achievements', targetRouteParams: {} };
+            case PushNotifications.Types.connectionRequestAccepted:
+            case PushNotifications.Types.newConnectionRequest:
+                if (fromUser?.id) {
+                    return { targetRouteView: 'ViewUser', targetRouteParams: { userInView: { id: fromUser.id } } };
+                }
+                return { targetRouteView: 'Connect', targetRouteParams: {} };
+            case PushNotifications.Types.newDirectMessage:
+                if (fromUser?.id) {
+                    return {
+                        targetRouteView: 'DirectMessage',
+                        targetRouteParams: {
+                            connectionDetails: { id: fromUser.id, userName: fromUser.userName },
+                        },
+                    };
+                }
+                return { targetRouteView: 'Notifications', targetRouteParams: {} };
+            case PushNotifications.Types.newGroupInvite:
+            case PushNotifications.Types.newGroupMembers:
+                return {
+                    targetRouteView: 'Groups',
+                    targetRouteParams: { activeTab: GROUPS_CAROUSEL_TABS.GROUPS },
+                };
+            case PushNotifications.Types.newGroupMessage:
+                if (groupId) {
+                    return {
+                        targetRouteView: 'ViewGroup',
+                        targetRouteParams: { activeTab: GROUP_CAROUSEL_TABS.CHAT, id: groupId },
+                    };
+                }
+                return {
+                    targetRouteView: 'Groups',
+                    targetRouteParams: { activeTab: GROUPS_CAROUSEL_TABS.GROUPS },
+                };
+            case PushNotifications.Types.newLikeReceived:
+            case PushNotifications.Types.newSuperLikeReceived:
+                if (postType === 'thoughts' && thought?.id) return buildThoughtRoute(thought);
+                if (area?.id) {
+                    if (postType === 'moments') return buildMomentRoute(area);
+                    return buildSpaceRoute(area);
+                }
+                return { targetRouteView: 'Notifications', targetRouteParams: {} };
+            case PushNotifications.Types.newAreasActivated:
+                return { targetRouteView: 'Areas', targetRouteParams: {} };
+            case PushNotifications.Types.nudgeSpaceEngagement:
+                if (area?.id) return buildSpaceRoute(area);
+                return { targetRouteView: 'Areas', targetRouteParams: {} };
+            case PushNotifications.Types.proximityRequiredMoment:
+                if (area?.id) return buildMomentRoute(area);
+                return { targetRouteView: 'Map', targetRouteParams: {} };
+            case PushNotifications.Types.proximityRequiredSpace:
+                if (area?.id) return buildSpaceRoute(area);
+                return { targetRouteView: 'Map', targetRouteParams: {} };
+            case PushNotifications.Types.newThoughtReplyReceived:
+                if (thought?.id) return buildThoughtRoute(thought);
+                return { targetRouteView: 'Notifications', targetRouteParams: {} };
+            case PushNotifications.Types.postVisitReviewReminder:
+                if (area?.id) return buildSpaceRoute(area);
+                return { targetRouteView: 'BookMarked', targetRouteParams: {} };
+            case PushNotifications.Types.reportConfirmed:
+                return { targetRouteView: 'Notifications', targetRouteParams: {} };
+
+            // HABITS pact / streak / partner / habit-reminder notifications.
+            // The matching screens (Pact view, Streak view, etc.) don't yet
+            // exist in TherrMobile; route to the in-app notifications list as
+            // a sensible default until those routes ship. Once the screens
+            // land, swap these branches for direct deep links.
+            case PushNotifications.Types.pactInvitation:
+            case PushNotifications.Types.pactAccepted:
+            case PushNotifications.Types.pactDeclined:
+            case PushNotifications.Types.pactCompleted:
+            case PushNotifications.Types.pactExpiring:
+            case PushNotifications.Types.partnerCheckedIn:
+            case PushNotifications.Types.partnerMissedDay:
+            case PushNotifications.Types.partnerCelebrated:
+            case PushNotifications.Types.streakMilestone:
+            case PushNotifications.Types.streakAtRisk:
+            case PushNotifications.Types.streakBroken:
+            case PushNotifications.Types.newPersonalRecord:
+            case PushNotifications.Types.dailyHabitReminder:
+            case PushNotifications.Types.morningMotivation:
+            case PushNotifications.Types.eveningCheckIn:
+                return { targetRouteView: 'Notifications', targetRouteParams: {} };
+
+            default:
+                return null;
         }
     };
 
@@ -1134,6 +1375,34 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
             }
 
             if (notification?.id && pressAction?.id === PushNotifications.PressActionIds.discovered) {
+                return Promise.resolve();
+            }
+
+            // Fallback: route by notification type when no specific press
+            // action matched. This catches:
+            //  - iOS APNs alert taps for createNotificationMessage payloads
+            //    (no notificationPressActionId is set on the data, so
+            //    handleRemoteMessageTap synthesizes a `default` press action).
+            //  - Android FCM notification-payload taps with no clickAction
+            //    or whose intent action wasn't matched in
+            //    handleFirebasePushNotificationEvent.
+            //  - HABITS / future notification types whose press-action ids
+            //    aren't yet wired up above.
+            // Without this, taps in those scenarios silently leave the user
+            // on the launch screen with no navigation.
+            const notificationType = typeof notification?.data?.type === 'string'
+                ? notification.data.type
+                : undefined;
+            const fallbackRoute = this.getRouteFromNotificationType(notificationType, notification?.data);
+            if (fallbackRoute) {
+                if (!isUserAuthorized) {
+                    this.setState({
+                        targetRouteView: fallbackRoute.targetRouteView,
+                        targetRouteParams: fallbackRoute.targetRouteParams,
+                    });
+                    return Promise.resolve();
+                }
+                RootNavigation.navigate(fallbackRoute.targetRouteView, fallbackRoute.targetRouteParams);
                 return Promise.resolve();
             }
         }

--- a/_bin/switch-brand.sh
+++ b/_bin/switch-brand.sh
@@ -11,7 +11,8 @@
 #      if it doesn't already match the target.
 #   3. Kills any running Metro bundler process.
 #   4. Clears Metro's temp caches.
-#   5. Prints next commands to run.
+#   5. Reminds to reinstall iOS Pods when the brand actually changed.
+#   6. Prints next commands to run.
 
 set -e
 
@@ -98,6 +99,18 @@ rm -rf "${TMPDIR}"react-native-packager-cache-* 2>/dev/null || true
 
 printMessageSuccess "Switched to brand: $ENUM_KEY"
 echo ""
+
+# Remind about iOS pod reinstall when the brand actually changed. Different
+# niches can exclude different native modules via react-native.config.js
+# (e.g. HABITS skips react-native-background-geolocation), so the iOS Pods
+# from the previous brand will be stale until you reinstall.
+if [ "$CURRENT_ENUM" != "$ENUM_KEY" ]; then
+    printMessageWarning "Brand changed: ${CURRENT_ENUM} → ${ENUM_KEY}."
+    printMessageWarning "If you're about to build iOS, run: cd TherrMobile && npm run ios:pod:install"
+    printMessageWarning "(autolinking can differ per brand — Android picks up changes on next build automatically)"
+    echo ""
+fi
+
 echo "Next commands (two terminals):"
 echo "  Terminal 1:  cd TherrMobile && npm start"
 echo "  Terminal 2:  cd TherrMobile && npm run android:${TARGET_LOWER}"

--- a/docs/NICHE_APP_DATABASE_GUIDELINES.md
+++ b/docs/NICHE_APP_DATABASE_GUIDELINES.md
@@ -2,37 +2,40 @@
 
 This document outlines database patterns and best practices for adding features to support niche app variants while maintaining compatibility with the core Therr application.
 
-## Core Principle: Shared Database, Isolated Features
+## Core Principle: Shared Database, Three Data Archetypes
 
-All brand variants share the same PostgreSQL database infrastructure. This enables:
-- Single user identity across all apps (same email/password)
-- Shared core data (users, connections, notifications)
-- Efficient infrastructure management
-- Cross-brand features when desired
+All brand variants share the same PostgreSQL database infrastructure and **single user identity** (one `main.users.id` per email regardless of which app the person signs into). To prevent cross-app data pollution, every shared data domain falls into exactly one of three archetypes. The archetype determines storage, enforcement, defaulting, and indexing — uniformly.
 
-However, brand-specific features should be **isolated** to prevent breaking existing functionality.
+> **Every new migration MUST declare its archetype in a header comment.** Reviewers reject PRs that omit it.
 
-## Schema Isolation Pattern
+### The three archetypes
 
-### Use Separate Schemas for Brand-Specific Features
+| Archetype | Definition | Storage | Enforcement | Default for existing rows |
+|-----------|------------|---------|-------------|---------------------------|
+| **Identity-shared** | One row per human regardless of brand. The data is about the person, not the app they used. | `main.*`, **no brand column** | None at row level. Brand only used when UX is conditional on enrollment (`brandVariations @> '["habits"]'`). | n/a — no schema change needed |
+| **Brand-scoped** | Same row shape, must be partitioned per brand so a user signed into multiple apps does not see leaked data. | `main.*` with `brandVariation TEXT NOT NULL DEFAULT 'therr'` column + composite index `(userId, brandVariation, ...)` | `BrandScopedStore` base class in each service's `src/store/` directory. Handlers cannot omit brand because the store method signatures require it. | Backfill `'therr'` in the same migration that adds the column (every row created before this work was created by the original Therr app) |
+| **Brand-only / niche** | Only exists for one brand. | Dedicated `<niche>.*` schema (e.g. `habits.*`), FK to `main.users(id)`. | Schema name is the boundary; no row-level filter needed. | n/a — only ever populated by the niche app |
 
-Instead of adding columns to existing `main.*` tables, create a new schema:
+### Archetype examples
 
-```sql
--- Good: Isolated schema
-CREATE SCHEMA IF NOT EXISTS habits;
+| Archetype | Examples |
+|-----------|----------|
+| Identity-shared | `main.users`, OAuth links, email/SMS verification, password resets, base profile, `main.userConnections` (a friendship is person-to-person, not app-to-app) |
+| Brand-scoped | `main.notifications`, `main.directMessages`, `main.userAchievements`, `main.moments`, `main.spaces`, `main.events`, `main.momentReactions`, `main.spaceReactions`, `main.eventReactions`, `main.forums`, `main.forumMessages`, `main.userDeviceTokens` |
+| Brand-only / niche | All `habits.*` tables (pacts, streaks, checkins, proofs), any future `teem.*`, etc. |
 
-CREATE TABLE habits.pacts (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    creatorUserId UUID NOT NULL REFERENCES main.users(id),
-    -- habit-specific columns
-);
+### When to use schema isolation (Brand-only archetype)
 
--- Avoid: Polluting existing tables with brand-specific columns
--- ALTER TABLE main.userConnections ADD COLUMN pactType VARCHAR;  -- Don't do this
-```
+| Scenario | Recommendation |
+|----------|----------------|
+| New feature domain (habits, streaks, pacts) | Create new `<niche>.*` schema |
+| Adding 1-2 columns to `main.users` for a niche feature | Extend `main.users` (with defaults) |
+| Complex relationship tables for one brand only | Create in new schema |
+| Temporary/experimental features | Create in new schema |
+| Core functionality used by all brands | Add to `main.*` (identity-shared) |
+| Same-shape data that must partition per brand | Add to `main.*` with `brandVariation` column (brand-scoped — see below) |
 
-### Benefits of Schema Isolation
+### Benefits of schema isolation (when it applies)
 
 | Benefit | Description |
 |---------|-------------|
@@ -41,16 +44,6 @@ CREATE TABLE habits.pacts (
 | Simpler migrations | Can develop/test independently |
 | Clean rollback | Drop entire schema if feature is removed |
 | Query performance | Indexes optimized for specific use cases |
-
-### When to Use Schema Isolation
-
-| Scenario | Recommendation |
-|----------|----------------|
-| New feature domain (habits, streaks, pacts) | Create new schema |
-| Adding 1-2 columns to users | Extend `main.users` (with defaults) |
-| Complex relationship tables | Create in new schema |
-| Temporary/experimental features | Create in new schema |
-| Core functionality used by all brands | Add to `main.*` tables |
 
 ## Migration Patterns
 
@@ -69,8 +62,12 @@ exports.down = function(knex) {
 
 ### Creating Tables in New Schema
 
+Every migration must declare its archetype in a header comment so reviewers can verify enforcement and indexing match the framework above.
+
 ```javascript
 // migrations/20250125000002_habits.habit_goals.js
+//
+// Archetype: Brand-only (habits schema)
 exports.up = function(knex) {
     return knex.schema.withSchema('habits').createTable('habit_goals', (table) => {
         table.uuid('id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
@@ -294,32 +291,98 @@ CREATE INDEX idx_goals_interests ON habits.habit_goals USING GIN(interestsKeys);
 SELECT * FROM habits.habit_goals WHERE interestsKeys @> '["fitness"]'
 ```
 
-## Brand-Conditional Queries
+## Brand-Scoped Tables and the BrandScopedStore Pattern
 
-### Do NOT Add brand_id Columns
+> **Earlier versions of this guide said "Do NOT add `brandVariation` columns to shared tables."**
+> That guidance was wrong for the **Brand-scoped** archetype and has been replaced. Identity-shared and brand-only archetypes still avoid the column — see the table at the top of this doc.
 
-Since all brands share the database, avoid adding `brandVariation` columns to tables. Instead:
+### Why brand-scoped tables exist
 
-1. **Use application-layer filtering** based on request headers
-2. **Use feature-specific tables** that only certain brands use
-3. **Use user preferences** to determine feature access
+A single user signed into multiple apps with the same identity must NOT see data from another app. Twelve+ shared tables in `main.*` carry per-app rows (notifications, DMs, content, achievements, reactions, push tokens, etc.). Without a brand discriminator, a query like `SELECT * FROM main.notifications WHERE userId = ?` returns Therr **and** Habits notifications together. Application-layer filtering alone is too easy to forget — the WIP auth branch (merged 2026-04-25) made identity context reliably available everywhere, so the data layer can now enforce isolation.
 
-### Example: Brand-Aware Query in Handler
+### Adding a brand column to a shared table
+
+```javascript
+// migrations/20260601000001_main.notifications.brandVariation.js
+//
+// Archetype: Brand-scoped
+// Adds brandVariation discriminator + composite index per
+// docs/NICHE_APP_DATABASE_GUIDELINES.md ("Brand-scoped" archetype).
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').alterTable('notifications', (table) => {
+        // NOT NULL with default — every existing row was created by the original Therr app.
+        table.string('brandVariation', 50).notNullable().defaultTo('therr');
+    });
+    await knex.raw(`
+        CREATE INDEX IF NOT EXISTS idx_notifications_user_brand_unread
+        ON main.notifications ("userId", "brandVariation", "isUnread")
+    `);
+};
+
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main.idx_notifications_user_brand_unread');
+    await knex.schema.withSchema('main').alterTable('notifications', (table) => {
+        table.dropColumn('brandVariation');
+    });
+};
+```
+
+Then add the table name to `eslint-config/brand-scoped-tables.js` (the ESLint rule auto-flags any direct string-literal reference outside the sanctioned store).
+
+### Routing queries through BrandScopedStore
+
+Every brand-scoped table has a corresponding `*Store.ts` that extends `BrandScopedStore` (a thin abstract base in each service's `src/store/` directory). Handlers pull `brandVariation` from `getBrandContext(req.headers)` (in `therr-js-utilities/http`) and pass it as the first argument to every store method:
 
 ```typescript
-const getAchievements = async (req, res) => {
-    const { brandVariation } = parseHeaders(req.headers);
+// handlers/notifications.ts
+import { getBrandContext } from 'therr-js-utilities/http';
 
-    // Get achievements for user
-    let achievements = await UserAchievementsStore.getByUserId(req.user.id);
+const searchNotifications = (req, res) => {
+    const { brandVariation } = getBrandContext(req.headers);
+    return Store.notifications.searchNotifications(brandVariation, req['x-userid'], req.query);
+};
 
-    // Filter based on brand
-    if (brandVariation !== BrandVariations.HABITS) {
-        // Exclude habit-specific achievements for non-HABITS brands
-        achievements = achievements.filter(a =>
-            !a.achievementClass.startsWith('habit')
-        );
+// store/NotificationsStore.ts
+import BrandScopedStore from './BrandScopedStore';
+import { NOTIFICATIONS_TABLE_NAME } from './tableNames';
+
+export default class NotificationsStore extends BrandScopedStore {
+    constructor(db) {
+        // 'enforce' once shadow mode reports zero misses for one full release cycle.
+        super(db, NOTIFICATIONS_TABLE_NAME, 'shadow');
     }
+
+    searchNotifications(brand, userId, conditions) {
+        const qb = this.scopedQuery(brand)
+            .select('*')
+            .where('userId', '=', userId);
+        return this.db.read.query(qb.toString()).then((r) => r.rows);
+    }
+}
+```
+
+Forgetting to pass `brand` is a TypeScript error. Forgetting to use the store at all (e.g. handwritten raw SQL referencing `'main.notifications'`) is an ESLint error.
+
+### Shadow vs enforce mode
+
+The base class accepts a third constructor argument: `'shadow'` (default) or `'enforce'`.
+
+- **`'shadow'`**: missing or unknown brand logs a warning but does not throw. Use during the rollout for one full release cycle so production logs surface any handler that forgot to pass brand.
+- **`'enforce'`**: missing or unknown brand throws `MissingBrandContextError`. Flip after shadow mode is clean.
+
+### When to use brand-conditional logic in a handler instead
+
+Some flows are genuinely brand-conditional even when the data is identity-shared (e.g. achievements list filtering). Continue to do that with `getBrandContext` at the handler level — the BrandScopedStore pattern is only required for tables in the **Brand-scoped** archetype.
+
+```typescript
+import { getBrandContext } from 'therr-js-utilities/http';
+import { BrandVariations } from 'therr-js-utilities/constants';
+
+const getAchievements = async (req, res) => {
+    const { brandVariation } = getBrandContext(req.headers);
+
+    // userAchievements is a brand-scoped table — store enforces the filter automatically.
+    const achievements = await Store.userAchievements.getByUserId(brandVariation, req['x-userid']);
 
     return res.json({ achievements });
 };

--- a/eslint-config/brand-scoped-tables.js
+++ b/eslint-config/brand-scoped-tables.js
@@ -1,0 +1,18 @@
+// List of fully-qualified table names that must only be accessed through a BrandScopedStore subclass.
+// See docs/NICHE_APP_DATABASE_GUIDELINES.md ("Brand-scoped" archetype) and the BrandScopedStore base class
+// in each service's src/store/ directory.
+//
+// Each phase of the multi-app data isolation rollout populates this list as it migrates a table:
+//   Phase 2: main.notifications
+//   Phase 3: main.directMessages, main.forums, main.forumMessages
+//   Phase 4: main.moments, main.spaces, main.events, main.momentReactions, main.spaceReactions, main.eventReactions
+//   Phase 5: main.userAchievements
+//
+// Adding a table here causes any string-literal reference to it (e.g. `.from('main.notifications')`,
+// raw SQL `FROM main.notifications`) to be flagged by ESLint everywhere except the sanctioned store
+// files listed in eslint-config/service.js overrides.
+const BRAND_SCOPED_TABLES = [];
+
+module.exports = {
+    BRAND_SCOPED_TABLES,
+};

--- a/eslint-config/brand-scoped-tables.js
+++ b/eslint-config/brand-scoped-tables.js
@@ -13,6 +13,9 @@
 // files listed in eslint-config/service.js overrides.
 const BRAND_SCOPED_TABLES = [
     'main.notifications',
+    'main.directMessages',
+    'main.forums',
+    'main.forumMessages',
 ];
 
 module.exports = {

--- a/eslint-config/brand-scoped-tables.js
+++ b/eslint-config/brand-scoped-tables.js
@@ -11,7 +11,9 @@
 // Adding a table here causes any string-literal reference to it (e.g. `.from('main.notifications')`,
 // raw SQL `FROM main.notifications`) to be flagged by ESLint everywhere except the sanctioned store
 // files listed in eslint-config/service.js overrides.
-const BRAND_SCOPED_TABLES = [];
+const BRAND_SCOPED_TABLES = [
+    'main.notifications',
+];
 
 module.exports = {
     BRAND_SCOPED_TABLES,

--- a/eslint-config/service.js
+++ b/eslint-config/service.js
@@ -5,8 +5,28 @@
 
 const path = require('path');
 const baseConfig = require('./base');
+const { BRAND_SCOPED_TABLES } = require('./brand-scoped-tables');
+
+// Build a no-restricted-syntax selector that flags string literals matching brand-scoped table names.
+// Catches `.from('main.notifications')`, `into('main.notifications')`, raw SQL `FROM main.notifications`,
+// and the `'main.notifications'` constant in tableNames.ts (intentional — only sanctioned stores should re-export it).
+// Storefiles that legitimately reference the table go in the per-service .eslintrc.js overrides.
+const buildBrandScopedTablesRule = () => {
+    if (!BRAND_SCOPED_TABLES.length) {
+        // No tables onboarded yet (early in the multi-app data isolation rollout). Rule is a no-op.
+        return [];
+    }
+    const selectors = BRAND_SCOPED_TABLES.map((tableName) => ({
+        selector: `Literal[value="${tableName}"]`,
+        message: `Direct reference to brand-scoped table "${tableName}" is forbidden. `
+            + 'Route the query through the BrandScopedStore subclass for this table. '
+            + 'See docs/NICHE_APP_DATABASE_GUIDELINES.md.',
+    }));
+    return [['error', ...selectors]];
+};
 
 module.exports = function createServiceConfig(serviceDir, overrides = {}) {
+    const brandScopedRule = buildBrandScopedTablesRule();
     return {
         ...baseConfig,
         env: {
@@ -33,6 +53,7 @@ module.exports = function createServiceConfig(serviceDir, overrides = {}) {
                     ],
                 },
             ],
+            ...(brandScopedRule.length ? { 'no-restricted-syntax': brandScopedRule[0] } : {}),
             ...(overrides.rules || {}),
         },
         overrides: [
@@ -42,6 +63,15 @@ module.exports = function createServiceConfig(serviceDir, overrides = {}) {
                     'no-unused-expressions': 'off',
                     '@typescript-eslint/no-unused-expressions': 'off',
                     '@typescript-eslint/no-empty-function': 'off',
+                },
+            },
+            // Migration files legitimately reference brand-scoped tables when creating, altering,
+            // or dropping them. The brand-scoping enforcement is at runtime via BrandScopedStore;
+            // schema-level operations are safe by definition.
+            {
+                files: ['src/store/migrations/**/*.js', 'src/store/seeds/**/*.js'],
+                rules: {
+                    'no-restricted-syntax': 'off',
                 },
             },
             ...(overrides.overrides || []),

--- a/therr-api-gateway/src/index.ts
+++ b/therr-api-gateway/src/index.ts
@@ -91,6 +91,8 @@ app.use(authenticate.unless({
         { url: '/v1/users-service/users', methods: ['POST'] }, // register
         { url: /\/v1\/users-service\/users\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/, methods: ['GET'] },
         { url: '/v1/users-service/auth/token/refresh', methods: ['POST'] }, // token refresh
+        { url: '/v1/users-service/auth/email-precheck', methods: ['POST'] }, // multi-app email lookup (enumeration-safe)
+        { url: '/v1/users-service/auth/handoff/redeem', methods: ['POST'] }, // cross-app handoff: code IS the credential
         { url: '/v1/users-service/users/forgot-password', methods: ['POST'] }, // one time password
         { url: '/v1/users-service/social-sync/oauth2-tiktok', methods: ['GET'] }, // TikTok OAuth
         { url: '/v1/users-service/social-sync/oauth2-facebook', methods: ['GET'] }, // Facebook OAuth

--- a/therr-api-gateway/src/middleware/authenticate.ts
+++ b/therr-api-gateway/src/middleware/authenticate.ts
@@ -42,6 +42,21 @@ const authenticate = async (req, res, next) => {
                 });
             }
 
+            // Multi-app brand binding. New JWTs carry a `brand` claim; reject requests where the
+            // client's x-brand-variation header doesn't match. Legacy tokens (no claim) are exempt
+            // so existing sessions keep working until they refresh into branded tokens.
+            // Logout is allowed regardless so users in a confused state can always sign out.
+            if (decoded?.brand && !req.path.includes('users-service/auth/logout')) {
+                const requestBrand = req.headers['x-brand-variation'];
+                if (requestBrand && requestBrand !== decoded.brand) {
+                    return handleHttpError({
+                        res,
+                        message: "Invalid 'authorization.' Token brand does not match request brand.",
+                        statusCode: 401,
+                    });
+                }
+            }
+
             req['x-userid'] = decoded.id;
             req['x-username'] = decoded.userName;
             req['x-user-access-levels'] = decoded.accessLevels ? JSON.stringify(decoded.accessLevels) : '[]';

--- a/therr-api-gateway/src/middleware/authenticate.ts
+++ b/therr-api-gateway/src/middleware/authenticate.ts
@@ -43,12 +43,15 @@ const authenticate = async (req, res, next) => {
             }
 
             // Multi-app brand binding. New JWTs carry a `brand` claim; reject requests where the
-            // client's x-brand-variation header doesn't match. Legacy tokens (no claim) are exempt
-            // so existing sessions keep working until they refresh into branded tokens.
-            // Logout is allowed regardless so users in a confused state can always sign out.
+            // client's x-brand-variation header doesn't match (or is absent — legitimate niche
+            // clients always set it via their axios interceptor). Without the missing-header
+            // case, an attacker could simply strip x-brand-variation to bypass enforcement.
+            // Legacy tokens (no claim) stay exempt so existing sessions keep working until they
+            // refresh into branded tokens. Logout is exempt so users in a confused state can
+            // always sign out.
             if (decoded?.brand && !req.path.includes('users-service/auth/logout')) {
                 const requestBrand = req.headers['x-brand-variation'];
-                if (requestBrand && requestBrand !== decoded.brand) {
+                if (!requestBrand || requestBrand !== decoded.brand) {
                     return handleHttpError({
                         res,
                         message: "Invalid 'authorization.' Token brand does not match request brand.",

--- a/therr-api-gateway/src/services/users/limitation/auth.ts
+++ b/therr-api-gateway/src/services/users/limitation/auth.ts
@@ -14,6 +14,8 @@ const userConnectionLimitReachedMessage = 'Too many user connection requests';
 const multiInviteLimitReachedMessage = 'Too many invite requests';
 const subscribeLimitReachedMessage = 'Too many requests to subscribe.';
 const unsubscribeLimitReachedMessage = 'Too many requests to unsubscribe.';
+const emailPrecheckLimitReachedMessage = 'Too many email lookup requests, please try again later.';
+const handoffMintLimitReachedMessage = 'Too many app handoff requests, please try again later.';
 
 const loginAttemptLimiter = RateLimit({
     store: RateLimiterRedisStore,
@@ -55,6 +57,9 @@ const userConnectionLimiter = buildRateLimiter(userConnectionLimitReachedMessage
 const multiInviteLimiter = buildRateLimiter(multiInviteLimitReachedMessage, 1, 5);
 const subscribeAttemptLimiter = buildRateLimiter(subscribeLimitReachedMessage);
 const unsubscribeAttemptLimiter = buildRateLimiter(unsubscribeLimitReachedMessage, 3, 60);
+// Generous enough for typed-then-blurred email behavior, tight enough to make enumeration unattractive.
+const emailPrecheckLimiter = buildRateLimiter(emailPrecheckLimitReachedMessage, 10, 1); // 10/min/IP
+const handoffMintLimiter = buildRateLimiter(handoffMintLimitReachedMessage, 10, 5); // 10 codes per 5 min/IP
 
 export {
     loginAttemptLimiter,
@@ -68,4 +73,6 @@ export {
     multiInviteLimiter,
     subscribeAttemptLimiter,
     unsubscribeAttemptLimiter,
+    emailPrecheckLimiter,
+    handoffMintLimiter,
 };

--- a/therr-api-gateway/src/services/users/router.ts
+++ b/therr-api-gateway/src/services/users/router.ts
@@ -10,6 +10,7 @@ import {
     invalidateApiKeyCache,
     revokeAllUserRefreshTokens,
     revokeRefreshToken,
+    revokeUserBrandRefreshTokens,
     storeRefreshToken,
 } from '../../store/redisClient';
 import { validate } from '../../validation';
@@ -52,6 +53,8 @@ import {
     multiInviteLimiter,
     subscribeAttemptLimiter,
     unsubscribeAttemptLimiter,
+    emailPrecheckLimiter,
+    handoffMintLimiter,
 } from './limitation/auth';
 import { createApiKeyValidation, revokeApiKeyValidation } from './validation/apiKeys';
 import { createUpdateSocialSyncsValidation } from './validation/socialSyncs';
@@ -120,11 +123,11 @@ usersServiceRouter.post('/auth', authenticateOptional, loginAttemptLimiter, auth
     // Store refresh token JTI on login for rotation tracking (fail-open)
     try {
         if (responseData?.refreshToken) {
-            const decoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number } | null;
+            const decoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number; brand?: string } | null;
             if (decoded?.jti && decoded?.id && decoded?.exp) {
                 const ttl = decoded.exp - Math.floor(Date.now() / 1000);
                 if (ttl > 0) {
-                    storeRefreshToken(decoded.id, decoded.jti, ttl);
+                    storeRefreshToken(decoded.id, decoded.jti, ttl, decoded.brand);
                 }
             }
         }
@@ -138,15 +141,23 @@ usersServiceRouter.post('/auth/logout', logoutUserValidation, validate, async (r
     try {
         const token = req.headers.authorization?.split(' ')[1];
         if (token) {
-            const decoded = jwt.decode(token) as { jti?: string; exp?: number; id?: string } | null;
+            const decoded = jwt.decode(token) as { jti?: string; exp?: number; id?: string; brand?: string } | null;
             if (decoded?.jti && decoded?.exp) {
                 const remainingTtl = decoded.exp - Math.floor(Date.now() / 1000);
                 if (remainingTtl > 0) {
                     await blacklistToken(decoded.jti, remainingTtl);
                 }
-                // Also revoke all refresh tokens for this user
+                // Refresh-token revocation scope:
+                //  - default: per-brand. Logging out of one app does NOT log a user out of sister apps.
+                //  - opt-in `scope=all`: revoke every refresh token for this user across all brands.
+                //  - legacy tokens (no `brand` claim): fall back to the legacy "all" behavior so existing
+                //    sessions continue to receive the safer cascade until they refresh into branded tokens.
                 if (decoded.id) {
-                    await revokeAllUserRefreshTokens(decoded.id);
+                    if (req.body?.scope === 'all' || !decoded.brand) {
+                        await revokeAllUserRefreshTokens(decoded.id);
+                    } else {
+                        await revokeUserBrandRefreshTokens(decoded.id, decoded.brand);
+                    }
                 }
             }
         }
@@ -176,20 +187,21 @@ usersServiceRouter.post('/auth/token/refresh', refreshTokenLimiter, handleServic
 }, (responseData, reqBody) => {
     // Server-side refresh token rotation tracking (fail-open)
     try {
-        // Revoke the old refresh token
+        // Revoke the old refresh token. If it has a brand+id (new shape), target the new key
+        // directly; otherwise fall back to the legacy `refresh-token:<jti>` key.
         if (reqBody?.refreshToken) {
-            const oldDecoded = jwt.decode(reqBody.refreshToken) as { jti?: string } | null;
+            const oldDecoded = jwt.decode(reqBody.refreshToken) as { jti?: string; id?: string; brand?: string } | null;
             if (oldDecoded?.jti) {
-                revokeRefreshToken(oldDecoded.jti);
+                revokeRefreshToken(oldDecoded.jti, { brand: oldDecoded.brand, userId: oldDecoded.id });
             }
         }
         // Store the new refresh token for reuse detection
         if (responseData?.refreshToken) {
-            const newDecoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number } | null;
+            const newDecoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number; brand?: string } | null;
             if (newDecoded?.jti && newDecoded?.id && newDecoded?.exp) {
                 const ttl = newDecoded.exp - Math.floor(Date.now() / 1000);
                 if (ttl > 0) {
-                    storeRefreshToken(newDecoded.id, newDecoded.jti, ttl);
+                    storeRefreshToken(newDecoded.id, newDecoded.jti, ttl, newDecoded.brand);
                 }
             }
         }
@@ -202,6 +214,46 @@ usersServiceRouter.post('/auth/token/refresh', refreshTokenLimiter, handleServic
             traceArgs: { 'error.message': err instanceof Error ? err.message : String(err) },
         });
     }
+}));
+
+// Email pre-check for multi-app login UX. Always returns 200 with a generic shape to avoid
+// account enumeration. Rate-limited per IP.
+usersServiceRouter.post('/auth/email-precheck', emailPrecheckLimiter, handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
+}));
+
+// Cross-app handoff. Mint and cancel require an authenticated session (the user is signed in to
+// the source app). Redeem is unauthed because the short-lived single-use code IS the credential;
+// it is exchanged for a fresh idToken+refreshToken stamped with the target brand.
+usersServiceRouter.post('/auth/handoff/mint', handoffMintLimiter, handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
+}));
+
+usersServiceRouter.post('/auth/handoff/redeem', loginAttemptLimiter, handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
+}, (responseData) => {
+    // Successful handoff = a fresh login. Track the new refresh token the same way /auth does.
+    try {
+        if (responseData?.refreshToken) {
+            const decoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number; brand?: string } | null;
+            if (decoded?.jti && decoded?.id && decoded?.exp) {
+                const ttl = decoded.exp - Math.floor(Date.now() / 1000);
+                if (ttl > 0) {
+                    storeRefreshToken(decoded.id, decoded.jti, ttl, decoded.brand);
+                }
+            }
+        }
+    } catch (err) {
+        // Non-critical
+    }
+}));
+
+usersServiceRouter.post('/auth/handoff/cancel', handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
 }));
 
 // Rewards

--- a/therr-api-gateway/src/store/redisClient.ts
+++ b/therr-api-gateway/src/store/redisClient.ts
@@ -156,44 +156,87 @@ export const isTokenBlacklisted = async (jti: string): Promise<boolean> => {
 };
 
 // Refresh token store helpers
+//
+// Key shape evolution (multi-app auth):
+//   Legacy (pre-multi-app): refresh-token:<jti>           -> userId
+//   Current:                refresh-token:<brand>:<userId>:<jti> -> userId
+//
+// Both shapes coexist during the transition. Newly minted tokens always use the current shape.
+// `scanAndRevokeTokens` matches `refresh-token:*` so both shapes are handled by per-user revoke.
+// `revokeRefreshToken` accepts an options object so callers can target either shape directly when
+// they have full context.
 const REFRESH_TOKEN_PREFIX = 'refresh-token:';
+const LEGACY_BRAND_TAG = 'unknown';
 
-export const storeRefreshToken = async (userId: string, jti: string, expiresInSeconds: number): Promise<void> => {
+const refreshTokenKey = (brand: string | undefined, userId: string | undefined, jti: string) => (
+    brand && userId
+        ? `${REFRESH_TOKEN_PREFIX}${brand}:${userId}:${jti}`
+        : `${REFRESH_TOKEN_PREFIX}${jti}`
+);
+
+export const storeRefreshToken = async (
+    userId: string,
+    jti: string,
+    expiresInSeconds: number,
+    brand?: string,
+): Promise<void> => {
     if (!userId || !jti || expiresInSeconds <= 0) return;
 
     try {
-        await redisClient.set(`${REFRESH_TOKEN_PREFIX}${jti}`, userId, 'EX', expiresInSeconds);
+        await redisClient.set(
+            refreshTokenKey(brand || LEGACY_BRAND_TAG, userId, jti),
+            userId,
+            'EX',
+            expiresInSeconds,
+        );
     } catch (err) {
         console.error('Failed to store refresh token:', err);
     }
 };
 
-export const getRefreshTokenUserId = async (jti: string): Promise<string | null> => {
+export const getRefreshTokenUserId = async (
+    jti: string,
+    options?: { brand?: string; userId?: string },
+): Promise<string | null> => {
     if (!jti) return null;
 
     try {
-        return await redisClient.get(`${REFRESH_TOKEN_PREFIX}${jti}`);
+        if (options?.brand && options?.userId) {
+            return await redisClient.get(refreshTokenKey(options.brand, options.userId, jti));
+        }
+        return await redisClient.get(refreshTokenKey(undefined, undefined, jti));
     } catch (err) {
         console.error('Failed to get refresh token:', err);
         return null;
     }
 };
 
-export const revokeRefreshToken = async (jti: string): Promise<void> => {
+export const revokeRefreshToken = async (
+    jti: string,
+    options?: { brand?: string; userId?: string },
+): Promise<void> => {
     if (!jti) return;
 
     try {
-        await redisClient.del(`${REFRESH_TOKEN_PREFIX}${jti}`);
+        const targetKey = options?.brand && options?.userId
+            ? refreshTokenKey(options.brand, options.userId, jti)
+            : refreshTokenKey(undefined, undefined, jti);
+        await redisClient.del(targetKey);
     } catch (err) {
         console.error('Failed to revoke refresh token:', err);
     }
 };
 
-const scanAndRevokeTokens = (userId: string, keyPrefix: string, cursor: string): Promise<void> => redisClient
-    .scan(cursor, 'MATCH', `${keyPrefix}${REFRESH_TOKEN_PREFIX}*`, 'COUNT', '100')
+const scanAndRevokeTokens = (
+    userId: string,
+    keyPrefix: string,
+    cursor: string,
+    matchPattern: string,
+): Promise<void> => redisClient
+    .scan(cursor, 'MATCH', matchPattern, 'COUNT', '100')
     .then(([nextCursor, keys]) => {
         if (!keys.length) {
-            return nextCursor !== '0' ? scanAndRevokeTokens(userId, keyPrefix, nextCursor) : undefined;
+            return nextCursor !== '0' ? scanAndRevokeTokens(userId, keyPrefix, nextCursor, matchPattern) : undefined;
         }
 
         // Strip the ioredis keyPrefix so pipeline commands re-add it correctly
@@ -209,7 +252,7 @@ const scanAndRevokeTokens = (userId: string, keyPrefix: string, cursor: string):
                 }
             });
             return delPipeline.exec();
-        }).then(() => (nextCursor !== '0' ? scanAndRevokeTokens(userId, keyPrefix, nextCursor) : undefined));
+        }).then(() => (nextCursor !== '0' ? scanAndRevokeTokens(userId, keyPrefix, nextCursor, matchPattern) : undefined));
     });
 
 export const revokeAllUserRefreshTokens = async (userId: string): Promise<void> => {
@@ -218,9 +261,84 @@ export const revokeAllUserRefreshTokens = async (userId: string): Promise<void> 
     const KEY_PREFIX = 'api-gateway:';
 
     try {
-        await scanAndRevokeTokens(userId, KEY_PREFIX, '0');
+        // Match both shapes so legacy and current keys are revoked together.
+        await scanAndRevokeTokens(userId, KEY_PREFIX, '0', `${KEY_PREFIX}${REFRESH_TOKEN_PREFIX}*`);
     } catch (err) {
         console.error('Failed to revoke all user refresh tokens:', err);
+    }
+};
+
+// Per-brand refresh-token revocation. Used by the default logout path so that signing out of one
+// app (e.g. Habits) leaves sister-app sessions (e.g. Therr) untouched. Legacy refresh-token keys
+// (no brand in the key) are revoked when called with brand === LEGACY_BRAND_TAG.
+export const revokeUserBrandRefreshTokens = async (userId: string, brand: string): Promise<void> => {
+    if (!userId || !brand) return;
+
+    const KEY_PREFIX = 'api-gateway:';
+
+    try {
+        const matchPattern = `${KEY_PREFIX}${REFRESH_TOKEN_PREFIX}${brand}:${userId}:*`;
+        await scanAndRevokeTokens(userId, KEY_PREFIX, '0', matchPattern);
+    } catch (err) {
+        console.error('Failed to revoke user/brand refresh tokens:', err);
+    }
+};
+
+// Cross-app handoff: short-lived single-use code → user/brand binding.
+// Stored on the ephemeral Redis (separate from rate-limit traffic). Use GETDEL on redeem so two
+// concurrent redemptions race-free; the loser sees null.
+const HANDOFF_PREFIX = 'handoff:';
+const HANDOFF_TTL_SECONDS = 60;
+
+export interface IHandoffEntry {
+    userId: string;
+    sourceBrand: string;
+    targetBrand: string;
+    deviceFingerprint?: string;
+}
+
+export const mintHandoffCode = async (code: string, entry: IHandoffEntry): Promise<void> => {
+    if (!code || !entry?.userId || !entry?.targetBrand) return;
+    try {
+        await redisEphemeralClient.set(
+            `${HANDOFF_PREFIX}${code}`,
+            JSON.stringify(entry),
+            'EX',
+            HANDOFF_TTL_SECONDS,
+        );
+    } catch (err) {
+        console.error('Failed to mint handoff code:', err);
+        throw err;
+    }
+};
+
+export const redeemHandoffCode = async (code: string): Promise<IHandoffEntry | null> => {
+    if (!code) return null;
+    try {
+        // GETDEL is atomic in Redis 6.2+; falls back to a MULTI pipeline on older servers.
+        const raw = typeof (redisEphemeralClient as any).getdel === 'function'
+            ? await (redisEphemeralClient as any).getdel(`${HANDOFF_PREFIX}${code}`)
+            : await (async () => {
+                const pipeline = redisEphemeralClient.multi();
+                pipeline.get(`${HANDOFF_PREFIX}${code}`);
+                pipeline.del(`${HANDOFF_PREFIX}${code}`);
+                const results = await pipeline.exec();
+                return results?.[0]?.[1] as string | null;
+            })();
+        if (!raw) return null;
+        return JSON.parse(raw as string) as IHandoffEntry;
+    } catch (err) {
+        console.error('Failed to redeem handoff code:', err);
+        return null;
+    }
+};
+
+export const cancelHandoffCode = async (code: string): Promise<void> => {
+    if (!code) return;
+    try {
+        await redisEphemeralClient.del(`${HANDOFF_PREFIX}${code}`);
+    } catch (err) {
+        console.error('Failed to cancel handoff code:', err);
     }
 };
 

--- a/therr-public-library/therr-js-utilities/src/db/brand-scoped.ts
+++ b/therr-public-library/therr-js-utilities/src/db/brand-scoped.ts
@@ -1,0 +1,51 @@
+import { BrandVariations } from '../constants/enums/Branding';
+
+export const BRAND_VARIATION_COLUMN = 'brandVariation';
+
+export type BrandScopeMode = 'shadow' | 'enforce';
+
+export class MissingBrandContextError extends Error {
+    constructor(tableName: string) {
+        super(`Brand-scoped table "${tableName}" was queried without a brandVariation. `
+            + 'Pass brandVariation from getBrandContext(req.headers) and route the call through BrandScopedStore.');
+        this.name = 'MissingBrandContextError';
+    }
+}
+
+const KNOWN_BRANDS = new Set<string>(Object.values(BrandVariations));
+
+export const isKnownBrand = (value: unknown): value is BrandVariations => typeof value === 'string' && KNOWN_BRANDS.has(value);
+
+interface AssertBrandOpts {
+    tableName: string;
+    mode?: BrandScopeMode;
+}
+
+export const assertBrand = (
+    brand: BrandVariations | string | undefined | null,
+    opts: AssertBrandOpts,
+): asserts brand is BrandVariations => {
+    const mode = opts.mode || 'enforce';
+    if (!brand || !isKnownBrand(brand)) {
+        if (mode === 'shadow') {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[brand-scope:shadow] table=${opts.tableName} missing or unknown brandVariation=${String(brand)} `
+                + '(would throw in enforce mode)',
+            );
+            return;
+        }
+        throw new MissingBrandContextError(opts.tableName);
+    }
+};
+
+export const applyBrandFilter = <TBuilder extends { andWhere: (...args: any[]) => TBuilder }>(
+    qb: TBuilder,
+    tableName: string,
+    brand: BrandVariations | string,
+): TBuilder => qb.andWhere(`${tableName}.${BRAND_VARIATION_COLUMN}`, '=', brand);
+
+export const withBrandOnInsert = <T extends Record<string, unknown>>(
+    row: T,
+    brand: BrandVariations | string,
+): T & { brandVariation: string } => ({ ...row, [BRAND_VARIATION_COLUMN]: brand });

--- a/therr-public-library/therr-js-utilities/src/db/index.ts
+++ b/therr-public-library/therr-js-utilities/src/db/index.ts
@@ -1,9 +1,25 @@
 import getDbCountQueryString, { ICountDbRecords } from './get-db-count-query-string';
 import getDbQueryString, { ISearchDbRecords } from './get-db-query-string';
+import {
+    BRAND_VARIATION_COLUMN,
+    BrandScopeMode,
+    MissingBrandContextError,
+    applyBrandFilter,
+    assertBrand,
+    isKnownBrand,
+    withBrandOnInsert,
+} from './brand-scoped';
 
 export {
     getDbCountQueryString,
     ICountDbRecords,
     getDbQueryString,
     ISearchDbRecords,
+    BRAND_VARIATION_COLUMN,
+    BrandScopeMode,
+    MissingBrandContextError,
+    applyBrandFilter,
+    assertBrand,
+    isKnownBrand,
+    withBrandOnInsert,
 };

--- a/therr-public-library/therr-js-utilities/src/http/get-brand-context.ts
+++ b/therr-public-library/therr-js-utilities/src/http/get-brand-context.ts
@@ -1,0 +1,24 @@
+import { BrandVariations } from '../constants/enums/Branding';
+import { isKnownBrand } from '../db/brand-scoped';
+
+export interface IBrandContext {
+    brandVariation: BrandVariations;
+    isLegacyToken: boolean;
+    hasExplicitBrand: boolean;
+}
+
+const getBrandContext = (headers: { [key: string]: any }): IBrandContext => {
+    const rawBrand = headers['x-brand-variation'];
+    const userId = headers['x-userid'];
+    const hasExplicitBrand = !!rawBrand && isKnownBrand(rawBrand);
+    const brandVariation: BrandVariations = hasExplicitBrand ? (rawBrand as BrandVariations) : BrandVariations.THERR;
+    const isLegacyToken = !rawBrand && !!userId;
+
+    return {
+        brandVariation,
+        isLegacyToken,
+        hasExplicitBrand,
+    };
+};
+
+export default getBrandContext;

--- a/therr-public-library/therr-js-utilities/src/http/index.ts
+++ b/therr-public-library/therr-js-utilities/src/http/index.ts
@@ -1,5 +1,6 @@
 import configureHandleHttpError, { IErrorArgs } from './configure-handle-http-error';
 import handleHttpError, { asyncHandler, HandleHttpError } from './async-handler';
+import getBrandContext, { IBrandContext } from './get-brand-context';
 import getSearchQueryArgs, { IReqQuery } from './get-search-query-args';
 import getSearchQueryString from './get-search-query-string';
 import parseHeaders from './parse-headers';
@@ -11,6 +12,8 @@ export {
     HandleHttpError,
     IErrorArgs,
     IReqQuery,
+    getBrandContext,
+    IBrandContext,
     getSearchQueryArgs,
     getSearchQueryString,
     parseHeaders,

--- a/therr-public-library/therr-react/src/components/AccountCenter.tsx
+++ b/therr-public-library/therr-react/src/components/AccountCenter.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import UsersService from '../services/UsersService';
+import { IBrandMembership } from '../types/redux/user';
+
+export interface IAccountCenterRenderArgs {
+    brandVariations: IBrandMembership[];
+    currentBrand: string;
+    isHandingOff: boolean;
+    handoffError: string | null;
+    /**
+     * Mint a handoff code for the target brand and invoke the consumer's opener (mobile uses
+     * Linking.openURL; web uses window.location.assign). Returns the URL that was opened, or null
+     * on failure. Never logs the underlying code.
+     */
+    openInApp: (targetBrand: string) => Promise<string | null>;
+}
+
+export interface IAccountCenterProps {
+    brandVariations?: IBrandMembership[];
+    currentBrand: string;
+    /**
+     * Consumer-supplied universal-link opener. Mobile passes Linking.openURL; web passes a wrapper
+     * around window.location.assign. Kept out of this component so it stays platform-agnostic.
+     */
+    openUrl: (url: string) => Promise<void> | void;
+    /**
+     * Optional. The host the handoff URL is built against (e.g. 'friendswithhabits.com'). When
+     * omitted, the URL falls back to therr.com — fine for development; production should pass the
+     * niche-specific host so the OS routes the link to the correct installed app via AASA.
+     */
+    handoffHost?: string;
+    children: (args: IAccountCenterRenderArgs) => React.ReactElement | null;
+}
+
+/**
+ * Headless component for the multi-app Account Center. Owns the handoff state machine; the
+ * consumer renders the UI. This keeps the component usable from React Native and web without
+ * binding to a particular styling system.
+ *
+ * Example:
+ *
+ *   <AccountCenter
+ *       brandVariations={user.details.brandVariations}
+ *       currentBrand={CURRENT_BRAND_VARIATION}
+ *       openUrl={Linking.openURL}
+ *   >
+ *       {({ brandVariations, openInApp, isHandingOff }) => (
+ *           <YourBrandList apps={brandVariations} onOpen={openInApp} loading={isHandingOff} />
+ *       )}
+ *   </AccountCenter>
+ */
+const AccountCenter: React.FunctionComponent<IAccountCenterProps> = ({
+    brandVariations,
+    currentBrand,
+    openUrl,
+    handoffHost,
+    children,
+}: IAccountCenterProps) => {
+    const [isHandingOff, setIsHandingOff] = React.useState(false);
+    const [handoffError, setHandoffError] = React.useState<string | null>(null);
+
+    const openInApp = React.useCallback(async (targetBrand: string): Promise<string | null> => {
+        if (!targetBrand || targetBrand === currentBrand) return null;
+        setIsHandingOff(true);
+        setHandoffError(null);
+        try {
+            const response = await UsersService.mintHandoff(targetBrand);
+            const code = response?.data?.code;
+            if (!code) {
+                setHandoffError('handoff_no_code');
+                return null;
+            }
+            // Inline-imported to avoid creating a cycle at module load when consumers tree-shake.
+            // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+            const { buildHandoffUrl } = require('../utilities/handoffClient');
+            const url: string = buildHandoffUrl(code, targetBrand, handoffHost);
+            await Promise.resolve(openUrl(url));
+            return url;
+        } catch (err: any) {
+            setHandoffError(err?.message || 'handoff_failed');
+            return null;
+        } finally {
+            setIsHandingOff(false);
+        }
+    }, [currentBrand, handoffHost, openUrl]);
+
+    return children({
+        brandVariations: brandVariations || [],
+        currentBrand,
+        isHandingOff,
+        handoffError,
+        openInApp,
+    });
+};
+
+export default AccountCenter;

--- a/therr-public-library/therr-react/src/components/index.ts
+++ b/therr-public-library/therr-react/src/components/index.ts
@@ -1,5 +1,6 @@
 // Miscellaneous
 import AccessControl from './AccessControl';
+import AccountCenter from './AccountCenter';
 import InlineSvg from './InlineSvg';
 import PaginationControls from './PaginationControls';
 
@@ -26,6 +27,7 @@ import {
 
 export {
     AccessControl,
+    AccountCenter,
     InlineSvg,
     PaginationControls,
     ButtonPrimary,

--- a/therr-public-library/therr-react/src/services/UsersService.ts
+++ b/therr-public-library/therr-react/src/services/UsersService.ts
@@ -205,6 +205,38 @@ class UsersService {
         data: { refreshToken, rememberMe },
     });
 
+    // Multi-app auth: enumeration-safe email pre-check. Backend always 200s with a generic shape;
+    // the `hint` drives client UI (enter_password / try_sso / magic_link / sign_up) without
+    // confirming whether the email is registered.
+    emailPrecheck = (email: string) => axios({
+        method: 'post',
+        url: '/users-service/auth/email-precheck',
+        data: { email },
+    });
+
+    // Mint a single-use, brand-bound handoff code from the currently-signed-in app. The returned
+    // `code` is exchanged via `redeemHandoff` in the target app for a fresh login response stamped
+    // with the target brand. TTL 60s; never log the code itself.
+    mintHandoff = (targetBrand: string) => axios({
+        method: 'post',
+        url: '/users-service/auth/handoff/mint',
+        data: { targetBrand },
+    });
+
+    // Redeem a handoff code in the target app. The code IS the credential — no auth header required.
+    // The `brand` argument must match the current app's brand variation; the backend enforces this.
+    redeemHandoff = (code: string, brand: string) => axios({
+        method: 'post',
+        url: '/users-service/auth/handoff/redeem',
+        data: { code, brand },
+    });
+
+    cancelHandoff = (code: string) => axios({
+        method: 'post',
+        url: '/users-service/auth/handoff/cancel',
+        data: { code },
+    });
+
     // Subscribers
     getSubscriptionPreferences = (emailToken: string) => axios({
         method: 'get',

--- a/therr-public-library/therr-react/src/types/redux/user.ts
+++ b/therr-public-library/therr-react/src/types/redux/user.ts
@@ -2,6 +2,16 @@ type IAccessLevel = Array<string>;
 
 export type IMobileThemeName = 'light' | 'dark' | 'retro';
 
+// Multi-app auth: which Therr-family apps a given user is active in. The backend appends to this
+// array on every successful login under a given x-brand-variation. Used by the AccountCenter to
+// render "Apps in your Therr account" and to gate cross-app handoff offers.
+export interface IBrandMembership {
+  brand: string;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  isActive: boolean;
+}
+
 export interface IUser {
   accessLevels: IAccessLevel;
   id: string;
@@ -13,6 +23,7 @@ export interface IUser {
   userName: string;
   media?: any;
   settingsTherrCoinTotal?: any;
+  brandVariations?: IBrandMembership[];
   [key: string]: any;
 }
 

--- a/therr-public-library/therr-react/src/utilities/handoffClient.ts
+++ b/therr-public-library/therr-react/src/utilities/handoffClient.ts
@@ -1,0 +1,65 @@
+// Cross-app handoff URL helpers.
+//
+// The flow:
+//   1. Source app (e.g. Therr) calls UsersService.mintHandoff(targetBrand) to get a code.
+//   2. Source app opens a universal/app link of the form `https://<host>/handoff?code=<code>&brand=<targetBrand>`.
+//   3. iOS / Android route that link to the installed target app via AASA / assetlinks.json.
+//   4. Target app extracts (code, brand) via parseHandoffUrl and calls UsersService.redeemHandoff(code, brand).
+//
+// Keep this file platform-agnostic: no React Native, no DOM. Consumers (mobile, web) supply their
+// own opener (Linking.openURL / window.location.assign).
+
+const HANDOFF_PATH = '/handoff';
+
+const HANDOFF_HOST_FALLBACK = 'therr.com';
+
+export interface IHandoffUrlParts {
+    code: string;
+    brand: string;
+}
+
+const sanitize = (value: string): string => value.replace(/[^A-Za-z0-9_-]/g, '');
+
+/**
+ * Build the universal-link URL the source app opens to hand off to the target app.
+ *
+ * @param code — handoff code returned by /auth/handoff/mint. Treat as a credential; never log.
+ * @param targetBrand — destination brand (e.g. 'habits'). Must be the brand the user is being handed off TO.
+ * @param host — optional. Defaults to therr.com. Pass the niche-specific domain when known so the
+ *               OS picks the right installed app via AASA.
+ */
+export const buildHandoffUrl = (code: string, targetBrand: string, host?: string): string => {
+    const safeCode = sanitize(code);
+    const safeBrand = sanitize(targetBrand);
+    const safeHost = (host || HANDOFF_HOST_FALLBACK).replace(/^https?:\/\//, '').replace(/\/+$/, '');
+    if (!safeCode || !safeBrand) {
+        throw new Error('buildHandoffUrl: code and targetBrand are required');
+    }
+    return `https://${safeHost}${HANDOFF_PATH}?code=${encodeURIComponent(safeCode)}&brand=${encodeURIComponent(safeBrand)}`;
+};
+
+/**
+ * Parse an inbound deep-link URL and return its handoff parts, or null if the URL is not a
+ * handoff link or is malformed. Tolerant of trailing slashes, query-only fragments, and
+ * platform-specific URL shapes (Linking on RN normalizes universal-links to https://...).
+ */
+export const parseHandoffUrl = (url: string): IHandoffUrlParts | null => {
+    if (!url || typeof url !== 'string') return null;
+    try {
+        // The URL constructor exists on both modern web and Hermes/React Native runtimes.
+        const parsed = new URL(url);
+        if (!parsed.pathname.startsWith(HANDOFF_PATH)) return null;
+        const code = sanitize(parsed.searchParams.get('code') || '');
+        const brand = sanitize(parsed.searchParams.get('brand') || '');
+        if (!code || !brand) return null;
+        return { code, brand };
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Convenience predicate. Useful when wiring up a router-level URL filter that should only react
+ * to handoff links and pass everything else through to the regular deep-link handler.
+ */
+export const isHandoffUrl = (url: string): boolean => parseHandoffUrl(url) !== null;

--- a/therr-services/maps-service/src/store/BrandScopedStore.ts
+++ b/therr-services/maps-service/src/store/BrandScopedStore.ts
@@ -1,0 +1,58 @@
+import KnexBuilder, { Knex } from 'knex';
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import { BrandVariations } from 'therr-js-utilities/constants';
+import {
+    BRAND_VARIATION_COLUMN,
+    BrandScopeMode,
+    applyBrandFilter,
+    assertBrand,
+    withBrandOnInsert,
+// eslint-disable-next-line import/extensions, import/no-unresolved
+} from 'therr-js-utilities/db';
+import { IConnection } from './connection';
+
+const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
+
+export type BrandValue = BrandVariations | string;
+
+export default abstract class BrandScopedStore {
+    protected db: IConnection;
+
+    protected readonly tableName: string;
+
+    protected readonly mode: BrandScopeMode;
+
+    constructor(db: IConnection, tableName: string, mode: BrandScopeMode = 'shadow') {
+        this.db = db;
+        this.tableName = tableName;
+        this.mode = mode;
+    }
+
+    protected assertBrand(brand: BrandValue | undefined | null) {
+        assertBrand(brand, { tableName: this.tableName, mode: this.mode });
+    }
+
+    protected scopedQuery(brand: BrandValue) {
+        this.assertBrand(brand);
+        return knexBuilder.from(this.tableName)
+            .where(`${this.tableName}.${BRAND_VARIATION_COLUMN}`, '=', brand);
+    }
+
+    protected withBrand<TBuilder extends { andWhere:(...args: any[]) => TBuilder }>(qb: TBuilder, brand: BrandValue): TBuilder {
+        this.assertBrand(brand);
+        return applyBrandFilter(qb, this.tableName, brand);
+    }
+
+    protected scopedInsert<T extends Record<string, unknown>>(brand: BrandValue, row: T) {
+        this.assertBrand(brand);
+        return knexBuilder.insert(withBrandOnInsert(row, brand)).into(this.tableName);
+    }
+
+    protected scopedUpdate(brand: BrandValue, conditions: Record<string, unknown>) {
+        this.assertBrand(brand);
+        return knexBuilder
+            .from(this.tableName)
+            .where(`${this.tableName}.${BRAND_VARIATION_COLUMN}`, '=', brand)
+            .where(conditions);
+    }
+}

--- a/therr-services/messages-service/src/handlers/directMessages.ts
+++ b/therr-services/messages-service/src/handlers/directMessages.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express';
 import moment from 'moment';
-import { getSearchQueryArgs, parseHeaders } from 'therr-js-utilities/http';
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import { getBrandContext, getSearchQueryArgs, parseHeaders } from 'therr-js-utilities/http';
 import handleHttpError from '../utilities/handleHttpError';
 import Store from '../store';
 import { findUsers } from '../api/usersService';
@@ -8,8 +9,9 @@ import { findUsers } from '../api/usersService';
 // CREATE
 const createDirectMessage = (req, res) => {
     const locale = req.headers['x-localecode'] || 'en-us';
+    const { brandVariation } = getBrandContext(req.headers);
 
-    return Store.directMessages.createDirectMessage({
+    return Store.directMessages.createDirectMessage(brandVariation, {
         message: req.body.message,
         toUserId: req.body.toUserId,
         fromUserId: req.body.fromUserId,
@@ -23,6 +25,7 @@ const createDirectMessage = (req, res) => {
 // READ
 const searchDirectMessages: RequestHandler = (req: any, res: any) => {
     const userId = req.headers['x-userid'];
+    const { brandVariation } = getBrandContext(req.headers);
     const {
         filterBy,
         query,
@@ -32,7 +35,7 @@ const searchDirectMessages: RequestHandler = (req: any, res: any) => {
     } = req.query;
     const integerColumns = [];
     const searchArgs = getSearchQueryArgs(req.query, integerColumns);
-    const searchPromise = Store.directMessages.searchDirectMessages(userId, searchArgs[0], searchArgs[1], shouldCheckReverse);
+    const searchPromise = Store.directMessages.searchDirectMessages(brandVariation, userId, searchArgs[0], searchArgs[1], shouldCheckReverse);
     // const countPromise = Store.directMessages.countRecords({
     //     filterBy,
     //     query,
@@ -62,6 +65,7 @@ const searchMyDirectMessages: RequestHandler = (req: any, res: any) => {
         locale,
         userId,
     } = parseHeaders(req.headers);
+    const { brandVariation } = getBrandContext(req.headers);
     const {
         filterBy,
         query,
@@ -71,7 +75,7 @@ const searchMyDirectMessages: RequestHandler = (req: any, res: any) => {
     const integerColumns = [];
     const searchArgs = getSearchQueryArgs(req.query, integerColumns);
 
-    return Store.directMessages.searchLatestDMs(userId, searchArgs[0]).then((results) => {
+    return Store.directMessages.searchLatestDMs(brandVariation, userId, searchArgs[0]).then((results) => {
         const userIds = results?.map((result) => (result.toUserId !== userId ? result.toUserId : result.fromUserId));
         // TODO: Fetch user details for display
         return findUsers(req.headers, userIds).then((usersResponse) => {

--- a/therr-services/messages-service/src/handlers/forumMessages.ts
+++ b/therr-services/messages-service/src/handlers/forumMessages.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express';
 import moment from 'moment';
-import { getSearchQueryArgs, parseHeaders } from 'therr-js-utilities/http';
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import { getBrandContext, getSearchQueryArgs, parseHeaders } from 'therr-js-utilities/http';
 import handleHttpError from '../utilities/handleHttpError';
 import Store from '../store';
 import * as globalConfig from '../../../../global-config';
@@ -9,8 +10,9 @@ import { findUsers } from '../api/usersService';
 // CREATE
 const createForumMessage = (req, res) => {
     const locale = req.headers['x-localecode'] || 'en-us';
+    const { brandVariation } = getBrandContext(req.headers);
 
-    return Store.forumMessages.createForumMessage({
+    return Store.forumMessages.createForumMessage(brandVariation, {
         forumId: req.body.forumId,
         message: req.body.message,
         fromUserId: req.body.fromUserId,
@@ -28,6 +30,7 @@ const searchForumMessages: RequestHandler = (req: any, res: any) => {
         locale,
         userId,
     } = parseHeaders(req.headers);
+    const { brandVariation } = getBrandContext(req.headers);
     const {
         filterBy,
         query,
@@ -37,8 +40,8 @@ const searchForumMessages: RequestHandler = (req: any, res: any) => {
     const { forumId } = req.params;
     const integerColumns = [];
     const searchArgs = getSearchQueryArgs(req.query, integerColumns);
-    const searchPromise = Store.forumMessages.searchForumMessages(forumId, searchArgs[0], searchArgs[1]);
-    const countPromise = Store.forumMessages.countRecords({
+    const searchPromise = Store.forumMessages.searchForumMessages(brandVariation, forumId, searchArgs[0], searchArgs[1]);
+    const countPromise = Store.forumMessages.countRecords(brandVariation, {
         filterBy,
         query,
     });

--- a/therr-services/messages-service/src/handlers/forums.ts
+++ b/therr-services/messages-service/src/handlers/forums.ts
@@ -1,7 +1,10 @@
 import { internalRestRequest, InternalConfigHeaders } from 'therr-js-utilities/internal-rest-request';
 import { RequestHandler } from 'express';
 import moment from 'moment';
-import { getSearchQueryArgs, getSearchQueryString, parseHeaders } from 'therr-js-utilities/http';
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import {
+    getBrandContext, getSearchQueryArgs, getSearchQueryString, parseHeaders,
+} from 'therr-js-utilities/http';
 import {
     ErrorCodes,
     GroupRequestStatuses,
@@ -27,6 +30,7 @@ const createActivity = (req, res) => {
         userId,
         whiteLabelOrigin,
     } = parseHeaders(req.headers);
+    const { brandVariation } = getBrandContext(req.headers);
 
     let forumId;
 
@@ -45,7 +49,7 @@ const createActivity = (req, res) => {
         });
     }
 
-    return Store.forums.createForum({
+    return Store.forums.createForum(brandVariation, {
         authorId: userId,
         authorLocale: locale,
         administratorIds: group.administratorIds,
@@ -96,7 +100,7 @@ const createActivity = (req, res) => {
         .catch((err) => {
             if (forumId) {
                 // Delete the forum if we fail to created the associated event
-                Store.forums.deleteForum(forumId).catch((error) => {
+                Store.forums.deleteForum(brandVariation, forumId).catch((error) => {
                     console.log('Failed to delete forum after error');
                     console.log(error);
                 });
@@ -112,8 +116,9 @@ const createForum = async (req, res) => {
         locale,
         userId,
     } = parseHeaders(req.headers);
+    const { brandVariation } = getBrandContext(req.headers);
 
-    const isDuplicate = await Store.forums.getForums({
+    const isDuplicate = await Store.forums.getForums(brandVariation, {
         authorId: userId,
         title: req.body.title,
     }, {
@@ -146,7 +151,7 @@ const createForum = async (req, res) => {
         media.featuredImage = req.body.media[0]?.path;
     }
 
-    return Store.forums.createForum({
+    return Store.forums.createForum(brandVariation, {
         authorId: userId,
         authorLocale: locale,
         administratorIds: req.body.administratorIds,
@@ -189,6 +194,7 @@ const getForum = (req, res) => {
         userId,
         whiteLabelOrigin,
     } = parseHeaders(req.headers);
+    const { brandVariation } = getBrandContext(req.headers);
     const { forumId } = req.params;
     const isAuthenticated = !!userId;
 
@@ -227,7 +233,7 @@ const getForum = (req, res) => {
         .then((response) => {
             const events = response?.data?.results || [];
 
-            return Store.forums.getForum(forumId)
+            return Store.forums.getForum(brandVariation, forumId)
                 .then((forums) => {
                     if (!forums?.length) {
                         return handleHttpError({
@@ -249,7 +255,7 @@ const getForum = (req, res) => {
                     }
 
                     // Update forum to mark most recently updated/active
-                    Store.forums.updateForum({
+                    Store.forums.updateForum(brandVariation, {
                         id: forum.id,
                     }, {}).catch((err) => {
                         console.log(err);
@@ -292,11 +298,12 @@ const findForums: RequestHandler = (req: any, res: any) => {
         locale,
         userId,
     } = parseHeaders(req.headers);
+    const { brandVariation } = getBrandContext(req.headers);
     const {
         ids,
     } = req.body;
 
-    return Store.forums.findForums(ids).then((results) => res.status(200).send(results));
+    return Store.forums.findForums(brandVariation, ids).then((results) => res.status(200).send(results));
 };
 
 const searchForums: RequestHandler = (req: any, res: any) => {
@@ -305,6 +312,7 @@ const searchForums: RequestHandler = (req: any, res: any) => {
         locale,
         userId,
     } = parseHeaders(req.headers);
+    const { brandVariation } = getBrandContext(req.headers);
     const {
         filterBy,
         query,
@@ -317,7 +325,7 @@ const searchForums: RequestHandler = (req: any, res: any) => {
 
     // For unauthenticated users, return only public forums without user/member enrichment
     if (!isAuthenticated) {
-        return Store.forums.searchForums(searchArgs[0], searchArgs[1], {
+        return Store.forums.searchForums(brandVariation, searchArgs[0], searchArgs[1], {
             usersInvitedForumIds: undefined,
             categoryTags: req.body.categoryTags,
             forumIds: req.body.forumIds,
@@ -342,7 +350,7 @@ const searchForums: RequestHandler = (req: any, res: any) => {
         }).catch((err) => handleHttpError({ err, res, message: 'SQL:FORUMS_ROUTES:ERROR' }));
     }
 
-    const searchPromise = Store.forums.searchForums(searchArgs[0], searchArgs[1], {
+    const searchPromise = Store.forums.searchForums(brandVariation, searchArgs[0], searchArgs[1], {
         usersInvitedForumIds: req.body.usersInvitedForumIds,
         categoryTags: req.body.categoryTags,
         forumIds: req.body.forumIds,
@@ -364,7 +372,7 @@ const searchForums: RequestHandler = (req: any, res: any) => {
 
         // Private groups that the user has an open or accepted invite to
         // TODO: It's probably better for the frontend to request this from a separate endpoint
-        const userMemberGroupsPromise = Store.forums.searchForums(searchArgs[0], searchArgs[1], {
+        const userMemberGroupsPromise = Store.forums.searchForums(brandVariation, searchArgs[0], searchArgs[1], {
             usersInvitedForumIds: validGroupIds,
             categoryTags: req.body.categoryTags,
             forumIds: req.body.forumIds,
@@ -457,6 +465,7 @@ const searchCategories: RequestHandler = (req: any, res: any) => {
 const updateForum = (req, res) => {
     const userId = req.headers['x-userid'];
     const locale = req.headers['x-localecode'] || 'en-us';
+    const { brandVariation } = getBrandContext(req.headers);
     const { forumId } = req.params;
 
     const updateParams: any = {
@@ -485,7 +494,7 @@ const updateForum = (req, res) => {
         updateParams.media = JSON.stringify({ featuredImage: req.body.media[0]?.path });
     }
 
-    return Store.forums.updateForum({
+    return Store.forums.updateForum(brandVariation, {
         id: forumId,
         authorId: userId,
     }, updateParams)
@@ -496,9 +505,10 @@ const updateForum = (req, res) => {
 const archiveForum = (req, res) => {
     const userId = req.headers['x-userid'];
     const locale = req.headers['x-localecode'] || 'en-us';
+    const { brandVariation } = getBrandContext(req.headers);
     const { forumId } = req.params;
 
-    return Store.forums.archiveForum({
+    return Store.forums.archiveForum(brandVariation, {
         id: forumId,
         authorId: userId,
     })

--- a/therr-services/messages-service/src/store/BrandScopedStore.ts
+++ b/therr-services/messages-service/src/store/BrandScopedStore.ts
@@ -1,0 +1,58 @@
+import KnexBuilder, { Knex } from 'knex';
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import { BrandVariations } from 'therr-js-utilities/constants';
+import {
+    BRAND_VARIATION_COLUMN,
+    BrandScopeMode,
+    applyBrandFilter,
+    assertBrand,
+    withBrandOnInsert,
+// eslint-disable-next-line import/extensions, import/no-unresolved
+} from 'therr-js-utilities/db';
+import { IConnection } from './connection';
+
+const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
+
+export type BrandValue = BrandVariations | string;
+
+export default abstract class BrandScopedStore {
+    protected db: IConnection;
+
+    protected readonly tableName: string;
+
+    protected readonly mode: BrandScopeMode;
+
+    constructor(db: IConnection, tableName: string, mode: BrandScopeMode = 'shadow') {
+        this.db = db;
+        this.tableName = tableName;
+        this.mode = mode;
+    }
+
+    protected assertBrand(brand: BrandValue | undefined | null) {
+        assertBrand(brand, { tableName: this.tableName, mode: this.mode });
+    }
+
+    protected scopedQuery(brand: BrandValue) {
+        this.assertBrand(brand);
+        return knexBuilder.from(this.tableName)
+            .where(`${this.tableName}.${BRAND_VARIATION_COLUMN}`, '=', brand);
+    }
+
+    protected withBrand<TBuilder extends { andWhere:(...args: any[]) => TBuilder }>(qb: TBuilder, brand: BrandValue): TBuilder {
+        this.assertBrand(brand);
+        return applyBrandFilter(qb, this.tableName, brand);
+    }
+
+    protected scopedInsert<T extends Record<string, unknown>>(brand: BrandValue, row: T) {
+        this.assertBrand(brand);
+        return knexBuilder.insert(withBrandOnInsert(row, brand)).into(this.tableName);
+    }
+
+    protected scopedUpdate(brand: BrandValue, conditions: Record<string, unknown>) {
+        this.assertBrand(brand);
+        return knexBuilder
+            .from(this.tableName)
+            .where(`${this.tableName}.${BRAND_VARIATION_COLUMN}`, '=', brand)
+            .where(conditions);
+    }
+}

--- a/therr-services/messages-service/src/store/DirectMessagesStore.ts
+++ b/therr-services/messages-service/src/store/DirectMessagesStore.ts
@@ -1,10 +1,14 @@
 import KnexBuilder, { Knex } from 'knex';
+// eslint-disable-next-line import/extensions, import/no-unresolved
 import { getDbCountQueryString } from 'therr-js-utilities/db';
+// eslint-disable-next-line import/extensions, import/no-unresolved
 import formatSQLJoinAsJSON from 'therr-js-utilities/format-sql-join-as-json';
+import BrandScopedStore, { BrandValue } from './BrandScopedStore';
 import { IConnection } from './connection';
 
 const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
 
+// eslint-disable-next-line no-restricted-syntax -- this is the sanctioned canonical reference
 export const DIRECT_MESSAGES_TABLE_NAME = 'main.directMessages';
 
 export interface ICreateDirectMessageParams {
@@ -24,31 +28,34 @@ export interface IUpdateDirectMessageParams {
     isUnread?: boolean;
 }
 
-export default class DirectMessagesStore {
-    db: IConnection;
-
-    constructor(dbConnection) {
-        this.db = dbConnection;
+export default class DirectMessagesStore extends BrandScopedStore {
+    constructor(dbConnection: IConnection) {
+        // Brand-scoped per docs/NICHE_APP_DATABASE_GUIDELINES.md.
+        // Stays in 'shadow' for one release cycle alongside the other Phase 3 stores.
+        super(dbConnection, DIRECT_MESSAGES_TABLE_NAME, 'shadow');
     }
 
-    countRecords(params) {
+    countRecords(brand: BrandValue, params) {
+        this.assertBrand(brand);
         const queryString = getDbCountQueryString({
             queryBuilder: knexBuilder,
             tableName: DIRECT_MESSAGES_TABLE_NAME,
             params,
-            defaultConditions: {},
+            defaultConditions: { [`${DIRECT_MESSAGES_TABLE_NAME}.brandVariation`]: brand },
         });
 
         return this.db.read.query(queryString).then((response) => response.rows);
     }
 
     // eslint-disable-next-line default-param-last
-    searchDirectMessages(userId, conditions: any = {}, returning, shouldCheckReverse?: string) {
+    searchDirectMessages(brand: BrandValue, userId, conditions: any = {}, returning, shouldCheckReverse?: string) {
+        this.assertBrand(brand);
         const offset = conditions.pagination.itemsPerPage * (conditions.pagination.pageNumber - 1);
         const limit = conditions.pagination.itemsPerPage;
         let queryString: any = knexBuilder
             .select((returning && returning.length) ? returning : '*')
             .from(DIRECT_MESSAGES_TABLE_NAME)
+            .where(`${DIRECT_MESSAGES_TABLE_NAME}.brandVariation`, '=', brand)
             .orderBy(`${DIRECT_MESSAGES_TABLE_NAME}.updatedAt`, 'desc');
 
         if (conditions.filterBy && conditions.query) {
@@ -57,7 +64,10 @@ export default class DirectMessagesStore {
             queryString = queryString.where('toUserId', userId).andWhere(conditions.filterBy, operator, query);
             if (shouldCheckReverse === 'true' && conditions.filterBy === 'fromUserId') {
                 queryString = queryString.orWhere('fromUserId', userId)
-                    .andWhere('toUserId', operator, query);
+                    .andWhere('toUserId', operator, query)
+                    // The orWhere() above resets brand isolation in the OR branch — re-apply it
+                    // so a Habits client's reverse search can't surface a Therr-stamped DM.
+                    .andWhere(`${DIRECT_MESSAGES_TABLE_NAME}.brandVariation`, '=', brand);
             }
         }
 
@@ -72,19 +82,24 @@ export default class DirectMessagesStore {
         });
     }
 
-    searchLatestDMs(userId: string, conditions: any = {}) {
+    searchLatestDMs(brand: BrandValue, userId: string, conditions: any = {}) {
+        this.assertBrand(brand);
         const offset = conditions.pagination.itemsPerPage * (conditions.pagination.pageNumber - 1);
         const limit = conditions.pagination.itemsPerPage;
+        // Brand filter is applied to BOTH the outer SELECT and the inner aggregate so a per-brand
+        // thread is treated as distinct from the cross-brand thread between the same user pair.
         const queryString = knexBuilder.raw(`
         SELECT
             *
         FROM
             "main"."directMessages"
-        WHERE ((least("fromUserId", "toUserId"), greatest("fromUserId", "toUserId")), "updatedAt")
+        WHERE "brandVariation" = '${brand}'
+            AND ((least("fromUserId", "toUserId"), greatest("fromUserId", "toUserId")), "updatedAt")
         in(
             SELECT
                 (least("fromUserId", "toUserId"), greatest("fromUserId", "toUserId")) AS users, max("updatedAt") AS "maxUpdated" FROM "main"."directMessages"
-            WHERE ("fromUserId" = '${userId}'
+            WHERE "brandVariation" = '${brand}'
+                AND ("fromUserId" = '${userId}'
                 OR "toUserId" = '${userId}')
         GROUP BY
             users
@@ -99,9 +114,8 @@ export default class DirectMessagesStore {
         return this.db.read.query(queryString).then((response) => response.rows);
     }
 
-    createDirectMessage(params: ICreateDirectMessageParams) {
-        const queryString = knexBuilder.insert(params)
-            .into(DIRECT_MESSAGES_TABLE_NAME)
+    createDirectMessage(brand: BrandValue, params: ICreateDirectMessageParams) {
+        const queryString = this.scopedInsert(brand, { ...params })
             .returning(['id', 'updatedAt'])
             .toString();
 

--- a/therr-services/messages-service/src/store/ForumMessagesStore.ts
+++ b/therr-services/messages-service/src/store/ForumMessagesStore.ts
@@ -1,10 +1,14 @@
 import KnexBuilder, { Knex } from 'knex';
+// eslint-disable-next-line import/extensions, import/no-unresolved
 import { getDbCountQueryString } from 'therr-js-utilities/db';
+// eslint-disable-next-line import/extensions, import/no-unresolved
 import formatSQLJoinAsJSON from 'therr-js-utilities/format-sql-join-as-json';
+import BrandScopedStore, { BrandValue } from './BrandScopedStore';
 import { IConnection } from './connection';
 
 const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
 
+// eslint-disable-next-line no-restricted-syntax -- this is the sanctioned canonical reference
 export const FORUM_MESSAGES_TABLE_NAME = 'main.forumMessages';
 
 export interface ICreateForumMessageParams {
@@ -23,27 +27,27 @@ export interface IUpdateForumMessageParams {
     message: string;
 }
 
-export default class ForumMessagesStore {
-    db: IConnection;
-
-    constructor(dbConnection) {
-        this.db = dbConnection;
+export default class ForumMessagesStore extends BrandScopedStore {
+    constructor(dbConnection: IConnection) {
+        // Brand-scoped per docs/NICHE_APP_DATABASE_GUIDELINES.md.
+        super(dbConnection, FORUM_MESSAGES_TABLE_NAME, 'shadow');
     }
 
-    // TODO: Update to actually match searchForumMessages (infinite scroll)
-    countRecords(params) {
+    countRecords(brand: BrandValue, params) {
+        this.assertBrand(brand);
         const queryString = getDbCountQueryString({
             queryBuilder: knexBuilder,
             tableName: FORUM_MESSAGES_TABLE_NAME,
             params,
-            defaultConditions: {},
+            defaultConditions: { [`${FORUM_MESSAGES_TABLE_NAME}.brandVariation`]: brand },
         });
 
         return this.db.read.query(queryString).then((response) => response.rows);
     }
 
     // eslint-disable-next-line default-param-last
-    searchForumMessages(forumId, conditions: any = {}, returning) {
+    searchForumMessages(brand: BrandValue, forumId, conditions: any = {}, returning) {
+        this.assertBrand(brand);
         const offset = conditions.pagination.itemsPerPage * (conditions.pagination.pageNumber - 1);
         const limit = conditions.pagination.itemsPerPage;
         let queryString: any = knexBuilder
@@ -53,6 +57,7 @@ export default class ForumMessagesStore {
                 forumId,
                 isAnnouncement: false,
             })
+            .andWhere(`${FORUM_MESSAGES_TABLE_NAME}.brandVariation`, '=', brand)
             .orderBy(`${FORUM_MESSAGES_TABLE_NAME}.createdAt`, 'desc');
 
         if (conditions.filterBy && conditions.query) {
@@ -72,9 +77,8 @@ export default class ForumMessagesStore {
         });
     }
 
-    createForumMessage(params: ICreateForumMessageParams) {
-        const queryString = knexBuilder.insert(params)
-            .into(FORUM_MESSAGES_TABLE_NAME)
+    createForumMessage(brand: BrandValue, params: ICreateForumMessageParams) {
+        const queryString = this.scopedInsert(brand, { ...params })
             .returning(['id', 'updatedAt'])
             .toString();
 

--- a/therr-services/messages-service/src/store/ForumsStore.ts
+++ b/therr-services/messages-service/src/store/ForumsStore.ts
@@ -1,12 +1,16 @@
 import KnexBuilder, { Knex } from 'knex';
+// eslint-disable-next-line import/extensions, import/no-unresolved
 import { getDbCountQueryString } from 'therr-js-utilities/db';
+// eslint-disable-next-line import/extensions, import/no-unresolved
 import formatSQLJoinAsJSON from 'therr-js-utilities/format-sql-join-as-json';
+import BrandScopedStore, { BrandValue } from './BrandScopedStore';
 import { CATEGORIES_TABLE_NAME } from './CategoriesStore';
 import { IConnection } from './connection';
 import { FORUM_CATEGORIES_TABLE_NAME } from './ForumCategoriesStore';
 
 const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
 
+// eslint-disable-next-line no-restricted-syntax -- this is the sanctioned canonical reference
 export const FORUMS_TABLE_NAME = 'main.forums';
 
 export interface ICreateForumParams {
@@ -74,39 +78,43 @@ export interface ISearchForumOptions {
     nearbyMaxDistanceKm?: number;
 }
 
-export default class ForumsStore {
-    db: IConnection;
-
-    constructor(dbConnection) {
-        this.db = dbConnection;
+export default class ForumsStore extends BrandScopedStore {
+    constructor(dbConnection: IConnection) {
+        // Brand-scoped per docs/NICHE_APP_DATABASE_GUIDELINES.md.
+        super(dbConnection, FORUMS_TABLE_NAME, 'shadow');
     }
 
     // TODO: Update to actually match searchForums (infinite scroll)
-    countRecords(params) {
+    countRecords(brand: BrandValue, params) {
+        this.assertBrand(brand);
         const queryString = getDbCountQueryString({
             queryBuilder: knexBuilder,
             tableName: FORUMS_TABLE_NAME,
             params,
-            defaultConditions: {},
+            defaultConditions: { [`${FORUMS_TABLE_NAME}.brandVariation`]: brand },
         });
 
         return this.db.read.query(queryString).then((response) => response.rows);
     }
 
-    getForum(id: string) {
+    getForum(brand: BrandValue, id: string) {
+        this.assertBrand(brand);
         const forumQueryString = knexBuilder.select('*')
             .from(FORUMS_TABLE_NAME)
             .where({
                 id,
+                brandVariation: brand,
             })
             .toString();
 
         return this.db.write.query(forumQueryString).then((response) => response.rows);
     }
 
-    getForums(conditions: any, orConditions: any, isNotArchived = true) {
+    getForums(brand: BrandValue, conditions: any, orConditions: any, isNotArchived = true) {
+        this.assertBrand(brand);
         let forumQueryString = knexBuilder.select('*')
-            .from(FORUMS_TABLE_NAME);
+            .from(FORUMS_TABLE_NAME)
+            .where(`${FORUMS_TABLE_NAME}.brandVariation`, '=', brand);
 
         if (isNotArchived) {
             forumQueryString = forumQueryString.whereNull('archivedAt');
@@ -115,22 +123,29 @@ export default class ForumsStore {
         forumQueryString = forumQueryString.where(conditions);
 
         if (orConditions) {
-            forumQueryString = forumQueryString.orWhere(orConditions);
+            // Ensure the OR branch retains the brand filter so a Habits query can't surface a
+            // Therr-stamped forum via the orWhere clause.
+            forumQueryString = forumQueryString.orWhere((qb) => {
+                qb.where(`${FORUMS_TABLE_NAME}.brandVariation`, '=', brand).where(orConditions);
+            });
         }
 
         return this.db.write.query(forumQueryString.toString()).then((response) => response.rows);
     }
 
-    findForums(ids: string[]) {
+    findForums(brand: BrandValue, ids: string[]) {
+        this.assertBrand(brand);
         const queryString = knexBuilder.select(['id', 'title'])
             .from(FORUMS_TABLE_NAME)
             .whereIn('id', ids)
+            .andWhere(`${FORUMS_TABLE_NAME}.brandVariation`, '=', brand)
             .toString();
         return this.db.read.query(queryString).then((response) => response.rows);
     }
 
     // eslint-disable-next-line default-param-last
-    async searchForums(conditions: any = {}, returning, options: ISearchForumOptions) {
+    async searchForums(brand: BrandValue, conditions: any = {}, returning, options: ISearchForumOptions) {
+        this.assertBrand(brand);
         const offset = conditions.pagination.itemsPerPage * (conditions.pagination.pageNumber - 1);
         const limit = conditions.pagination.itemsPerPage;
         let queryString: any = knexBuilder
@@ -172,7 +187,8 @@ export default class ForumsStore {
             ])
             .orderBy(`${FORUMS_TABLE_NAME}.updatedAt`, conditions.order)
             .whereNull('archivedAt')
-            .where('isPublic', !options.usersInvitedForumIds);
+            .where('isPublic', !options.usersInvitedForumIds)
+            .andWhere(`${FORUMS_TABLE_NAME}.brandVariation`, '=', brand);
 
         if (options.usersInvitedForumIds) {
             queryString = queryString.whereIn('id', options.usersInvitedForumIds);
@@ -228,7 +244,7 @@ export default class ForumsStore {
         });
     }
 
-    createForum(params: ICreateForumParams) {
+    createForum(brand: BrandValue, params: ICreateForumParams) {
         const forumParams: IUpdateForumParams = {
             ...params,
             administratorIds: params.administratorIds,
@@ -239,8 +255,7 @@ export default class ForumsStore {
 
         delete forumParams.categoryTags;
 
-        const queryString = knexBuilder.insert(forumParams)
-            .into(FORUMS_TABLE_NAME)
+        const queryString = this.scopedInsert(brand, forumParams as Record<string, unknown>)
             .returning('*')
             .toString();
 
@@ -259,7 +274,7 @@ export default class ForumsStore {
         });
     }
 
-    updateForum(conditions: IUpdateForumConditions, params: IUpdateForumParams) {
+    updateForum(brand: BrandValue, conditions: IUpdateForumConditions, params: IUpdateForumParams) {
         const forumParams = {
             ...params,
         };
@@ -267,43 +282,38 @@ export default class ForumsStore {
         delete forumParams.categoryTags;
 
         // TODO: Updated categories (sql transaction)
-        // params.categoryTags.forEach((tag) => [
 
-        // ]);
-
-        const forumQueryString = knexBuilder.update({
-            ...forumParams,
-            updatedAt: new Date(),
-        })
-            .into(FORUMS_TABLE_NAME)
-            .where(conditions)
+        const forumQueryString = this.scopedUpdate(brand, conditions as unknown as Record<string, unknown>)
+            .update({
+                ...forumParams,
+                updatedAt: new Date(),
+            })
             .returning(['id'])
             .toString();
 
         return this.db.write.query(forumQueryString).then((response) => response.rows);
     }
 
-    archiveForum(conditions: {
+    archiveForum(brand: BrandValue, conditions: {
         id: string,
         authorId: string; // to prevent non-owner from archiving
     }) {
-        const forumQueryString = knexBuilder.update({
-            archivedAt: new Date(),
-        })
-            .into(FORUMS_TABLE_NAME)
-            .where(conditions)
+        const forumQueryString = this.scopedUpdate(brand, conditions as unknown as Record<string, unknown>)
+            .update({
+                archivedAt: new Date(),
+            })
             .returning(['id'])
             .toString();
 
         return this.db.write.query(forumQueryString).then((response) => response.rows);
     }
 
-    deleteForum(id: string) {
-        const forumQueryString = knexBuilder.delete()
-            .into(FORUMS_TABLE_NAME)
-            .where({
-                id,
-            })
+    deleteForum(brand: BrandValue, id: string) {
+        this.assertBrand(brand);
+        const forumQueryString = knexBuilder
+            .from(FORUMS_TABLE_NAME)
+            .where({ id, brandVariation: brand })
+            .delete()
             .returning(['id'])
             .toString();
 

--- a/therr-services/messages-service/src/store/migrations/20260425000004_main.directMessages.brandVariation.js
+++ b/therr-services/messages-service/src/store/migrations/20260425000004_main.directMessages.brandVariation.js
@@ -1,0 +1,49 @@
+/**
+ * Add brandVariation to main.directMessages.
+ *
+ * Archetype: Brand-scoped (per docs/NICHE_APP_DATABASE_GUIDELINES.md).
+ *
+ * Phase 3 of the multi-app data isolation rollout. Without this column, two users signed into
+ * the same app see DMs that one of them sent under a different brand interleaved with their
+ * current-brand thread. With it, every DM is stamped with the sender's brand at create time
+ * and reads are filtered to the requester's current brand. A "Therr DM" between A and B is a
+ * different thread from a "Habits DM" between A and B.
+ *
+ * Auto-enroll semantic (per the architecture decision): a recipient who hasn't yet opened the
+ * sender's brand will not see the DM. The first time they open that brand, the existing login
+ * path (UsersStore.upsertBrandVariation) enrolls them and the DM becomes visible. No new
+ * notification or auto-enroll endpoint is needed at this phase.
+ *
+ * Defaults:
+ *   - NOT NULL with default 'therr' so legacy rows (all created before this migration ran by
+ *     the original Therr app) keep showing up to Therr users.
+ *   - DirectMessagesStore stays in shadow mode for one release cycle.
+ *
+ * Index strategy:
+ *   - Composite (toUserId, fromUserId, brandVariation, updatedAt) covers the dominant query
+ *     pattern: latest DMs in this brand for this user pair. brandVariation goes after the
+ *     user-id pair because user-pair selectivity is much higher than brand selectivity (~7
+ *     possible brands vs millions of user pairs). Replaces nothing — keep the original
+ *     (toUserId, fromUserId) index because it serves writes and existing analytics queries.
+ *
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').alterTable('directMessages', (table) => {
+        table.string('brandVariation', 50).notNullable().defaultTo('therr');
+    });
+    await knex.raw(`
+        CREATE INDEX IF NOT EXISTS idx_dm_to_from_brand_updated
+        ON main."directMessages" ("toUserId", "fromUserId", "brandVariation", "updatedAt" DESC)
+    `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main.idx_dm_to_from_brand_updated');
+    await knex.schema.withSchema('main').alterTable('directMessages', (table) => {
+        table.dropColumn('brandVariation');
+    });
+};

--- a/therr-services/messages-service/src/store/migrations/20260425000005_main.forums.brandVariation.js
+++ b/therr-services/messages-service/src/store/migrations/20260425000005_main.forums.brandVariation.js
@@ -1,0 +1,42 @@
+/**
+ * Add brandVariation to main.forums.
+ *
+ * Archetype: Brand-scoped (per docs/NICHE_APP_DATABASE_GUIDELINES.md).
+ *
+ * Phase 3 of the multi-app data isolation rollout. A forum belongs to a single brand — joining
+ * a "running buddies" forum on Habits should not surface that forum to a Therr user with the
+ * same identity. Reads filter by brand; creates stamp brand at insert time.
+ *
+ * Defaults:
+ *   - NOT NULL with default 'therr' so legacy rows keep showing up to Therr users.
+ *   - ForumsStore stays in shadow mode for one release cycle.
+ *
+ * Index strategy:
+ *   - Composite (brandVariation, isPublic, archivedAt) covers the discovery query for the
+ *     public forum feed within a brand. archivedAt is included because the dominant filter
+ *     is `whereNull('archivedAt')` — a partial-index alternative was rejected because the
+ *     planner already handles the IS NULL predicate well with a btree index.
+ *   - Per-author lookups (`authorId`) keep the existing single-column index; brand isn't
+ *     leading there because authorId is far more selective.
+ *
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').alterTable('forums', (table) => {
+        table.string('brandVariation', 50).notNullable().defaultTo('therr');
+    });
+    await knex.raw(`
+        CREATE INDEX IF NOT EXISTS idx_forums_brand_public_archived
+        ON main."forums" ("brandVariation", "isPublic", "archivedAt")
+    `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main.idx_forums_brand_public_archived');
+    await knex.schema.withSchema('main').alterTable('forums', (table) => {
+        table.dropColumn('brandVariation');
+    });
+};

--- a/therr-services/messages-service/src/store/migrations/20260425000006_main.forumMessages.brandVariation.js
+++ b/therr-services/messages-service/src/store/migrations/20260425000006_main.forumMessages.brandVariation.js
@@ -1,0 +1,41 @@
+/**
+ * Add brandVariation to main.forumMessages.
+ *
+ * Archetype: Brand-scoped (per docs/NICHE_APP_DATABASE_GUIDELINES.md).
+ *
+ * Phase 3 of the multi-app data isolation rollout. A forum message belongs to its parent
+ * forum's brand. Stamping the brand on the message itself (rather than always joining to
+ * forums to derive it) keeps hot-path reads single-table.
+ *
+ * Defaults:
+ *   - NOT NULL with default 'therr' so legacy rows keep showing up to Therr users.
+ *   - ForumMessagesStore stays in shadow mode for one release cycle.
+ *
+ * Index strategy:
+ *   - Composite (forumId, brandVariation, createdAt DESC) covers the dominant query: latest
+ *     messages in this forum scoped to the requester's brand. forumId is leading because the
+ *     usual access pattern is "messages in forum X" with brand as a redundancy check (since
+ *     a forum belongs to one brand, the brand filter is functionally a no-op once forumId is
+ *     pinned, but the column still defends against query mistakes that drop the forum filter).
+ *
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').alterTable('forumMessages', (table) => {
+        table.string('brandVariation', 50).notNullable().defaultTo('therr');
+    });
+    await knex.raw(`
+        CREATE INDEX IF NOT EXISTS idx_forum_messages_forum_brand_created
+        ON main."forumMessages" ("forumId", "brandVariation", "createdAt" DESC)
+    `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main.idx_forum_messages_forum_brand_created');
+    await knex.schema.withSchema('main').alterTable('forumMessages', (table) => {
+        table.dropColumn('brandVariation');
+    });
+};

--- a/therr-services/messages-service/tests/integration/directMessages.integration.test.ts
+++ b/therr-services/messages-service/tests/integration/directMessages.integration.test.ts
@@ -76,7 +76,7 @@ describe('Integration Tests - Direct Messages', () => {
                 locale: 'en-us',
             };
 
-            const createdMessages = await directMessagesStore.createDirectMessage(testMessage);
+            const createdMessages = await directMessagesStore.createDirectMessage('therr', testMessage);
 
             expect(createdMessages).to.be.an('array');
             expect(createdMessages.length).to.equal(1);
@@ -95,7 +95,7 @@ describe('Integration Tests - Direct Messages', () => {
                 locale: 'en-us',
             };
 
-            const createdMessages = await directMessagesStore.createDirectMessage(testMessage);
+            const createdMessages = await directMessagesStore.createDirectMessage('therr', testMessage);
 
             expect(createdMessages).to.be.an('array');
             expect(createdMessages[0].id).to.be.a('string');
@@ -112,7 +112,7 @@ describe('Integration Tests - Direct Messages', () => {
                 locale: 'fr-fr',
             };
 
-            const createdMessages = await directMessagesStore.createDirectMessage(testMessage);
+            const createdMessages = await directMessagesStore.createDirectMessage('therr', testMessage);
 
             expect(createdMessages).to.be.an('array');
             expect(createdMessages[0].id).to.be.a('string');
@@ -124,14 +124,14 @@ describe('Integration Tests - Direct Messages', () => {
             if (skipTests) return;
 
             // Create test messages
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'Search test message 1',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
                 isUnread: true,
                 locale: 'en-us',
             });
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'Search test message 2',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
@@ -140,7 +140,7 @@ describe('Integration Tests - Direct Messages', () => {
             });
 
             // Search for messages
-            const foundMessages = await directMessagesStore.searchDirectMessages(
+            const foundMessages = await directMessagesStore.searchDirectMessages('therr', 
                 TEST_USER_2,
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -160,7 +160,7 @@ describe('Integration Tests - Direct Messages', () => {
             if (skipTests) return;
 
             // Create 5 test messages
-            await Promise.all([0, 1, 2, 3, 4].map((i) => directMessagesStore.createDirectMessage({
+            await Promise.all([0, 1, 2, 3, 4].map((i) => directMessagesStore.createDirectMessage('therr', {
                 message: `Pagination test message ${i}`,
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
@@ -169,7 +169,7 @@ describe('Integration Tests - Direct Messages', () => {
             })));
 
             // Get first page
-            const page1 = await directMessagesStore.searchDirectMessages(
+            const page1 = await directMessagesStore.searchDirectMessages('therr', 
                 TEST_USER_2,
                 {
                     pagination: { itemsPerPage: 2, pageNumber: 1 },
@@ -181,7 +181,7 @@ describe('Integration Tests - Direct Messages', () => {
             );
 
             // Get second page
-            const page2 = await directMessagesStore.searchDirectMessages(
+            const page2 = await directMessagesStore.searchDirectMessages('therr', 
                 TEST_USER_2,
                 {
                     pagination: { itemsPerPage: 2, pageNumber: 2 },
@@ -201,14 +201,14 @@ describe('Integration Tests - Direct Messages', () => {
             if (skipTests) return;
 
             // Create messages in both directions
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'From user 1 to user 2',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
                 isUnread: true,
                 locale: 'en-us',
             });
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'From user 2 to user 1',
                 toUserId: TEST_USER_1,
                 fromUserId: TEST_USER_2,
@@ -217,7 +217,7 @@ describe('Integration Tests - Direct Messages', () => {
             });
 
             // Search with reverse check
-            const foundMessages = await directMessagesStore.searchDirectMessages(
+            const foundMessages = await directMessagesStore.searchDirectMessages('therr', 
                 TEST_USER_1,
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -239,14 +239,14 @@ describe('Integration Tests - Direct Messages', () => {
             if (skipTests) return;
 
             // Create conversation with user 2
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'First message to user 2',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
                 isUnread: true,
                 locale: 'en-us',
             });
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'Second message to user 2',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
@@ -255,7 +255,7 @@ describe('Integration Tests - Direct Messages', () => {
             });
 
             // Create conversation with user 3
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'Message to user 3',
                 toUserId: TEST_USER_3,
                 fromUserId: TEST_USER_1,
@@ -264,7 +264,7 @@ describe('Integration Tests - Direct Messages', () => {
             });
 
             // Search latest DMs - should group by conversation
-            const latestDMs = await directMessagesStore.searchLatestDMs(TEST_USER_1, {
+            const latestDMs = await directMessagesStore.searchLatestDMs('therr', TEST_USER_1, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             });
 
@@ -277,7 +277,7 @@ describe('Integration Tests - Direct Messages', () => {
             if (skipTests) return;
 
             // Create multiple messages in same conversation
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'Older message',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
@@ -288,7 +288,7 @@ describe('Integration Tests - Direct Messages', () => {
             // Small delay to ensure different timestamps
             await new Promise((resolve) => { setTimeout(resolve, 100); });
 
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'Newest message',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
@@ -296,7 +296,7 @@ describe('Integration Tests - Direct Messages', () => {
                 locale: 'en-us',
             });
 
-            const latestDMs = await directMessagesStore.searchLatestDMs(TEST_USER_1, {
+            const latestDMs = await directMessagesStore.searchLatestDMs('therr', TEST_USER_1, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             });
 
@@ -314,7 +314,7 @@ describe('Integration Tests - Direct Messages', () => {
             if (skipTests) return;
 
             // Create test messages
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'Count test message',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
@@ -322,7 +322,7 @@ describe('Integration Tests - Direct Messages', () => {
                 locale: 'en-us',
             });
 
-            const countResult = await directMessagesStore.countRecords({
+            const countResult = await directMessagesStore.countRecords('therr', {
                 filterBy: 'fromUserId',
                 query: TEST_USER_1,
             });
@@ -336,7 +336,7 @@ describe('Integration Tests - Direct Messages', () => {
             if (skipTests) return;
 
             // Create unread message
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'Unread message',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
@@ -345,7 +345,7 @@ describe('Integration Tests - Direct Messages', () => {
             });
 
             // Create read message
-            await directMessagesStore.createDirectMessage({
+            await directMessagesStore.createDirectMessage('therr', {
                 message: 'Read message',
                 toUserId: TEST_USER_2,
                 fromUserId: TEST_USER_1,
@@ -353,7 +353,7 @@ describe('Integration Tests - Direct Messages', () => {
                 locale: 'en-us',
             });
 
-            const unreadCount = await directMessagesStore.countRecords({
+            const unreadCount = await directMessagesStore.countRecords('therr', {
                 filterBy: 'isUnread',
                 query: true,
             });

--- a/therr-services/messages-service/tests/integration/forumMessages.integration.test.ts
+++ b/therr-services/messages-service/tests/integration/forumMessages.integration.test.ts
@@ -74,7 +74,7 @@ describe('Integration Tests - Forum Messages', () => {
                 isPublic: true,
             };
 
-            const createdForums = await forumsStore.createForum(testForum);
+            const createdForums = await forumsStore.createForum('therr', testForum);
             testForumId = Number(createdForums[0].id);
         } catch (err) {
             console.log('\n⚠️  Error creating test forum. Skipping forum messages integration tests.');
@@ -118,7 +118,7 @@ describe('Integration Tests - Forum Messages', () => {
                 isAnnouncement: false,
             };
 
-            const createdMessages = await forumMessagesStore.createForumMessage(testMessage);
+            const createdMessages = await forumMessagesStore.createForumMessage('therr', testMessage);
 
             expect(createdMessages).to.be.an('array');
             expect(createdMessages.length).to.equal(1);
@@ -137,7 +137,7 @@ describe('Integration Tests - Forum Messages', () => {
                 isAnnouncement: true,
             };
 
-            const createdMessages = await forumMessagesStore.createForumMessage(testMessage);
+            const createdMessages = await forumMessagesStore.createForumMessage('therr', testMessage);
 
             expect(createdMessages).to.be.an('array');
             expect(createdMessages[0].id).to.be.a('number');
@@ -153,7 +153,7 @@ describe('Integration Tests - Forum Messages', () => {
                 fromUserLocale: 2, // Different locale code
             };
 
-            const createdMessages = await forumMessagesStore.createForumMessage(testMessage);
+            const createdMessages = await forumMessagesStore.createForumMessage('therr', testMessage);
 
             expect(createdMessages).to.be.an('array');
             expect(createdMessages[0].id).to.be.a('number');
@@ -162,14 +162,14 @@ describe('Integration Tests - Forum Messages', () => {
         it('should create messages from multiple users', async () => {
             if (skipTests || !testForumId) return;
 
-            const message1 = await forumMessagesStore.createForumMessage({
+            const message1 = await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Message from user 1',
                 fromUserId: TEST_USER_1,
                 fromUserLocale: 1,
             });
 
-            const message2 = await forumMessagesStore.createForumMessage({
+            const message2 = await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Message from user 2',
                 fromUserId: TEST_USER_2,
@@ -185,14 +185,14 @@ describe('Integration Tests - Forum Messages', () => {
             if (skipTests || !testForumId) return;
 
             // Create test messages
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Search test message 1',
                 fromUserId: TEST_USER_1,
                 fromUserLocale: 1,
                 isAnnouncement: false,
             });
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Search test message 2',
                 fromUserId: TEST_USER_2,
@@ -201,7 +201,7 @@ describe('Integration Tests - Forum Messages', () => {
             });
 
             // Search messages
-            const foundMessages = await forumMessagesStore.searchForumMessages(
+            const foundMessages = await forumMessagesStore.searchForumMessages('therr', 
                 testForumId,
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -217,7 +217,7 @@ describe('Integration Tests - Forum Messages', () => {
             if (skipTests || !testForumId) return;
 
             // Create regular message
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Regular message',
                 fromUserId: TEST_USER_1,
@@ -226,7 +226,7 @@ describe('Integration Tests - Forum Messages', () => {
             });
 
             // Create announcement
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Announcement message',
                 fromUserId: TEST_USER_1,
@@ -235,7 +235,7 @@ describe('Integration Tests - Forum Messages', () => {
             });
 
             // Search messages (should exclude announcements)
-            const foundMessages = await forumMessagesStore.searchForumMessages(
+            const foundMessages = await forumMessagesStore.searchForumMessages('therr', 
                 testForumId,
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -252,7 +252,7 @@ describe('Integration Tests - Forum Messages', () => {
 
             // Create 5 test messages
             await Promise.all([0, 1, 2, 3, 4].map(async (i) => {
-                await forumMessagesStore.createForumMessage({
+                await forumMessagesStore.createForumMessage('therr', {
                     forumId: testForumId as number,
                     message: `Pagination test message ${i}`,
                     fromUserId: TEST_USER_1,
@@ -262,7 +262,7 @@ describe('Integration Tests - Forum Messages', () => {
             }));
 
             // Get first page
-            const page1 = await forumMessagesStore.searchForumMessages(
+            const page1 = await forumMessagesStore.searchForumMessages('therr', 
                 testForumId,
                 {
                     pagination: { itemsPerPage: 2, pageNumber: 1 },
@@ -271,7 +271,7 @@ describe('Integration Tests - Forum Messages', () => {
             );
 
             // Get second page
-            const page2 = await forumMessagesStore.searchForumMessages(
+            const page2 = await forumMessagesStore.searchForumMessages('therr', 
                 testForumId,
                 {
                     pagination: { itemsPerPage: 2, pageNumber: 2 },
@@ -288,7 +288,7 @@ describe('Integration Tests - Forum Messages', () => {
             if (skipTests || !testForumId) return;
 
             // Create messages with small delays
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'First message',
                 fromUserId: TEST_USER_1,
@@ -298,7 +298,7 @@ describe('Integration Tests - Forum Messages', () => {
 
             await new Promise((resolve) => { setTimeout(resolve, 100); });
 
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Second message',
                 fromUserId: TEST_USER_1,
@@ -307,7 +307,7 @@ describe('Integration Tests - Forum Messages', () => {
             });
 
             // Search messages
-            const foundMessages = await forumMessagesStore.searchForumMessages(
+            const foundMessages = await forumMessagesStore.searchForumMessages('therr', 
                 testForumId,
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -323,14 +323,14 @@ describe('Integration Tests - Forum Messages', () => {
             if (skipTests || !testForumId) return;
 
             // Create messages from different users
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Message from user 1',
                 fromUserId: TEST_USER_1,
                 fromUserLocale: 1,
                 isAnnouncement: false,
             });
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Message from user 2',
                 fromUserId: TEST_USER_2,
@@ -339,7 +339,7 @@ describe('Integration Tests - Forum Messages', () => {
             });
 
             // Filter by user 1
-            const foundMessages = await forumMessagesStore.searchForumMessages(
+            const foundMessages = await forumMessagesStore.searchForumMessages('therr', 
                 testForumId,
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -359,14 +359,14 @@ describe('Integration Tests - Forum Messages', () => {
             if (skipTests || !testForumId) return;
 
             // Create test messages
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Count test message 1',
                 fromUserId: TEST_USER_1,
                 fromUserLocale: 1,
                 isAnnouncement: false,
             });
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Count test message 2',
                 fromUserId: TEST_USER_1,
@@ -374,7 +374,7 @@ describe('Integration Tests - Forum Messages', () => {
                 isAnnouncement: false,
             });
 
-            const countResult = await forumMessagesStore.countRecords({
+            const countResult = await forumMessagesStore.countRecords('therr', {
                 filterBy: 'forumId',
                 query: testForumId,
             });
@@ -388,21 +388,21 @@ describe('Integration Tests - Forum Messages', () => {
             if (skipTests || !testForumId) return;
 
             // Create regular and announcement messages
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Regular message',
                 fromUserId: TEST_USER_1,
                 fromUserLocale: 1,
                 isAnnouncement: false,
             });
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Announcement 1',
                 fromUserId: TEST_USER_1,
                 fromUserLocale: 1,
                 isAnnouncement: true,
             });
-            await forumMessagesStore.createForumMessage({
+            await forumMessagesStore.createForumMessage('therr', {
                 forumId: testForumId,
                 message: 'Announcement 2',
                 fromUserId: TEST_USER_1,
@@ -410,7 +410,7 @@ describe('Integration Tests - Forum Messages', () => {
                 isAnnouncement: true,
             });
 
-            const announcementCount = await forumMessagesStore.countRecords({
+            const announcementCount = await forumMessagesStore.countRecords('therr', {
                 filterBy: 'isAnnouncement',
                 query: true,
             });
@@ -429,7 +429,7 @@ describe('Integration Tests - Forum Messages', () => {
             const validCategoryTag = categoryResult.rows[0]?.tag || 'general';
 
             // Create a second forum
-            const secondForum = await forumsStore.createForum({
+            const secondForum = await forumsStore.createForum('therr', {
                 authorId: TEST_USER_1,
                 authorLocale: 'en-us',
                 administratorIds: TEST_USER_1,
@@ -446,7 +446,7 @@ describe('Integration Tests - Forum Messages', () => {
 
             try {
                 // Create message in first forum
-                await forumMessagesStore.createForumMessage({
+                await forumMessagesStore.createForumMessage('therr', {
                     forumId: testForumId,
                     message: 'Message in first forum',
                     fromUserId: TEST_USER_1,
@@ -455,7 +455,7 @@ describe('Integration Tests - Forum Messages', () => {
                 });
 
                 // Create message in second forum
-                await forumMessagesStore.createForumMessage({
+                await forumMessagesStore.createForumMessage('therr', {
                     forumId: secondForumId,
                     message: 'Message in second forum',
                     fromUserId: TEST_USER_1,
@@ -464,7 +464,7 @@ describe('Integration Tests - Forum Messages', () => {
                 });
 
                 // Search first forum
-                const firstForumMessages = await forumMessagesStore.searchForumMessages(
+                const firstForumMessages = await forumMessagesStore.searchForumMessages('therr', 
                     testForumId,
                     {
                         pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -473,7 +473,7 @@ describe('Integration Tests - Forum Messages', () => {
                 );
 
                 // Search second forum
-                const secondForumMessages = await forumMessagesStore.searchForumMessages(
+                const secondForumMessages = await forumMessagesStore.searchForumMessages('therr', 
                     secondForumId,
                     {
                         pagination: { itemsPerPage: 10, pageNumber: 1 },

--- a/therr-services/messages-service/tests/integration/forums.integration.test.ts
+++ b/therr-services/messages-service/tests/integration/forums.integration.test.ts
@@ -95,7 +95,7 @@ describe('Integration Tests - Forums', () => {
                 isPublic: true,
             };
 
-            const createdForums = await forumsStore.createForum(testForum);
+            const createdForums = await forumsStore.createForum('therr', testForum);
             createdForumIds.push(createdForums[0].id);
 
             expect(createdForums).to.be.an('array');
@@ -122,7 +122,7 @@ describe('Integration Tests - Forums', () => {
                 iconColor: '#28a745',
             };
 
-            const createdForums = await forumsStore.createForum(testForum);
+            const createdForums = await forumsStore.createForum('therr', testForum);
             createdForumIds.push(createdForums[0].id);
 
             expect(createdForums[0].id).to.be.a('string');
@@ -145,7 +145,7 @@ describe('Integration Tests - Forums', () => {
                 isPublic: false,
             };
 
-            const createdForums = await forumsStore.createForum(testForum);
+            const createdForums = await forumsStore.createForum('therr', testForum);
             createdForumIds.push(createdForums[0].id);
 
             expect(createdForums[0].isPublic).to.be.eq(false);
@@ -157,7 +157,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create a forum first
-            const createdForums = await forumsStore.createForum({
+            const createdForums = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -173,7 +173,7 @@ describe('Integration Tests - Forums', () => {
             const forumId = createdForums[0].id;
 
             // Retrieve the forum
-            const retrievedForums = await forumsStore.getForum(forumId);
+            const retrievedForums = await forumsStore.getForum('therr', forumId);
 
             expect(retrievedForums).to.be.an('array');
             expect(retrievedForums.length).to.equal(1);
@@ -184,7 +184,7 @@ describe('Integration Tests - Forums', () => {
         it('should return empty array for non-existent forum', async () => {
             if (skipTests) return;
 
-            const retrievedForums = await forumsStore.getForum('00000000-0000-0000-0000-000000000000');
+            const retrievedForums = await forumsStore.getForum('therr', '00000000-0000-0000-0000-000000000000');
 
             expect(retrievedForums).to.be.an('array');
             expect(retrievedForums.length).to.equal(0);
@@ -196,7 +196,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create forums by different authors
-            const forum1 = await forumsStore.createForum({
+            const forum1 = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -210,7 +210,7 @@ describe('Integration Tests - Forums', () => {
             });
             createdForumIds.push(forum1[0].id);
 
-            const forum2 = await forumsStore.createForum({
+            const forum2 = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID_2,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID_2,
@@ -225,7 +225,7 @@ describe('Integration Tests - Forums', () => {
             createdForumIds.push(forum2[0].id);
 
             // Get forums by author 1
-            const authorForums = await forumsStore.getForums({ authorId: TEST_AUTHOR_ID }, null);
+            const authorForums = await forumsStore.getForums('therr', { authorId: TEST_AUTHOR_ID }, null);
 
             const authorForumIds = authorForums.map((f) => f.id);
             expect(authorForumIds).to.include(forum1[0].id);
@@ -235,7 +235,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create and archive a forum
-            const forum = await forumsStore.createForum({
+            const forum = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -249,13 +249,13 @@ describe('Integration Tests - Forums', () => {
             });
             createdForumIds.push(forum[0].id);
 
-            await forumsStore.archiveForum({
+            await forumsStore.archiveForum('therr', {
                 id: forum[0].id,
                 authorId: TEST_AUTHOR_ID,
             });
 
             // Get forums - should not include archived
-            const activeForums = await forumsStore.getForums({ authorId: TEST_AUTHOR_ID }, null, true);
+            const activeForums = await forumsStore.getForums('therr', { authorId: TEST_AUTHOR_ID }, null, true);
 
             const activeForumIds = activeForums.map((f) => f.id);
             expect(activeForumIds).to.not.include(forum[0].id);
@@ -267,7 +267,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create multiple forums
-            const forum1 = await forumsStore.createForum({
+            const forum1 = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -281,7 +281,7 @@ describe('Integration Tests - Forums', () => {
             });
             createdForumIds.push(forum1[0].id);
 
-            const forum2 = await forumsStore.createForum({
+            const forum2 = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -296,7 +296,7 @@ describe('Integration Tests - Forums', () => {
             createdForumIds.push(forum2[0].id);
 
             // Find both forums
-            const foundForums = await forumsStore.findForums([forum1[0].id, forum2[0].id]);
+            const foundForums = await forumsStore.findForums('therr', [forum1[0].id, forum2[0].id]);
 
             expect(foundForums).to.be.an('array');
             expect(foundForums.length).to.equal(2);
@@ -310,7 +310,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create public forum
-            const forum = await forumsStore.createForum({
+            const forum = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -326,7 +326,7 @@ describe('Integration Tests - Forums', () => {
             createdForumIds.push(forum[0].id);
 
             // Search public forums
-            const searchResults = await forumsStore.searchForums(
+            const searchResults = await forumsStore.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
                     order: 'desc',
@@ -341,7 +341,7 @@ describe('Integration Tests - Forums', () => {
         it('should search forums by specific IDs', async () => {
             if (skipTests) return;
 
-            const forum = await forumsStore.createForum({
+            const forum = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -357,7 +357,7 @@ describe('Integration Tests - Forums', () => {
             createdForumIds.push(forum[0].id);
 
             // Search by specific forum ID
-            const searchResults = await forumsStore.searchForums(
+            const searchResults = await forumsStore.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
                     order: 'desc',
@@ -375,7 +375,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create forum
-            const forum = await forumsStore.createForum({
+            const forum = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -390,7 +390,7 @@ describe('Integration Tests - Forums', () => {
             createdForumIds.push(forum[0].id);
 
             // Update forum
-            const updateResult = await forumsStore.updateForum(
+            const updateResult = await forumsStore.updateForum('therr', 
                 { id: forum[0].id, authorId: TEST_AUTHOR_ID },
                 {
                     title: ['Updated Title'],
@@ -402,7 +402,7 @@ describe('Integration Tests - Forums', () => {
             expect(updateResult[0].id).to.equal(forum[0].id);
 
             // Verify update
-            const updatedForum = await forumsStore.getForum(forum[0].id);
+            const updatedForum = await forumsStore.getForum('therr', forum[0].id);
             expect(updatedForum[0].title).to.include('Updated Title');
             expect(updatedForum[0].description).to.equal('Updated description');
         });
@@ -411,7 +411,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create public forum
-            const forum = await forumsStore.createForum({
+            const forum = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -427,13 +427,13 @@ describe('Integration Tests - Forums', () => {
             createdForumIds.push(forum[0].id);
 
             // Update to private
-            await forumsStore.updateForum(
+            await forumsStore.updateForum('therr', 
                 { id: forum[0].id, authorId: TEST_AUTHOR_ID },
                 { isPublic: false },
             );
 
             // Verify update
-            const updatedForum = await forumsStore.getForum(forum[0].id);
+            const updatedForum = await forumsStore.getForum('therr', forum[0].id);
             expect(updatedForum[0].isPublic).to.be.eq(false);
         });
 
@@ -441,7 +441,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create forum
-            const forum = await forumsStore.createForum({
+            const forum = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -456,7 +456,7 @@ describe('Integration Tests - Forums', () => {
             createdForumIds.push(forum[0].id);
 
             // Try to update with wrong author
-            const updateResult = await forumsStore.updateForum(
+            const updateResult = await forumsStore.updateForum('therr', 
                 { id: forum[0].id, authorId: '00000000-0000-0000-0000-000000000001' },
                 { title: ['Unauthorized Update'] },
             );
@@ -472,7 +472,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create forum
-            const forum = await forumsStore.createForum({
+            const forum = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -487,7 +487,7 @@ describe('Integration Tests - Forums', () => {
             createdForumIds.push(forum[0].id);
 
             // Archive forum
-            const archiveResult = await forumsStore.archiveForum({
+            const archiveResult = await forumsStore.archiveForum('therr', {
                 id: forum[0].id,
                 authorId: TEST_AUTHOR_ID,
             });
@@ -496,7 +496,7 @@ describe('Integration Tests - Forums', () => {
             expect(archiveResult[0].id).to.equal(forum[0].id);
 
             // Verify archived
-            const archivedForum = await forumsStore.getForum(forum[0].id);
+            const archivedForum = await forumsStore.getForum('therr', forum[0].id);
             expect(archivedForum[0].archivedAt).to.not.be.eq(null);
         });
 
@@ -504,7 +504,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create forum
-            const forum = await forumsStore.createForum({
+            const forum = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -519,7 +519,7 @@ describe('Integration Tests - Forums', () => {
             createdForumIds.push(forum[0].id);
 
             // Try to archive with wrong author
-            const archiveResult = await forumsStore.archiveForum({
+            const archiveResult = await forumsStore.archiveForum('therr', {
                 id: forum[0].id,
                 authorId: '00000000-0000-0000-0000-000000000001',
             });
@@ -535,7 +535,7 @@ describe('Integration Tests - Forums', () => {
             if (skipTests) return;
 
             // Create forum
-            const forum = await forumsStore.createForum({
+            const forum = await forumsStore.createForum('therr', {
                 authorId: TEST_AUTHOR_ID,
                 authorLocale: 'en-us',
                 administratorIds: TEST_AUTHOR_ID,
@@ -553,12 +553,12 @@ describe('Integration Tests - Forums', () => {
             await cleanupTestData('forumCategories', { forumId: forum[0].id });
 
             // Delete forum
-            const deleteResult = await forumsStore.deleteForum(forum[0].id);
+            const deleteResult = await forumsStore.deleteForum('therr', forum[0].id);
 
             expect(deleteResult).to.be.an('array');
 
             // Verify deleted
-            const deletedForum = await forumsStore.getForum(forum[0].id);
+            const deletedForum = await forumsStore.getForum('therr', forum[0].id);
             expect(deletedForum.length).to.equal(0);
         });
     });

--- a/therr-services/messages-service/tests/unit/DirectMessagesStore.test.ts
+++ b/therr-services/messages-service/tests/unit/DirectMessagesStore.test.ts
@@ -10,14 +10,14 @@ describe('DirectMessagesStore', () => {
 
     describe('countRecords', () => {
         it('queries for total records with filter', () => {
-            const expected = `select count(*) from "main"."directMessages" where "isUnread" = false`;
+            const expected = `select count(*) from "main"."directMessages" where "main.directMessages.brandVariation" = 'therr' and "isUnread" = false`;
             const mockStore = {
                 read: {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ count: '5' }] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            store.countRecords({
+            const store = new DirectMessagesStore(mockStore as any);
+            store.countRecords('therr', {
                 filterBy: 'isUnread',
                 query: false,
             });
@@ -31,8 +31,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ count: '15' }] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            const result = await store.countRecords({});
+            const store = new DirectMessagesStore(mockStore as any);
+            const result = await store.countRecords('therr', {});
 
             expect(result).to.be.an('array');
             expect(result[0].count).to.equal('15');
@@ -41,14 +41,14 @@ describe('DirectMessagesStore', () => {
 
     describe('searchDirectMessages', () => {
         it('queries and paginates response', () => {
-            const expected = `select * from "main"."directMessages" where "toUserId" = 10 and "main"."directMessages"."toUserId" > 7 order by "main"."directMessages"."updatedAt" desc limit 100 offset 100`;
+            const expected = `select * from "main"."directMessages" where "main"."directMessages"."brandVariation" = 'therr' and "toUserId" = 10 and "main"."directMessages"."toUserId" > 7 order by "main"."directMessages"."updatedAt" desc limit 100 offset 100`;
             const mockStore = {
                 read: {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            store.searchDirectMessages(10, {
+            const store = new DirectMessagesStore(mockStore as any);
+            store.searchDirectMessages('therr', 10, {
                 pagination: {
                     itemsPerPage: 100,
                     pageNumber: 2,
@@ -67,8 +67,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            store.searchDirectMessages('user-1', {
+            const store = new DirectMessagesStore(mockStore as any);
+            store.searchDirectMessages('therr', 'user-1', {
                 pagination: { itemsPerPage: 20, pageNumber: 1 },
             }, []);
 
@@ -84,8 +84,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            store.searchDirectMessages('user-1', {
+            const store = new DirectMessagesStore(mockStore as any);
+            store.searchDirectMessages('therr', 'user-1', {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             }, []);
 
@@ -99,8 +99,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            store.searchDirectMessages('user-1', {
+            const store = new DirectMessagesStore(mockStore as any);
+            store.searchDirectMessages('therr', 'user-1', {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
                 filterBy: 'message',
                 filterOperator: 'ilike',
@@ -117,8 +117,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            store.searchDirectMessages('user-1', {
+            const store = new DirectMessagesStore(mockStore as any);
+            store.searchDirectMessages('therr', 'user-1', {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
                 filterBy: 'fromUserId',
                 filterOperator: '=',
@@ -146,8 +146,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: mockMessages })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            const result = await store.searchDirectMessages('user-1', {
+            const store = new DirectMessagesStore(mockStore as any);
+            const result = await store.searchDirectMessages('therr', 'user-1', {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             }, []);
 
@@ -163,8 +163,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            store.searchLatestDMs('user-123', {
+            const store = new DirectMessagesStore(mockStore as any);
+            store.searchLatestDMs('therr', 'user-123', {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             });
 
@@ -181,8 +181,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            store.searchLatestDMs('user-123', {
+            const store = new DirectMessagesStore(mockStore as any);
+            store.searchLatestDMs('therr', 'user-123', {
                 pagination: { itemsPerPage: 15, pageNumber: 3 },
             });
 
@@ -197,8 +197,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            store.searchLatestDMs('user-123', {
+            const store = new DirectMessagesStore(mockStore as any);
+            store.searchLatestDMs('therr', 'user-123', {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             });
 
@@ -221,8 +221,8 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: mockConversations })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
-            const result = await store.searchLatestDMs('user-123', {
+            const store = new DirectMessagesStore(mockStore as any);
+            const result = await store.searchLatestDMs('therr', 'user-123', {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             });
 
@@ -238,7 +238,7 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: '1', updatedAt: new Date() }] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
+            const store = new DirectMessagesStore(mockStore as any);
 
             const params: ICreateDirectMessageParams = {
                 message: 'Hello there!',
@@ -248,7 +248,7 @@ describe('DirectMessagesStore', () => {
                 locale: 'en-us',
             };
 
-            store.createDirectMessage(params);
+            store.createDirectMessage('therr', params);
 
             const queryString = mockStore.write.query.args[0][0];
             expect(queryString).to.include('insert into "main"."directMessages"');
@@ -268,9 +268,9 @@ describe('DirectMessagesStore', () => {
                     })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
+            const store = new DirectMessagesStore(mockStore as any);
 
-            const result = await store.createDirectMessage({
+            const result = await store.createDirectMessage('therr', {
                 message: 'Test',
                 toUserId: 'user-2',
                 fromUserId: 'user-1',
@@ -290,9 +290,9 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: '1', updatedAt: new Date() }] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
+            const store = new DirectMessagesStore(mockStore as any);
 
-            store.createDirectMessage({
+            store.createDirectMessage('therr', {
                 message: 'Test',
                 toUserId: 'user-2',
                 fromUserId: 'user-1',
@@ -310,9 +310,9 @@ describe('DirectMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: '1', updatedAt: new Date() }] })),
                 },
             };
-            const store = new DirectMessagesStore(mockStore);
+            const store = new DirectMessagesStore(mockStore as any);
 
-            store.createDirectMessage({
+            store.createDirectMessage('therr', {
                 message: 'Bonjour',
                 toUserId: 'user-2',
                 fromUserId: 'user-1',

--- a/therr-services/messages-service/tests/unit/ForumMessagesStore.test.ts
+++ b/therr-services/messages-service/tests/unit/ForumMessagesStore.test.ts
@@ -10,14 +10,14 @@ describe('ForumMessagesStore', () => {
 
     describe('countRecords', () => {
         it('queries for total records with filter', () => {
-            const expected = `select count(*) from "main"."forumMessages" where "isAnnouncement" = false`;
+            const expected = `select count(*) from "main"."forumMessages" where "main.forumMessages.brandVariation" = 'therr' and "isAnnouncement" = false`;
             const mockStore = {
                 read: {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ count: '10' }] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            store.countRecords({
+            const store = new ForumMessagesStore(mockStore as any);
+            store.countRecords('therr', {
                 filterBy: 'isAnnouncement',
                 query: false,
             });
@@ -31,8 +31,8 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ count: '25' }] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            const result = await store.countRecords({});
+            const store = new ForumMessagesStore(mockStore as any);
+            const result = await store.countRecords('therr', {});
 
             expect(result).to.be.an('array');
             expect(result[0].count).to.equal('25');
@@ -47,8 +47,8 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            store.searchForumMessages(forumId, {
+            const store = new ForumMessagesStore(mockStore as any);
+            store.searchForumMessages('therr', forumId, {
                 pagination: {
                     itemsPerPage: 20,
                     pageNumber: 1,
@@ -68,8 +68,8 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            store.searchForumMessages(1, {
+            const store = new ForumMessagesStore(mockStore as any);
+            store.searchForumMessages('therr', 1, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             }, []);
 
@@ -83,8 +83,8 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            store.searchForumMessages(1, {
+            const store = new ForumMessagesStore(mockStore as any);
+            store.searchForumMessages('therr', 1, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             }, []);
 
@@ -98,8 +98,8 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            store.searchForumMessages(1, {
+            const store = new ForumMessagesStore(mockStore as any);
+            store.searchForumMessages('therr', 1, {
                 pagination: { itemsPerPage: 15, pageNumber: 3 },
             }, []);
 
@@ -114,8 +114,8 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            store.searchForumMessages(1, {
+            const store = new ForumMessagesStore(mockStore as any);
+            store.searchForumMessages('therr', 1, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
                 filterBy: 'fromUserId',
                 filterOperator: '=',
@@ -132,8 +132,8 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            store.searchForumMessages(1, {
+            const store = new ForumMessagesStore(mockStore as any);
+            store.searchForumMessages('therr', 1, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
                 filterBy: 'message',
                 filterOperator: 'ilike',
@@ -158,8 +158,8 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: mockMessages })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            const result = await store.searchForumMessages(1, {
+            const store = new ForumMessagesStore(mockStore as any);
+            const result = await store.searchForumMessages('therr', 1, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             }, []);
 
@@ -174,8 +174,8 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
-            store.searchForumMessages(1, {
+            const store = new ForumMessagesStore(mockStore as any);
+            store.searchForumMessages('therr', 1, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             }, ['id', 'message', 'createdAt']);
 
@@ -191,7 +191,7 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: 1, updatedAt: new Date() }] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
+            const store = new ForumMessagesStore(mockStore as any);
 
             const params: ICreateForumMessageParams = {
                 forumId: 1,
@@ -201,7 +201,7 @@ describe('ForumMessagesStore', () => {
                 isAnnouncement: false,
             };
 
-            store.createForumMessage(params);
+            store.createForumMessage('therr', params);
 
             const queryString = mockStore.write.query.args[0][0];
             expect(queryString).to.include('insert into "main"."forumMessages"');
@@ -219,9 +219,9 @@ describe('ForumMessagesStore', () => {
                     })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
+            const store = new ForumMessagesStore(mockStore as any);
 
-            const result = await store.createForumMessage({
+            const result = await store.createForumMessage('therr', {
                 forumId: 1,
                 message: 'Test',
                 fromUserId: 'user-1',
@@ -240,9 +240,9 @@ describe('ForumMessagesStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: 1, updatedAt: new Date() }] })),
                 },
             };
-            const store = new ForumMessagesStore(mockStore);
+            const store = new ForumMessagesStore(mockStore as any);
 
-            store.createForumMessage({
+            store.createForumMessage('therr', {
                 forumId: 1,
                 message: 'Important announcement',
                 fromUserId: 'admin-user',

--- a/therr-services/messages-service/tests/unit/ForumsStore.test.ts
+++ b/therr-services/messages-service/tests/unit/ForumsStore.test.ts
@@ -10,14 +10,14 @@ describe('ForumsStore', () => {
 
     describe('countRecords', () => {
         it('queries for total records with filter', () => {
-            const expected = `select count(*) from "main"."forums" where "isPublic" = true`;
+            const expected = `select count(*) from "main"."forums" where "main.forums.brandVariation" = 'therr' and "isPublic" = true`;
             const mockStore = {
                 read: {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ count: '5' }] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            store.countRecords({
+            const store = new ForumsStore(mockStore as any);
+            store.countRecords('therr', {
                 filterBy: 'isPublic',
                 query: true,
             });
@@ -29,14 +29,14 @@ describe('ForumsStore', () => {
     describe('getForum', () => {
         it('queries for a forum by id', () => {
             const forumId = 'forum-123';
-            const expected = `select * from "main"."forums" where "id" = '${forumId}'`;
+            const expected = `select * from "main"."forums" where "id" = '${forumId}' and "brandVariation" = 'therr'`;
             const mockStore = {
                 write: {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            store.getForum(forumId);
+            const store = new ForumsStore(mockStore as any);
+            store.getForum('therr', forumId);
 
             expect(mockStore.write.query.args[0][0]).to.be.equal(expected);
         });
@@ -52,8 +52,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [mockForum] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            const result = await store.getForum('forum-123');
+            const store = new ForumsStore(mockStore as any);
+            const result = await store.getForum('therr', 'forum-123');
 
             expect(result).to.be.an('array');
             expect(result.length).to.equal(1);
@@ -68,8 +68,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            store.getForums({ authorId: 'user-1' }, null);
+            const store = new ForumsStore(mockStore as any);
+            store.getForums('therr', { authorId: 'user-1' }, null);
 
             const queryString = mockStore.write.query.args[0][0];
             expect(queryString).to.include('select * from "main"."forums"');
@@ -83,8 +83,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            store.getForums({ authorId: 'user-1' }, null, false);
+            const store = new ForumsStore(mockStore as any);
+            store.getForums('therr', { authorId: 'user-1' }, null, false);
 
             const queryString = mockStore.write.query.args[0][0];
             expect(queryString).to.not.include('"archivedAt" is null');
@@ -96,8 +96,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            store.getForums({ authorId: 'user-1', title: 'Test' }, { authorId: 'user-1', subtitle: 'Subtitle' });
+            const store = new ForumsStore(mockStore as any);
+            store.getForums('therr', { authorId: 'user-1', title: 'Test' }, { authorId: 'user-1', subtitle: 'Subtitle' });
 
             const queryString = mockStore.write.query.args[0][0];
             expect(queryString).to.include('"authorId"');
@@ -114,8 +114,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            store.findForums(ids);
+            const store = new ForumsStore(mockStore as any);
+            store.findForums('therr', ids);
 
             const queryString = mockStore.read.query.args[0][0];
             expect(queryString).to.include('select "id", "title" from "main"."forums"');
@@ -132,8 +132,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: mockForums })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            const result = await store.findForums(['forum-1', 'forum-2']);
+            const store = new ForumsStore(mockStore as any);
+            const result = await store.findForums('therr', ['forum-1', 'forum-2']);
 
             expect(result).to.be.an('array');
             expect(result.length).to.equal(2);
@@ -149,8 +149,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            await store.searchForums(
+            const store = new ForumsStore(mockStore as any);
+            await store.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 2 },
                     order: 'desc',
@@ -170,8 +170,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            await store.searchForums(
+            const store = new ForumsStore(mockStore as any);
+            await store.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
                     order: 'desc',
@@ -191,8 +191,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            await store.searchForums(
+            const store = new ForumsStore(mockStore as any);
+            await store.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
                     order: 'desc',
@@ -211,8 +211,8 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
-            await store.searchForums(
+            const store = new ForumsStore(mockStore as any);
+            await store.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
                     order: 'desc',
@@ -244,7 +244,7 @@ describe('ForumsStore', () => {
                         .resolves({ rows: [] }),
                 },
             };
-            const store = new ForumsStore(mockStore);
+            const store = new ForumsStore(mockStore as any);
 
             const params: ICreateForumParams = {
                 authorId: 'user-1',
@@ -259,7 +259,7 @@ describe('ForumsStore', () => {
                 iconColor: '#000000',
             };
 
-            const result = await store.createForum(params);
+            const result = await store.createForum('therr', params);
 
             expect(mockStore.write.query.calledTwice).to.be.eq(true);
             expect(result).to.be.an('array');
@@ -283,9 +283,9 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: 'forum-123' }] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
+            const store = new ForumsStore(mockStore as any);
 
-            await store.updateForum(
+            await store.updateForum('therr', 
                 { id: 'forum-123', authorId: 'user-1' },
                 { title: ['Updated Title'] },
             );
@@ -303,9 +303,9 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: 'forum-123' }] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
+            const store = new ForumsStore(mockStore as any);
 
-            const result = await store.updateForum(
+            const result = await store.updateForum('therr', 
                 { id: 'forum-123' },
                 { description: 'New description' },
             );
@@ -322,9 +322,9 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: 'forum-123' }] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
+            const store = new ForumsStore(mockStore as any);
 
-            await store.archiveForum({ id: 'forum-123', authorId: 'user-1' });
+            await store.archiveForum('therr', { id: 'forum-123', authorId: 'user-1' });
 
             const queryString = mockStore.write.query.args[0][0];
             expect(queryString).to.include('update "main"."forums"');
@@ -339,9 +339,9 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: 'forum-123' }] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
+            const store = new ForumsStore(mockStore as any);
 
-            const result = await store.archiveForum({ id: 'forum-123', authorId: 'user-1' });
+            const result = await store.archiveForum('therr', { id: 'forum-123', authorId: 'user-1' });
 
             expect(result).to.be.an('array');
             expect(result[0].id).to.equal('forum-123');
@@ -355,9 +355,9 @@ describe('ForumsStore', () => {
                     query: sinon.stub().callsFake(() => Promise.resolve({ rows: [{ id: 'forum-123' }] })),
                 },
             };
-            const store = new ForumsStore(mockStore);
+            const store = new ForumsStore(mockStore as any);
 
-            await store.deleteForum('forum-123');
+            await store.deleteForum('therr', 'forum-123');
 
             const queryString = mockStore.write.query.args[0][0];
             expect(queryString).to.include('delete from "main"."forums"');

--- a/therr-services/messages-service/tests/unit/handlers-directMessages.test.ts
+++ b/therr-services/messages-service/tests/unit/handlers-directMessages.test.ts
@@ -21,7 +21,7 @@ describe('Direct Messages Handler', () => {
 
             const createDMStub = sinon.stub(Store.directMessages, 'createDirectMessage').resolves([mockMessage]);
 
-            const result = await Store.directMessages.createDirectMessage({
+            const result = await Store.directMessages.createDirectMessage('therr', {
                 message: 'Hello!',
                 toUserId: 'user-2',
                 fromUserId: 'user-1',
@@ -38,7 +38,7 @@ describe('Direct Messages Handler', () => {
         it('should include locale in the message', async () => {
             const createDMStub = sinon.stub(Store.directMessages, 'createDirectMessage').resolves([{ id: 'msg-1' }]);
 
-            await Store.directMessages.createDirectMessage({
+            await Store.directMessages.createDirectMessage('therr', {
                 message: 'Bonjour',
                 toUserId: 'user-2',
                 fromUserId: 'user-1',
@@ -47,14 +47,14 @@ describe('Direct Messages Handler', () => {
             });
 
             expect(createDMStub.calledOnce).to.be.eq(true);
-            const callArgs = createDMStub.args[0][0];
+            const callArgs = createDMStub.args[0][1];
             expect(callArgs.locale).to.equal('fr-fr');
         });
 
         it('should handle unread flag correctly', async () => {
             const createDMStub = sinon.stub(Store.directMessages, 'createDirectMessage').resolves([{ id: 'msg-1' }]);
 
-            await Store.directMessages.createDirectMessage({
+            await Store.directMessages.createDirectMessage('therr', {
                 message: 'Read message',
                 toUserId: 'user-2',
                 fromUserId: 'user-1',
@@ -62,7 +62,7 @@ describe('Direct Messages Handler', () => {
                 locale: 'en-us',
             });
 
-            const callArgs = createDMStub.args[0][0];
+            const callArgs = createDMStub.args[0][1];
             expect(callArgs.isUnread).to.be.eq(false);
         });
     });
@@ -76,7 +76,7 @@ describe('Direct Messages Handler', () => {
 
             const searchStub = sinon.stub(Store.directMessages, 'searchDirectMessages').resolves(mockMessages);
 
-            const result = await Store.directMessages.searchDirectMessages(
+            const result = await Store.directMessages.searchDirectMessages('therr', 
                 'user-1',
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -95,7 +95,7 @@ describe('Direct Messages Handler', () => {
         it('should support reverse direction check', async () => {
             const searchStub = sinon.stub(Store.directMessages, 'searchDirectMessages').resolves([]);
 
-            await Store.directMessages.searchDirectMessages(
+            await Store.directMessages.searchDirectMessages('therr', 
                 'user-1',
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -125,7 +125,7 @@ describe('Direct Messages Handler', () => {
 
             const searchLatestStub = sinon.stub(Store.directMessages, 'searchLatestDMs').resolves(mockConversations);
 
-            const result = await Store.directMessages.searchLatestDMs('user-1', {
+            const result = await Store.directMessages.searchLatestDMs('therr', 'user-1', {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
             });
 
@@ -137,12 +137,12 @@ describe('Direct Messages Handler', () => {
         it('should paginate conversation list', async () => {
             const searchLatestStub = sinon.stub(Store.directMessages, 'searchLatestDMs').resolves([]);
 
-            await Store.directMessages.searchLatestDMs('user-1', {
+            await Store.directMessages.searchLatestDMs('therr', 'user-1', {
                 pagination: { itemsPerPage: 5, pageNumber: 2 },
             });
 
             expect(searchLatestStub.calledOnce).to.be.eq(true);
-            const callArgs = searchLatestStub.args[0][1];
+            const callArgs = searchLatestStub.args[0][2];
             expect(callArgs.pagination.itemsPerPage).to.equal(5);
             expect(callArgs.pagination.pageNumber).to.equal(2);
         });
@@ -152,7 +152,7 @@ describe('Direct Messages Handler', () => {
         it('should count messages with filter', async () => {
             const countStub = sinon.stub(Store.directMessages, 'countRecords').resolves([{ count: '42' }]);
 
-            const result = await Store.directMessages.countRecords({
+            const result = await Store.directMessages.countRecords('therr', {
                 filterBy: 'isUnread',
                 query: true,
             });
@@ -164,7 +164,7 @@ describe('Direct Messages Handler', () => {
         it('should return count without filter', async () => {
             const countStub = sinon.stub(Store.directMessages, 'countRecords').resolves([{ count: '100' }]);
 
-            const result = await Store.directMessages.countRecords({});
+            const result = await Store.directMessages.countRecords('therr', {});
 
             expect(result[0].count).to.equal('100');
         });

--- a/therr-services/messages-service/tests/unit/handlers-forumMessages.test.ts
+++ b/therr-services/messages-service/tests/unit/handlers-forumMessages.test.ts
@@ -21,7 +21,7 @@ describe('Forum Messages Handler', () => {
 
             const createMessageStub = sinon.stub(Store.forumMessages, 'createForumMessage').resolves([mockMessage]);
 
-            const result = await Store.forumMessages.createForumMessage({
+            const result = await Store.forumMessages.createForumMessage('therr', {
                 forumId: 123,
                 message: 'Hello forum!',
                 fromUserId: 'user-1',
@@ -38,7 +38,7 @@ describe('Forum Messages Handler', () => {
         it('should create an announcement message', async () => {
             const createMessageStub = sinon.stub(Store.forumMessages, 'createForumMessage').resolves([{ id: 1 }]);
 
-            await Store.forumMessages.createForumMessage({
+            await Store.forumMessages.createForumMessage('therr', {
                 forumId: 123,
                 message: 'Important announcement!',
                 fromUserId: 'admin-user',
@@ -47,21 +47,21 @@ describe('Forum Messages Handler', () => {
             });
 
             expect(createMessageStub.calledOnce).to.be.eq(true);
-            const callArgs = createMessageStub.args[0][0];
+            const callArgs = createMessageStub.args[0][1];
             expect(callArgs.isAnnouncement).to.be.eq(true);
         });
 
         it('should include fromUserLocale', async () => {
             const createMessageStub = sinon.stub(Store.forumMessages, 'createForumMessage').resolves([{ id: 1 }]);
 
-            await Store.forumMessages.createForumMessage({
+            await Store.forumMessages.createForumMessage('therr', {
                 forumId: 123,
                 message: 'Message',
                 fromUserId: 'user-1',
                 fromUserLocale: 2, // Different locale
             });
 
-            const callArgs = createMessageStub.args[0][0];
+            const callArgs = createMessageStub.args[0][1];
             expect(callArgs.fromUserLocale).to.equal(2);
         });
 
@@ -72,7 +72,7 @@ describe('Forum Messages Handler', () => {
                 updatedAt,
             }]);
 
-            const result = await Store.forumMessages.createForumMessage({
+            const result = await Store.forumMessages.createForumMessage('therr', {
                 forumId: 1,
                 message: 'Test',
                 fromUserId: 'user-1',
@@ -97,7 +97,7 @@ describe('Forum Messages Handler', () => {
 
             const searchStub = sinon.stub(Store.forumMessages, 'searchForumMessages').resolves(mockMessages);
 
-            const result = await Store.forumMessages.searchForumMessages(
+            const result = await Store.forumMessages.searchForumMessages('therr', 
                 123,
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -114,7 +114,7 @@ describe('Forum Messages Handler', () => {
         it('should filter messages by fromUserId', async () => {
             const searchStub = sinon.stub(Store.forumMessages, 'searchForumMessages').resolves([]);
 
-            await Store.forumMessages.searchForumMessages(
+            await Store.forumMessages.searchForumMessages('therr', 
                 123,
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -132,7 +132,7 @@ describe('Forum Messages Handler', () => {
         it('should support text search with ilike', async () => {
             const searchStub = sinon.stub(Store.forumMessages, 'searchForumMessages').resolves([]);
 
-            await Store.forumMessages.searchForumMessages(
+            await Store.forumMessages.searchForumMessages('therr', 
                 123,
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
@@ -149,7 +149,7 @@ describe('Forum Messages Handler', () => {
         it('should handle page 2 correctly', async () => {
             const searchStub = sinon.stub(Store.forumMessages, 'searchForumMessages').resolves([]);
 
-            await Store.forumMessages.searchForumMessages(
+            await Store.forumMessages.searchForumMessages('therr', 
                 123,
                 {
                     pagination: { itemsPerPage: 20, pageNumber: 2 },
@@ -166,7 +166,7 @@ describe('Forum Messages Handler', () => {
         it('should count messages with filter', async () => {
             const countStub = sinon.stub(Store.forumMessages, 'countRecords').resolves([{ count: '50' }]);
 
-            const result = await Store.forumMessages.countRecords({
+            const result = await Store.forumMessages.countRecords('therr', {
                 filterBy: 'forumId',
                 query: 123,
             });
@@ -178,7 +178,7 @@ describe('Forum Messages Handler', () => {
         it('should count all messages without filter', async () => {
             const countStub = sinon.stub(Store.forumMessages, 'countRecords').resolves([{ count: '1000' }]);
 
-            const result = await Store.forumMessages.countRecords({});
+            const result = await Store.forumMessages.countRecords('therr', {});
 
             expect(result[0].count).to.equal('1000');
         });
@@ -186,13 +186,13 @@ describe('Forum Messages Handler', () => {
         it('should filter by announcement status', async () => {
             const countStub = sinon.stub(Store.forumMessages, 'countRecords').resolves([{ count: '5' }]);
 
-            await Store.forumMessages.countRecords({
+            await Store.forumMessages.countRecords('therr', {
                 filterBy: 'isAnnouncement',
                 query: true,
             });
 
-            expect(countStub.args[0][0].filterBy).to.equal('isAnnouncement');
-            expect(countStub.args[0][0].query).to.be.eq(true);
+            expect(countStub.args[0][1].filterBy).to.equal('isAnnouncement');
+            expect(countStub.args[0][1].query).to.be.eq(true);
         });
     });
 });

--- a/therr-services/messages-service/tests/unit/handlers-forums.test.ts
+++ b/therr-services/messages-service/tests/unit/handlers-forums.test.ts
@@ -21,7 +21,7 @@ describe('Forums Handler', () => {
 
             const createForumStub = sinon.stub(Store.forums, 'createForum').resolves([mockForum]);
 
-            const result = await Store.forums.createForum({
+            const result = await Store.forums.createForum('therr', {
                 authorId: 'user-1',
                 authorLocale: 'en-us',
                 administratorIds: 'user-1',
@@ -43,7 +43,7 @@ describe('Forums Handler', () => {
         it('should create forum with category associations', async () => {
             const createForumStub = sinon.stub(Store.forums, 'createForum').resolves([{ id: 'forum-1' }]);
 
-            await Store.forums.createForum({
+            await Store.forums.createForum('therr', {
                 authorId: 'user-1',
                 authorLocale: 'en-us',
                 administratorIds: 'user-1',
@@ -57,14 +57,14 @@ describe('Forums Handler', () => {
             });
 
             expect(createForumStub.calledOnce).to.be.eq(true);
-            const callArgs = createForumStub.args[0][0];
+            const callArgs = createForumStub.args[0][1];
             expect(callArgs.categoryTags).to.deep.equal(['tech', 'programming', 'javascript']);
         });
 
         it('should set default values for optional fields', async () => {
             const createForumStub = sinon.stub(Store.forums, 'createForum').resolves([{ id: 'forum-1' }]);
 
-            await Store.forums.createForum({
+            await Store.forums.createForum('therr', {
                 authorId: 'user-1',
                 authorLocale: 'en-us',
                 administratorIds: 'user-1',
@@ -79,7 +79,7 @@ describe('Forums Handler', () => {
                 doesExpire: true,
             });
 
-            const callArgs = createForumStub.args[0][0];
+            const callArgs = createForumStub.args[0][1];
             expect(callArgs.maxCommentsPerMin).to.equal(50);
             expect(callArgs.doesExpire).to.be.eq(true);
         });
@@ -95,7 +95,7 @@ describe('Forums Handler', () => {
 
             const getForumStub = sinon.stub(Store.forums, 'getForum').resolves([mockForum]);
 
-            const result = await Store.forums.getForum('forum-123');
+            const result = await Store.forums.getForum('therr', 'forum-123');
 
             expect(getForumStub.calledOnce).to.be.eq(true);
             expect(getForumStub.calledWith('forum-123')).to.be.eq(true);
@@ -105,7 +105,7 @@ describe('Forums Handler', () => {
         it('should return empty array when forum not found', async () => {
             const getForumStub = sinon.stub(Store.forums, 'getForum').resolves([]);
 
-            const result = await Store.forums.getForum('nonexistent-id');
+            const result = await Store.forums.getForum('therr', 'nonexistent-id');
 
             expect(result).to.be.an('array');
             expect(result.length).to.equal(0);
@@ -116,7 +116,7 @@ describe('Forums Handler', () => {
         it('should filter out archived forums by default', async () => {
             const getForumsStub = sinon.stub(Store.forums, 'getForums').resolves([]);
 
-            await Store.forums.getForums({ authorId: 'user-1' }, null, true);
+            await Store.forums.getForums('therr', { authorId: 'user-1' }, null, true);
 
             expect(getForumsStub.calledOnce).to.be.eq(true);
             expect(getForumsStub.args[0][2]).to.be.eq(true);
@@ -125,7 +125,7 @@ describe('Forums Handler', () => {
         it('should include archived forums when flag is false', async () => {
             const getForumsStub = sinon.stub(Store.forums, 'getForums').resolves([]);
 
-            await Store.forums.getForums({ authorId: 'user-1' }, null, false);
+            await Store.forums.getForums('therr', { authorId: 'user-1' }, null, false);
 
             expect(getForumsStub.args[0][2]).to.be.eq(false);
         });
@@ -133,7 +133,7 @@ describe('Forums Handler', () => {
         it('should apply OR conditions', async () => {
             const getForumsStub = sinon.stub(Store.forums, 'getForums').resolves([]);
 
-            await Store.forums.getForums(
+            await Store.forums.getForums('therr', 
                 { authorId: 'user-1', title: 'Title1' },
                 { authorId: 'user-1', subtitle: 'Sub1' },
             );
@@ -151,7 +151,7 @@ describe('Forums Handler', () => {
 
             const findForumsStub = sinon.stub(Store.forums, 'findForums').resolves(mockForums);
 
-            const result = await Store.forums.findForums(['forum-1', 'forum-2']);
+            const result = await Store.forums.findForums('therr', ['forum-1', 'forum-2']);
 
             expect(findForumsStub.calledOnce).to.be.eq(true);
             expect(result.length).to.equal(2);
@@ -164,7 +164,7 @@ describe('Forums Handler', () => {
 
             const findForumsStub = sinon.stub(Store.forums, 'findForums').resolves(mockForums);
 
-            const result = await Store.forums.findForums(['forum-1']);
+            const result = await Store.forums.findForums('therr', ['forum-1']);
 
             expect(result[0]).to.have.property('id');
             expect(result[0]).to.have.property('title');
@@ -175,7 +175,7 @@ describe('Forums Handler', () => {
         it('should search public forums with pagination', async () => {
             const searchForumsStub = sinon.stub(Store.forums, 'searchForums').resolves([]);
 
-            await Store.forums.searchForums(
+            await Store.forums.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
                     order: 'desc',
@@ -190,7 +190,7 @@ describe('Forums Handler', () => {
         it('should filter by invited forum IDs for private forums', async () => {
             const searchForumsStub = sinon.stub(Store.forums, 'searchForums').resolves([]);
 
-            await Store.forums.searchForums(
+            await Store.forums.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
                     order: 'desc',
@@ -205,7 +205,7 @@ describe('Forums Handler', () => {
         it('should filter by category tags', async () => {
             const searchForumsStub = sinon.stub(Store.forums, 'searchForums').resolves([]);
 
-            await Store.forums.searchForums(
+            await Store.forums.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
                     order: 'desc',
@@ -220,7 +220,7 @@ describe('Forums Handler', () => {
         it('should apply text filter with ilike', async () => {
             const searchForumsStub = sinon.stub(Store.forums, 'searchForums').resolves([]);
 
-            await Store.forums.searchForums(
+            await Store.forums.searchForums('therr', 
                 {
                     pagination: { itemsPerPage: 10, pageNumber: 1 },
                     order: 'desc',
@@ -232,8 +232,8 @@ describe('Forums Handler', () => {
                 {},
             );
 
-            expect(searchForumsStub.args[0][0].filterBy).to.equal('title');
-            expect(searchForumsStub.args[0][0].filterOperator).to.equal('ilike');
+            expect(searchForumsStub.args[0][1].filterBy).to.equal('title');
+            expect(searchForumsStub.args[0][1].filterOperator).to.equal('ilike');
         });
     });
 
@@ -241,19 +241,19 @@ describe('Forums Handler', () => {
         it('should update forum with author authorization', async () => {
             const updateForumStub = sinon.stub(Store.forums, 'updateForum').resolves([{ id: 'forum-123' }]);
 
-            await Store.forums.updateForum(
+            await Store.forums.updateForum('therr', 
                 { id: 'forum-123', authorId: 'user-1' },
                 { title: ['Updated Title'] },
             );
 
             expect(updateForumStub.calledOnce).to.be.eq(true);
-            expect(updateForumStub.args[0][0].authorId).to.equal('user-1');
+            expect(updateForumStub.args[0][1].authorId).to.equal('user-1');
         });
 
         it('should update multiple fields', async () => {
             const updateForumStub = sinon.stub(Store.forums, 'updateForum').resolves([{ id: 'forum-123' }]);
 
-            await Store.forums.updateForum(
+            await Store.forums.updateForum('therr', 
                 { id: 'forum-123' },
                 {
                     title: ['New Title'],
@@ -263,7 +263,7 @@ describe('Forums Handler', () => {
                 },
             );
 
-            const updateParams = updateForumStub.args[0][1];
+            const updateParams = updateForumStub.args[0][2];
             expect(updateParams.title).to.deep.equal(['New Title']);
             expect(updateParams.subtitle).to.deep.equal(['New Subtitle']);
             expect(updateParams.isPublic).to.be.eq(false);
@@ -274,20 +274,20 @@ describe('Forums Handler', () => {
         it('should archive forum with author authorization', async () => {
             const archiveForumStub = sinon.stub(Store.forums, 'archiveForum').resolves([{ id: 'forum-123' }]);
 
-            await Store.forums.archiveForum({
+            await Store.forums.archiveForum('therr', {
                 id: 'forum-123',
                 authorId: 'user-1',
             });
 
             expect(archiveForumStub.calledOnce).to.be.eq(true);
-            expect(archiveForumStub.args[0][0].id).to.equal('forum-123');
-            expect(archiveForumStub.args[0][0].authorId).to.equal('user-1');
+            expect(archiveForumStub.args[0][1].id).to.equal('forum-123');
+            expect(archiveForumStub.args[0][1].authorId).to.equal('user-1');
         });
 
         it('should return archived forum id', async () => {
             const archiveForumStub = sinon.stub(Store.forums, 'archiveForum').resolves([{ id: 'forum-123' }]);
 
-            const result = await Store.forums.archiveForum({
+            const result = await Store.forums.archiveForum('therr', {
                 id: 'forum-123',
                 authorId: 'user-1',
             });
@@ -300,7 +300,7 @@ describe('Forums Handler', () => {
         it('should hard delete forum by id', async () => {
             const deleteForumStub = sinon.stub(Store.forums, 'deleteForum').resolves([{ id: 'forum-123' }]);
 
-            await Store.forums.deleteForum('forum-123');
+            await Store.forums.deleteForum('therr', 'forum-123');
 
             expect(deleteForumStub.calledOnce).to.be.eq(true);
             expect(deleteForumStub.calledWith('forum-123')).to.be.eq(true);

--- a/therr-services/reactions-service/src/store/BrandScopedStore.ts
+++ b/therr-services/reactions-service/src/store/BrandScopedStore.ts
@@ -1,0 +1,58 @@
+import KnexBuilder, { Knex } from 'knex';
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import { BrandVariations } from 'therr-js-utilities/constants';
+import {
+    BRAND_VARIATION_COLUMN,
+    BrandScopeMode,
+    applyBrandFilter,
+    assertBrand,
+    withBrandOnInsert,
+// eslint-disable-next-line import/extensions, import/no-unresolved
+} from 'therr-js-utilities/db';
+import { IConnection } from './connection';
+
+const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
+
+export type BrandValue = BrandVariations | string;
+
+export default abstract class BrandScopedStore {
+    protected db: IConnection;
+
+    protected readonly tableName: string;
+
+    protected readonly mode: BrandScopeMode;
+
+    constructor(db: IConnection, tableName: string, mode: BrandScopeMode = 'shadow') {
+        this.db = db;
+        this.tableName = tableName;
+        this.mode = mode;
+    }
+
+    protected assertBrand(brand: BrandValue | undefined | null) {
+        assertBrand(brand, { tableName: this.tableName, mode: this.mode });
+    }
+
+    protected scopedQuery(brand: BrandValue) {
+        this.assertBrand(brand);
+        return knexBuilder.from(this.tableName)
+            .where(`${this.tableName}.${BRAND_VARIATION_COLUMN}`, '=', brand);
+    }
+
+    protected withBrand<TBuilder extends { andWhere:(...args: any[]) => TBuilder }>(qb: TBuilder, brand: BrandValue): TBuilder {
+        this.assertBrand(brand);
+        return applyBrandFilter(qb, this.tableName, brand);
+    }
+
+    protected scopedInsert<T extends Record<string, unknown>>(brand: BrandValue, row: T) {
+        this.assertBrand(brand);
+        return knexBuilder.insert(withBrandOnInsert(row, brand)).into(this.tableName);
+    }
+
+    protected scopedUpdate(brand: BrandValue, conditions: Record<string, unknown>) {
+        this.assertBrand(brand);
+        return knexBuilder
+            .from(this.tableName)
+            .where(`${this.tableName}.${BRAND_VARIATION_COLUMN}`, '=', brand)
+            .where(conditions);
+    }
+}

--- a/therr-services/users-service/src/handlers/auth.ts
+++ b/therr-services/users-service/src/handlers/auth.ts
@@ -1,6 +1,10 @@
+import { randomBytes } from 'crypto';
 import { RequestHandler } from 'express';
+import * as bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import { AccessLevels, CurrentSocialValuations, OAuthIntegrationProviders } from 'therr-js-utilities/constants';
+import {
+    AccessLevels, BrandVariations, CurrentSocialValuations, OAuthIntegrationProviders,
+} from 'therr-js-utilities/constants';
 import logSpan from 'therr-js-utilities/log-or-update-span';
 import normalizePhoneNumber from 'therr-js-utilities/normalize-phone-number';
 import { parseHeaders } from 'therr-js-utilities/http';
@@ -12,6 +16,11 @@ import translate from '../utilities/translator';
 import { redactUserCreds, validateCredentials } from './helpers/user';
 import TherrEventEmitter from '../api/TherrEventEmitter';
 import decryptIntegrationsAccess from '../utilities/decryptIntegrationsAccess';
+import {
+    mintHandoffCode,
+    redeemHandoffCode,
+    cancelHandoffCode,
+} from '../store/redisClient';
 
 // calling normalizeEmail on a userName will have no change
 const userNameOrEmailOrPhone = (user) => normalizeEmail(user.userName?.trim() || user.userEmail?.trim() || user.email?.trim()?.replace(/\s/g, '') || '')
@@ -191,8 +200,8 @@ const login: RequestHandler = (req: any, res: any) => {
                         return [];
                     });
 
-                    const idToken = createUserToken(user, userOrgs, req.body.rememberMe);
-                    const refreshTokenData = createRefreshToken(user.id, req.body.rememberMe);
+                    const idToken = createUserToken(user, userOrgs, req.body.rememberMe, brandVariation);
+                    const refreshTokenData = createRefreshToken(user.id, req.body.rememberMe, brandVariation);
                     userHash = basicHash(userNameEmailPhone);
 
                     logSpan({
@@ -273,6 +282,25 @@ const login: RequestHandler = (req: any, res: any) => {
                         const finalUser = userResponse[0];
                         // Remove credentials from object
                         redactUserCreds(finalUser);
+                        // Track which apps a user actually uses. Fire-and-forget: a failure here
+                        // must not block the login response, but we want to log it for observability.
+                        // Skip DASHBOARD_THERR for non-business accounts so dashboard sign-ins don't
+                        // pollute consumer brand membership records.
+                        const shouldTrackBrand = brandVariation
+                            && !(brandVariation === BrandVariations.DASHBOARD_THERR && !finalUser?.isBusinessAccount);
+                        if (shouldTrackBrand) {
+                            Store.users.upsertBrandVariation(user.id, brandVariation).catch((err) => {
+                                logSpan({
+                                    level: 'error',
+                                    messageOrigin: 'API_SERVER',
+                                    messages: [err?.message, 'Failed to upsert brandVariations on login'],
+                                    traceArgs: {
+                                        'user.id': user.id,
+                                        'brand.variation': brandVariation,
+                                    },
+                                });
+                            });
+                        }
                         // TODO: Save, Encrypt, and return stored user integrations
                         // const storedIntegrations = encryptIntegrationsAccess(access);
                         return res.status(201).send({
@@ -383,8 +411,15 @@ const refreshToken: RequestHandler = async (req: any, res: any) => {
             },
         };
 
-        const newIdToken = createUserToken(userWithIntegrations, userOrgs, rememberMe);
-        const newRefreshTokenData = createRefreshToken(user.id, rememberMe);
+        // Brand stickiness on refresh: the refresh token represents a session for the brand it
+        // was originally issued under. We re-stamp the new id+refresh tokens with that same brand.
+        // For pre-multi-app refresh tokens that have no `brand` claim, opportunistically upgrade
+        // using the current request's brand-variation header.
+        const { brandVariation: refreshHeaderBrand } = parseHeaders(req.headers);
+        const stickyBrand = decoded.brand || refreshHeaderBrand;
+
+        const newIdToken = createUserToken(userWithIntegrations, userOrgs, rememberMe, stickyBrand);
+        const newRefreshTokenData = createRefreshToken(user.id, rememberMe, stickyBrand);
 
         redactUserCreds(userWithIntegrations);
 
@@ -431,9 +466,231 @@ const verifyToken: RequestHandler = (req: any, res: any) => {
     }
 };
 
+// Pre-computed dummy bcrypt hash. Used to keep precheck timing constant when no user exists,
+// so the response time itself doesn't reveal whether the email is registered. The salt is fixed
+// (precomputed once at module load) so we don't pay a fresh hash cost on every cold start.
+const PRECHECK_DUMMY_HASH = bcrypt.hashSync('precheck-timing-equalizer', 12);
+
+const PRECHECK_HINTS = {
+    enterPassword: 'enter_password',
+    trySSO: 'try_sso',
+    magicLink: 'magic_link',
+    signUp: 'sign_up',
+} as const;
+
+type PrecheckHint = typeof PRECHECK_HINTS[keyof typeof PRECHECK_HINTS];
+
+const pickRandomUnknownHint = (): PrecheckHint => (
+    randomBytes(1)[0] < 180 ? PRECHECK_HINTS.signUp : PRECHECK_HINTS.magicLink
+);
+
+// Email pre-check: tells the client what to render next (password field, SSO button, magic link, or
+// signup) without leaking whether the email exists. All branches return 200 with the same response
+// shape and run a bcrypt comparison so timing is uniform. The hint is what the client renders; the
+// actual side-effect (sending a magic-link email) happens elsewhere and is gated on real existence.
+const emailPrecheck: RequestHandler = async (req: any, res: any) => {
+    const { locale } = parseHeaders(req.headers);
+    const rawEmail = (req.body?.email || '').toString();
+    const email = normalizeEmail(rawEmail.trim());
+
+    let hint: PrecheckHint;
+
+    try {
+        const userResults = email
+            ? await Store.users.getUserByConditions({ email })
+            : [];
+        const user = userResults?.[0];
+
+        // Always run bcrypt to equalize timing across the existence boundary.
+        await bcrypt.compare('precheck-timing-equalizer', user?.password || PRECHECK_DUMMY_HASH);
+
+        if (!user) {
+            hint = pickRandomUnknownHint();
+        } else if (user.password) {
+            hint = PRECHECK_HINTS.enterPassword;
+        } else if (user.integrationsAccess) {
+            hint = PRECHECK_HINTS.trySSO;
+        } else {
+            hint = PRECHECK_HINTS.magicLink;
+        }
+    } catch (err: any) {
+        // Fail open with the most common path so we never block the signup funnel on Redis/DB hiccups.
+        // Log so we can spot a regression without exposing the failure mode to the client.
+        logSpan({
+            level: 'error',
+            messageOrigin: 'API_SERVER',
+            messages: [err?.message, 'email-precheck failed; returning sign_up'],
+            traceArgs: {},
+        });
+        hint = PRECHECK_HINTS.signUp;
+    }
+
+    return res.status(200).send({
+        status: 'continue',
+        hint,
+        message: translate(locale, 'authMessages.emailPrecheckGeneric'),
+    });
+};
+
+// Cross-app handoff. The source app (where the user is signed in) mints a single-use code bound
+// to a target brand. The target app, opened via universal link, redeems that code for fresh
+// tokens stamped with the target brand. This is the first-party analog of OAuth's authorization
+// code flow — but without the consent screen ceremony, since both apps are owned by us and the
+// user has already authenticated to the source app.
+
+const isKnownBrand = (brand: any): boolean => typeof brand === 'string'
+    && (Object.values(BrandVariations) as string[]).includes(brand);
+
+const mintHandoff: RequestHandler = async (req: any, res: any) => {
+    const userId = req.headers['x-userid'];
+    const sourceBrand = (req.headers['x-brand-variation'] as string) || '';
+    const targetBrand = (req.body?.targetBrand || '').toString();
+    const deviceFingerprint = req.body?.deviceFingerprint
+        ? String(req.body.deviceFingerprint).slice(0, 256)
+        : undefined;
+
+    if (!userId) {
+        return handleHttpError({ res, message: 'Unauthorized', statusCode: 401 });
+    }
+    if (!isKnownBrand(targetBrand)) {
+        return handleHttpError({ res, message: 'Invalid targetBrand', statusCode: 400 });
+    }
+    if (sourceBrand && sourceBrand === targetBrand) {
+        return handleHttpError({ res, message: 'Source and target brand cannot match', statusCode: 400 });
+    }
+
+    // 128 bits of entropy → 22 url-safe chars. Big enough that brute-force is hopeless within the
+    // 60s TTL even at the per-IP rate limit. Never log the code itself.
+    const code = randomBytes(16).toString('base64url');
+
+    try {
+        await mintHandoffCode(code, {
+            userId,
+            sourceBrand,
+            targetBrand,
+            deviceFingerprint,
+            issuedAt: Date.now(),
+        });
+    } catch (err: any) {
+        return handleHttpError({
+            res, err, message: 'Failed to mint handoff code', statusCode: 500,
+        });
+    }
+
+    return res.status(200).send({ code, expiresInSeconds: 60, targetBrand });
+};
+
+const redeemHandoff: RequestHandler = async (req: any, res: any) => {
+    const { locale } = parseHeaders(req.headers);
+    const code = (req.body?.code || '').toString();
+    const requestedBrand = (req.body?.brand || '').toString();
+    const headerBrand = (req.headers['x-brand-variation'] as string) || '';
+
+    if (!code || !requestedBrand) {
+        return handleHttpError({ res, message: 'code and brand are required', statusCode: 400 });
+    }
+    // The header brand must match the requested brand. The redeeming app is supposed to set its
+    // own brand header consistently — a mismatch suggests a malicious or misconfigured caller.
+    if (headerBrand && headerBrand !== requestedBrand) {
+        return handleHttpError({ res, message: 'Brand mismatch', statusCode: 403 });
+    }
+
+    let entry;
+    try {
+        entry = await redeemHandoffCode(code);
+    } catch (err: any) {
+        return handleHttpError({
+            res, err, message: 'Failed to redeem handoff code', statusCode: 500,
+        });
+    }
+
+    if (!entry) {
+        // Either expired, never issued, or already redeemed. Same response either way to avoid
+        // leaking which case it is.
+        return handleHttpError({ res, message: 'Invalid or expired code', statusCode: 410 });
+    }
+
+    if (entry.targetBrand !== requestedBrand) {
+        return handleHttpError({ res, message: 'Code is not valid for this brand', statusCode: 403 });
+    }
+
+    try {
+        const userResults = await Store.users.getUserByConditions({ id: entry.userId });
+        if (!userResults?.length) {
+            return handleHttpError({ res, message: 'User not found', statusCode: 404 });
+        }
+        const dbUser = userResults[0];
+        if (dbUser.isBlocked) {
+            return handleHttpError({ res, message: 'User is blocked', statusCode: 403 });
+        }
+
+        const userOrgs = await Store.userOrganizations.get({ userId: dbUser.id }).catch(() => []);
+
+        const userWithIntegrations = {
+            ...dbUser,
+            isSSO: false,
+            integrations: {
+                ...decryptIntegrationsAccess(dbUser?.integrationsAccess),
+            },
+        };
+
+        const idToken = createUserToken(userWithIntegrations, userOrgs, false, requestedBrand);
+        const refreshTokenData = createRefreshToken(dbUser.id, false, requestedBrand);
+
+        // Track that this user is now active in the target brand. Fire-and-forget.
+        Store.users.upsertBrandVariation(dbUser.id, requestedBrand).catch((err) => {
+            logSpan({
+                level: 'error',
+                messageOrigin: 'API_SERVER',
+                messages: [err?.message, 'Failed to upsert brandVariations on handoff redeem'],
+                traceArgs: { 'user.id': dbUser.id, 'brand.variation': requestedBrand },
+            });
+        });
+
+        redactUserCreds(userWithIntegrations);
+
+        return res.status(200).send({
+            ...userWithIntegrations,
+            idToken,
+            refreshToken: refreshTokenData.token,
+            integrations: userWithIntegrations.integrations || {},
+            userOrganizations: userOrgs,
+        });
+    } catch (err: any) {
+        return handleHttpError({
+            res, err, message: translate(locale, 'errorMessages.auth.incorrectUserPass'), statusCode: 500,
+        });
+    }
+};
+
+const cancelHandoff: RequestHandler = async (req: any, res: any) => {
+    const userId = req.headers['x-userid'];
+    const code = (req.body?.code || '').toString();
+
+    if (!userId) {
+        return handleHttpError({ res, message: 'Unauthorized', statusCode: 401 });
+    }
+    if (!code) {
+        return handleHttpError({ res, message: 'code is required', statusCode: 400 });
+    }
+
+    try {
+        await cancelHandoffCode(code);
+        return res.status(200).send({ status: 'cancelled' });
+    } catch (err: any) {
+        return handleHttpError({
+            res, err, message: 'Failed to cancel handoff code', statusCode: 500,
+        });
+    }
+};
+
 export {
     login,
     logout,
     refreshToken,
     verifyToken,
+    emailPrecheck,
+    mintHandoff,
+    redeemHandoff,
+    cancelHandoff,
 };

--- a/therr-services/users-service/src/handlers/auth.ts
+++ b/therr-services/users-service/src/handlers/auth.ts
@@ -22,6 +22,12 @@ import {
     cancelHandoffCode,
 } from '../store/redisClient';
 
+// Multi-app brand check. Used to gate writes to user.brandVariations on login (so a malicious
+// x-brand-variation header can't pollute the JSONB array) and to validate handoff endpoints'
+// targetBrand / requestedBrand inputs.
+const isKnownBrand = (brand: any): boolean => typeof brand === 'string'
+    && (Object.values(BrandVariations) as string[]).includes(brand);
+
 // calling normalizeEmail on a userName will have no change
 const userNameOrEmailOrPhone = (user) => normalizeEmail(user.userName?.trim() || user.userEmail?.trim() || user.email?.trim()?.replace(/\s/g, '') || '')
     || normalizePhoneNumber(
@@ -286,7 +292,12 @@ const login: RequestHandler = (req: any, res: any) => {
                         // must not block the login response, but we want to log it for observability.
                         // Skip DASHBOARD_THERR for non-business accounts so dashboard sign-ins don't
                         // pollute consumer brand membership records.
-                        const shouldTrackBrand = brandVariation
+                        // Only track brands we recognize. Without this guard a malicious client could
+                        // submit `x-brand-variation: <anything>` to pollute the user's brandVariations
+                        // array (no SQL injection — it's parameterized — but it would let an attacker
+                        // grow the JSONB array unboundedly via repeated logins under different bogus
+                        // values, an integrity / DoS angle).
+                        const shouldTrackBrand = isKnownBrand(brandVariation)
                             && !(brandVariation === BrandVariations.DASHBOARD_THERR && !finalUser?.isBusinessAccount);
                         if (shouldTrackBrand) {
                             Store.users.upsertBrandVariation(user.id, brandVariation).catch((err) => {
@@ -471,29 +482,15 @@ const verifyToken: RequestHandler = (req: any, res: any) => {
 // (precomputed once at module load) so we don't pay a fresh hash cost on every cold start.
 const PRECHECK_DUMMY_HASH = bcrypt.hashSync('precheck-timing-equalizer', 12);
 
-const PRECHECK_HINTS = {
-    enterPassword: 'enter_password',
-    trySSO: 'try_sso',
-    magicLink: 'magic_link',
-    signUp: 'sign_up',
-} as const;
-
-type PrecheckHint = typeof PRECHECK_HINTS[keyof typeof PRECHECK_HINTS];
-
-const pickRandomUnknownHint = (): PrecheckHint => (
-    randomBytes(1)[0] < 180 ? PRECHECK_HINTS.signUp : PRECHECK_HINTS.magicLink
-);
-
-// Email pre-check: tells the client what to render next (password field, SSO button, magic link, or
-// signup) without leaking whether the email exists. All branches return 200 with the same response
-// shape and run a bcrypt comparison so timing is uniform. The hint is what the client renders; the
-// actual side-effect (sending a magic-link email) happens elsewhere and is gated on real existence.
+// Email pre-check: tells the client to render the universal "continue" UI (password field +
+// SSO buttons + magic-link option, all visible). Deliberately returns a single neutral hint
+// regardless of account state so the response cannot be used to enumerate registered emails.
+// We still do the DB lookup and a bcrypt compare to keep timing constant with future variants
+// that might attach state to the result.
 const emailPrecheck: RequestHandler = async (req: any, res: any) => {
     const { locale } = parseHeaders(req.headers);
     const rawEmail = (req.body?.email || '').toString();
     const email = normalizeEmail(rawEmail.trim());
-
-    let hint: PrecheckHint;
 
     try {
         const userResults = email
@@ -501,33 +498,26 @@ const emailPrecheck: RequestHandler = async (req: any, res: any) => {
             : [];
         const user = userResults?.[0];
 
-        // Always run bcrypt to equalize timing across the existence boundary.
+        // Always run bcrypt against the user hash if present, otherwise the dummy hash. Equalizes
+        // wall-clock time so an attacker cannot infer existence from the response latency.
         await bcrypt.compare('precheck-timing-equalizer', user?.password || PRECHECK_DUMMY_HASH);
-
-        if (!user) {
-            hint = pickRandomUnknownHint();
-        } else if (user.password) {
-            hint = PRECHECK_HINTS.enterPassword;
-        } else if (user.integrationsAccess) {
-            hint = PRECHECK_HINTS.trySSO;
-        } else {
-            hint = PRECHECK_HINTS.magicLink;
-        }
     } catch (err: any) {
-        // Fail open with the most common path so we never block the signup funnel on Redis/DB hiccups.
-        // Log so we can spot a regression without exposing the failure mode to the client.
+        // Lookup or bcrypt failure must NOT alter the response — falling through gives the same
+        // shape an attacker would see for any input. Log so we can spot a regression internally.
         logSpan({
             level: 'error',
             messageOrigin: 'API_SERVER',
-            messages: [err?.message, 'email-precheck failed; returning sign_up'],
+            messages: [err?.message, 'email-precheck DB/bcrypt failure (response unchanged)'],
             traceArgs: {},
         });
-        hint = PRECHECK_HINTS.signUp;
     }
 
+    // Single neutral hint for everyone. The client renders the full continuation UI and lets the
+    // user pick how to proceed; the actual /auth call decides what works. This is the only
+    // enumeration-resistant shape — any per-account branching here leaks existence.
     return res.status(200).send({
         status: 'continue',
-        hint,
+        hint: 'continue',
         message: translate(locale, 'authMessages.emailPrecheckGeneric'),
     });
 };
@@ -538,12 +528,9 @@ const emailPrecheck: RequestHandler = async (req: any, res: any) => {
 // code flow — but without the consent screen ceremony, since both apps are owned by us and the
 // user has already authenticated to the source app.
 
-const isKnownBrand = (brand: any): boolean => typeof brand === 'string'
-    && (Object.values(BrandVariations) as string[]).includes(brand);
-
 const mintHandoff: RequestHandler = async (req: any, res: any) => {
     const userId = req.headers['x-userid'];
-    const sourceBrand = (req.headers['x-brand-variation'] as string) || '';
+    const rawSourceBrand = (req.headers['x-brand-variation'] as string) || '';
     const targetBrand = (req.body?.targetBrand || '').toString();
     const deviceFingerprint = req.body?.deviceFingerprint
         ? String(req.body.deviceFingerprint).slice(0, 256)
@@ -555,6 +542,10 @@ const mintHandoff: RequestHandler = async (req: any, res: any) => {
     if (!isKnownBrand(targetBrand)) {
         return handleHttpError({ res, message: 'Invalid targetBrand', statusCode: 400 });
     }
+    // Source brand is informational (it's stored on the Redis entry; redemption only enforces
+    // targetBrand), but accepting arbitrary strings would let a caller embed garbage into the
+    // record — we'd surface that on logs and analytics. Drop unknown values.
+    const sourceBrand = isKnownBrand(rawSourceBrand) ? rawSourceBrand : '';
     if (sourceBrand && sourceBrand === targetBrand) {
         return handleHttpError({ res, message: 'Source and target brand cannot match', statusCode: 400 });
     }
@@ -589,9 +580,16 @@ const redeemHandoff: RequestHandler = async (req: any, res: any) => {
     if (!code || !requestedBrand) {
         return handleHttpError({ res, message: 'code and brand are required', statusCode: 400 });
     }
-    // The header brand must match the requested brand. The redeeming app is supposed to set its
-    // own brand header consistently — a mismatch suggests a malicious or misconfigured caller.
-    if (headerBrand && headerBrand !== requestedBrand) {
+    // Reject when the request brand isn't a recognized variant. Without this guard, the body
+    // alone could carry an arbitrary string into downstream code paths.
+    if (!isKnownBrand(requestedBrand)) {
+        return handleHttpError({ res, message: 'Invalid brand', statusCode: 400 });
+    }
+    // Require the x-brand-variation header AND require it to match the body. Legitimate niche
+    // apps always set the header via their axios interceptor — its absence indicates a forged
+    // or misconfigured caller. Without this check, an attacker stripping the header could pass
+    // a body-only `brand` value the redeeming environment doesn't actually represent.
+    if (!headerBrand || headerBrand !== requestedBrand) {
         return handleHttpError({ res, message: 'Brand mismatch', statusCode: 403 });
     }
 

--- a/therr-services/users-service/src/handlers/helpers/user.ts
+++ b/therr-services/users-service/src/handlers/helpers/user.ts
@@ -277,13 +277,16 @@ const createUserHelper = (
                     userAccessLevels.add(AccessLevels.EMAIL_VERIFIED);
                 }
             }
+            const nowIso = new Date().toISOString();
             return Store.users.createUser({
                 accessLevels: JSON.stringify([...userAccessLevels]),
                 brandVariations: (headers['x-brand-variation'] && isBrandValid(headers['x-brand-variation']))
-                    ? JSON.stringify({
+                    ? JSON.stringify([{
                         brand: headers['x-brand-variation'],
-                        details: {},
-                    })
+                        firstSeenAt: nowIso,
+                        lastSeenAt: nowIso,
+                        isActive: true,
+                    }])
                     : undefined,
                 email: userDetails.email,
                 firstName: userDetails.firstName || undefined,

--- a/therr-services/users-service/src/handlers/notifications.ts
+++ b/therr-services/users-service/src/handlers/notifications.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from 'express';
-import { getSearchQueryArgs, parseHeaders } from 'therr-js-utilities/http';
+import { getBrandContext, getSearchQueryArgs, parseHeaders } from 'therr-js-utilities/http';
 import handleHttpError from '../utilities/handleHttpError';
 import Store from '../store';
 import translate from '../utilities/translator';
@@ -69,26 +69,30 @@ const createNotification = (req, res) => {
 };
 
 // READ
-const getNotification = (req, res) => Store.notifications.getNotifications({
-    requestingUserId: req.params.notificationId,
-})
-    .then((results) => {
-        const locale = req.headers['x-localecode'] || 'en-us';
-
-        if (!results.length) {
-            return handleHttpError({
-                res,
-                message: `No notification found with id, ${req.params.notificationId}.`,
-                statusCode: 404,
-            });
-        }
-        return res.status(200).send(translateNotification(results[0], locale));
+const getNotification = (req, res) => {
+    const { brandVariation } = getBrandContext(req.headers);
+    return Store.notifications.getNotifications(brandVariation, {
+        requestingUserId: req.params.notificationId,
     })
-    .catch((err) => handleHttpError({ err, res, message: 'SQL:NOTIFICATIONS_ROUTES:ERROR' }));
+        .then((results) => {
+            const locale = req.headers['x-localecode'] || 'en-us';
+
+            if (!results.length) {
+                return handleHttpError({
+                    res,
+                    message: `No notification found with id, ${req.params.notificationId}.`,
+                    statusCode: 404,
+                });
+            }
+            return res.status(200).send(translateNotification(results[0], locale));
+        })
+        .catch((err) => handleHttpError({ err, res, message: 'SQL:NOTIFICATIONS_ROUTES:ERROR' }));
+};
 
 const searchNotifications: RequestHandler = (req: any, res: any) => {
     const userId = req.headers['x-userid'];
     const locale = req.headers['x-localecode'] || 'en-us';
+    const { brandVariation } = getBrandContext(req.headers);
     const {
         filterBy,
         query,
@@ -97,7 +101,7 @@ const searchNotifications: RequestHandler = (req: any, res: any) => {
     } = req.query;
     const integerColumns = ['id'];
     const searchArgs = getSearchQueryArgs(req.query, integerColumns);
-    const searchPromise = Store.notifications.searchNotifications(userId, searchArgs[0]);
+    const searchPromise = Store.notifications.searchNotifications(brandVariation, userId, searchArgs[0]);
 
     /**
      * This is simply an event trigger. It could be triggered by a user logging in, or any other common event.
@@ -131,32 +135,35 @@ const searchNotifications: RequestHandler = (req: any, res: any) => {
 };
 
 // UPDATE
-const updateNotification = (req, res) => Store.notifications.getNotifications({
-    id: req.params.notificationId,
-})
-    .then((getResults) => {
-        const locale = req.headers['x-localecode'] || 'en-us';
-        const {
-            isUnread,
-        } = req.body;
-
-        if (!getResults.length) {
-            return handleHttpError({
-                res,
-                message: `No notification found with id, ${req.params.notificationId}.`,
-                statusCode: 404,
-            });
-        }
-
-        return Store.notifications
-            .updateNotification({
-                id: req.params.notificationId,
-            }, {
-                isUnread,
-            })
-            .then((results) => res.status(202).send(translateNotification(results[0], locale)));
+const updateNotification = (req, res) => {
+    const { brandVariation } = getBrandContext(req.headers);
+    return Store.notifications.getNotifications(brandVariation, {
+        id: req.params.notificationId,
     })
-    .catch((err) => handleHttpError({ err, res, message: 'SQL:NOTIFICATIONS_ROUTES:ERROR' }));
+        .then((getResults) => {
+            const locale = req.headers['x-localecode'] || 'en-us';
+            const {
+                isUnread,
+            } = req.body;
+
+            if (!getResults.length) {
+                return handleHttpError({
+                    res,
+                    message: `No notification found with id, ${req.params.notificationId}.`,
+                    statusCode: 404,
+                });
+            }
+
+            return Store.notifications
+                .updateNotification(brandVariation, {
+                    id: req.params.notificationId,
+                }, {
+                    isUnread,
+                })
+                .then((results) => res.status(202).send(translateNotification(results[0], locale)));
+        })
+        .catch((err) => handleHttpError({ err, res, message: 'SQL:NOTIFICATIONS_ROUTES:ERROR' }));
+};
 
 export {
     createNotification,

--- a/therr-services/users-service/src/handlers/userConnections.ts
+++ b/therr-services/users-service/src/handlers/userConnections.ts
@@ -252,7 +252,7 @@ const createUserConnection: RequestHandler = async (req: any, res: any) => {
                 brandVariation,
             });
 
-            return connectionPromise.then(([userConnection]) => Store.notifications.createNotification({
+            return connectionPromise.then(([userConnection]) => Store.notifications.createNotification(brandVariation, {
                 userId: acceptingUser.id as string,
                 type: Notifications.Types.CONNECTION_REQUEST_RECEIVED,
                 associationId: userConnection.id,

--- a/therr-services/users-service/src/handlers/users.ts
+++ b/therr-services/users-service/src/handlers/users.ts
@@ -8,6 +8,7 @@ import handleHttpError from '../utilities/handleHttpError';
 import Store from '../store';
 import translate from '../utilities/translator';
 import { updatePassword } from '../utilities/passwordUtils';
+import syncDeviceTokenForBrand from '../utilities/syncDeviceTokenForBrand';
 import sendUserDeletedEmail from '../api/email/admin/sendUserDeletedEmail';
 import sendSpaceClaimRequestEmail from '../api/email/admin/sendSpaceClaimRequestEmail';
 import {
@@ -680,6 +681,9 @@ const updateUser = (req, res) => {
                             // Remove credentials from object
                             redactUserCreds(user);
 
+                            // Phase 2 dual-write to brand-scoped token table. Fire-and-forget; legacy column above stays authoritative until cutover.
+                            syncDeviceTokenForBrand(req.headers, user.id, req.body.deviceMobileFirebaseToken);
+
                             const userOrgs = await Store.userOrganizations.get({
                                 userId: user.id,
                             }).catch((err) => {
@@ -900,6 +904,9 @@ const updateUserCoins = (req, res) => {
                         const user = results[0];
                         // Remove credentials from object
                         redactUserCreds(user);
+
+                        // Phase 2 dual-write to brand-scoped token table.
+                        syncDeviceTokenForBrand(req.headers, user.id, req.body.deviceMobileFirebaseToken);
 
                         // TODO: Investigate security issue
                         // Lockdown updateUser
@@ -1206,6 +1213,10 @@ const clearUserDeviceToken: RequestHandler = (req, res) => {
     }
     return Store.users.clearDeviceToken(userId, deviceToken)
         .then((rows: any[]) => {
+            // Phase 2: also clean up the brand-scoped token table. Token strings are globally
+            // unique to a device install regardless of brand, so deletion by token alone is safe.
+            // Fire-and-forget — failure here must not break legacy cleanup.
+            Store.userDeviceTokens.deleteByToken(deviceToken).catch(() => undefined);
             logSpan({
                 level: 'info',
                 messageOrigin: 'API_SERVER',

--- a/therr-services/users-service/src/locales/en-us/dictionary.json
+++ b/therr-services/users-service/src/locales/en-us/dictionary.json
@@ -1,4 +1,7 @@
 {
+    "authMessages": {
+        "emailPrecheckGeneric": "If this email is registered, we'll guide you through signing in."
+    },
     "errorMessages": {
         "auth": {
             "accountNotVerified": "Account not verified. Check your E-mail for verification or navigate to /verify-account to resend",

--- a/therr-services/users-service/src/locales/es/dictionary.json
+++ b/therr-services/users-service/src/locales/es/dictionary.json
@@ -1,4 +1,7 @@
 {
+    "authMessages": {
+        "emailPrecheckGeneric": "Si este correo está registrado, te guiaremos para iniciar sesión."
+    },
     "errorMessages": {
         "auth": {
             "accountNotVerified": "Cuenta no verificada. Revisa tu correo electrónico para la verificación o navega a /verify-account para reenviar",

--- a/therr-services/users-service/src/locales/fr-ca/dictionary.json
+++ b/therr-services/users-service/src/locales/fr-ca/dictionary.json
@@ -1,4 +1,7 @@
 {
+    "authMessages": {
+        "emailPrecheckGeneric": "Si ce courriel est inscrit, nous vous guiderons pour vous connecter."
+    },
     "errorMessages": {
         "auth": {
             "accountNotVerified": "Compte non vérifié. Vérifie ton courriel pour la vérification ou rends-toi à /verify-account pour renvoyer le lien",

--- a/therr-services/users-service/src/routes/authRouter.ts
+++ b/therr-services/users-service/src/routes/authRouter.ts
@@ -1,7 +1,11 @@
 import * as express from 'express';
 import {
+    cancelHandoff,
+    emailPrecheck,
     login,
     logout,
+    mintHandoff,
+    redeemHandoff,
     refreshToken,
     verifyToken,
 } from '../handlers/auth';
@@ -19,5 +23,14 @@ router.post('/token/refresh', refreshToken);
 
 // Verify user token (after login)
 router.post('/user-token/validate', verifyToken);
+
+// Pre-check an email (does NOT confirm account existence). Returns a hint the client uses to render
+// the next step (password field, SSO button, magic link, sign up).
+router.post('/email-precheck', emailPrecheck);
+
+// Cross-app handoff (first-party single-sign-on between sister apps).
+router.post('/handoff/mint', mintHandoff);
+router.post('/handoff/redeem', redeemHandoff);
+router.post('/handoff/cancel', cancelHandoff);
 
 export default router;

--- a/therr-services/users-service/src/store/BrandScopedStore.ts
+++ b/therr-services/users-service/src/store/BrandScopedStore.ts
@@ -1,0 +1,58 @@
+import KnexBuilder, { Knex } from 'knex';
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import { BrandVariations } from 'therr-js-utilities/constants';
+import {
+    BRAND_VARIATION_COLUMN,
+    BrandScopeMode,
+    applyBrandFilter,
+    assertBrand,
+    withBrandOnInsert,
+// eslint-disable-next-line import/extensions, import/no-unresolved
+} from 'therr-js-utilities/db';
+import { IConnection } from './connection';
+
+const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
+
+export type BrandValue = BrandVariations | string;
+
+export default abstract class BrandScopedStore {
+    protected db: IConnection;
+
+    protected readonly tableName: string;
+
+    protected readonly mode: BrandScopeMode;
+
+    constructor(db: IConnection, tableName: string, mode: BrandScopeMode = 'shadow') {
+        this.db = db;
+        this.tableName = tableName;
+        this.mode = mode;
+    }
+
+    protected assertBrand(brand: BrandValue | undefined | null) {
+        assertBrand(brand, { tableName: this.tableName, mode: this.mode });
+    }
+
+    protected scopedQuery(brand: BrandValue) {
+        this.assertBrand(brand);
+        return knexBuilder.from(this.tableName)
+            .where(`${this.tableName}.${BRAND_VARIATION_COLUMN}`, '=', brand);
+    }
+
+    protected withBrand<TBuilder extends { andWhere:(...args: any[]) => TBuilder }>(qb: TBuilder, brand: BrandValue): TBuilder {
+        this.assertBrand(brand);
+        return applyBrandFilter(qb, this.tableName, brand);
+    }
+
+    protected scopedInsert<T extends Record<string, unknown>>(brand: BrandValue, row: T) {
+        this.assertBrand(brand);
+        return knexBuilder.insert(withBrandOnInsert(row, brand)).into(this.tableName);
+    }
+
+    protected scopedUpdate(brand: BrandValue, conditions: Record<string, unknown>) {
+        this.assertBrand(brand);
+        return knexBuilder
+            .from(this.tableName)
+            .where(`${this.tableName}.${BRAND_VARIATION_COLUMN}`, '=', brand)
+            .where(conditions);
+    }
+}

--- a/therr-services/users-service/src/store/NotificationsStore.ts
+++ b/therr-services/users-service/src/store/NotificationsStore.ts
@@ -1,12 +1,17 @@
 import KnexBuilder, { Knex } from 'knex';
-import { Notifications, PushNotifications } from 'therr-js-utilities/constants';
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import { Notifications } from 'therr-js-utilities/constants';
+// eslint-disable-next-line import/extensions, import/no-unresolved
 import { getDbCountQueryString } from 'therr-js-utilities/db';
+// eslint-disable-next-line import/extensions, import/no-unresolved
 import formatSQLJoinAsJSON from 'therr-js-utilities/format-sql-join-as-json';
+import BrandScopedStore, { BrandValue } from './BrandScopedStore';
 import { IConnection } from './connection';
 import { USER_CONNECTIONS_TABLE_NAME } from './tableNames';
 
 const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
 
+// eslint-disable-next-line no-restricted-syntax -- this is the sanctioned canonical reference
 export const NOTIFICATIONS_TABLE_NAME = 'main.notifications';
 
 export interface ICreateNotificationParams {
@@ -32,29 +37,30 @@ export interface IUpdateNotificationParams {
     messageParams?: any;
 }
 
-export default class NotificationsStore {
-    db: IConnection;
-
-    constructor(dbConnection) {
-        this.db = dbConnection;
+export default class NotificationsStore extends BrandScopedStore {
+    constructor(dbConnection: IConnection) {
+        // Brand-scoped table per docs/NICHE_APP_DATABASE_GUIDELINES.md.
+        // Stays in 'shadow' for one release cycle; flip to 'enforce' once shadow logs are clean.
+        super(dbConnection, NOTIFICATIONS_TABLE_NAME, 'shadow');
     }
 
     // TODO: This value is incorrect
     // Need to make the search query a transaction and include the count there
-    countRecords(params) {
+    countRecords(brand: BrandValue, params) {
+        this.assertBrand(brand);
         const queryString = getDbCountQueryString({
             queryBuilder: knexBuilder,
             tableName: NOTIFICATIONS_TABLE_NAME,
             params,
-            defaultConditions: {},
+            defaultConditions: { [`${NOTIFICATIONS_TABLE_NAME}.brandVariation`]: brand },
         });
 
         return this.db.read.query(queryString).then((response) => response.rows);
     }
 
-    getNotifications(conditions = {}) {
-        const queryString = knexBuilder.select('*')
-            .from(NOTIFICATIONS_TABLE_NAME)
+    getNotifications(brand: BrandValue, conditions: Record<string, unknown> = {}) {
+        const queryString = this.scopedQuery(brand)
+            .select('*')
             .where(conditions)
             .toString();
         return this.db.read.query(queryString).then((response) => response.rows);
@@ -62,7 +68,8 @@ export default class NotificationsStore {
 
     // TODO: RSERV:25 - Make this dynamic to support various associationIds
     // WARNING: This could become a potential bottleneck
-    searchNotifications(userId, conditions: any = {}) {
+    searchNotifications(brand: BrandValue, userId, conditions: any = {}) {
+        this.assertBrand(brand);
         const offset = conditions.pagination.itemsPerPage * (conditions.pagination.pageNumber - 1);
         const limit = conditions.pagination.itemsPerPage;
         let queryString: any = knexBuilder
@@ -89,6 +96,8 @@ export default class NotificationsStore {
             ])
             .where(`${NOTIFICATIONS_TABLE_NAME}.userId`, '=', userId);
 
+        queryString = this.withBrand(queryString, brand);
+
         // if (conditions.filterBy && conditions.query) {
         //     const operator = conditions.filterOperator || '=';
         //     const query = operator === 'ilike' ? `%${conditions.query}%` : conditions.query;
@@ -111,26 +120,24 @@ export default class NotificationsStore {
         });
     }
 
-    createNotification(params: ICreateNotificationParams) {
+    createNotification(brand: BrandValue, params: ICreateNotificationParams) {
         const modifiedParams = {
             ...params,
             messageParams: JSON.stringify(params.messageParams),
         };
-        const queryString = knexBuilder.insert(modifiedParams)
-            .into(NOTIFICATIONS_TABLE_NAME)
+        const queryString = this.scopedInsert(brand, modifiedParams)
             .returning('*')
             .toString();
 
         return this.db.write.query(queryString).then((response) => response.rows);
     }
 
-    updateNotification(conditions: IUpdateNotificationConditions, params: IUpdateNotificationParams) {
-        const queryString = knexBuilder.update({
-            ...params,
-            updatedAt: new Date(),
-        })
-            .into(NOTIFICATIONS_TABLE_NAME)
-            .where(conditions)
+    updateNotification(brand: BrandValue, conditions: IUpdateNotificationConditions, params: IUpdateNotificationParams) {
+        const queryString = this.scopedUpdate(brand, { ...conditions })
+            .update({
+                ...params,
+                updatedAt: new Date(),
+            })
             .returning('*')
             .toString();
 

--- a/therr-services/users-service/src/store/UserDeviceTokensStore.ts
+++ b/therr-services/users-service/src/store/UserDeviceTokensStore.ts
@@ -1,0 +1,68 @@
+import KnexBuilder, { Knex } from 'knex';
+import BrandScopedStore, { BrandValue } from './BrandScopedStore';
+import { IConnection } from './connection';
+
+const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
+
+export const USER_DEVICE_TOKENS_TABLE_NAME = 'main.userDeviceTokens';
+
+export interface IUserDeviceTokenRow {
+    id: string;
+    userId: string;
+    brandVariation: string;
+    platform: string;
+    token: string;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export default class UserDeviceTokensStore extends BrandScopedStore {
+    constructor(dbConnection: IConnection) {
+        // Brand-scoped per docs/NICHE_APP_DATABASE_GUIDELINES.md.
+        // Stays in 'shadow' for one release cycle alongside NotificationsStore.
+        super(dbConnection, USER_DEVICE_TOKENS_TABLE_NAME, 'shadow');
+    }
+
+    // Upsert keyed on the unique (userId, brandVariation, platform) constraint.
+    // A re-registration from the same device under the same brand bumps the token
+    // and updatedAt; first registration inserts a new row. Returns the upserted row.
+    upsertToken(brand: BrandValue, userId: string, platform: string, token: string) {
+        this.assertBrand(brand);
+        // Use raw SQL because Knex's onConflict().merge() doesn't include updatedAt
+        // recomputation in the way we want — explicit raw is clearer.
+        const queryString = knexBuilder
+            .raw(
+                `INSERT INTO ?? ("userId", "brandVariation", "platform", "token")
+                 VALUES (?::uuid, ?, ?, ?)
+                 ON CONFLICT ("userId", "brandVariation", "platform")
+                 DO UPDATE SET "token" = EXCLUDED."token", "updatedAt" = now()
+                 RETURNING *`,
+                [USER_DEVICE_TOKENS_TABLE_NAME, userId, brand, platform, token],
+            )
+            .toString();
+        return this.db.write.query(queryString).then((response) => response.rows);
+    }
+
+    // Used by push routing: get the device tokens this user has registered for the given brand.
+    // Returns at most one row per platform.
+    getTokensForUser(brand: BrandValue, userId: string) {
+        const queryString = this.scopedQuery(brand)
+            .select('*')
+            .where('userId', '=', userId)
+            .toString();
+        return this.db.read.query(queryString).then((response) => response.rows as IUserDeviceTokenRow[]);
+    }
+
+    // Removes any (any-brand) token row matching this exact token string. Used during invalid-token
+    // cleanup when FCM tells us a token has been invalidated. The token value is globally unique to
+    // a device install regardless of brand, so we wipe all matching rows defensively. Brand is not
+    // required here because the input token alone identifies the row(s).
+    deleteByToken(token: string) {
+        const queryString = knexBuilder
+            .from(USER_DEVICE_TOKENS_TABLE_NAME)
+            .where('token', '=', token)
+            .delete()
+            .toString();
+        return this.db.write.query(queryString).then((response) => response.rowCount ?? 0);
+    }
+}

--- a/therr-services/users-service/src/store/UsersStore.ts
+++ b/therr-services/users-service/src/store/UsersStore.ts
@@ -563,6 +563,45 @@ export default class UsersStore {
         return this.db.write.query(queryString.toString()).then((response) => response.rows);
     }
 
+    // Append or refresh a brand-variation membership entry on the user record.
+    // Uses a single JSONB statement so concurrent logins from different brands cannot lose entries.
+    // - If an entry for the brand exists, bump its lastSeenAt.
+    // - Otherwise append a new entry with firstSeenAt = lastSeenAt = now() and isActive = true.
+    upsertBrandVariation(userId: string, brand: string) {
+        if (!userId || !brand) return Promise.resolve();
+        const queryString = knexBuilder
+            .raw(
+                `UPDATE ?? SET "brandVariations" = (
+                    CASE WHEN EXISTS (
+                        SELECT 1 FROM jsonb_array_elements("brandVariations") AS elem
+                        WHERE elem->>'brand' = ?
+                    )
+                    THEN (
+                        SELECT jsonb_agg(
+                            CASE WHEN elem->>'brand' = ?
+                                THEN jsonb_set(elem, '{lastSeenAt}', to_jsonb(now()::text))
+                                ELSE elem
+                            END
+                        )
+                        FROM jsonb_array_elements("brandVariations") AS elem
+                    )
+                    ELSE "brandVariations" || jsonb_build_array(
+                        jsonb_build_object(
+                            'brand', ?::text,
+                            'firstSeenAt', now()::text,
+                            'lastSeenAt', now()::text,
+                            'isActive', true
+                        )
+                    )
+                    END
+                )
+                WHERE id = ?`,
+                [USERS_TABLE_NAME, brand, brand, brand, userId],
+            )
+            .toString();
+        return this.db.write.query(queryString);
+    }
+
     // Clears the stored FCM device token for a user, but only if the currently
     // stored token matches the one we know to be invalid. This avoids a race
     // where the mobile client has already rotated the token between the time a

--- a/therr-services/users-service/src/store/index.ts
+++ b/therr-services/users-service/src/store/index.ts
@@ -15,6 +15,7 @@ import SubscribersStore from './SubscribersStore';
 import ThoughtsStore from './ThoughtsStore';
 import UserAchievementsStore from './UserAchievementsStore';
 import UserConnectionsStore from './UserConnectionsStore';
+import UserDeviceTokensStore from './UserDeviceTokensStore';
 import UserInterestsStore from './UserInterestsStore';
 import UserMetricsStore from './UserMetricsStore';
 import UserLocationsStore from './UserLocationsStore';
@@ -56,6 +57,8 @@ class Store {
     userAchievements: UserAchievementsStore;
 
     userConnections: UserConnectionsStore;
+
+    userDeviceTokens: UserDeviceTokensStore;
 
     userInterests: UserInterestsStore;
 
@@ -104,6 +107,7 @@ class Store {
         this.users = new UsersStore(this.db);
         this.userAchievements = new UserAchievementsStore(this.db);
         this.userConnections = new UserConnectionsStore(this.db);
+        this.userDeviceTokens = new UserDeviceTokensStore(this.db);
         this.userInterests = new UserInterestsStore(this.db);
         this.userMetrics = new UserMetricsStore(this.db);
         this.userLocations = new UserLocationsStore(this.db);

--- a/therr-services/users-service/src/store/migrations/20260425000001_main.users.brandVariations_v2.js
+++ b/therr-services/users-service/src/store/migrations/20260425000001_main.users.brandVariations_v2.js
@@ -1,0 +1,38 @@
+/**
+ * brandVariations normalization for multi-app auth.
+ *
+ * Two cleanups:
+ *
+ * 1. Earlier signups (handlers/helpers/user.ts:282-287 prior to this commit) wrote a single
+ *    JSONB *object* into a column whose default is a JSONB *array*. Normalize any object-shaped
+ *    rows to a single-element array so downstream code can safely treat the column as a list of
+ *    brand memberships.
+ *
+ * 2. Add a GIN index so per-brand membership queries (e.g. "active users in HABITS in last 30d")
+ *    don't degrade as the array grows. jsonb_path_ops is the smaller / faster operator class for
+ *    containment-style lookups, which is the predominant access pattern here.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+    await knex.raw(`
+        UPDATE main.users
+        SET "brandVariations" = jsonb_build_array("brandVariations")
+        WHERE jsonb_typeof("brandVariations") = 'object';
+    `);
+
+    await knex.raw(`
+        CREATE INDEX IF NOT EXISTS idx_users_brand_variations_gin
+        ON main.users USING GIN ("brandVariations" jsonb_path_ops);
+    `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main.idx_users_brand_variations_gin;');
+    // Object-shaped rows are not restored; they were inconsistent with the column default.
+};

--- a/therr-services/users-service/src/store/migrations/20260425000002_main.notifications.brandVariation.js
+++ b/therr-services/users-service/src/store/migrations/20260425000002_main.notifications.brandVariation.js
@@ -1,0 +1,49 @@
+/**
+ * Add brandVariation to main.notifications.
+ *
+ * Archetype: Brand-scoped (per docs/NICHE_APP_DATABASE_GUIDELINES.md).
+ *
+ * Phase 2 of the multi-app data isolation rollout. Until this column exists,
+ * a user signed into multiple apps with the same identity sees notifications
+ * from every app interleaved. With it, NotificationsStore (extending
+ * BrandScopedStore) filters every read and stamps every write so cross-app
+ * leakage is impossible at the data layer.
+ *
+ * Defaults:
+ *   - NOT NULL with default 'therr' so legacy rows (all created before this
+ *     migration ran by the original Therr app) keep showing up to Therr users.
+ *   - NotificationsStore stays in shadow mode for one release cycle. After
+ *     shadow logs are clean, flip to enforce mode in code (no follow-up
+ *     migration needed).
+ *
+ * Index strategy:
+ *   - Composite (userId, brandVariation, isUnread) covers the dominant query
+ *     pattern: "give me my unread notifications for this app." brandVariation
+ *     is in the middle position because it has very low cardinality (one of
+ *     ~7 brand enum values), so leading with userId keeps the per-user prefix
+ *     selective and the brand filter narrows from there before isUnread
+ *     applies. Replaces nothing — the existing single-column userId index and
+ *     (userId, updatedAt) index stay because they serve different access
+ *     patterns (count by user, sort by recency).
+ *
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').alterTable('notifications', (table) => {
+        table.string('brandVariation', 50).notNullable().defaultTo('therr');
+    });
+    await knex.raw(`
+        CREATE INDEX IF NOT EXISTS idx_notifications_user_brand_unread
+        ON main.notifications ("userId", "brandVariation", "isUnread")
+    `);
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main.idx_notifications_user_brand_unread');
+    await knex.schema.withSchema('main').alterTable('notifications', (table) => {
+        table.dropColumn('brandVariation');
+    });
+};

--- a/therr-services/users-service/src/store/migrations/20260425000003_main.userDeviceTokens.js
+++ b/therr-services/users-service/src/store/migrations/20260425000003_main.userDeviceTokens.js
@@ -1,0 +1,69 @@
+/**
+ * Create main.userDeviceTokens — per-(user, brand, platform) FCM/APNS device tokens.
+ *
+ * Archetype: Brand-scoped (per docs/NICHE_APP_DATABASE_GUIDELINES.md).
+ *
+ * Phase 2 of the multi-app data isolation rollout. Replaces the single
+ * `users.deviceMobileFirebaseToken` column, which is the highest-stakes
+ * cross-app leak today: when a user installs a second branded app on the same
+ * device, that column gets overwritten with the new app's token. Subsequent
+ * notifications from the original brand then either (a) silently drop because
+ * the token now belongs to a different Firebase project, or (b) get delivered
+ * to the wrong app. Routing tokens by (userId, brandVariation, platform)
+ * makes the bug structurally impossible.
+ *
+ * Migration story (no backfill of historical column):
+ *   - This migration only creates the new table; it does not copy from
+ *     `users.deviceMobileFirebaseToken`. The historical column has no brand
+ *     marker — copying it would just guess a brand (most likely 'therr') and
+ *     produce wrong-app routing for any user whose device was last registered
+ *     under a non-Therr brand. Existing tokens stay readable by the old
+ *     code path during the dual-write window described below.
+ *
+ *   - Code will dual-write for one release cycle: the existing UpdateUser
+ *     handler keeps writing `users.deviceMobileFirebaseToken` AND now also
+ *     upserts the (userId, brand, platform, token) row in this new table.
+ *     Push routing reads from this table first; falls back to the old column
+ *     if no row exists yet. Once mobile clients have re-registered (typically
+ *     on next app open), the fallback can be deleted in a follow-up commit.
+ *
+ *   - The old column itself is left in place by this migration so a rollback
+ *     is non-destructive. It will be dropped in a follow-up migration after
+ *     the dual-write window closes and shadow logs confirm the new path is
+ *     authoritative.
+ *
+ * Index / constraint strategy:
+ *   - UNIQUE (userId, brandVariation, platform) — at most one active token
+ *     per user per app per platform. Re-registration is an UPDATE on this
+ *     unique row, not an INSERT.
+ *   - Index on (userId, brandVariation) for the hot read path "give me this
+ *     user's tokens for this brand."
+ *   - Index on token for the invalid-token cleanup path
+ *     (clearInvalidDeviceToken).
+ *
+ * @param { import("knex").Knex } knex
+ */
+exports.up = (knex) => knex.schema.withSchema('main').createTable('userDeviceTokens', (table) => {
+    table.uuid('id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
+
+    table.uuid('userId').notNullable()
+        .references('id').inTable('main.users')
+        .onUpdate('CASCADE')
+        .onDelete('CASCADE');
+
+    table.string('brandVariation', 50).notNullable();
+    table.string('platform', 20).notNullable(); // 'ios' | 'android' | 'web'
+    table.text('token').notNullable();
+
+    table.timestamp('createdAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp('updatedAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+
+    table.unique(['userId', 'brandVariation', 'platform']);
+    table.index(['userId', 'brandVariation']);
+    table.index('token');
+});
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = (knex) => knex.schema.withSchema('main').dropTableIfExists('userDeviceTokens');

--- a/therr-services/users-service/src/store/redisClient.ts
+++ b/therr-services/users-service/src/store/redisClient.ts
@@ -1,0 +1,104 @@
+import Redis from 'ioredis';
+import logSpan from 'therr-js-utilities/log-or-update-span';
+
+// Ephemeral Redis client for short-lived auth artifacts:
+//  - cross-app handoff codes (60s TTL)
+//
+// Reuses the same ephemeral instance used by the gateway for token blacklist / rate-limit work.
+// Lazy-connect + indefinite retry so a Redis blip doesn't crash the service on boot.
+const redisEphemeralClient = new Redis({
+    host: process.env.REDIS_EPHEMERAL_HOST,
+    port: Number(process.env.REDIS_EPHEMERAL_PORT),
+    keyPrefix: 'users-service:',
+    lazyConnect: true,
+    retryStrategy(times) {
+        return Math.min(times * 50, 5000);
+    },
+    maxRetriesPerRequest: null,
+});
+
+redisEphemeralClient.on('error', (error: any) => {
+    logSpan({
+        level: 'error',
+        messageOrigin: 'REDIS_EPHEMERAL_CONNECTION_ERROR',
+        messages: error?.toString?.() || 'unknown redis error',
+        traceArgs: {},
+    });
+});
+
+redisEphemeralClient.on('connect', () => {
+    // eslint-disable-next-line no-console
+    console.log('users-service connected to ephemeral Redis');
+});
+
+// Best-effort connect; further commands trigger reconnects per ioredis retryStrategy.
+redisEphemeralClient.connect().catch(() => {
+    // eslint-disable-next-line no-console
+    console.log('users-service: deferred Redis ephemeral connect (will retry on first use)');
+});
+
+const HANDOFF_PREFIX = 'handoff:';
+const HANDOFF_TTL_SECONDS = 60;
+
+export interface IHandoffEntry {
+    userId: string;
+    sourceBrand: string;
+    targetBrand: string;
+    deviceFingerprint?: string;
+    issuedAt: number;
+}
+
+export const mintHandoffCode = async (code: string, entry: IHandoffEntry): Promise<void> => {
+    if (!code || !entry?.userId || !entry?.targetBrand) {
+        throw new Error('mintHandoffCode requires code, userId, and targetBrand');
+    }
+    await redisEphemeralClient.set(
+        `${HANDOFF_PREFIX}${code}`,
+        JSON.stringify(entry),
+        'EX',
+        HANDOFF_TTL_SECONDS,
+    );
+};
+
+// Atomic single-use redemption. GETDEL was added to Redis 6.2; we fall back to a MULTI pipeline
+// for older servers so the value is always pulled and deleted together.
+export const redeemHandoffCode = async (code: string): Promise<IHandoffEntry | null> => {
+    if (!code) return null;
+    let raw: string | null = null;
+    try {
+        if (typeof (redisEphemeralClient as any).getdel === 'function') {
+            raw = await (redisEphemeralClient as any).getdel(`${HANDOFF_PREFIX}${code}`);
+        } else {
+            const pipeline = redisEphemeralClient.multi();
+            pipeline.get(`${HANDOFF_PREFIX}${code}`);
+            pipeline.del(`${HANDOFF_PREFIX}${code}`);
+            const results = await pipeline.exec();
+            raw = (results?.[0]?.[1] as string) ?? null;
+        }
+    } catch (err) {
+        logSpan({
+            level: 'error',
+            messageOrigin: 'API_SERVER',
+            messages: ['Failed to redeem handoff code', (err as any)?.message],
+            traceArgs: {},
+        });
+        return null;
+    }
+    if (!raw) return null;
+    try {
+        return JSON.parse(raw) as IHandoffEntry;
+    } catch {
+        return null;
+    }
+};
+
+export const cancelHandoffCode = async (code: string): Promise<void> => {
+    if (!code) return;
+    try {
+        await redisEphemeralClient.del(`${HANDOFF_PREFIX}${code}`);
+    } catch {
+        // Best effort
+    }
+};
+
+export default redisEphemeralClient;

--- a/therr-services/users-service/src/store/seeds/004_dev_habits.js
+++ b/therr-services/users-service/src/store/seeds/004_dev_habits.js
@@ -1,0 +1,387 @@
+/**
+ * Seed file for Friends with Habits (HABITS app) dev data.
+ * Run with: npm run seeds:run (from users-service directory) — runs after 003_dev_users.
+ *
+ * Generates a believable demo state for the HABITS app:
+ *   - Enrolls dev users alice..hannah (the first 8 from 003_dev_users) into the HABITS brand
+ *   - Creates 6 system-template habit goals (browse / "discover" surface)
+ *   - Creates 4 user-created habit goals
+ *   - Creates 4 pacts (3 active, 1 pending invite) pairing different users
+ *   - Creates pact_members rows for each pact participant
+ *   - Backfills 14 days of habit_checkins with realistic completion patterns
+ *   - Maintains streaks rows derived from those checkins
+ *
+ * Idempotent: predictable UUIDs + ON CONFLICT DO NOTHING throughout, so re-running
+ * adds only new dates and never duplicates rows.
+ *
+ * Dev-only. Do not run in production — the user IDs come from 003_dev_users which
+ * is also dev-only.
+ */
+
+const HABITS_BRAND = 'habits';
+
+// Dev users a0000001..a0000008 from 003_dev_users.js — alice through hannah.
+const HABITS_USER_IDS = [
+    'a0000001-de00-4000-a000-d00000000001', // alice
+    'a0000002-de00-4000-a000-d00000000002', // bob
+    'a0000003-de00-4000-a000-d00000000003', // charlie
+    'a0000004-de00-4000-a000-d00000000004', // diana
+    'a0000005-de00-4000-a000-d00000000005', // ethan
+    'a0000006-de00-4000-a000-d00000000006', // fiona
+    'a0000007-de00-4000-a000-d00000000007', // george
+    'a0000008-de00-4000-a000-d00000000008', // hannah
+];
+
+const TEMPLATE_GOALS = [
+    {
+        id: 'b0000001-de00-4000-a000-000000000001',
+        name: 'Morning workout',
+        description: '20-minute movement session before 9am',
+        category: 'fitness',
+        emoji: '🏋️',
+    },
+    {
+        id: 'b0000002-de00-4000-a000-000000000002',
+        name: 'Read 15 minutes',
+        description: 'Read a book (no phone) for 15 minutes daily',
+        category: 'learning',
+        emoji: '📚',
+    },
+    {
+        id: 'b0000003-de00-4000-a000-000000000003',
+        name: 'Meditation',
+        description: '10 minutes of guided or silent meditation',
+        category: 'mindfulness',
+        emoji: '🧘',
+    },
+    {
+        id: 'b0000004-de00-4000-a000-000000000004',
+        name: 'Drink 64oz water',
+        description: 'Hit your hydration target by end of day',
+        category: 'health',
+        emoji: '💧',
+    },
+    {
+        id: 'b0000005-de00-4000-a000-000000000005',
+        name: 'Daily journal',
+        description: '3 sentences: what went well, what didn\'t, what\'s next',
+        category: 'mindfulness',
+        emoji: '📓',
+    },
+    {
+        id: 'b0000006-de00-4000-a000-000000000006',
+        name: 'No phone first hour',
+        description: 'No phone for the first hour after waking',
+        category: 'productivity',
+        emoji: '📵',
+    },
+];
+
+const USER_GOALS = [
+    {
+        id: 'b0000101-de00-4000-a000-000000000101',
+        createdByUserId: HABITS_USER_IDS[0], // alice
+        name: 'Pull-ups',
+        description: 'Work up to 10 unbroken pull-ups',
+        category: 'fitness',
+        emoji: '💪',
+    },
+    {
+        id: 'b0000102-de00-4000-a000-000000000102',
+        createdByUserId: HABITS_USER_IDS[2], // charlie
+        name: 'Spanish lesson',
+        description: '15 minutes on Duolingo',
+        category: 'learning',
+        emoji: '🇪🇸',
+    },
+    {
+        id: 'b0000103-de00-4000-a000-000000000103',
+        createdByUserId: HABITS_USER_IDS[4], // ethan
+        name: 'Stretching',
+        description: '5 minutes of mobility work',
+        category: 'health',
+        emoji: '🤸',
+    },
+    {
+        id: 'b0000104-de00-4000-a000-000000000104',
+        createdByUserId: HABITS_USER_IDS[6], // george
+        name: 'Sketch a thing',
+        description: 'One sketch per day, any subject, any quality',
+        category: 'creative',
+        emoji: '✏️',
+    },
+];
+
+// Pacts: pair users on a goal. status='active' means both have joined.
+const PACTS = [
+    {
+        id: 'c0000001-de00-4000-a000-000000000001',
+        creatorUserId: HABITS_USER_IDS[0], // alice
+        partnerUserId: HABITS_USER_IDS[1], // bob
+        habitGoalId: TEMPLATE_GOALS[0].id, // morning workout
+        status: 'active',
+        durationDays: 30,
+        daysAgoStart: 12,
+    },
+    {
+        id: 'c0000002-de00-4000-a000-000000000002',
+        creatorUserId: HABITS_USER_IDS[2], // charlie
+        partnerUserId: HABITS_USER_IDS[3], // diana
+        habitGoalId: TEMPLATE_GOALS[1].id, // read 15 min
+        status: 'active',
+        durationDays: 30,
+        daysAgoStart: 7,
+    },
+    {
+        id: 'c0000003-de00-4000-a000-000000000003',
+        creatorUserId: HABITS_USER_IDS[4], // ethan
+        partnerUserId: HABITS_USER_IDS[5], // fiona
+        habitGoalId: TEMPLATE_GOALS[2].id, // meditation
+        status: 'active',
+        durationDays: 14,
+        daysAgoStart: 5,
+    },
+    {
+        id: 'c0000004-de00-4000-a000-000000000004',
+        creatorUserId: HABITS_USER_IDS[6], // george (waiting on hannah)
+        partnerUserId: HABITS_USER_IDS[7], // hannah
+        habitGoalId: TEMPLATE_GOALS[3].id, // water
+        status: 'pending',
+        durationDays: 7,
+        daysAgoStart: null,
+    },
+];
+
+// Per-pact-member: how often the user successfully checks in (0..1).
+// Generates a believable mix of streaks — alice/bob both consistent, diana spotty, ethan strong.
+const MEMBER_COMPLETION_RATES = {
+    [HABITS_USER_IDS[0]]: 0.92, // alice
+    [HABITS_USER_IDS[1]]: 0.85, // bob
+    [HABITS_USER_IDS[2]]: 0.78, // charlie
+    [HABITS_USER_IDS[3]]: 0.55, // diana — spotty
+    [HABITS_USER_IDS[4]]: 0.95, // ethan — strong
+    [HABITS_USER_IDS[5]]: 0.70, // fiona
+};
+
+// Deterministic pseudo-random via DJB2-style hash so re-runs produce stable completion patterns
+// per (user, date) pair. Avoids bitwise ops to satisfy lint; modulo prevents overflow drift.
+const MOD = 2147483647;
+const isCompleted = (userId, dateIso, rate) => {
+    const seedStr = `${userId}|${dateIso}`;
+    let hash = 5381;
+    for (let i = 0; i < seedStr.length; i += 1) {
+        hash = (hash * 33 + seedStr.charCodeAt(i)) % MOD;
+    }
+    return (hash / MOD) < rate;
+};
+
+const daysAgoIso = (n) => {
+    const d = new Date();
+    d.setUTCHours(0, 0, 0, 0);
+    d.setUTCDate(d.getUTCDate() - n);
+    return d.toISOString().slice(0, 10); // YYYY-MM-DD
+};
+
+const range = (n) => Array.from({ length: n }, (_, i) => i);
+
+const enrollUsersInHabits = async (knex) => {
+    // Reuses the same JSONB upsert pattern as UsersStore.upsertBrandVariation so the canonical
+    // {brand, firstSeenAt, lastSeenAt, isActive} shape is consistent with what login produces.
+    const results = await Promise.all(HABITS_USER_IDS.map((userId) => knex.raw(`
+        UPDATE main.users SET "brandVariations" = (
+            CASE WHEN EXISTS (
+                SELECT 1 FROM jsonb_array_elements("brandVariations") AS elem
+                WHERE elem->>'brand' = ?
+            )
+            THEN "brandVariations"
+            ELSE "brandVariations" || jsonb_build_array(
+                jsonb_build_object(
+                    'brand', ?::text,
+                    'firstSeenAt', now()::text,
+                    'lastSeenAt', now()::text,
+                    'isActive', true
+                )
+            )
+            END
+        )
+        WHERE id = ?::uuid
+    `, [HABITS_BRAND, HABITS_BRAND, userId])));
+    return results.filter((r) => r.rowCount > 0).length;
+};
+
+const insertHabitGoals = async (knex) => {
+    const all = [
+        ...TEMPLATE_GOALS.map((g) => ({
+            ...g, createdByUserId: HABITS_USER_IDS[0], isTemplate: true, isPublic: true,
+        })),
+        ...USER_GOALS.map((g) => ({ ...g, isTemplate: false, isPublic: false })),
+    ];
+    const results = await Promise.all(all.map((goal) => knex.raw(`
+        INSERT INTO habits.habit_goals (
+            id, name, description, category, emoji,
+            "frequencyType", "frequencyCount",
+            "createdByUserId", "isTemplate", "isPublic"
+        ) VALUES (
+            ?::uuid, ?, ?, ?, ?,
+            'daily', 1,
+            ?::uuid, ?, ?
+        ) ON CONFLICT (id) DO NOTHING
+    `, [
+        goal.id, goal.name, goal.description, goal.category, goal.emoji,
+        goal.createdByUserId, goal.isTemplate, goal.isPublic,
+    ])));
+    return results.filter((r) => r.rowCount > 0).length;
+};
+
+const insertPacts = async (knex) => {
+    const results = await Promise.all(PACTS.map((pact) => {
+        const startDate = pact.daysAgoStart != null ? daysAgoIso(pact.daysAgoStart) : null;
+        const endDate = startDate ? daysAgoIso(pact.daysAgoStart - pact.durationDays) : null;
+        return knex.raw(`
+            INSERT INTO habits.pacts (
+                id, "creatorUserId", "partnerUserId", "habitGoalId",
+                "pactType", status, "durationDays", "startDate", "endDate"
+            ) VALUES (
+                ?::uuid, ?::uuid, ?::uuid, ?::uuid,
+                'accountability', ?, ?, ?::timestamptz, ?::timestamptz
+            ) ON CONFLICT (id) DO NOTHING
+        `, [
+            pact.id, pact.creatorUserId, pact.partnerUserId, pact.habitGoalId,
+            pact.status, pact.durationDays, startDate, endDate,
+        ]);
+    }));
+    return results.filter((r) => r.rowCount > 0).length;
+};
+
+const insertPactMembers = async (knex) => {
+    const memberRows = PACTS.flatMap((pact) => [
+        { pact, userId: pact.creatorUserId, role: 'creator' },
+        { pact, userId: pact.partnerUserId, role: 'partner' },
+    ].filter((m) => m.userId));
+
+    const results = await Promise.all(memberRows.map(({ pact, userId, role }) => {
+        const status = pact.status === 'pending' && role === 'partner' ? 'pending' : 'active';
+        const joinedAt = status === 'active' && pact.daysAgoStart != null ? daysAgoIso(pact.daysAgoStart) : null;
+        return knex.raw(`
+            INSERT INTO habits.pact_members (
+                "pactId", "userId", role, status,
+                "joinedAt", "celebratePartnerCheckins"
+            ) VALUES (
+                ?::uuid, ?::uuid, ?, ?,
+                ?::timestamptz, true
+            ) ON CONFLICT ("pactId", "userId") DO NOTHING
+        `, [pact.id, userId, role, status, joinedAt]);
+    }));
+    return results.filter((r) => r.rowCount > 0).length;
+};
+
+// Walk dates oldest -> newest computing streak state. Pure / no I/O so safe to run synchronously.
+const buildPactUserPlan = (pact, userId) => {
+    const rate = MEMBER_COMPLETION_RATES[userId] ?? 0.7;
+    const dates = range(pact.daysAgoStart + 1)
+        .map((i) => pact.daysAgoStart - i) // oldest first
+        .map((n) => {
+            const dateIso = daysAgoIso(n);
+            return { dateIso, completed: isCompleted(userId, dateIso, rate) };
+        });
+    const initial = {
+        currentStreak: 0,
+        runStart: null,
+        lastCompletedDate: null,
+        longestStreak: 0,
+        longestStart: null,
+        longestEnd: null,
+    };
+    const state = dates.reduce((acc, { dateIso, completed }) => {
+        if (!completed) return { ...acc, currentStreak: 0, runStart: null };
+        const newCurrent = acc.currentStreak + 1;
+        const newRunStart = acc.runStart || dateIso;
+        const isNewRecord = newCurrent > acc.longestStreak;
+        return {
+            currentStreak: newCurrent,
+            runStart: newRunStart,
+            lastCompletedDate: dateIso,
+            longestStreak: isNewRecord ? newCurrent : acc.longestStreak,
+            longestStart: isNewRecord ? newRunStart : acc.longestStart,
+            longestEnd: isNewRecord ? dateIso : acc.longestEnd,
+        };
+    }, initial);
+    return { dates, state };
+};
+
+const insertCheckinsAndStreaks = async (knex) => {
+    const activePacts = PACTS.filter((p) => p.status === 'active' && p.daysAgoStart != null);
+    const plans = activePacts.flatMap((pact) => [pact.creatorUserId, pact.partnerUserId]
+        .filter(Boolean)
+        .map((userId) => ({ pact, userId, ...buildPactUserPlan(pact, userId) })));
+
+    const checkinResults = await Promise.all(plans.flatMap(({ pact, userId, dates }) => dates.map(({ dateIso, completed }) => knex.raw(`
+        INSERT INTO habits.habit_checkins (
+            "userId", "pactId", "habitGoalId", "scheduledDate",
+            "completedAt", status, "contributedToStreak"
+        ) VALUES (
+            ?::uuid, ?::uuid, ?::uuid, ?::date,
+            ?, ?, ?
+        ) ON CONFLICT ("userId", "habitGoalId", "scheduledDate") DO NOTHING
+    `, [
+        userId, pact.id, pact.habitGoalId, dateIso,
+        completed ? `${dateIso}T15:00:00Z` : null,
+        completed ? 'completed' : 'missed',
+        completed,
+    ]))));
+
+    const streakResults = await Promise.all(plans.map(({ pact, userId, state }) => knex.raw(`
+        INSERT INTO habits.streaks (
+            "userId", "habitGoalId", "pactId",
+            "currentStreak", "currentStreakStartDate", "lastCompletedDate",
+            "longestStreak", "longestStreakStartDate", "longestStreakEndDate",
+            "isActive"
+        ) VALUES (
+            ?::uuid, ?::uuid, ?::uuid,
+            ?, ?::date, ?::date,
+            ?, ?::date, ?::date,
+            true
+        ) ON CONFLICT ("userId", "habitGoalId") DO UPDATE SET
+            "currentStreak" = EXCLUDED."currentStreak",
+            "currentStreakStartDate" = EXCLUDED."currentStreakStartDate",
+            "lastCompletedDate" = EXCLUDED."lastCompletedDate",
+            "longestStreak" = GREATEST(habits.streaks."longestStreak", EXCLUDED."longestStreak"),
+            "longestStreakStartDate" = CASE
+                WHEN EXCLUDED."longestStreak" > habits.streaks."longestStreak"
+                THEN EXCLUDED."longestStreakStartDate"
+                ELSE habits.streaks."longestStreakStartDate"
+            END,
+            "longestStreakEndDate" = CASE
+                WHEN EXCLUDED."longestStreak" > habits.streaks."longestStreak"
+                THEN EXCLUDED."longestStreakEndDate"
+                ELSE habits.streaks."longestStreakEndDate"
+            END,
+            "updatedAt" = now()
+    `, [
+        userId, pact.habitGoalId, pact.id,
+        state.currentStreak, state.currentStreak > 0 ? state.runStart : null, state.lastCompletedDate,
+        state.longestStreak, state.longestStart, state.longestEnd,
+    ])));
+
+    return {
+        checkinsInserted: checkinResults.filter((r) => r.rowCount > 0).length,
+        streaksTouched: streakResults.filter((r) => r.rowCount > 0).length,
+    };
+};
+
+exports.seed = async (knex) => {
+    const enrolled = await enrollUsersInHabits(knex);
+    const goalsInserted = await insertHabitGoals(knex);
+    const pactsInserted = await insertPacts(knex);
+    const membersInserted = await insertPactMembers(knex);
+    const { checkinsInserted, streaksTouched } = await insertCheckinsAndStreaks(knex);
+
+    console.log('HABITS dev seed complete:');
+    console.log(`  - users enrolled in HABITS brand: ${enrolled} (idempotent; re-runs add only new entries)`);
+    console.log(`  - habit_goals inserted: ${goalsInserted} (${TEMPLATE_GOALS.length} templates + ${USER_GOALS.length} user-created)`);
+    console.log(`  - pacts inserted: ${pactsInserted}`);
+    console.log(`  - pact_members inserted: ${membersInserted}`);
+    console.log(`  - habit_checkins inserted: ${checkinsInserted} (today + back-fill, deterministic per user)`);
+    console.log(`  - streaks rows touched: ${streaksTouched}`);
+    console.log('Login as alice.anderson@test.local / TestPass123! to see HABITS data.');
+};

--- a/therr-services/users-service/src/utilities/notifyUserOfUpdate.ts
+++ b/therr-services/users-service/src/utilities/notifyUserOfUpdate.ts
@@ -1,4 +1,5 @@
 import { Notifications, PushNotifications } from 'therr-js-utilities/constants';
+import { getBrandContext } from 'therr-js-utilities/http';
 import { internalRestRequest, InternalConfigHeaders } from 'therr-js-utilities/internal-rest-request';
 import { ICreateNotificationParams } from '../store/NotificationsStore';
 import Store from '../store';
@@ -61,8 +62,9 @@ export default (
     messageLocaleKey: string;
     messageParams?: any;
 }|undefined> => {
+    const { brandVariation } = getBrandContext(headers);
     const dbNotificationPromise = config.shouldCreateDBNotification
-        ? Store.notifications.createNotification({
+        ? Store.notifications.createNotification(brandVariation, {
             userId: dbNotification.userId,
             type: dbNotification.type, // DB Notification type
             associationId: dbNotification.associationId, // userConnections.id, forum.id, etc.

--- a/therr-services/users-service/src/utilities/sendEmailAndOrPushNotification.ts
+++ b/therr-services/users-service/src/utilities/sendEmailAndOrPushNotification.ts
@@ -5,8 +5,24 @@ import sendPendingInviteEmail from '../api/email/for-social/retention/sendPendin
 import sendNewGroupMembersEmail from '../api/email/for-social/sendNewGroupMembersEmail';
 import sendNewGroupInviteEmail from '../api/email/for-social/sendNewGroupInviteEmail';
 import * as globalConfig from '../../../../global-config';
+import Store from '../store';
 import { IFindUserArgs } from '../store/UsersStore';
 import translate from './translator';
+
+// Phase 2 of the multi-app data isolation rollout. Look up the brand-scoped device token first,
+// fall back to the legacy users.deviceMobileFirebaseToken column when no row exists yet (users
+// whose device hasn't re-registered against the new endpoint). After mobile clients have
+// re-registered (typically on next app open) and shadow logs are clean for one release cycle,
+// the fallback can be deleted.
+const resolveDeviceTokenForBrand = async (
+    brand: string,
+    toUserId: string,
+    legacyToken: string | null | undefined,
+): Promise<string | null | undefined> => {
+    if (!brand || !toUserId) return legacyToken;
+    const rows = await Store.userDeviceTokens.getTokensForUser(brand, toUserId).catch(() => [] as { token: string }[]);
+    return rows[0]?.token || legacyToken;
+};
 
 export interface ISendPushNotification extends PushNotifications.INotificationData {
     authorization: any;
@@ -53,12 +69,17 @@ export default (
         shouldSendEmail: true,
     },
 ): Promise<any> => findUser({ id: toUserId }, ['deviceMobileFirebaseToken', 'email', 'isUnclaimed', 'settingsEmailInvites', 'settingsLocale'])
-    .then((userResults) => {
+    .then(async (userResults) => {
         const destinationUser = userResults?.[0];
         if (!destinationUser || destinationUser.isUnclaimed) {
             // Don't send notification/email
             return Promise.resolve({});
         }
+        const resolvedDeviceToken = await resolveDeviceTokenForBrand(
+            brandVariation,
+            toUserId,
+            destinationUser.deviceMobileFirebaseToken,
+        );
 
         const emailLocale = (destinationUser as any).settingsLocale || locale || 'en-us';
         let sendEmail: () => Promise<any> = () => Promise.resolve();
@@ -161,7 +182,7 @@ export default (
                     groupName,
                     groupMembersList: fromUserNames,
                     postType,
-                    toUserDeviceToken: destinationUser.deviceMobileFirebaseToken,
+                    toUserDeviceToken: resolvedDeviceToken,
                     type,
                     thought,
                     // achievementsCount,

--- a/therr-services/users-service/src/utilities/syncDeviceTokenForBrand.ts
+++ b/therr-services/users-service/src/utilities/syncDeviceTokenForBrand.ts
@@ -1,0 +1,45 @@
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import { getBrandContext } from 'therr-js-utilities/http';
+// eslint-disable-next-line import/extensions, import/no-unresolved
+import logSpan from 'therr-js-utilities/log-or-update-span';
+import Store from '../store';
+
+// Phase 2 of the multi-app data isolation rollout. The legacy `users.deviceMobileFirebaseToken`
+// column gets overwritten when a user installs a second branded app on the same device, which
+// breaks push routing for the original brand. The new `main.userDeviceTokens` table stores one
+// row per (userId, brand, platform), making cross-app routing structurally correct.
+//
+// Until mobile clients have re-registered against the new endpoint (typically on next app
+// open), both writes must succeed for backwards compatibility. Push routing reads the new
+// table first and falls back to the legacy column when no row exists.
+//
+// This helper is fire-and-forget for the new write path: a failure here must NOT block the
+// surrounding user update because the legacy column is still authoritative during the
+// dual-write window. Errors are logged for diagnosis but swallowed.
+const syncDeviceTokenForBrand = async (
+    headers: { [key: string]: any },
+    userId: string | undefined,
+    token: string | undefined | null,
+): Promise<void> => {
+    if (!token || !userId) return;
+    const { brandVariation } = getBrandContext(headers);
+    const platform = (headers['x-platform'] as string) || 'mobile';
+    try {
+        await Store.userDeviceTokens.upsertToken(brandVariation, userId, platform, token);
+    } catch (err: any) {
+        logSpan({
+            level: 'warn',
+            messageOrigin: 'API_SERVER',
+            messages: ['Failed to upsert userDeviceTokens row (Phase 2 dual-write)'],
+            traceArgs: {
+                'error.message': err?.message,
+                'user.id': userId,
+                'pushNotification.brandVariation': brandVariation,
+                'pushNotification.platform': platform,
+                source: 'users-service',
+            },
+        });
+    }
+};
+
+export default syncDeviceTokenForBrand;

--- a/therr-services/users-service/src/utilities/userHelpers.ts
+++ b/therr-services/users-service/src/utilities/userHelpers.ts
@@ -6,7 +6,7 @@ const saltRounds = 12;
 
 export const hashPassword = (password: string) => bcrypt.hash(password, saltRounds);
 
-export const createUserToken = (user: any, userOrgs: any[], rememberMe?: boolean) => {
+export const createUserToken = (user: any, userOrgs: any[], rememberMe?: boolean, brand?: string) => {
     const {
         id,
         userName,
@@ -25,20 +25,27 @@ export const createUserToken = (user: any, userOrgs: any[], rememberMe?: boolean
         }, {});
     const jti = uuidv4();
 
-    // Sign the JWT
+    // brand is omitted when undefined so legacy callers and pre-multi-app tokens already
+    // in the wild keep their existing payload shape. Gateway treats a missing claim as
+    // legacy / cross-brand-allowed.
+    const payload: Record<string, any> = {
+        jti,
+        id,
+        userName,
+        email,
+        phoneNumber,
+        isBlocked,
+        integrations,
+        isSSO: isSSO || false,
+        accessLevels,
+        organizations: mappedUserOrgs,
+    };
+    if (brand) {
+        payload.brand = brand;
+    }
+
     return jwt.sign(
-        {
-            jti,
-            id,
-            userName,
-            email,
-            phoneNumber,
-            isBlocked,
-            integrations,
-            isSSO: isSSO || false,
-            accessLevels,
-            organizations: mappedUserOrgs,
-        },
+        payload,
         (process.env.JWT_SECRET || ''),
         {
             algorithm: 'HS256',
@@ -47,15 +54,20 @@ export const createUserToken = (user: any, userOrgs: any[], rememberMe?: boolean
     );
 };
 
-export const createRefreshToken = (userId: string, rememberMe?: boolean) => {
+export const createRefreshToken = (userId: string, rememberMe?: boolean, brand?: string) => {
     const jti = uuidv4();
 
+    const payload: Record<string, any> = {
+        jti,
+        id: userId,
+        type: 'refresh',
+    };
+    if (brand) {
+        payload.brand = brand;
+    }
+
     const token = jwt.sign(
-        {
-            jti,
-            id: userId,
-            type: 'refresh',
-        },
+        payload,
         (process.env.JWT_SECRET || ''),
         {
             algorithm: 'HS256',
@@ -63,7 +75,9 @@ export const createRefreshToken = (userId: string, rememberMe?: boolean) => {
         },
     );
 
-    return { token, jti };
+    return {
+        token, jti, brand,
+    };
 };
 
 export const createUserEmailToken = (user: { id: string, email: string }) => {

--- a/therr-services/users-service/tests/integration/notifications.integration.test.ts
+++ b/therr-services/users-service/tests/integration/notifications.integration.test.ts
@@ -113,7 +113,7 @@ describe('Integration Tests - Notifications', () => {
 
             const user = await createTestUser('notif1');
 
-            const notifications = await notificationsStore.createNotification({
+            const notifications = await notificationsStore.createNotification('therr', {
                 userId: user.id,
                 type: Notifications.Types.ACHIEVEMENT_COMPLETED,
                 isUnread: true,
@@ -145,7 +145,7 @@ describe('Integration Tests - Notifications', () => {
             createdConnectionIds.push(connections[0].id);
 
             // Create notification for user2 about the request
-            const notifications = await notificationsStore.createNotification({
+            const notifications = await notificationsStore.createNotification('therr', {
                 userId: user2.id,
                 type: Notifications.Types.CONNECTION_REQUEST_RECEIVED,
                 associationId: connections[0].id,
@@ -170,7 +170,7 @@ describe('Integration Tests - Notifications', () => {
 
             const user = await createTestUser('notif3');
 
-            const created = await notificationsStore.createNotification({
+            const created = await notificationsStore.createNotification('therr', {
                 userId: user.id,
                 type: Notifications.Types.NEW_LIKE_RECEIVED,
                 isUnread: true,
@@ -178,7 +178,7 @@ describe('Integration Tests - Notifications', () => {
             });
             createdNotificationIds.push(created[0].id);
 
-            const found = await notificationsStore.getNotifications({ id: created[0].id });
+            const found = await notificationsStore.getNotifications('therr', { id: created[0].id });
 
             expect(found.length).to.equal(1);
             expect(found[0].id).to.equal(created[0].id);
@@ -190,7 +190,7 @@ describe('Integration Tests - Notifications', () => {
             const user = await createTestUser('notif4');
 
             // Create multiple notifications
-            const notifPromises = Array.from({ length: 5 }, (_, i) => notificationsStore.createNotification({
+            const notifPromises = Array.from({ length: 5 }, (_, i) => notificationsStore.createNotification('therr', {
                 userId: user.id,
                 type: Notifications.Types.ACHIEVEMENT_COMPLETED,
                 isUnread: true,
@@ -201,7 +201,7 @@ describe('Integration Tests - Notifications', () => {
             notifResults.forEach((notif) => createdNotificationIds.push(notif[0].id));
 
             // Search with pagination
-            const results = await notificationsStore.searchNotifications(user.id, {
+            const results = await notificationsStore.searchNotifications('therr', user.id, {
                 pagination: { itemsPerPage: 3, pageNumber: 1 },
                 order: 'desc',
             });
@@ -224,7 +224,7 @@ describe('Integration Tests - Notifications', () => {
             createdConnectionIds.push(connections[0].id);
 
             // Create notification with connection associationId
-            const notifications = await notificationsStore.createNotification({
+            const notifications = await notificationsStore.createNotification('therr', {
                 userId: user2.id,
                 type: Notifications.Types.CONNECTION_REQUEST_RECEIVED,
                 associationId: connections[0].id,
@@ -234,7 +234,7 @@ describe('Integration Tests - Notifications', () => {
             createdNotificationIds.push(notifications[0].id);
 
             // Search should include userConnection data via join
-            const results = await notificationsStore.searchNotifications(user2.id, {
+            const results = await notificationsStore.searchNotifications('therr', user2.id, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
                 order: 'desc',
             });
@@ -261,7 +261,7 @@ describe('Integration Tests - Notifications', () => {
 
             const user = await createTestUser('notif6');
 
-            const created = await notificationsStore.createNotification({
+            const created = await notificationsStore.createNotification('therr', {
                 userId: user.id,
                 type: Notifications.Types.NEW_SUPER_LIKE_RECEIVED,
                 isUnread: true,
@@ -273,6 +273,7 @@ describe('Integration Tests - Notifications', () => {
 
             // Mark as read
             const updated = await notificationsStore.updateNotification(
+                'therr',
                 { id: created[0].id },
                 { isUnread: false },
             );
@@ -285,7 +286,7 @@ describe('Integration Tests - Notifications', () => {
 
             const user = await createTestUser('notif7');
 
-            const created = await notificationsStore.createNotification({
+            const created = await notificationsStore.createNotification('therr', {
                 userId: user.id,
                 type: Notifications.Types.NEW_DM_RECEIVED,
                 isUnread: true,
@@ -298,6 +299,7 @@ describe('Integration Tests - Notifications', () => {
 
             // Update notification
             const updated = await notificationsStore.updateNotification(
+                'therr',
                 { id: created[0].id },
                 { isUnread: false },
             );
@@ -318,7 +320,7 @@ describe('Integration Tests - Notifications', () => {
             const user = await createTestUser('notif8');
 
             // Create multiple notifications (some read, some unread)
-            const notifPromises = Array.from({ length: 3 }, () => notificationsStore.createNotification({
+            const notifPromises = Array.from({ length: 3 }, () => notificationsStore.createNotification('therr', {
                 userId: user.id,
                 type: Notifications.Types.ACHIEVEMENT_COMPLETED,
                 isUnread: true,
@@ -329,12 +331,13 @@ describe('Integration Tests - Notifications', () => {
 
             // Mark one as read
             await notificationsStore.updateNotification(
+                'therr',
                 { id: createdNotificationIds[0] },
                 { isUnread: false },
             );
 
             // Count unread
-            const countResult = await notificationsStore.countRecords({
+            const countResult = await notificationsStore.countRecords('therr', {
                 filterBy: 'isUnread',
                 query: true,
             });
@@ -360,7 +363,7 @@ describe('Integration Tests - Notifications', () => {
             createdConnectionIds.push(connections[0].id);
 
             // Step 2: Create notification for accepter about the request
-            const requestNotif = await notificationsStore.createNotification({
+            const requestNotif = await notificationsStore.createNotification('therr', {
                 userId: accepter.id,
                 type: Notifications.Types.CONNECTION_REQUEST_RECEIVED,
                 associationId: connections[0].id,
@@ -380,7 +383,7 @@ describe('Integration Tests - Notifications', () => {
             );
 
             // Step 4: Create notification for requester about acceptance
-            const acceptNotif = await notificationsStore.createNotification({
+            const acceptNotif = await notificationsStore.createNotification('therr', {
                 userId: requester.id,
                 type: Notifications.Types.CONNECTION_REQUEST_ACCEPTED,
                 associationId: connections[0].id,
@@ -395,16 +398,17 @@ describe('Integration Tests - Notifications', () => {
 
             // Step 5: Mark the original request notification as read
             await notificationsStore.updateNotification(
+                'therr',
                 { id: requestNotif[0].id },
                 { isUnread: false },
             );
 
             // Verify the flow
-            const accepterNotifs = await notificationsStore.searchNotifications(accepter.id, {
+            const accepterNotifs = await notificationsStore.searchNotifications('therr', accepter.id, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
                 order: 'desc',
             });
-            const requesterNotifs = await notificationsStore.searchNotifications(requester.id, {
+            const requesterNotifs = await notificationsStore.searchNotifications('therr', requester.id, {
                 pagination: { itemsPerPage: 10, pageNumber: 1 },
                 order: 'desc',
             });

--- a/therr-services/users-service/tests/unit/NotificationsStore.test.ts
+++ b/therr-services/users-service/tests/unit/NotificationsStore.test.ts
@@ -3,35 +3,43 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import NotificationsStore, { NOTIFICATIONS_TABLE_NAME } from '../../src/store/NotificationsStore';
 
+const buildMockConnection = () => {
+    const readStub = sinon.stub().callsFake(() => Promise.resolve({ rows: [] }));
+    const writeStub = sinon.stub().callsFake(() => Promise.resolve({ rows: [] }));
+    return {
+        connection: {
+            read: { query: readStub } as any,
+            write: { query: writeStub } as any,
+        },
+        readStub,
+        writeStub,
+    };
+};
+
 describe('NotificationsStore', () => {
     describe('countRecords', () => {
-        it('queries for total records', () => {
-            const expected = `select count(*) from "main"."notifications" where "isUnread" = true`;
-            const mockStore = {
-                read: {
-                    query: sinon.stub().callsFake(() => Promise.resolve({})),
-                },
-            };
-            const store = new NotificationsStore(mockStore);
-            store.countRecords({
+        it('queries for total records scoped by brand', () => {
+            // BrandScopedStore injects brandVariation into defaultConditions, so the count query
+            // sees both the user-supplied filter (isUnread = true) AND the brand filter.
+            const expected = `select count(*) from "main"."notifications" where "main.notifications.brandVariation" = 'therr' and "isUnread" = true`;
+            const { connection, readStub } = buildMockConnection();
+            const store = new NotificationsStore(connection);
+            store.countRecords('therr', {
                 filterBy: 'isUnread',
                 query: true,
             });
 
-            expect(mockStore.read.query.args[0][0]).to.be.equal(expected);
+            expect(readStub.args[0][0]).to.be.equal(expected);
         });
     });
 
     describe('searchNotifications', () => {
-        it('joins on userConnections', () => {
-            const expected = `select "main"."notifications"."id", "main"."notifications"."userId", "main"."notifications"."type", "main"."notifications"."associationId", "main"."notifications"."isUnread", "main"."notifications"."messageLocaleKey", "main"."notifications"."messageParams", "main"."notifications"."createdAt", "main"."notifications"."updatedAt", "main"."userConnections"."requestingUserId" as "userConnection.requestingUserId", "main"."userConnections"."acceptingUserId" as "userConnection.acceptingUserId", "main"."userConnections"."requestStatus" as "userConnection.requestStatus", "main"."userConnections"."updatedAt" as "userConnection.updatedAt" from "main"."notifications" left join "main"."userConnections" on "main"."notifications"."associationId" = "main"."userConnections".id AND (main.notifications.type = 'CONNECTION_REQUEST_ACCEPTED' OR main.notifications.type = 'CONNECTION_REQUEST_RECEIVED') where "main"."notifications"."userId" = 5 order by "main"."notifications"."updatedAt" desc limit 100 offset 100`;
-            const mockStore = {
-                read: {
-                    query: sinon.stub().callsFake(() => Promise.resolve({})),
-                },
-            };
-            const store = new NotificationsStore(mockStore);
-            store.searchNotifications(5, {
+        it('joins on userConnections and applies brand filter', () => {
+            // Brand filter is appended via withBrand → andWhere, so it lands after the userId clause.
+            const expected = `select "main"."notifications"."id", "main"."notifications"."userId", "main"."notifications"."type", "main"."notifications"."associationId", "main"."notifications"."isUnread", "main"."notifications"."messageLocaleKey", "main"."notifications"."messageParams", "main"."notifications"."createdAt", "main"."notifications"."updatedAt", "main"."userConnections"."requestingUserId" as "userConnection.requestingUserId", "main"."userConnections"."acceptingUserId" as "userConnection.acceptingUserId", "main"."userConnections"."requestStatus" as "userConnection.requestStatus", "main"."userConnections"."updatedAt" as "userConnection.updatedAt" from "main"."notifications" left join "main"."userConnections" on "main"."notifications"."associationId" = "main"."userConnections".id AND (main.notifications.type = 'CONNECTION_REQUEST_ACCEPTED' OR main.notifications.type = 'CONNECTION_REQUEST_RECEIVED') where "main"."notifications"."userId" = 5 and "main.notifications.brandVariation" = 'therr' order by "main"."notifications"."updatedAt" desc limit 100 offset 100`;
+            const { connection, readStub } = buildMockConnection();
+            const store = new NotificationsStore(connection);
+            store.searchNotifications('therr', 5, {
                 pagination: {
                     itemsPerPage: 100,
                     pageNumber: 2,
@@ -42,7 +50,7 @@ describe('NotificationsStore', () => {
                 order: 'desc',
             });
 
-            expect(mockStore.read.query.args[0][0]).to.be.equal(expected);
+            expect(readStub.args[0][0]).to.be.equal(expected);
         });
     });
 });

--- a/therr-services/users-service/tests/unit/handlers-notifications.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-notifications.test.ts
@@ -22,7 +22,7 @@ describe('Notifications Handler', () => {
             };
             const createStub = sinon.stub(Store.notifications, 'createNotification').resolves([mockNotification]);
 
-            const result = await Store.notifications.createNotification({
+            const result = await Store.notifications.createNotification('therr', {
                 userId: 'user-1',
                 type: Notifications.Types.CONNECTION_REQUEST_RECEIVED,
                 associationId: 'conn-123',
@@ -48,7 +48,7 @@ describe('Notifications Handler', () => {
             };
             const createStub = sinon.stub(Store.notifications, 'createNotification').resolves([mockNotification]);
 
-            const result = await Store.notifications.createNotification({
+            const result = await Store.notifications.createNotification('therr', {
                 userId: 'user-1',
                 type: Notifications.Types.CONNECTION_REQUEST_RECEIVED,
                 associationId: 'conn-123',
@@ -76,7 +76,7 @@ describe('Notifications Handler', () => {
             };
             const getStub = sinon.stub(Store.notifications, 'getNotifications').resolves([mockNotification]);
 
-            const result = await Store.notifications.getNotifications({
+            const result = await Store.notifications.getNotifications('therr', {
                 id: 'notif-123',
             });
 
@@ -87,7 +87,7 @@ describe('Notifications Handler', () => {
         it('should return empty array when notification not found', async () => {
             const getStub = sinon.stub(Store.notifications, 'getNotifications').resolves([]);
 
-            const result = await Store.notifications.getNotifications({
+            const result = await Store.notifications.getNotifications('therr', {
                 id: 'nonexistent',
             });
 
@@ -104,7 +104,7 @@ describe('Notifications Handler', () => {
             ];
             const searchStub = sinon.stub(Store.notifications, 'searchNotifications').resolves(mockNotifications);
 
-            const result = await Store.notifications.searchNotifications('user-1', {
+            const result = await Store.notifications.searchNotifications('therr', 'user-1', {
                 pagination: { itemsPerPage: 20, pageNumber: 1 },
                 order: 'desc',
             });
@@ -121,7 +121,7 @@ describe('Notifications Handler', () => {
 
             // User ID should come from header, not query params (security)
             const userId = 'user-1';
-            const result = await Store.notifications.searchNotifications(userId, {
+            const result = await Store.notifications.searchNotifications('therr', userId, {
                 pagination: { itemsPerPage: 20, pageNumber: 1 },
             });
 
@@ -139,6 +139,7 @@ describe('Notifications Handler', () => {
             const updateStub = sinon.stub(Store.notifications, 'updateNotification').resolves([mockNotification]);
 
             const result = await Store.notifications.updateNotification(
+                'therr',
                 { id: 'notif-123' },
                 { isUnread: false },
             );
@@ -155,6 +156,7 @@ describe('Notifications Handler', () => {
             const updateStub = sinon.stub(Store.notifications, 'updateNotification').resolves([mockNotification]);
 
             const result = await Store.notifications.updateNotification(
+                'therr',
                 { id: 'notif-123' },
                 { isUnread: true },
             );
@@ -322,7 +324,7 @@ describe('Notifications Handler', () => {
         it('should count notifications by filter', async () => {
             const countStub = sinon.stub(Store.notifications, 'countRecords').resolves([{ count: '15' }]);
 
-            const result = await Store.notifications.countRecords({
+            const result = await Store.notifications.countRecords('therr', {
                 filterBy: 'isUnread',
                 query: true,
             });
@@ -346,7 +348,7 @@ describe('Notifications Handler', () => {
             ];
             const searchStub = sinon.stub(Store.notifications, 'searchNotifications').resolves(mockNotifications);
 
-            const result = await Store.notifications.searchNotifications('user-1', {
+            const result = await Store.notifications.searchNotifications('therr', 'user-1', {
                 pagination: { itemsPerPage: 20, pageNumber: 1 },
             });
 

--- a/therr-services/websocket-service/src/handlers/messages.ts
+++ b/therr-services/websocket-service/src/handlers/messages.ts
@@ -11,7 +11,7 @@ import {
 import restRequest from '../utilities/restRequest';
 import redisHelper from '../utilities/redisHelper';
 import globalConfig from '../../../../global-config';
-import { FORUM_PREFIX } from './rooms';
+import { getRoomKey } from './rooms';
 import { COMMON_DATE_FORMAT } from '../constants';
 
 const sendDirectMessage = (internalConfig: IInternalConfig, socket: socketio.Socket, data: any, decodedAuthenticationToken: any) => {
@@ -151,7 +151,7 @@ const sendForumMessage = (internalConfig: IInternalConfig, socket: socketio.Sock
                 },
             },
         });
-        socket.broadcast.to(`${FORUM_PREFIX}${data.roomId}`).emit(SOCKET_MIDDLEWARE_ACTION, {
+        socket.broadcast.to(getRoomKey(internalConfig.headers?.['x-brand-variation'] as string | undefined, data.roomId)).emit(SOCKET_MIDDLEWARE_ACTION, {
             type: SocketServerActionTypes.SEND_MESSAGE,
             data: {
                 roomId: data.roomId,

--- a/therr-services/websocket-service/src/handlers/rooms.ts
+++ b/therr-services/websocket-service/src/handlers/rooms.ts
@@ -2,12 +2,26 @@ import moment from 'moment';
 import * as socketio from 'socket.io';
 import logSpan from 'therr-js-utilities/log-or-update-span';
 import { IInternalConfig } from 'therr-js-utilities/internal-rest-request';
-import { SocketServerActionTypes, SOCKET_MIDDLEWARE_ACTION } from 'therr-js-utilities/constants';
+import { BrandVariations, SocketServerActionTypes, SOCKET_MIDDLEWARE_ACTION } from 'therr-js-utilities/constants';
 import { COMMON_DATE_FORMAT } from '../constants';
 import restRequest from '../utilities/restRequest';
 import globalConfig from '../../../../global-config';
 
 export const FORUM_PREFIX = 'FORUM:';
+
+// Phase 3 of the multi-app data isolation rollout. Socket rooms are runtime state, not DB, but
+// they need brand isolation too: a user signed into both Therr and Habits gets two sockets, two
+// sets of room memberships. Without a brand-scoped room key, joining a forum on Habits would
+// also surface in the Therr socket because both connections would land in the same `FORUM:<id>`
+// room, and broadcast.to() would fan out to both.
+//
+// The brand always comes from the AUTHENTICATED socket's handshake (set by the gateway / client
+// axios interceptor), never from client-supplied event payloads — that prevents a client from
+// joining another brand's room by spoofing the room key.
+export const getRoomKey = (brand: BrandVariations | string | undefined, roomId: string) => {
+    const safeBrand = brand || BrandVariations.THERR;
+    return `${safeBrand}:${FORUM_PREFIX}${roomId}`;
+};
 
 interface IRoomData {
     roomId: string;
@@ -19,13 +33,14 @@ interface IRoomData {
 
 const joinRoom = (internalConfig: IInternalConfig, socket: socketio.Socket, data: IRoomData, decodedAuthenticationToken: any) => {
     const now = moment(Date.now()).format(COMMON_DATE_FORMAT); // TODO: RFRONT-25 - localize dates
-    const roomId = `${FORUM_PREFIX}${data.roomId}`;
+    const brandVariation = internalConfig.headers?.['x-brand-variation'] as string | undefined;
+    const roomKey = getRoomKey(brandVariation, data.roomId);
 
-    if (socket.rooms.has(roomId)) {
+    if (socket.rooms.has(roomKey)) {
         return;
     }
 
-    socket.join(roomId);
+    socket.join(roomKey);
 
     const socketMessage = `You joined the room, ${data.roomName}`;
     const dbMessage = `${data.userName} joined the room, ${data.roomName}`;
@@ -59,7 +74,7 @@ const joinRoom = (internalConfig: IInternalConfig, socket: socketio.Socket, data
         });
 
         // Broadcasts an event back to the client for all users in the specified room (excluding the user who triggered it)
-        socket.broadcast.to(`${FORUM_PREFIX}${data.roomId}`).emit(SOCKET_MIDDLEWARE_ACTION, {
+        socket.broadcast.to(roomKey).emit(SOCKET_MIDDLEWARE_ACTION, {
             type: SocketServerActionTypes.OTHER_JOINED_ROOM,
             data: {
                 roomId: data.roomId,
@@ -89,8 +104,10 @@ const joinRoom = (internalConfig: IInternalConfig, socket: socketio.Socket, data
 
 const leaveRoom = (internalConfig: IInternalConfig, socket: socketio.Socket, data: IRoomData, decodedAuthenticationToken: any) => {
     const now = moment(Date.now()).format(COMMON_DATE_FORMAT); // TODO: RFRONT-25 - localize dates
+    const brandVariation = internalConfig.headers?.['x-brand-variation'] as string | undefined;
+    const roomKey = getRoomKey(brandVariation, data.roomId);
 
-    socket.leave(`${FORUM_PREFIX}${data.roomId}`);
+    socket.leave(roomKey);
 
     // Emits an event back to the client who left
     socket.emit(SOCKET_MIDDLEWARE_ACTION, {
@@ -109,7 +126,7 @@ const leaveRoom = (internalConfig: IInternalConfig, socket: socketio.Socket, dat
     });
 
     // Broadcasts an event back to the client for all users in the specified room (excluding the user who triggered it)
-    socket.broadcast.to(`${FORUM_PREFIX}${data.roomId}`).emit(SOCKET_MIDDLEWARE_ACTION, {
+    socket.broadcast.to(roomKey).emit(SOCKET_MIDDLEWARE_ACTION, {
         type: SocketServerActionTypes.LEFT_ROOM,
         data: {
             roomId: data.roomId,


### PR DESCRIPTION
Tapping the foreground "new areas activated" notification navigated to
the generic Areas screen, losing the list of freshly activated
moments/spaces. The in-app notification row (Notifications/index.tsx)
already routes to the ActivatedAreas screen with the specific IDs as
params; the foreground path now matches, passing the activated moment
and space IDs through the notifee data field and falling back to Nearby
when neither list has entries.