### PR TITLE
feat(habits): apply purple/gold brand palette to mobile theme

### DIFF
--- a/TherrMobile/main/styles/themes/index.ts
+++ b/TherrMobile/main/styles/themes/index.ts
@@ -57,7 +57,20 @@ const brandColorOverrides: Partial<
 > = {
     [BrandVariations.THERR]: {},
     [BrandVariations.TEEM]: {},
-    [BrandVariations.HABITS]: {},
+    // Sampled from TherrMobile/main/assets/habits-icons/adaptive-foreground.svg —
+    // chameleon body gradient (#5B4273 → #6E5C85 → #7C8094) and stripe (#D49617).
+    [BrandVariations.HABITS]: {
+        brand: '#6E5C85',
+        brandDark: '#5B4273',
+        brandFaded: 'rgba(91, 66, 115, 0.4)',
+        onBrand: '#fcfeff',
+        accent: '#D49617',
+        onAccent: '#fcfeff',
+        primary3: '#6E5C85',
+        primary4: '#5B4273',
+        secondary: '#D49617',
+        brandingBlueGreen: '#6E5C85',
+    },
     [BrandVariations.OTAKU]: {},
     [BrandVariations.PARALLELS]: {},
     [BrandVariations.APPY_SOCIAL]: {},
@@ -69,7 +82,12 @@ const brandColorVariationOverrides: Partial<
 > = {
     [BrandVariations.THERR]: {},
     [BrandVariations.TEEM]: {},
-    [BrandVariations.HABITS]: {},
+    [BrandVariations.HABITS]: {
+        primary3LightFade: 'rgba(110, 92, 133, 0.85)',
+        primary3Fade: 'rgba(110, 92, 133, 0.75)',
+        primary3Disabled: '#8a79a0',
+        primary4Fade: 'rgba(91, 66, 115, 0.5)',
+    },
     [BrandVariations.OTAKU]: {},
     [BrandVariations.PARALLELS]: {},
     [BrandVariations.APPY_SOCIAL]: {},

--- a/TherrMobile/main/styles/themes/paper.ts
+++ b/TherrMobile/main/styles/themes/paper.ts
@@ -302,7 +302,16 @@ type PaperColorPatch = Partial<MD3Theme['colors']>;
 const brandPaperColorOverrides: Partial<Record<BrandVariations, PaperColorPatch>> = {
     [BrandVariations.THERR]: {},
     [BrandVariations.TEEM]: {},
-    [BrandVariations.HABITS]: {},
+    // Mirrors brandColorOverrides[HABITS] in ./index.ts so Paper-driven
+    // components (FAB, AppBar, TextInput, Snackbar, Card) render the
+    // HABITS purple/gold palette.
+    [BrandVariations.HABITS]: {
+        primary: '#6E5C85',
+        onPrimary: '#fcfeff',
+        primaryContainer: 'rgba(110, 92, 133, 0.15)',
+        secondary: '#D49617',
+        onSecondary: '#fcfeff',
+    },
     [BrandVariations.OTAKU]: {},
     [BrandVariations.PARALLELS]: {},
     [BrandVariations.APPY_SOCIAL]: {},


### PR DESCRIPTION
Populate the HABITS entries in `brandColorOverrides`,
`brandColorVariationOverrides`, and `brandPaperColorOverrides` (Phase 6
scaffold landed in ef030d5). Until now the HABITS variant rendered the
canonical Therr teal everywhere despite shipping HABITS app icons.

Palette is sampled directly from the Sage chameleon icon
(`TherrMobile/main/assets/habits-icons/adaptive-foreground.svg`):

  brand            #6E5C85   (body gradient mid)
  brandDark        #5B4273   (body gradient start)
  brandFaded       rgba(91, 66, 115, 0.4)
  accent           #D49617   (stripe gradient end)
  onBrand/onAccent #fcfeff

Legacy slots (`primary3`, `primary4`, `secondary`, `brandingBlueGreen`)
mirror the aliases so unmigrated screens visually align with HABITS
purple, and `brandingBlueGreen` is overridden specifically because
`BaseButton variant="primary"` reads it directly. Paper-MD3 mirrors
populate `primary`/`onPrimary`/`primaryContainer`/`secondary`/
`onSecondary` so FAB, AppBar, TextInput, Snackbar, and Card render the
same palette.

No new components, no logic changes — pure data filling the empty
override stubs the Phase 6 audit shipped on `general`.

https://claude.ai/code/session_01UoFaGUTGXb3y5yMwfuDc6a