### PR TITLE
fix: route recently-activated foreground notification to ActivatedAreas

### DIFF
--- a/TherrMobile/main/constants/index.tsx
+++ b/TherrMobile/main/constants/index.tsx
@@ -25,6 +25,10 @@ const PROFILE_CAROUSEL_TABS = {
     THOUGHTS: 'people',
     MEDIA: 'groups',
     MOMENTS: 'moments',
+    // HABITS profile tabs (Friends with Habits niche app)
+    GOALS: 'goals',
+    PACTS: 'pacts',
+    ACHIEVEMENTS: 'achievements',
 };
 
 const HAPTIC_FEEDBACK_TYPE = 'soft';

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -702,6 +702,7 @@
         "addImageNote": "Select an existing image or capture a new one to represent your thought.",
         "cost": "Cost: {pointCost} coins",
         "message": "Have an idea...?",
+        "messageGoal": "What's your goal today?",
         "messageReply": "Share your reply",
         "notificationMsg": "Title or Location Name",
         "hashTags": "Hashtags (ie. my_tag, myTag)",
@@ -710,7 +711,9 @@
         "radius": "Radius: {meters} meters"
       },
       "deleteConfirmation": "Are you sure you want to delete this thought?",
+      "deleteConfirmationGoal": "Are you sure you want to delete this goal?",
       "backendSuccessMessage": "You have shared a thought!",
+      "backendSuccessMessageGoal": "You have shared a goal!",
       "backendErrorMessage": "Connection error. Please try again later."
     },
     "forgotPassword": {
@@ -1392,7 +1395,8 @@
       }
     },
     "editThought": {
-      "headerTitle": "Share a Thought"
+      "headerTitle": "Share a Thought",
+      "headerTitleGoal": "Share a Goal"
     },
     "emailVerification": {
       "buttons": {
@@ -1687,6 +1691,7 @@
     },
     "viewThought": {
       "headerTitle": "Thoughts",
+      "headerTitleGoal": "Goal",
       "reply": "Reply",
       "replies": "Replies"
     },

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -2127,7 +2127,8 @@
         "noMeGoals": "No goals yet. Tap the + button to log your first goal.",
         "noGoals": "This user has not shared any goals yet.",
         "noMePacts": "No pacts yet. Invite a friend to create your first pact.",
-        "noMeAchievements": "No achievements yet. Keep building habits to unlock rewards."
+        "noMeAchievements": "No achievements yet. Keep building habits to unlock rewards.",
+        "noAchievements": "This user hasn't earned any achievements yet."
       }
     }
   }

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1000,6 +1000,9 @@
       "media": "Media",
       "news": "News",
       "thoughts": "Thoughts",
+      "goals": "Goals",
+      "pacts": "Pacts",
+      "achievements": "Achievements",
       "groupsDiscover": "Discover"
     },
     "mapActions": {
@@ -2115,7 +2118,11 @@
         "noMeMoments": "No moments to display. You can create moments from the map.",
         "noMoments": "No moments to display. Travel where they travel to activate nearby moments.",
         "noMeThoughts": "No thoughts to display. You can create thoughts from the 'Discovered' page.",
-        "noThoughts": "This user has not shared any thoughts yet."
+        "noThoughts": "This user has not shared any thoughts yet.",
+        "noMeGoals": "No goals yet. Tap the + button to log your first goal.",
+        "noGoals": "This user has not shared any goals yet.",
+        "noMePacts": "No pacts yet. Invite a friend to create your first pact.",
+        "noMeAchievements": "No achievements yet. Keep building habits to unlock rewards."
       }
     }
   }

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1000,6 +1000,9 @@
       "media": "Multimedia",
       "news": "Noticias",
       "thoughts": "Pensamientos",
+      "goals": "Metas",
+      "pacts": "Pactos",
+      "achievements": "Logros",
       "groupsDiscover": "Descubrir"
     },
     "mapActions": {
@@ -2115,7 +2118,11 @@
         "noMeMoments": "No hay momentos para mostrar. Puedes crear momentos desde el mapa.",
         "noMoments": "No hay momentos para mostrar. Viaja donde ellos viajan para activar momentos cercanos.",
         "noMeThoughts": "No hay pensamientos para mostrar. Puedes crear pensamientos desde la página de 'Descubiertos'.",
-        "noThoughts": "Este usuario aún no ha compartido ningún pensamiento."
+        "noThoughts": "Este usuario aún no ha compartido ningún pensamiento.",
+        "noMeGoals": "Aún no tienes metas. Toca el botón + para registrar tu primera meta.",
+        "noGoals": "Este usuario aún no ha compartido ninguna meta.",
+        "noMePacts": "Aún no tienes pactos. Invita a un amigo para crear tu primer pacto.",
+        "noMeAchievements": "Aún no tienes logros. Sigue construyendo hábitos para desbloquear recompensas."
       }
     }
   }

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -2127,7 +2127,8 @@
         "noMeGoals": "Aún no tienes metas. Toca el botón + para registrar tu primera meta.",
         "noGoals": "Este usuario aún no ha compartido ninguna meta.",
         "noMePacts": "Aún no tienes pactos. Invita a un amigo para crear tu primer pacto.",
-        "noMeAchievements": "Aún no tienes logros. Sigue construyendo hábitos para desbloquear recompensas."
+        "noMeAchievements": "Aún no tienes logros. Sigue construyendo hábitos para desbloquear recompensas.",
+        "noAchievements": "Este usuario aún no ha obtenido ningún logro."
       }
     }
   }

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -702,6 +702,7 @@
         "addImageNote": "Selecciona una imagen existente o captura una nueva para representar tu pensamiento.",
         "cost": "Costo: {pointCost} monedas",
         "message": "¿Tienes una idea...?",
+        "messageGoal": "¿Cuál es tu meta hoy?",
         "messageReply": "Comparte tu respuesta",
         "notificationMsg": "Título o nombre del lugar",
         "hashTags": "Hashtags (ej. mi_etiqueta, miEtiqueta)",
@@ -710,7 +711,9 @@
         "radius": "Radio: {meters} metros"
       },
       "deleteConfirmation": "¿Estás seguro de que quieres eliminar este pensamiento?",
+      "deleteConfirmationGoal": "¿Estás seguro de que quieres eliminar esta meta?",
       "backendSuccessMessage": "¡Has compartido un pensamiento!",
+      "backendSuccessMessageGoal": "¡Has compartido una meta!",
       "backendErrorMessage": "Error de conexión. Por favor, inténtalo de nuevo más tarde."
     },
     "forgotPassword": {
@@ -1392,7 +1395,8 @@
       }
     },
     "editThought": {
-      "headerTitle": "Compartir un pensamiento"
+      "headerTitle": "Compartir un pensamiento",
+      "headerTitleGoal": "Comparte una meta"
     },
     "emailVerification": {
       "buttons": {
@@ -1687,6 +1691,7 @@
     },
     "viewThought": {
       "headerTitle": "Pensamientos",
+      "headerTitleGoal": "Meta",
       "reply": "Responder",
       "replies": "Respuestas"
     },

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -1000,6 +1000,9 @@
       "media": "Médias",
       "news": "Nouvelles",
       "thoughts": "Pensées",
+      "goals": "Objectifs",
+      "pacts": "Pactes",
+      "achievements": "Réalisations",
       "groupsDiscover": "Découvrir"
     },
     "mapActions": {
@@ -2115,7 +2118,11 @@
         "noMeMoments": "Aucun moment à afficher. Vous pouvez créer des moments depuis la carte.",
         "noMoments": "Aucun moment à afficher. Voyagez là où ils voyagent pour activer les moments à proximité.",
         "noMeThoughts": "Aucune pensée à afficher. Vous pouvez créer des pensées depuis la page « Découvertes ».",
-        "noThoughts": "Cet utilisateur n'a pas encore partagé de pensées."
+        "noThoughts": "Cet utilisateur n'a pas encore partagé de pensées.",
+        "noMeGoals": "Aucun objectif pour le moment. Appuyez sur le bouton + pour enregistrer votre premier objectif.",
+        "noGoals": "Cet utilisateur n'a encore partagé aucun objectif.",
+        "noMePacts": "Aucun pacte pour le moment. Invitez un ami à créer votre premier pacte.",
+        "noMeAchievements": "Aucune réalisation pour le moment. Continuez à bâtir vos habitudes pour débloquer des récompenses."
       }
     }
   }

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -2127,7 +2127,8 @@
         "noMeGoals": "Aucun objectif pour le moment. Appuyez sur le bouton + pour enregistrer votre premier objectif.",
         "noGoals": "Cet utilisateur n'a encore partagé aucun objectif.",
         "noMePacts": "Aucun pacte pour le moment. Invitez un ami à créer votre premier pacte.",
-        "noMeAchievements": "Aucune réalisation pour le moment. Continuez à bâtir vos habitudes pour débloquer des récompenses."
+        "noMeAchievements": "Aucune réalisation pour le moment. Continuez à bâtir vos habitudes pour débloquer des récompenses.",
+        "noAchievements": "Cet utilisateur n'a encore obtenu aucune réalisation."
       }
     }
   }

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -702,6 +702,7 @@
         "addImageNote": "Sélectionnez une image existante ou prenez-en une nouvelle pour représenter votre pensée.",
         "cost": "Coût : {pointCost} pièces",
         "message": "Avez-vous une idée...?",
+        "messageGoal": "Quel est votre objectif aujourd'hui?",
         "messageReply": "Partagez votre réponse",
         "notificationMsg": "Titre ou nom du lieu",
         "hashTags": "Mots-clics (ex. mon_tag, monTag)",
@@ -710,7 +711,9 @@
         "radius": "Rayon : {meters} mètres"
       },
       "deleteConfirmation": "Êtes-vous sûr de vouloir supprimer cette pensée?",
+      "deleteConfirmationGoal": "Êtes-vous sûr de vouloir supprimer cet objectif?",
       "backendSuccessMessage": "Vous avez partagé une pensée!",
+      "backendSuccessMessageGoal": "Vous avez partagé un objectif!",
       "backendErrorMessage": "Erreur de connexion. Veuillez réessayer plus tard."
     },
     "forgotPassword": {
@@ -1392,7 +1395,8 @@
       }
     },
     "editThought": {
-      "headerTitle": "Partager une pensée"
+      "headerTitle": "Partager une pensée",
+      "headerTitleGoal": "Partager un objectif"
     },
     "emailVerification": {
       "buttons": {
@@ -1687,6 +1691,7 @@
     },
     "viewThought": {
       "headerTitle": "Pensées",
+      "headerTitleGoal": "Objectif",
       "reply": "Répondre",
       "replies": "Réponses"
     },

--- a/TherrMobile/main/routes/EditThought/index.tsx
+++ b/TherrMobile/main/routes/EditThought/index.tsx
@@ -8,7 +8,8 @@ import EditFormFooter from '../../components/EditFormFooter';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import RNFB from 'react-native-blob-util';
 import { IUserState } from 'therr-react/types';
-import { Categories, Content, FilePaths } from 'therr-js-utilities/constants';
+import { BrandVariations, Categories, Content, FilePaths } from 'therr-js-utilities/constants';
+import { CURRENT_BRAND_VARIATION } from '../../config/brandConfig';
 import ImageCropPicker from 'react-native-image-crop-picker';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
@@ -39,6 +40,12 @@ import { requestOSCameraPermissions } from '../../utilities/requestOSPermissions
 import { SheetManager } from 'react-native-actions-sheet';
 
 const { width: viewportWidth } = Dimensions.get('window');
+
+const IS_HABITS = CURRENT_BRAND_VARIATION === BrandVariations.HABITS;
+// On HABITS the "thought" backend hosts the user's Goals feed; surface goal-specific copy.
+const HEADER_TITLE_KEY = IS_HABITS ? 'pages.editThought.headerTitleGoal' : 'pages.editThought.headerTitle';
+const MESSAGE_PLACEHOLDER_KEY = IS_HABITS ? 'forms.editThought.labels.messageGoal' : 'forms.editThought.labels.message';
+const SUCCESS_MESSAGE_KEY = IS_HABITS ? 'forms.editThought.backendSuccessMessageGoal' : 'forms.editThought.backendSuccessMessage';
 
 const hapticFeedbackOptions = {
     enableVibrateFallback: false,
@@ -136,7 +143,7 @@ export class EditThought extends React.Component<IEditThoughtProps, IEditThought
         const { navigation } = this.props;
 
         navigation.setOptions({
-            title: this.translate('pages.editThought.headerTitle'),
+            title: this.translate(HEADER_TITLE_KEY),
         });
 
         this.unsubscribeNavListener = navigation.addListener('beforeRemove', () => {
@@ -241,7 +248,7 @@ export class EditThought extends React.Component<IEditThoughtProps, IEditThought
             createOrUpdatePromise
                 .then(() => {
                     this.setState({
-                        successMsg: this.translate('forms.editThought.backendSuccessMessage'),
+                        successMsg: this.translate(SUCCESS_MESSAGE_KEY),
                     });
 
                     logEvent(getAnalytics(),'thought_create', {
@@ -451,9 +458,7 @@ export class EditThought extends React.Component<IEditThoughtProps, IEditThought
                         <Pressable style={this.themeAccentLayout.styles.container} onPress={Keyboard.dismiss}>
                             <RoundTextInput
                                 autoFocus
-                                placeholder={this.translate(
-                                    'forms.editThought.labels.message'
-                                )}
+                                placeholder={this.translate(MESSAGE_PLACEHOLDER_KEY)}
                                 value={inputs.message}
                                 onChangeText={(text) =>
                                     this.onInputChange('message', text)

--- a/TherrMobile/main/routes/ViewThought/index.tsx
+++ b/TherrMobile/main/routes/ViewThought/index.tsx
@@ -10,7 +10,9 @@ import { bindActionCreators } from 'redux';
 import { Button as PaperButton, Divider, Text as PaperText, TextInput as PaperTextInput } from 'react-native-paper';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import { IContentState, IUserState } from 'therr-react/types';
+import { BrandVariations } from 'therr-js-utilities/constants';
 import { ContentActions } from 'therr-react/redux/actions';
+import { CURRENT_BRAND_VARIATION } from '../../config/brandConfig';
 import UsersActions from '../../redux/actions/UsersActions';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
@@ -32,6 +34,11 @@ import { getReactionUpdateArgs } from '../../utilities/reactions';
 import TherrIcon from '../../components/TherrIcon';
 import { HAPTIC_FEEDBACK_TYPE } from '../../constants';
 import { navToViewContent } from '../../utilities/postViewHelpers';
+
+const IS_HABITS = CURRENT_BRAND_VARIATION === BrandVariations.HABITS;
+// On HABITS the "thought" backend hosts the user's Goals feed; surface goal-specific copy.
+const HEADER_TITLE_KEY = IS_HABITS ? 'pages.viewThought.headerTitleGoal' : 'pages.viewThought.headerTitle';
+const DELETE_CONFIRM_KEY = IS_HABITS ? 'forms.editThought.deleteConfirmationGoal' : 'forms.editThought.deleteConfirmation';
 
 const localStyles = StyleSheet.create({
     contentContainer: {
@@ -155,7 +162,7 @@ const ViewThought = ({
         });
 
         navigation.setOptions({
-            title: translate('pages.viewThought.headerTitle'),
+            title: translate(HEADER_TITLE_KEY),
         });
 
         const unsubscribeNavListener = navigation.addListener('beforeRemove', () => {
@@ -453,7 +460,7 @@ const ViewThought = ({
                 isVisible={isDeleteDialogVisible}
                 onCancel={() => setIsDeleteDialogVisible(false)}
                 onConfirm={handleDeleteConfirm}
-                text={translate('forms.editThought.deleteConfirmation')}
+                text={translate(DELETE_CONFIRM_KEY)}
                 textConfirm={translate('forms.editThought.buttons.confirm')}
                 textCancel={translate('forms.editThought.buttons.cancel')}
                 translate={translate}

--- a/TherrMobile/main/routes/ViewUser/UserDisplayHeader.tsx
+++ b/TherrMobile/main/routes/ViewUser/UserDisplayHeader.tsx
@@ -7,18 +7,31 @@ import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import { getUserImageUri } from '../../utilities/content';
 import SocialIconLink from './SocialIconLink';
 import { createIconSetFromIcoMoon } from 'react-native-vector-icons';
+import { BrandVariations } from 'therr-js-utilities/constants';
+import { IStreak } from 'therr-react/types';
 import spacingStyles from '../../styles/layouts/spacing';
 import therrIconConfig from '../../assets/therr-font-config.json';
 import TherrIcon from '../../components/TherrIcon';
 import SuperUserStatusIcon from '../../components/SuperUserStatusIcon';
 import { IUserProfileAction } from '../../components/ActionSheet/UserProfileSheet';
+import { CURRENT_BRAND_VARIATION } from '../../config/brandConfig';
 import { buildUserUrl } from '../../utilities/shareUrls';
+import StreakWidget from '../../components/Habits/StreakWidget';
 
 const LogoIcon = createIconSetFromIcoMoon(
     therrIconConfig,
     'TherrFont',
     'TherrFont.ttf'
 );
+
+const IS_HABITS = CURRENT_BRAND_VARIATION === BrandVariations.HABITS;
+
+const pickTopStreak = (streaks: IStreak[] = []): IStreak | null => {
+    if (!streaks.length) {
+        return null;
+    }
+    return streaks.reduce((top, s) => (s.currentStreak > top.currentStreak ? s : top), streaks[0]);
+};
 
 interface IActionItem {
     id: string;
@@ -188,13 +201,16 @@ const UserDisplayHeader = ({
     onProfilePicturePress,
     themeForms,
     themeUser,
+    themeHabits,
     translate,
     user,
     userInView,
+    activeStreaks,
 }) => {
     // eslint-disable-next-line eqeqeq
     const isMe = user.details?.id == userInView.id;
     const actionsList = getActionableOptions(isMe, userInView);
+    const topStreak = IS_HABITS && isMe ? pickTopStreak(activeStreaks) : null;
 
     const handleAction = (action: IUserProfileAction) => {
         switch (action.name) {
@@ -393,6 +409,15 @@ const UserDisplayHeader = ({
                     }
                 />
             </View>
+            {topStreak && themeHabits && (
+                <View style={spacingStyles.marginHorizLg}>
+                    <StreakWidget
+                        streak={topStreak}
+                        themeHabits={themeHabits}
+                        translate={translate}
+                    />
+                </View>
+            )}
         </>
     );
 };

--- a/TherrMobile/main/routes/ViewUser/index.tsx
+++ b/TherrMobile/main/routes/ViewUser/index.tsx
@@ -119,6 +119,7 @@ interface IViewUserState {
     tabRoutes: { key: string; title: string }[];
     userInViewsMoments: any[];
     userInViewsThoughts: any[];
+    userInViewsAchievements: any[];
 }
 
 const mapStateToProps = (state) => ({
@@ -190,6 +191,7 @@ class ViewUser extends React.Component<
             tabRoutes: this.buildTabRoutes(isMe),
             userInViewsMoments: [],
             userInViewsThoughts: [],
+            userInViewsAchievements: [],
         };
 
         this.loaderId = getRandomLoaderId();
@@ -236,6 +238,7 @@ class ViewUser extends React.Component<
                 tabRoutes: this.buildTabRoutes(isMe),
                 userInViewsMoments: [],
                 userInViewsThoughts: [],
+                userInViewsAchievements: [],
             });
             this.fetchUser();
         }
@@ -249,9 +252,14 @@ class ViewUser extends React.Component<
             if (isMe) {
                 routes.push(
                     { key: PROFILE_CAROUSEL_TABS.PACTS, title: this.translate('menus.headerTabs.pacts') },
-                    { key: PROFILE_CAROUSEL_TABS.ACHIEVEMENTS, title: this.translate('menus.headerTabs.achievements') },
                 );
             }
+            // Achievements are visible on every HABITS profile. For self, the dedicated screen
+            // owns the claim flow; for other users, the public endpoint returns only completed
+            // achievements with private fields stripped.
+            routes.push(
+                { key: PROFILE_CAROUSEL_TABS.ACHIEVEMENTS, title: this.translate('menus.headerTabs.achievements') },
+            );
             return routes;
         }
         const routes = [
@@ -282,8 +290,12 @@ class ViewUser extends React.Component<
                     .catch((err) => console.log('getIntegratedMoments failed:', err));
                 this.fetchMoments();
                 this.fetchThoughts();
-                if (IS_HABITS && isMe) {
-                    this.fetchHabitsProfileData();
+                if (IS_HABITS) {
+                    if (isMe) {
+                        this.fetchHabitsProfileData();
+                    } else {
+                        this.fetchPublicAchievements(response.id);
+                    }
                 }
             }
         }).catch((error) => {
@@ -503,9 +515,27 @@ class ViewUser extends React.Component<
         ]).catch((err) => console.log('fetchHabitsProfileData failed:', err));
     };
 
+    // Public achievements are stored in local state rather than Redux because they belong to
+    // the viewed user, not the current user — putting them in the global user.achievements slice
+    // would clobber the viewer's own claim flow on the dedicated Achievements screen.
+    fetchPublicAchievements = (targetUserId: string) => UsersService
+        .getPublicUserAchievements(targetUserId)
+        .then(({ data }) => {
+            this.setState({
+                userInViewsAchievements: Array.isArray(data) ? data : [],
+            });
+        })
+        .catch((err) => console.log('fetchPublicAchievements failed:', err));
+
     handleHabitsRefresh = () => {
+        const { user } = this.props;
+        const isMe = user.userInView?.id === user.details.id;
+        const targetUserId = user.userInView?.id;
         this.setState({ isRefreshingHabitsData: true });
-        this.fetchHabitsProfileData().finally(() => {
+        const refresh = isMe
+            ? this.fetchHabitsProfileData()
+            : (targetUserId ? this.fetchPublicAchievements(targetUserId) : Promise.resolve());
+        refresh.finally(() => {
             this.setState({ isRefreshingHabitsData: false });
         });
     };
@@ -739,14 +769,19 @@ class ViewUser extends React.Component<
         </View>
     );
 
-    renderEmptyAchievements = () => (
-        <View style={this.themeHabits.styles.emptyStateContainer}>
-            <Text style={this.themeHabits.styles.emptyStateEmoji}>{'🏆'}</Text>
-            <Text style={this.themeHabits.styles.emptyStateSubtitle}>
-                {this.translate('user.profile.text.noMeAchievements')}
-            </Text>
-        </View>
-    );
+    renderEmptyAchievements = () => {
+        const { user } = this.props;
+        const isMe = user.userInView?.id === user.details.id;
+        const messageKey = isMe ? 'user.profile.text.noMeAchievements' : 'user.profile.text.noAchievements';
+        return (
+            <View style={this.themeHabits.styles.emptyStateContainer}>
+                <Text style={this.themeHabits.styles.emptyStateEmoji}>{'🏆'}</Text>
+                <Text style={this.themeHabits.styles.emptyStateSubtitle}>
+                    {this.translate(messageKey)}
+                </Text>
+            </View>
+        );
+    };
 
     renderPactItem = ({ item }: { item: IPact }) => {
         const { navigation, user } = this.props;
@@ -763,17 +798,21 @@ class ViewUser extends React.Component<
     };
 
     renderAchievementItem = ({ item }: { item: any }) => {
-        // Profile tab is a read-only summary — taps and claims both route to the dedicated
-        // Achievements screen, which owns the full claim flow.
-        const goToAchievements = () => this.props.navigation.navigate('Achievements');
+        const { navigation, user } = this.props;
+        const isMe = user.userInView?.id === user.details.id;
+        // For self: tile press routes to the dedicated Achievements screen which owns the full
+        // claim flow. For other users the public endpoint already strips unclaimedRewardPts so
+        // the claim button never renders, and tile press is a no-op (no public detail screen).
+        const noop = () => {};
+        const onPress = isMe ? () => navigation.navigate('Achievements') : noop;
         return (
             <AchievementTile
                 userAchievement={item}
                 claimText={this.translate('pages.achievements.info.claimRewards')}
                 completedText={this.translate('pages.achievements.info.completed')}
-                handleClaim={goToAchievements}
+                handleClaim={onPress}
                 isClaiming={false}
-                onPressAchievement={goToAchievements}
+                onPressAchievement={onPress}
                 themeAchievements={this.themeAchievements}
             />
         );
@@ -807,8 +846,14 @@ class ViewUser extends React.Component<
 
     renderHabitsAchievementsScene = () => {
         const { user } = this.props;
-        const { isRefreshingHabitsData } = this.state;
-        const achievements = Object.values(user.achievements || {});
+        const { isRefreshingHabitsData, userInViewsAchievements } = this.state;
+        const isMe = user.userInView?.id === user.details.id;
+        // Self uses the Redux user.achievements slice (already loaded by the dedicated Achievements
+        // screen and refreshed via fetchHabitsProfileData); other users use the public endpoint
+        // result kept in local state so the viewer's Redux slice stays clean for their claim flow.
+        const achievements = isMe
+            ? Object.values(user.achievements || {})
+            : userInViewsAchievements;
         return (
             <FlatList
                 data={achievements}

--- a/TherrMobile/main/routes/ViewUser/index.tsx
+++ b/TherrMobile/main/routes/ViewUser/index.tsx
@@ -6,9 +6,11 @@ import {
     View} from 'react-native';
 import { FAB } from 'react-native-paper';
 import 'react-native-gesture-handler';
+import { FlatList, RefreshControl } from 'react-native-gesture-handler';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {
+    HabitActions,
     MapActions,
     UserConnectionsActions,
 } from 'therr-react/redux/actions';
@@ -20,7 +22,10 @@ import {
     IContentState,
     IUserState,
     IUserConnectionsState,
+    IHabitsState,
+    IPact,
 } from 'therr-react/types';
+import { BrandVariations } from 'therr-js-utilities/constants';
 import { TabBar, TabView } from 'react-native-tab-view';
 import { showToast } from '../../utilities/toasts';
 import { ContentActions } from 'therr-react/redux/actions';
@@ -34,6 +39,8 @@ import { buildStyles as buildFormStyles } from '../../styles/forms';
 import { buildStyles as buildLoaderStyles } from '../../styles/loaders';
 import { buildStyles as buildMenuStyles } from '../../styles/navigation/buttonMenu';
 import { buildStyles as buildUserStyles } from '../../styles/user-content/user-display';
+import { buildStyles as buildHabitStyles } from '../../styles/habits';
+import { buildStyles as buildAchievementStyles } from '../../styles/achievements';
 import translator from '../../utilities/translator';
 import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
 import LottieLoader, { ILottieId } from '../../components/LottieLoader';
@@ -42,6 +49,8 @@ import ConfirmModal from '../../components/Modals/ConfirmModal';
 import LazyPlaceholder from '../../components/LazyPlaceholder';
 import TabViewLoadingOverlay from '../../components/TabViewLoadingOverlay';
 import AreaCarousel from '../Areas/AreaCarousel';
+import { PactCard } from '../../components/Habits';
+import AchievementTile from '../Achievements/AchievementTile';
 import { isMyContent } from '../../utilities/content';
 import { SheetManager } from 'react-native-actions-sheet';
 import { IContentSelectionType } from '../../components/ActionSheet/ContentOptionsSheet';
@@ -49,8 +58,12 @@ import { handleAreaReaction, handleThoughtReaction, navToViewContent } from '../
 import TherrIcon from '../../components/TherrIcon';
 import getDirections from '../../utilities/getDirections';
 import { PEOPLE_CAROUSEL_TABS, PROFILE_CAROUSEL_TABS } from '../../constants';
+import { CURRENT_BRAND_VARIATION } from '../../config/brandConfig';
+
+const IS_HABITS = CURRENT_BRAND_VARIATION === BrandVariations.HABITS;
 
 const { width: viewportWidth } = Dimensions.get('window');
+const HABITS_TAB_LIST_CONTENT_STYLE = { paddingBottom: 120, paddingTop: 8 };
 
 const renderIdeaIcon = (props: { size: number; color: string }) => (
     <TherrIcon name="idea" size={props.size} color={props.color} />
@@ -73,12 +86,17 @@ interface IViewUserDispatchProps {
     updateUserInView: Function;
     createUserConnection: Function;
     updateUserConnection: Function;
+    getMyAchievements: Function;
+    getActivePacts: Function;
+    getUserPacts: Function;
+    getActiveStreaks: Function;
 }
 
 interface IStoreProps extends IViewUserDispatchProps {
     content: IContentState;
     user: IUserState;
     userConnections: IUserConnectionsState;
+    habits: IHabitsState;
 }
 
 // Regular component props
@@ -96,6 +114,7 @@ interface IViewUserState {
     isRefreshingUserMedia: boolean;
     isRefreshingUserMoments: boolean;
     isRefreshingUserThoughts: boolean;
+    isRefreshingHabitsData: boolean;
     isTabViewLaidOut: boolean;
     tabRoutes: { key: string; title: string }[];
     userInViewsMoments: any[];
@@ -106,6 +125,7 @@ const mapStateToProps = (state) => ({
     content: state.content,
     notifications: state.notifications,
     user: state.user,
+    habits: state.habits,
 });
 
 const mapDispatchToProps = (dispatch: any) => bindActionCreators({
@@ -120,6 +140,10 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
     updateUserInView: UsersActions.updateUserInView,
     createUserConnection: UserConnectionsActions.create,
     updateUserConnection: UserConnectionsActions.update,
+    getMyAchievements: UsersActions.getMyAchievements,
+    getActivePacts: HabitActions.getActivePacts,
+    getUserPacts: HabitActions.getUserPacts,
+    getActiveStreaks: HabitActions.getActiveStreaks,
 }, dispatch);
 
 class ViewUser extends React.Component<
@@ -138,6 +162,8 @@ class ViewUser extends React.Component<
     private themeLoader = buildLoaderStyles();
     private themeMenu = buildMenuStyles();
     private themeUser = buildUserStyles();
+    private themeHabits = buildHabitStyles();
+    private themeAchievements = buildAchievementStyles();
 
     constructor(props) {
         super(props);
@@ -149,12 +175,6 @@ class ViewUser extends React.Component<
         const { userInView } = route.params;
         const activeTabIndex = 0;
         const isMe = userInView?.id === props.user.details.id;
-        const tabRoutes = [
-            { key: PROFILE_CAROUSEL_TABS.THOUGHTS, title: this.translate('menus.headerTabs.thoughts') },
-        ];
-        if (isMe) {
-            tabRoutes.unshift({ key: PROFILE_CAROUSEL_TABS.MOMENTS, title: this.translate('menus.headerTabs.moments') });
-        }
 
         this.state = {
             activeTabIndex,
@@ -165,8 +185,9 @@ class ViewUser extends React.Component<
             isRefreshingUserMedia: false,
             isRefreshingUserMoments: false,
             isRefreshingUserThoughts: false,
+            isRefreshingHabitsData: false,
             isTabViewLaidOut: false,
-            tabRoutes,
+            tabRoutes: this.buildTabRoutes(isMe),
             userInViewsMoments: [],
             userInViewsThoughts: [],
         };
@@ -179,6 +200,8 @@ class ViewUser extends React.Component<
         this.themeLoader = buildLoaderStyles(props.user.settings?.mobileThemeName);
         this.themeMenu = buildMenuStyles(props.user.settings?.mobileThemeName);
         this.themeUser = buildUserStyles(props.user.settings?.mobileThemeName);
+        this.themeHabits = buildHabitStyles(props.user.settings?.mobileThemeName);
+        this.themeAchievements = buildAchievementStyles(props.user.settings?.mobileThemeName);
         this.translate = (key: string, params: any): string =>
             translator(props.user.settings?.locale || 'en-us', key, params);
     }
@@ -208,15 +231,9 @@ class ViewUser extends React.Component<
 
         if (routeParamChanged || reduxOutOfSync) {
             const isMe = currentRouteUserId === this.props.user.details.id;
-            const tabRoutes = [
-                { key: PROFILE_CAROUSEL_TABS.THOUGHTS, title: this.translate('menus.headerTabs.thoughts') },
-            ];
-            if (isMe) {
-                tabRoutes.unshift({ key: PROFILE_CAROUSEL_TABS.MOMENTS, title: this.translate('menus.headerTabs.moments') });
-            }
             this.setState({
                 isLoading: true,
-                tabRoutes,
+                tabRoutes: this.buildTabRoutes(isMe),
                 userInViewsMoments: [],
                 userInViewsThoughts: [],
             });
@@ -224,8 +241,30 @@ class ViewUser extends React.Component<
         }
     }
 
+    buildTabRoutes = (isMe: boolean): { key: string; title: string }[] => {
+        if (IS_HABITS) {
+            const routes = [
+                { key: PROFILE_CAROUSEL_TABS.GOALS, title: this.translate('menus.headerTabs.goals') },
+            ];
+            if (isMe) {
+                routes.push(
+                    { key: PROFILE_CAROUSEL_TABS.PACTS, title: this.translate('menus.headerTabs.pacts') },
+                    { key: PROFILE_CAROUSEL_TABS.ACHIEVEMENTS, title: this.translate('menus.headerTabs.achievements') },
+                );
+            }
+            return routes;
+        }
+        const routes = [
+            { key: PROFILE_CAROUSEL_TABS.THOUGHTS, title: this.translate('menus.headerTabs.thoughts') },
+        ];
+        if (isMe) {
+            routes.unshift({ key: PROFILE_CAROUSEL_TABS.MOMENTS, title: this.translate('menus.headerTabs.moments') });
+        }
+        return routes;
+    };
+
     fetchUser = () => {
-        const { getUser, getIntegratedMoments, navigation, route } = this.props;
+        const { getUser, getIntegratedMoments, navigation, route, user } = this.props;
         const { userInView } = route.params;
 
         getUser(userInView.id).then((response) => {
@@ -236,12 +275,16 @@ class ViewUser extends React.Component<
                 isLoading: false,
             });
             if (response?.id) {
+                const isMe = response.id === user.details.id;
                 // Media
                 // TODO: Maybe only load after clicking tab
                 Promise.resolve(getIntegratedMoments(response?.id))
                     .catch((err) => console.log('getIntegratedMoments failed:', err));
                 this.fetchMoments();
                 this.fetchThoughts();
+                if (IS_HABITS && isMe) {
+                    this.fetchHabitsProfileData();
+                }
             }
         }).catch((error) => {
             console.log(error);
@@ -450,6 +493,23 @@ class ViewUser extends React.Component<
         });
     };
 
+    fetchHabitsProfileData = () => {
+        const { getActivePacts, getUserPacts, getMyAchievements, getActiveStreaks } = this.props;
+        return Promise.all([
+            getActivePacts(),
+            getUserPacts(),
+            getMyAchievements(),
+            getActiveStreaks(),
+        ]).catch((err) => console.log('fetchHabitsProfileData failed:', err));
+    };
+
+    handleHabitsRefresh = () => {
+        this.setState({ isRefreshingHabitsData: true });
+        this.fetchHabitsProfileData().finally(() => {
+            this.setState({ isRefreshingHabitsData: false });
+        });
+    };
+
     handleEditThought = () => {
         const { navigation } = this.props;
 
@@ -596,9 +656,11 @@ class ViewUser extends React.Component<
     };
 
     onTabSelect = (index: number) => {
-        if (index === 0) {
+        const { tabRoutes } = this.state;
+        const key = tabRoutes[index]?.key;
+        if (key === PROFILE_CAROUSEL_TABS.MOMENTS) {
             this.carouselMomentsRef?.scrollToOffset({ animated: true, offset: 0 });
-        } else if (index === 1) {
+        } else if (key === PROFILE_CAROUSEL_TABS.THOUGHTS || key === PROFILE_CAROUSEL_TABS.GOALS) {
             this.carouselThoughtsRef?.scrollToOffset({ animated: true, offset: 0 });
         }
         this.setState({
@@ -635,8 +697,137 @@ class ViewUser extends React.Component<
         );
     };
 
+    renderThoughtsScene = (emptyMessageKey: string) => {
+        const { isRefreshingUserMedia, userInViewsThoughts } = this.state;
+        const { content, user } = this.props;
+        const fetchMedia = () => {};
+        const noop = () => {};
+        return (
+            <AreaCarousel
+                activeData={userInViewsThoughts}
+                content={content}
+                inspectContent={this.goToContent}
+                isLoading={isRefreshingUserMedia}
+                fetchMedia={fetchMedia}
+                goToViewMap={noop}
+                goToViewUser={this.goToViewUser}
+                toggleAreaOptions={noop}
+                toggleThoughtOptions={this.toggleThoughtOptions}
+                translate={this.translate}
+                containerRef={(component) => { this.carouselThoughtsRef = component; }}
+                handleRefresh={this.handleUserThoughtsRefresh}
+                onEndReached={noop} // TODO
+                updateEventReaction={noop}
+                updateMomentReaction={noop}
+                updateSpaceReaction={noop}
+                updateThoughtReaction={this.createUpdateThoughtReaction}
+                emptyListMessage={this.translate(emptyMessageKey)}
+                renderHeader={() => null}
+                renderLoader={() => <LottieLoader id={this.loaderId} theme={this.themeLoader} />}
+                user={user}
+                rootStyles={this.theme.styles}
+            />
+        );
+    };
+
+    renderEmptyPacts = () => (
+        <View style={this.themeHabits.styles.emptyStateContainer}>
+            <Text style={this.themeHabits.styles.emptyStateEmoji}>{'🤝'}</Text>
+            <Text style={this.themeHabits.styles.emptyStateSubtitle}>
+                {this.translate('user.profile.text.noMePacts')}
+            </Text>
+        </View>
+    );
+
+    renderEmptyAchievements = () => (
+        <View style={this.themeHabits.styles.emptyStateContainer}>
+            <Text style={this.themeHabits.styles.emptyStateEmoji}>{'🏆'}</Text>
+            <Text style={this.themeHabits.styles.emptyStateSubtitle}>
+                {this.translate('user.profile.text.noMeAchievements')}
+            </Text>
+        </View>
+    );
+
+    renderPactItem = ({ item }: { item: IPact }) => {
+        const { navigation, user } = this.props;
+        const currentUserId = user.details?.id || '';
+        return (
+            <PactCard
+                pact={item}
+                currentUserId={currentUserId}
+                onPress={() => navigation.navigate('PactDetail', { pactId: item.id })}
+                themeHabits={this.themeHabits}
+                translate={this.translate}
+            />
+        );
+    };
+
+    renderAchievementItem = ({ item }: { item: any }) => {
+        // Profile tab is a read-only summary — taps and claims both route to the dedicated
+        // Achievements screen, which owns the full claim flow.
+        const goToAchievements = () => this.props.navigation.navigate('Achievements');
+        return (
+            <AchievementTile
+                userAchievement={item}
+                claimText={this.translate('pages.achievements.info.claimRewards')}
+                completedText={this.translate('pages.achievements.info.completed')}
+                handleClaim={goToAchievements}
+                isClaiming={false}
+                onPressAchievement={goToAchievements}
+                themeAchievements={this.themeAchievements}
+            />
+        );
+    };
+
+    renderHabitsPactsScene = () => {
+        const { habits } = this.props;
+        const { isRefreshingHabitsData } = this.state;
+        // Show active pacts first, then completed pacts beneath. Filter out other lifecycle states
+        // (pending, abandoned, expired) — those belong on the dedicated PactsList screen.
+        const allPacts = habits.pacts || [];
+        const activePacts = allPacts.filter((p) => p.status === 'active');
+        const completedPacts = allPacts.filter((p) => p.status === 'completed');
+        const data: IPact[] = [...activePacts, ...completedPacts];
+        return (
+            <FlatList
+                data={data}
+                keyExtractor={(item) => item.id}
+                renderItem={this.renderPactItem}
+                refreshControl={
+                    <RefreshControl
+                        refreshing={isRefreshingHabitsData}
+                        onRefresh={this.handleHabitsRefresh}
+                    />
+                }
+                ListEmptyComponent={this.renderEmptyPacts}
+                contentContainerStyle={HABITS_TAB_LIST_CONTENT_STYLE}
+            />
+        );
+    };
+
+    renderHabitsAchievementsScene = () => {
+        const { user } = this.props;
+        const { isRefreshingHabitsData } = this.state;
+        const achievements = Object.values(user.achievements || {});
+        return (
+            <FlatList
+                data={achievements}
+                keyExtractor={(item: any) => item.id}
+                renderItem={this.renderAchievementItem}
+                refreshControl={
+                    <RefreshControl
+                        refreshing={isRefreshingHabitsData}
+                        onRefresh={this.handleHabitsRefresh}
+                    />
+                }
+                ListEmptyComponent={this.renderEmptyAchievements}
+                contentContainerStyle={HABITS_TAB_LIST_CONTENT_STYLE}
+            />
+        );
+    };
+
     renderSceneMap = ({ route }) => {
-        const { isRefreshingUserMedia, userInViewsThoughts, userInViewsMoments } = this.state;
+        const { isRefreshingUserMedia, userInViewsMoments } = this.state;
         const {
             content,
             user,
@@ -649,10 +840,9 @@ class ViewUser extends React.Component<
 
         switch (route.key) {
             case PROFILE_CAROUSEL_TABS.MOMENTS:
-                const momentsData = userInViewsMoments;
                 return (
                     <AreaCarousel
-                        activeData={momentsData}
+                        activeData={userInViewsMoments}
                         content={content}
                         inspectContent={this.goToContent}
                         isLoading={isRefreshingUserMedia}
@@ -674,47 +864,28 @@ class ViewUser extends React.Component<
                         renderLoader={() => <LottieLoader id={this.loaderId} theme={this.themeLoader} />}
                         user={user}
                         rootStyles={this.theme.styles}
-                        // viewportHeight={viewportHeight}
-                        // viewportWidth={viewportWidth}
                     />
                 );
             case PROFILE_CAROUSEL_TABS.THOUGHTS:
-                const thoughtsData = userInViewsThoughts;
-                return (
-                    <AreaCarousel
-                        activeData={thoughtsData}
-                        content={content}
-                        inspectContent={this.goToContent}
-                        isLoading={isRefreshingUserMedia}
-                        fetchMedia={fetchMedia}
-                        goToViewMap={noop}
-                        goToViewUser={this.goToViewUser}
-                        toggleAreaOptions={noop}
-                        toggleThoughtOptions={this.toggleThoughtOptions}
-                        translate={this.translate}
-                        containerRef={(component) => { this.carouselThoughtsRef = component; }}
-                        handleRefresh={this.handleUserThoughtsRefresh}
-                        onEndReached={noop} // TODO
-                        updateEventReaction={noop}
-                        updateMomentReaction={noop}
-                        updateSpaceReaction={noop}
-                        updateThoughtReaction={this.createUpdateThoughtReaction}
-                        emptyListMessage={this.translate(isMe ? 'user.profile.text.noMeThoughts' : 'user.profile.text.noThoughts')}
-                        renderHeader={() => null}
-                        renderLoader={() => <LottieLoader id={this.loaderId} theme={this.themeLoader} />}
-                        user={user}
-                        rootStyles={this.theme.styles}
-                        // viewportHeight={viewportHeight}
-                        // viewportWidth={viewportWidth}
-                    />
+                return this.renderThoughtsScene(
+                    isMe ? 'user.profile.text.noMeThoughts' : 'user.profile.text.noThoughts',
                 );
+            case PROFILE_CAROUSEL_TABS.GOALS:
+                // HABITS reuses the thoughts data path; backend filters to habits-tagged thoughts.
+                return this.renderThoughtsScene(
+                    isMe ? 'user.profile.text.noMeGoals' : 'user.profile.text.noGoals',
+                );
+            case PROFILE_CAROUSEL_TABS.PACTS:
+                return this.renderHabitsPactsScene();
+            case PROFILE_CAROUSEL_TABS.ACHIEVEMENTS:
+                return this.renderHabitsAchievementsScene();
             default:
                 return null;
         }
     };
 
     render() {
-        const { navigation, user } = this.props;
+        const { habits, navigation, user } = this.props;
         const {
             activeTabIndex,
             activeConfirmModal,
@@ -744,9 +915,11 @@ class ViewUser extends React.Component<
                                     onReportUser={this.onReportUser}
                                     themeForms={this.themeForms}
                                     themeUser={this.themeUser}
+                                    themeHabits={this.themeHabits}
                                     translate={this.translate}
                                     user={user}
                                     userInView={user.userInView || {}}
+                                    activeStreaks={habits?.activeStreaks || []}
                                 />
                                 <View style={this.theme.styles.tabviewContainer} onLayout={this.handleTabContainerLayout}>
                                     <TabView


### PR DESCRIPTION
Tapping the foreground "new areas activated" notification navigated to
the generic Areas screen, losing the list of freshly activated
moments/spaces. The in-app notification row (Notifications/index.tsx)
already routes to the ActivatedAreas screen with the specific IDs as
params; the foreground path now matches, passing the activated moment
and space IDs through the notifee data field and falling back to Nearby
when neither list has entries.