### PR TITLE
Remove unreliable navigator.onLine initialization from network listener

### DIFF
--- a/therr-client-web/src/services/networkService.ts
+++ b/therr-client-web/src/services/networkService.ts
@@ -21,15 +21,15 @@ const startNetworkListener = (dispatch: any) => {
         });
     };
 
+    // Intentionally not seeding from navigator.onLine: it has well-known
+    // false-negative cases (Linux without a configured NetworkManager,
+    // virtualized adapters, certain Chromium builds) that made the offline
+    // badge appear on a healthy connection. The reducer defaults to
+    // isConnected: true, and the online/offline events fire reliably on
+    // real transitions.
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
     isListening = true;
-
-    // Set initial state
-    dispatch({
-        type: NetworkActionTypes.SET_NETWORK_STATUS,
-        data: { isConnected: navigator.onLine },
-    });
 };
 
 const stopNetworkListener = () => {


### PR DESCRIPTION
## Summary
Removed the initialization of network status based on `navigator.onLine` from the network listener setup. The API has well-known reliability issues across different platforms and browsers that were causing false negatives (showing offline status on healthy connections).

## Key Changes
- Removed the `SET_NETWORK_STATUS` dispatch that seeded the initial state from `navigator.onLine`
- Added detailed comment explaining why `navigator.onLine` is not used for initialization
- Network status now relies solely on `online` and `offline` event listeners, which fire reliably on real connection transitions
- The reducer defaults to `isConnected: true`, providing a sensible default state

## Implementation Details
The change addresses known issues with `navigator.onLine` on:
- Linux systems without a configured NetworkManager
- Virtualized network adapters
- Certain Chromium builds

By removing this unreliable initialization and relying only on the `online`/`offline` events, the network status indicator will be more accurate and won't show false offline states on healthy connections.

https://claude.ai/code/session_01AVkZ3bCz8zuaMBEWZV8D6c