### PR TITLE
feat(mobile): add EAS Google Play internal testing track for HABITS Android

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,27 @@ jobs:
       - run:
           name: Run Integration Tests
           command: echo "Hello, Integration Tests"
+  eas_build_habits_android:
+    docker:
+      - image: cimg/node:24.12.0
+    steps:
+      - checkout
+      - run:
+          name: Install EAS CLI
+          command: npm install -g eas-cli
+      - run:
+          name: Build and Submit HABITS Android to Google Play Internal Testing
+          # EXPO_TOKEN must be set as a CircleCI project-level environment variable.
+          # GOOGLE_APIS_ANDROID_KEY and the Google Play service account key must be
+          # stored as EAS secrets (see docs/SECRETS_AND_LOCAL_BOOTSTRAP.md).
+          command: |
+            cd TherrMobile
+            eas build \
+              --platform android \
+              --profile habits-internal \
+              --non-interactive \
+              --auto-submit
+
   deploy:
     docker:
       - image: cimg/gcp:2025.01
@@ -253,3 +274,11 @@ workflows:
             branches:
               only:
                 - main
+
+  habits_mobile_release:
+    jobs:
+      - eas_build_habits_android:
+          filters:
+            branches:
+              only:
+                - niche/HABITS-main

--- a/TherrMobile/android/app/build.gradle
+++ b/TherrMobile/android/app/build.gradle
@@ -29,7 +29,11 @@ react {
     // debuggableVariants = ["liteDebug", "prodDebug"]
     /* Bundling */
     //   A list containing the node command and its flags. Default is just 'node'.
-    nodeExecutableAndArgs = ["/Users/zacharyanselm/.nvm/versions/node/v24.12.0/bin/node"]
+    // Only override when the developer's local NVM node is present; EAS build servers use PATH.
+    def localNode = new File("/Users/zacharyanselm/.nvm/versions/node/v24.12.0/bin/node")
+    if (localNode.exists()) {
+        nodeExecutableAndArgs = [localNode.absolutePath]
+    }
     //
     //   The command to run when bundling. By default is 'bundle'
     // bundleCommand = "ram-bundle"

--- a/TherrMobile/app.json
+++ b/TherrMobile/app.json
@@ -1,4 +1,17 @@
 {
-  "name": "Therr",
-  "displayName": "Therr Mobile"
+  "name": "Friends with Habits",
+  "displayName": "Friends with Habits",
+  "expo": {
+    "owner": "REPLACE_WITH_EXPO_OWNER",
+    "name": "Friends with Habits",
+    "slug": "friends-with-habits",
+    "android": {
+      "package": "com.therr.habits"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "REPLACE_WITH_EAS_PROJECT_ID"
+      }
+    }
+  }
 }

--- a/TherrMobile/eas.json
+++ b/TherrMobile/eas.json
@@ -1,0 +1,25 @@
+{
+  "cli": {
+    "version": ">= 15.0.0",
+    "promptToConfigurePushNotifications": false
+  },
+  "build": {
+    "habits-internal": {
+      "distribution": "store",
+      "android": {
+        "buildType": "app-bundle",
+        "gradleCommand": ":app:bundleRelease",
+        "credentialsSource": "remote"
+      }
+    }
+  },
+  "submit": {
+    "habits-internal": {
+      "android": {
+        "track": "internal",
+        "releaseStatus": "draft",
+        "changesNotSentForReview": true
+      }
+    }
+  }
+}

--- a/docs/SECRETS_AND_LOCAL_BOOTSTRAP.md
+++ b/docs/SECRETS_AND_LOCAL_BOOTSTRAP.md
@@ -146,6 +146,58 @@ This requires Play Console support intervention and can take 1–2 weeks.
 
 ---
 
+---
+
+## EAS (Expo Application Services) — HABITS Android CI/CD
+
+The `niche/HABITS-main` branch triggers an EAS cloud build + Google Play submit
+via CircleCI (`habits_mobile_release` workflow in `.circleci/config.yml`).
+EAS runs the actual Android build on Expo's infrastructure, so the CI runner
+only needs `eas-cli` installed — no local Android SDK required.
+
+### One-time setup (do this before the first CI build)
+
+1. **Create an Expo account** at https://expo.dev if you don't have one.
+
+2. **Link the project to EAS** from the `TherrMobile` directory:
+   ```bash
+   cd TherrMobile
+   npm install -g eas-cli
+   eas login
+   eas init --id <new-project-id>   # or let eas init auto-create the project
+   ```
+   After `eas init`, commit the updated `app.json` — it will have the real
+   `projectId` replacing `REPLACE_WITH_EAS_PROJECT_ID`, and `owner` set to
+   your Expo username.
+
+3. **Upload the HABITS keystore to EAS credentials**:
+   ```bash
+   eas credentials --platform android --profile habits-internal
+   ```
+   Choose "Upload an existing keystore" and provide `habits-upload.keystore`
+   (see keystore section below). EAS stores it encrypted; the CI job will
+   download it at build time via `credentialsSource: "remote"` in `eas.json`.
+
+4. **Store the Google Maps API key as an EAS secret**:
+   ```bash
+   eas secret:create --scope project --name GOOGLE_APIS_ANDROID_KEY --value <key>
+   ```
+   Use the Android-restricted Maps SDK key for `com.therr.habits`.
+
+5. **Store the Google Play service account key as an EAS secret**:
+   ```bash
+   eas secret:create --scope project --name EXPO_GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON \
+     --type file --value ./path-to-service-account.json
+   ```
+   This is the service account JSON from the Google Play Console that has
+   "Release manager" or "Release" permissions on the `com.therr.habits` listing.
+   EAS Submit reads it automatically when `EXPO_GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON`
+   is set.
+
+6. **Add `EXPO_TOKEN` to CircleCI project environment variables**:
+   - Generate a token at https://expo.dev/settings/access-tokens
+   - In CircleCI: Project Settings → Environment Variables → `EXPO_TOKEN`
+
 ### `TherrMobile/android/app/habits-upload.keystore` (planned, not yet created)
 
 **What it will be:** Android upload signing key for the Friends with Habits


### PR DESCRIPTION
- `TherrMobile/eas.json` — new EAS config with `habits-internal` build
  profile (AAB, remote credentials) and submit profile (internal track,
  draft status, no auto-review request)
- `TherrMobile/app.json` — add `expo` section required by EAS CLI:
  package `com.therr.habits`, slug `friends-with-habits`, and placeholder
  `projectId` / `owner` fields to fill in after running `eas init`
- `TherrMobile/android/app/build.gradle` — make `nodeExecutableAndArgs`
  conditional on the local NVM path existing so EAS cloud build servers
  fall back to system node instead of failing with a missing-binary error
- `.circleci/config.yml` — add `eas_build_habits_android` job and
  `habits_mobile_release` workflow; triggers only on `niche/HABITS-main`,
  installs `eas-cli`, then runs `eas build --auto-submit` (build + Google
  Play internal submit in one step); requires `EXPO_TOKEN` CircleCI env var
- `docs/SECRETS_AND_LOCAL_BOOTSTRAP.md` — document six one-time manual
  setup steps: `eas init`, keystore upload via `eas credentials`, three
  `eas secret:create` calls (Maps key, Play service account JSON), and
  CircleCI `EXPO_TOKEN` env var

https://claude.ai/code/session_012kLWkMb6MGHdiwVAfCqCPQ