### PR TITLE
fix: route recently-activated foreground notification to ActivatedAreas

### DIFF
--- a/therr-public-library/therr-js-utilities/src/config/achievements/index.ts
+++ b/therr-public-library/therr-js-utilities/src/config/achievements/index.ts
@@ -1,3 +1,4 @@
+import { BrandVariations } from '../../constants/enums/Branding';
 import activist from './activist';
 import communityLeader from './communityLeader';
 import critic from './critic';
@@ -58,6 +59,28 @@ export const achievementsByClass: { [key: string]: { [key: string]: IAchievement
     socialite,
     thinker,
     tourGuide,
+};
+
+// Maps an achievement class to the brands that may earn it. Every existing class
+// is Therr-themed (location/social/content), so non-Therr brands are excluded
+// until they ship their own classes (e.g., streak-based for HABITS — see
+// docs/niche-sub-apps/HABITS_PROJECT_BRIEF.md). Without this gate, registration
+// seeds and connection/thought activity would create Therr achievements stamped
+// with the niche brand, which then surface in the niche app's achievements list
+// even though brand-scoped SQL filters are working as intended.
+const ALL_THERR_CLASSES = Object.keys(achievementsByClass);
+export const achievementClassesByBrand: { [brand: string]: ReadonlySet<string> } = {
+    [BrandVariations.THERR]: new Set(ALL_THERR_CLASSES),
+    [BrandVariations.DASHBOARD_THERR]: new Set(ALL_THERR_CLASSES),
+};
+
+export const isAchievementClassEnabledForBrand = (
+    achievementClass: string,
+    brand: BrandVariations | string | undefined | null,
+): boolean => {
+    if (!brand) return false;
+    const allowed = achievementClassesByBrand[brand];
+    return !!allowed && allowed.has(achievementClass);
 };
 
 export default achievements;

--- a/therr-public-library/therr-js-utilities/src/config/index.ts
+++ b/therr-public-library/therr-js-utilities/src/config/index.ts
@@ -1,7 +1,14 @@
-import achievements, { achievementsByClass, IAchievement } from './achievements';
+import achievements, {
+    achievementsByClass,
+    achievementClassesByBrand,
+    isAchievementClassEnabledForBrand,
+    IAchievement,
+} from './achievements';
 
 export {
     achievements,
     achievementsByClass,
+    achievementClassesByBrand,
+    isAchievementClassEnabledForBrand,
     IAchievement,
 };

--- a/therr-public-library/therr-js-utilities/tests/achievements-by-brand.test.ts
+++ b/therr-public-library/therr-js-utilities/tests/achievements-by-brand.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Brand-scoped achievement classes — niche apps must not silently surface
+ * Therr-themed achievements (`socialite`, `explorer`, `influencer`, `thinker`,
+ * etc.) just because the SQL row was stamped with their brandVariation. The
+ * BrandScopedStore filter prevents cross-brand reads at the row level, but the
+ * classes themselves are content-coupled to Therr — niche brands like HABITS
+ * will ship their own (streak-based) classes per HABITS_PROJECT_BRIEF.md.
+ *
+ * Until those niche classes exist, every current class must be locked to THERR
+ * so registration seeds and activity-driven creates skip on niche brands.
+ */
+import { expect } from 'chai';
+import { BrandVariations } from '../src/constants/enums/Branding';
+import {
+    achievementClassesByBrand,
+    achievementsByClass,
+    isAchievementClassEnabledForBrand,
+} from '../src/config/achievements';
+
+describe('isAchievementClassEnabledForBrand', () => {
+    const allClasses = Object.keys(achievementsByClass);
+
+    it('allows every Therr-themed class for the THERR brand', () => {
+        allClasses.forEach((cls) => {
+            expect(
+                isAchievementClassEnabledForBrand(cls, BrandVariations.THERR),
+                `expected ${cls} to be enabled for THERR`,
+            ).to.equal(true);
+        });
+    });
+
+    it('blocks every Therr-themed class for the HABITS brand', () => {
+        allClasses.forEach((cls) => {
+            expect(
+                isAchievementClassEnabledForBrand(cls, BrandVariations.HABITS),
+                `expected ${cls} to be blocked for HABITS`,
+            ).to.equal(false);
+        });
+    });
+
+    it('blocks every Therr-themed class for the TEEM brand', () => {
+        allClasses.forEach((cls) => {
+            expect(
+                isAchievementClassEnabledForBrand(cls, BrandVariations.TEEM),
+                `expected ${cls} to be blocked for TEEM`,
+            ).to.equal(false);
+        });
+    });
+
+    it('returns false when the brand is missing or empty', () => {
+        expect(isAchievementClassEnabledForBrand('socialite', undefined)).to.equal(false);
+        expect(isAchievementClassEnabledForBrand('socialite', null)).to.equal(false);
+        expect(isAchievementClassEnabledForBrand('socialite', '')).to.equal(false);
+    });
+
+    it('returns false for an unknown brand even on a known class', () => {
+        expect(isAchievementClassEnabledForBrand('socialite', 'made-up-brand')).to.equal(false);
+    });
+
+    it('returns false for an unknown class even on the THERR brand', () => {
+        expect(isAchievementClassEnabledForBrand('madeUpClass', BrandVariations.THERR)).to.equal(false);
+    });
+
+    it('exposes the brand → classes map only for Therr brands today', () => {
+        // Sanity check the data shape — adding HABITS-specific classes in the future
+        // should land an entry here AND in this test.
+        expect(achievementClassesByBrand).to.have.property(BrandVariations.THERR);
+        expect(achievementClassesByBrand).to.have.property(BrandVariations.DASHBOARD_THERR);
+        expect(achievementClassesByBrand).to.not.have.property(BrandVariations.HABITS);
+        expect(achievementClassesByBrand).to.not.have.property(BrandVariations.TEEM);
+    });
+});

--- a/therr-services/users-service/src/handlers/helpers/achievements.ts
+++ b/therr-services/users-service/src/handlers/helpers/achievements.ts
@@ -1,4 +1,4 @@
-import { achievementsByClass } from 'therr-js-utilities/config';
+import { achievementsByClass, isAchievementClassEnabledForBrand } from 'therr-js-utilities/config';
 import { Notifications } from 'therr-js-utilities/constants';
 import { getBrandContext } from 'therr-js-utilities/http';
 import logSpan from 'therr-js-utilities/log-or-update-span';
@@ -6,6 +6,12 @@ import { internalRestRequest, InternalConfigHeaders } from 'therr-js-utilities/i
 import Store from '../../store';
 import { ICreateOrUpdateResponse, IDBAchievement } from '../../store/UserAchievementsStore';
 import notifyUserOfUpdate from '../../utilities/notifyUserOfUpdate';
+
+const NO_OP_RESPONSE: ICreateOrUpdateResponse = {
+    created: [],
+    updated: [],
+    action: 'incomplete',
+};
 
 const getAchIdNumber = (id: string) => {
     const arr = id.split('_');
@@ -26,6 +32,16 @@ const createOrUpdateAchievement: (
     }
 
     const { brandVariation } = getBrandContext(headers as Record<string, any>);
+
+    // Skip Therr-themed achievement creation/updates when the request is from a
+    // niche brand. Otherwise activity from a HABITS user (e.g., a connection
+    // request triggering 'socialite_1_1') would write a Therr-themed row stamped
+    // with brandVariation='habits' — passes the SQL brand filter, but surfaces a
+    // Therr-shaped achievement (and ACHIEVEMENT_COMPLETED notification) in the
+    // niche app. See therr-js-utilities/config/achievements for the brand map.
+    if (!isAchievementClassEnabledForBrand(achievementClass, brandVariation)) {
+        return Promise.resolve(NO_OP_RESPONSE);
+    }
 
     return Store.userAchievements.get(brandVariation, {
         userId: headers['x-userid'] || '',

--- a/therr-services/users-service/src/handlers/helpers/user.ts
+++ b/therr-services/users-service/src/handlers/helpers/user.ts
@@ -4,6 +4,7 @@ import appleSignin from 'apple-signin-auth';
 import {
     AccessLevels, BrandVariations, ReferralRewards, UserConnectionTypes,
 } from 'therr-js-utilities/constants';
+import { isAchievementClassEnabledForBrand } from 'therr-js-utilities/config';
 import isValidPassword from 'therr-js-utilities/is-valid-password';
 import normalizeEmail from 'normalize-email';
 import { getBrandContext } from 'therr-js-utilities/http';
@@ -396,47 +397,30 @@ const createUserHelper = (
             }
 
             // Fire and forget: Create initial achievement so user is aware of invite rewards.
-            // Use the registering brand so a Habits signup doesn't pre-seed Therr achievements.
+            // Filter the seed list against the brand's enabled achievement classes — every
+            // current class is Therr-themed, so a Habits/Teem registration seeds nothing
+            // until those brands ship their own classes (see HABITS_PROJECT_BRIEF.md).
             const { brandVariation: registrationBrand } = getBrandContext(headers as Record<string, any>);
-            Store.userAchievements.create(registrationBrand, [
-                {
-                    achievementId: 'socialite_1_1',
-                    userId: user.id,
-                    achievementClass: 'socialite',
-                    achievementTier: '1_1',
-                    progressCount: 0,
-                },
-                {
-                    achievementId: 'explorer_1_1',
-                    userId: user.id,
-                    achievementClass: 'explorer',
-                    achievementTier: '1_1',
-                    progressCount: 0,
-                },
-                {
-                    achievementId: 'influencer_1_1',
-                    userId: user.id,
-                    achievementClass: 'influencer',
-                    achievementTier: '1_1',
-                    progressCount: 0,
-                },
-                {
-                    achievementId: 'thinker_1_1',
-                    userId: user.id,
-                    achievementClass: 'thinker',
-                    achievementTier: '1_1',
-                    progressCount: 0,
-                },
-            ]).catch((err) => {
-                logSpan({
-                    level: 'error',
-                    messageOrigin: 'API_SERVER',
-                    messages: ['Error while creating socialite achievements during registration'],
-                    traceArgs: {
-                        'error.message': err?.message,
-                    },
+            const seedAchievements = [
+                { achievementId: 'socialite_1_1', achievementClass: 'socialite', achievementTier: '1_1' },
+                { achievementId: 'explorer_1_1', achievementClass: 'explorer', achievementTier: '1_1' },
+                { achievementId: 'influencer_1_1', achievementClass: 'influencer', achievementTier: '1_1' },
+                { achievementId: 'thinker_1_1', achievementClass: 'thinker', achievementTier: '1_1' },
+            ]
+                .filter((seed) => isAchievementClassEnabledForBrand(seed.achievementClass, registrationBrand))
+                .map((seed) => ({ ...seed, userId: user.id, progressCount: 0 }));
+            if (seedAchievements.length > 0) {
+                Store.userAchievements.create(registrationBrand, seedAchievements).catch((err) => {
+                    logSpan({
+                        level: 'error',
+                        messageOrigin: 'API_SERVER',
+                        messages: ['Error while creating socialite achievements during registration'],
+                        traceArgs: {
+                            'error.message': err?.message,
+                        },
+                    });
                 });
-            });
+            }
 
             if (isSSO || !!userByInviteDetails) {
                 // TODO: RMOBILE-26: Centralize password requirements

--- a/therr-services/users-service/tests/unit/handlers-helpers-achievements.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-helpers-achievements.test.ts
@@ -1,0 +1,150 @@
+/* eslint-disable quotes, max-len */
+/**
+ * Regression tests for niche-brand achievement isolation.
+ *
+ * Setup: every current achievement class (`socialite`, `explorer`, `influencer`,
+ * `thinker`, `communityLeader`, etc.) is content-coupled to Therr. A niche app
+ * (HABITS, TEEM) must not write Therr-themed achievements stamped with its
+ * brandVariation, even though the SQL filter would technically return them as
+ * "same-brand" rows.
+ *
+ * The brand-row SQL filter (BrandScopedStore) prevents cross-brand reads.
+ * `createOrUpdateAchievement` adds the second layer: skip Therr-themed classes
+ * entirely when the request comes from a niche brand, so neither the
+ * userAchievement row nor the resulting ACHIEVEMENT_COMPLETED notification gets
+ * written under the niche brand's tag.
+ */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { BrandVariations } from 'therr-js-utilities/constants';
+import Store from '../../src/store';
+import { createOrUpdateAchievement } from '../../src/handlers/helpers/achievements';
+
+describe('createOrUpdateAchievement — brand gating', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('no-ops on a niche brand (HABITS) and never touches the achievements store', async () => {
+        const getStub = sinon.stub(Store.userAchievements, 'get');
+        const updateAndCreateStub = sinon.stub(Store.userAchievements, 'updateAndCreateConsecutive');
+
+        const result = await createOrUpdateAchievement({
+            authorization: 'Bearer test',
+            'x-userid': 'user-1',
+            'x-brand-variation': BrandVariations.HABITS,
+            'x-platform': 'mobile',
+            'x-localecode': 'en-us',
+        }, {
+            achievementClass: 'socialite',
+            achievementTier: '1_1',
+            progressCount: 1,
+        });
+
+        expect(getStub.called, 'Store.userAchievements.get must not be called for HABITS').to.equal(false);
+        expect(updateAndCreateStub.called, 'updateAndCreateConsecutive must not be called for HABITS').to.equal(false);
+        expect(result).to.deep.equal({ created: [], updated: [], action: 'incomplete' });
+    });
+
+    it('no-ops on a niche brand (TEEM) for every Therr-themed class', async () => {
+        const getStub = sinon.stub(Store.userAchievements, 'get');
+        const updateAndCreateStub = sinon.stub(Store.userAchievements, 'updateAndCreateConsecutive');
+
+        const therrClasses = ['socialite', 'explorer', 'influencer', 'thinker', 'communityLeader'];
+        for (const achievementClass of therrClasses) {
+            // eslint-disable-next-line no-await-in-loop
+            const result = await createOrUpdateAchievement({
+                authorization: 'Bearer test',
+                'x-userid': 'user-1',
+                'x-brand-variation': BrandVariations.TEEM,
+                'x-platform': 'mobile',
+                'x-localecode': 'en-us',
+            }, {
+                achievementClass,
+                achievementTier: '1_1',
+                progressCount: 1,
+            });
+            expect(result.created).to.have.lengthOf(0);
+            expect(result.updated).to.have.lengthOf(0);
+        }
+
+        expect(getStub.called).to.equal(false);
+        expect(updateAndCreateStub.called).to.equal(false);
+    });
+
+    it('proceeds normally on the THERR brand', async () => {
+        const getStub = sinon.stub(Store.userAchievements, 'get').resolves([]);
+        const updateAndCreateStub = sinon.stub(Store.userAchievements, 'updateAndCreateConsecutive').resolves({
+            created: [],
+            updated: [],
+            action: 'incomplete',
+        });
+
+        await createOrUpdateAchievement({
+            authorization: 'Bearer test',
+            'x-userid': 'user-1',
+            'x-brand-variation': BrandVariations.THERR,
+            'x-platform': 'mobile',
+            'x-localecode': 'en-us',
+        }, {
+            achievementClass: 'socialite',
+            achievementTier: '1_1',
+            progressCount: 1,
+        });
+
+        expect(getStub.calledOnce, 'Store.userAchievements.get should run for THERR').to.equal(true);
+        expect(updateAndCreateStub.calledOnce, 'updateAndCreateConsecutive should run for THERR').to.equal(true);
+        // First arg is the brand — must thread through unchanged.
+        expect(getStub.firstCall.args[0]).to.equal(BrandVariations.THERR);
+        expect(updateAndCreateStub.firstCall.args[0]).to.equal(BrandVariations.THERR);
+    });
+
+    it('rejects an unknown achievement class regardless of brand', async () => {
+        const getStub = sinon.stub(Store.userAchievements, 'get');
+
+        try {
+            await createOrUpdateAchievement({
+                authorization: 'Bearer test',
+                'x-userid': 'user-1',
+                'x-brand-variation': BrandVariations.THERR,
+                'x-platform': 'mobile',
+                'x-localecode': 'en-us',
+            }, {
+                achievementClass: 'madeUpClass',
+                achievementTier: '1_1',
+                progressCount: 1,
+            });
+            expect.fail('expected createOrUpdateAchievement to reject');
+        } catch (err: any) {
+            expect(err.message).to.equal('invalid-achievement-class');
+        }
+        expect(getStub.called).to.equal(false);
+    });
+
+    it('defaults to a non-explicit brand context as THERR (legacy token path)', async () => {
+        // Legacy clients without x-brand-variation are treated as THERR by
+        // getBrandContext — see therr-js-utilities/http/get-brand-context. The
+        // achievement helper must respect that and proceed as THERR, not skip.
+        const getStub = sinon.stub(Store.userAchievements, 'get').resolves([]);
+        const updateAndCreateStub = sinon.stub(Store.userAchievements, 'updateAndCreateConsecutive').resolves({
+            created: [],
+            updated: [],
+            action: 'incomplete',
+        });
+
+        await createOrUpdateAchievement({
+            authorization: 'Bearer test',
+            'x-userid': 'user-1',
+            'x-platform': 'mobile',
+            'x-localecode': 'en-us',
+        } as any, {
+            achievementClass: 'socialite',
+            achievementTier: '1_1',
+            progressCount: 1,
+        });
+
+        expect(getStub.calledOnce).to.equal(true);
+        expect(getStub.firstCall.args[0]).to.equal(BrandVariations.THERR);
+        expect(updateAndCreateStub.calledOnce).to.equal(true);
+    });
+});


### PR DESCRIPTION
Tapping the foreground "new areas activated" notification navigated to
the generic Areas screen, losing the list of freshly activated
moments/spaces. The in-app notification row (Notifications/index.tsx)
already routes to the ActivatedAreas screen with the specific IDs as
params; the foreground path now matches, passing the activated moment
and space IDs through the notifee data field and falling back to Nearby
when neither list has entries.