### PR TITLE
Defer TherrMobile permission asks to engagement triggers

### DIFF
--- a/TherrMobile/main/components/Layout.tsx
+++ b/TherrMobile/main/components/Layout.tsx
@@ -15,10 +15,10 @@ import {
     getInitialNotification,
     getMessaging,
     getToken,
+    hasPermission,
     onMessage,
     onNotificationOpenedApp,
     registerDeviceForRemoteMessages,
-    requestPermission,
     AuthorizationStatus,
 } from '@react-native-firebase/messaging';
 import LogRocket from '@logrocket/react-native';
@@ -60,6 +60,9 @@ import { buildStyles as buildFormStyles } from '../styles/forms';
 import { buildStyles as buildModalStyles } from '../styles/modal';
 import { buildStyles as buildInfoModalStyles } from '../styles/modal/infoModal';
 import { buildStyles as buildMenuStyles } from '../styles/modal/headerMenuModal';
+import { buildStyles as buildDisclosureStyles } from '../styles/modal/locationDisclosure';
+import permissions, { PermType } from '../utilities/permissionsOrchestrator';
+import PermissionPrimerModal from './Modals/PermissionPrimerModal';
 import { navigationRef, RootNavigation } from './RootNavigation';
 import PlatformNativeEventEmitter from '../PlatformNativeEventEmitter';
 import HeaderTherrLogo from './HeaderTherrLogo';
@@ -134,6 +137,7 @@ export interface ILayoutProps extends IStoreProps {
 interface ILayoutState {
     targetRouteView: string;
     targetRouteParams: any;
+    permissionPrimerType: PermType | null;
 }
 
 const mapStateToProps = (state: any) => ({
@@ -191,6 +195,10 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
     private themeInfoModal = buildInfoModalStyles();
     private themeModal = buildModalStyles();
     private themeMenu = buildMenuStyles();
+    private themeDisclosure = buildDisclosureStyles();
+    private permissionPrimerResolve: ((allowed: boolean) => void) | null = null;
+    private unsubscribeNotificationsGranted: (() => void) | null = null;
+    private fcmRegistrationStarted = false;
     subscriptions: Subscription[] = [];
 
     constructor(props) {
@@ -199,6 +207,7 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
         this.state = {
             targetRouteView: '',
             targetRouteParams: {},
+            permissionPrimerType: null,
         };
 
         this.reloadTheme();
@@ -272,20 +281,37 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
 
         this.readyAndStartBackgroundGeolocation();
         this.prefetchContent();
+
+        // Wire the permissions orchestrator: a single primer modal lives at the
+        // root, opened by any call site that goes through `permissions.request`.
+        permissions.registerPrimerListener(({ type, resolve }) => {
+            this.permissionPrimerResolve = resolve;
+            this.setState({ permissionPrimerType: type });
+        });
+        // Whenever notifications are granted (login already-granted path or
+        // post-primer OS approval), register the FCM device token and the
+        // foreground message handler. Replaces the unconditional chain that
+        // used to run on auth state change.
+        this.unsubscribeNotificationsGranted = permissions.onGranted('notifications', () => {
+            this.registerDeviceForFCM();
+        });
+
+        // If the user is already authenticated at app launch, this is a returning
+        // session. Try the silent FCM registration (no-op if not authorized) and
+        // give the soft-ask a chance via the second-session fallback.
+        if (this.props.user?.isAuthenticated) {
+            this.tryRegisterDeviceTokenIfAuthorized();
+            permissions.requestIfAppropriate('notifications', { trigger: 'secondSession' });
+        }
     }
 
     componentDidUpdate(prevProps: ILayoutProps) {
         const { targetRouteView, targetRouteParams } = this.state;
         const {
             forums,
-            addNotification,
-            location,
             searchCategories,
-            searchActiveMomentsByIds,
-            searchActiveSpacesByIds,
             updateLocationPermissions,
             user,
-            updateUser,
         } = this.props;
 
         if (prevProps.user?.settings?.mobileThemeName !== user?.settings?.mobileThemeName) {
@@ -358,88 +384,19 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
                     });
                 }
 
-                this.requestNotificationPermissions()
-                    .then(() => {
-                        return registerDeviceForRemoteMessages(getMessaging());
-                    })
-                    .then(() => {
-                        // Get the token
-                        return getToken(getMessaging());
-                    })
-                    .then((deviceToken) => {
-                        axios.defaults.headers['x-user-device-token'] = deviceToken;
-                        if (user.details.deviceMobileFirebaseToken !== deviceToken) {
-                            updateUser(user.details.id, { deviceMobileFirebaseToken: deviceToken });
-                        }
-                        this.unsubscribePushNotifications = onMessage(getMessaging(), async remoteMessage => {
-                            await wrapOnMessageReceived(true, remoteMessage);
-
-                            if (remoteMessage?.data?.areasActivated) {
-                                const parsedAreasData = typeof (remoteMessage?.data?.areasActivated) === 'string'
-                                    ? JSON.parse(remoteMessage?.data?.areasActivated)
-                                    : [];
-                                const momentsData = parsedAreasData.filter(area => area.momentId);
-                                const spacesData = parsedAreasData.filter(area => area.spaceId);
-                                if (parsedAreasData.length) {
-                                    sendForegroundNotification({
-                                        title: this.translate('alertTitles.newAreasActivated'),
-                                        body: this.translate('alertMessages.newAreasActivated', {
-                                            total: momentsData.length + spacesData.length,
-                                        }),
-                                        android: {
-                                            pressAction: { id: PushNotifications.PressActionIds.discovered, launchActivity: 'default' },
-                                        },
-                                        data: {
-                                            activatedMomentIds: JSON.stringify(momentsData.map((moment) => moment.momentId)),
-                                            activatedSpaceIds: JSON.stringify(spacesData.map((space) => space.spaceId)),
-                                        },
-                                    }, getAndroidChannel(AndroidChannelIds.contentDiscovery, false));
-                                    if (momentsData.length) {
-                                        searchActiveMomentsByIds({
-                                            userLatitude: location?.user?.latitude,
-                                            userLongitude: location?.user?.longitude,
-                                            withMedia: true,
-                                            withUser: true,
-                                            blockedUsers: user.details.blockedUsers,
-                                            shouldHideMatureContent: user.details.shouldHideMatureContent,
-                                        }, momentsData.map(moment => moment.momentId));
-                                    }
-                                    if (spacesData.length) {
-                                        searchActiveSpacesByIds({
-                                            userLatitude: location?.user?.latitude,
-                                            userLongitude: location?.user?.longitude,
-                                            withMedia: true,
-                                            withUser: true,
-                                            blockedUsers: user.details.blockedUsers,
-                                            shouldHideMatureContent: user.details.shouldHideMatureContent,
-                                        }, spacesData.map(space => space.spaceId));
-                                    }
-                                }
-                                // TODO: Fetch associated media files
-                                // TODO: Fetch and call insertActiveMoments to "activate" moments on map and discovered
-                            }
-                            if (remoteMessage?.data?.notificationData) {
-                                const parsedNotificationData = typeof (remoteMessage?.data?.notificationData) === 'string'
-                                    ? JSON.parse(remoteMessage?.data?.notificationData)
-                                    : {};
-                                addNotification(parsedNotificationData);
-                            }
-                        });
-                    })
-                    .catch((err) => {
-                        console.log('NOTIFICATIONS_ERROR', err);
-                        if (!__DEV__) {
-                            try {
-                                const crashlytics = getCrashlytics();
-                                crashlyticsLog(crashlytics, `NOTIFICATIONS_ERROR: ${err?.message || String(err)}`);
-                                recordError(crashlytics, err instanceof Error ? err : new Error(String(err)));
-                            } catch {
-                                // Crashlytics may not be initialized yet on very early startup.
-                            }
-                        }
-                    });
+                // Silent token registration only — no OS prompt fires here.
+                // Notification permission asks are anchored to engagement triggers
+                // and a second-session fallback via permissionsOrchestrator.
+                this.tryRegisterDeviceTokenIfAuthorized();
             } else {
                 BackgroundGeolocation.stop();
+                // Tear down the FCM subscription so a subsequent login re-registers
+                // (refreshes the device token and re-attaches axios headers).
+                if (this.unsubscribePushNotifications) {
+                    this.unsubscribePushNotifications();
+                    this.unsubscribePushNotifications = undefined;
+                }
+                this.fcmRegistrationStarted = false;
             }
         }
     }
@@ -458,6 +415,9 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
         this.unsubscribePushNotifications && this.unsubscribePushNotifications();
         this.fcmOpenedUnsubscribe && this.fcmOpenedUnsubscribe();
         this.subscriptions.forEach((subscription) => subscription.remove());
+        this.unsubscribeNotificationsGranted?.();
+        this.unsubscribeNotificationsGranted = null;
+        permissions.registerPrimerListener(null);
     }
 
     handleSocketReconnectAttempt = () => {
@@ -547,6 +507,7 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
         this.themeMenu = buildMenuStyles(themeName);
         this.themeInfoModal = buildInfoModalStyles(themeName);
         this.themeModal = buildModalStyles(themeName);
+        this.themeDisclosure = buildDisclosureStyles(themeName);
         if (shouldForceUpdate) {
             this.forceUpdate();
         }
@@ -1702,31 +1663,108 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
         }
     };
 
-    // TODO(engagement): wrap this in a "soft opt-in" UX — show an in-app
-    // explainer tied to a user action (first moment / first pact invite /
-    // first DM) before triggering the OS prompt. iOS default opt-in ~50%;
-    // a well-anchored soft-ask typically reaches 70–80%. This is the single
-    // highest-ROI push-notification improvement. See
-    // docs/PUSH_NOTIFICATIONS_ENGAGEMENT_ROADMAP.md (item #1).
-    requestNotificationPermissions = () => {
-        // Android 13+ (API 33) requires runtime POST_NOTIFICATIONS permission
-        const androidPermissionPromise = Platform.OS === 'android' && Number(Platform.Version) >= 33
-            ? PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS)
-            : Promise.resolve(null);
+    // Silent FCM token registration. Runs at login and on app launch when the
+    // user is already authenticated; only proceeds if the OS-level notification
+    // permission is already authorized, so it never surfaces an OS prompt.
+    // Soft-asks (and the OS prompt itself) are owned by permissionsOrchestrator.
+    tryRegisterDeviceTokenIfAuthorized = async () => {
+        try {
+            const status = await hasPermission(getMessaging());
+            const authorized = status === AuthorizationStatus.AUTHORIZED
+                || status === AuthorizationStatus.PROVISIONAL;
+            if (!authorized) return;
+            this.registerDeviceForFCM();
+        } catch (err) {
+            console.log('NOTIFICATIONS_HAS_PERMISSION_ERROR', err);
+        }
+    };
 
-        return androidPermissionPromise
-            .then(() => notifee.requestPermission())
-            .then((permissions) => {
-                if (permissions?.authorizationStatus !== 1) {
-                    console.log('Notifee authorization status:', permissions);
+    registerDeviceForFCM = () => {
+        const {
+            addNotification,
+            location,
+            searchActiveMomentsByIds,
+            searchActiveSpacesByIds,
+            user,
+            updateUser,
+        } = this.props;
+        // Avoid double-subscribing. The token chain is async so the
+        // `unsubscribePushNotifications` ref is only set once getToken resolves;
+        // the synchronous flag closes the race when two callers (e.g. login
+        // transition + orchestrator's onGranted) trigger registration in the
+        // same tick.
+        if (this.fcmRegistrationStarted) return;
+        this.fcmRegistrationStarted = true;
+        registerDeviceForRemoteMessages(getMessaging())
+            .then(() => getToken(getMessaging()))
+            .then((deviceToken) => {
+                axios.defaults.headers['x-user-device-token'] = deviceToken;
+                if (user.details.deviceMobileFirebaseToken !== deviceToken) {
+                    updateUser(user.details.id, { deviceMobileFirebaseToken: deviceToken });
                 }
-                return requestPermission(getMessaging());
+                this.unsubscribePushNotifications = onMessage(getMessaging(), async (remoteMessage) => {
+                    await wrapOnMessageReceived(true, remoteMessage);
+
+                    if (remoteMessage?.data?.areasActivated) {
+                        const parsedAreasData = typeof (remoteMessage?.data?.areasActivated) === 'string'
+                            ? JSON.parse(remoteMessage?.data?.areasActivated)
+                            : [];
+                        const momentsData = parsedAreasData.filter((area) => area.momentId);
+                        const spacesData = parsedAreasData.filter((area) => area.spaceId);
+                        if (parsedAreasData.length) {
+                            sendForegroundNotification({
+                                title: this.translate('alertTitles.newAreasActivated'),
+                                body: this.translate('alertMessages.newAreasActivated', {
+                                    total: momentsData.length + spacesData.length,
+                                }),
+                                android: {
+                                    pressAction: { id: PushNotifications.PressActionIds.discovered, launchActivity: 'default' },
+                                },
+                                data: {
+                                    activatedMomentIds: JSON.stringify(momentsData.map((moment) => moment.momentId)),
+                                    activatedSpaceIds: JSON.stringify(spacesData.map((space) => space.spaceId)),
+                                },
+                            }, getAndroidChannel(AndroidChannelIds.contentDiscovery, false));
+                            if (momentsData.length) {
+                                searchActiveMomentsByIds({
+                                    userLatitude: location?.user?.latitude,
+                                    userLongitude: location?.user?.longitude,
+                                    withMedia: true,
+                                    withUser: true,
+                                    blockedUsers: user.details.blockedUsers,
+                                    shouldHideMatureContent: user.details.shouldHideMatureContent,
+                                }, momentsData.map((moment) => moment.momentId));
+                            }
+                            if (spacesData.length) {
+                                searchActiveSpacesByIds({
+                                    userLatitude: location?.user?.latitude,
+                                    userLongitude: location?.user?.longitude,
+                                    withMedia: true,
+                                    withUser: true,
+                                    blockedUsers: user.details.blockedUsers,
+                                    shouldHideMatureContent: user.details.shouldHideMatureContent,
+                                }, spacesData.map((space) => space.spaceId));
+                            }
+                        }
+                    }
+                    if (remoteMessage?.data?.notificationData) {
+                        const parsedNotificationData = typeof (remoteMessage?.data?.notificationData) === 'string'
+                            ? JSON.parse(remoteMessage?.data?.notificationData)
+                            : {};
+                        addNotification(parsedNotificationData);
+                    }
+                });
             })
-            .then((authStatus) => {
-                const enabled = authStatus === AuthorizationStatus.AUTHORIZED
-                    || authStatus === AuthorizationStatus.PROVISIONAL;
-                if (!enabled) {
-                    console.log('Notifications authorization status:', authStatus);
+            .catch((err) => {
+                console.log('NOTIFICATIONS_ERROR', err);
+                if (!__DEV__) {
+                    try {
+                        const crashlytics = getCrashlytics();
+                        crashlyticsLog(crashlytics, `NOTIFICATIONS_ERROR: ${err?.message || String(err)}`);
+                        recordError(crashlytics, err instanceof Error ? err : new Error(String(err)));
+                    } catch {
+                        // Crashlytics may not be initialized yet on very early startup.
+                    }
                 }
             });
     };
@@ -1771,6 +1809,20 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
         return logout(userDetails);
     };
 
+    handlePermissionPrimerAllow = () => {
+        const resolve = this.permissionPrimerResolve;
+        this.permissionPrimerResolve = null;
+        this.setState({ permissionPrimerType: null });
+        resolve?.(true);
+    };
+
+    handlePermissionPrimerNotNow = () => {
+        const resolve = this.permissionPrimerResolve;
+        this.permissionPrimerResolve = null;
+        this.setState({ permissionPrimerType: null });
+        resolve?.(false);
+    };
+
     render() {
         const {
             location,
@@ -1778,6 +1830,7 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
             updateGpsStatus,
             user,
         } = this.props;
+        const { permissionPrimerType } = this.state;
 
         return (
             <NavigationContainer
@@ -2041,6 +2094,16 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
                             return <Stack.Screen key={route.name} {...route} />;
                         })}
                 </Stack.Navigator>
+                {permissionPrimerType ? (
+                    <PermissionPrimerModal
+                        permissionType={permissionPrimerType}
+                        isVisible={!!permissionPrimerType}
+                        onAllow={this.handlePermissionPrimerAllow}
+                        onNotNow={this.handlePermissionPrimerNotNow}
+                        translate={this.translate}
+                        themeDisclosure={this.themeDisclosure}
+                    />
+                ) : null}
             </NavigationContainer>
         );
     }

--- a/TherrMobile/main/components/Modals/PermissionPrimerModal.tsx
+++ b/TherrMobile/main/components/Modals/PermissionPrimerModal.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { Button, Dialog, Portal } from 'react-native-paper';
+
+export type PermissionPrimerType = 'notifications' | 'camera' | 'contacts';
+
+interface IPermissionPrimerModalProps {
+    permissionType: PermissionPrimerType;
+    isVisible: boolean;
+    onAllow: () => void;
+    onNotNow: () => void;
+    translate: Function;
+    themeDisclosure: {
+        styles: any;
+    };
+}
+
+const PermissionPrimerModal = ({
+    permissionType,
+    isVisible,
+    onAllow,
+    onNotNow,
+    translate,
+    themeDisclosure,
+}: IPermissionPrimerModalProps) => {
+    const titleKey = `permissions.primer.${permissionType}.title`;
+    const bodyKey = `permissions.primer.${permissionType}.body`;
+
+    return (
+        <Portal>
+            <Dialog
+                visible={isVisible}
+                onDismiss={onNotNow}
+                style={themeDisclosure.styles.container}
+            >
+                <Dialog.Title style={themeDisclosure.styles.header}>
+                    {translate(titleKey)}
+                </Dialog.Title>
+                <Dialog.Content>
+                    <Text style={themeDisclosure.styles.text}>{translate(bodyKey)}</Text>
+                </Dialog.Content>
+                <Dialog.Actions>
+                    <Button
+                        mode="text"
+                        onPress={onNotNow}
+                    >
+                        {translate('permissions.primer.shared.notNow')}
+                    </Button>
+                    <Button
+                        mode="contained"
+                        icon="check"
+                        onPress={onAllow}
+                    >
+                        {translate('permissions.primer.shared.allow')}
+                    </Button>
+                </Dialog.Actions>
+            </Dialog>
+        </Portal>
+    );
+};
+
+export default PermissionPrimerModal;

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1927,6 +1927,24 @@
       "no": "NO",
       "yes": "YES",
       "close": "Close"
+    },
+    "primer": {
+      "shared": {
+        "allow": "Allow",
+        "notNow": "Not now"
+      },
+      "notifications": {
+        "title": "Stay in the loop",
+        "body": "Get notified when friends reply, accept your invites, or post nearby."
+      },
+      "camera": {
+        "title": "Capture the moment",
+        "body": "Therr needs camera access to attach a photo to your post."
+      },
+      "contacts": {
+        "title": "Find friends faster",
+        "body": "Match contacts who are already on Therr. Your address book stays on your device."
+      }
     }
   },
   "validations": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1927,6 +1927,24 @@
       "no": "NO",
       "yes": "SÍ",
       "close": "Cerrar"
+    },
+    "primer": {
+      "shared": {
+        "allow": "Permitir",
+        "notNow": "Ahora no"
+      },
+      "notifications": {
+        "title": "Mantente al tanto",
+        "body": "Recibe avisos cuando tus amigos respondan, acepten tus invitaciones o publiquen cerca."
+      },
+      "camera": {
+        "title": "Captura el momento",
+        "body": "Therr necesita acceso a la cámara para adjuntar una foto a tu publicación."
+      },
+      "contacts": {
+        "title": "Encuentra amigos más rápido",
+        "body": "Conecta con contactos que ya están en Therr. Tu agenda permanece en tu dispositivo."
+      }
     }
   },
   "validations": {

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -1927,6 +1927,24 @@
       "no": "NON",
       "yes": "OUI",
       "close": "Fermer"
+    },
+    "primer": {
+      "shared": {
+        "allow": "Autoriser",
+        "notNow": "Pas maintenant"
+      },
+      "notifications": {
+        "title": "Reste au courant",
+        "body": "Reçois une notification quand tes amis répondent, acceptent tes invitations ou publient à proximité."
+      },
+      "camera": {
+        "title": "Capte l'instant",
+        "body": "Therr a besoin d'accéder à la caméra pour joindre une photo à ta publication."
+      },
+      "contacts": {
+        "title": "Trouve tes amis plus vite",
+        "body": "Identifie les contacts déjà sur Therr. Ton carnet d'adresses reste sur ton appareil."
+      }
     }
   },
   "validations": {

--- a/TherrMobile/main/routes/DirectMessage/index.tsx
+++ b/TherrMobile/main/routes/DirectMessage/index.tsx
@@ -19,6 +19,7 @@ import TherrIcon from '../../components/TherrIcon';
 import LoadingPlaceholder from './LoadingPlaceholder';
 import spacingStyles from '../../styles/layouts/spacing';
 import ListEmpty from '../../components/ListEmpty';
+import permissions from '../../utilities/permissionsOrchestrator';
 
 const ITEMS_PER_PAGE = 50;
 
@@ -166,6 +167,13 @@ class DirectMessage extends React.Component<
 
             this.setState({
                 msgInputVal: '',
+            });
+
+            // Engagement-anchored soft-ask. The first DM a user sends is when
+            // the value of receiving notifications becomes obvious. No-op if
+            // already asked, granted, or blocked.
+            permissions.requestIfAppropriate('notifications', {
+                trigger: 'firstMessageSent',
             });
 
             // Brief cooldown to prevent double-tap

--- a/TherrMobile/main/routes/EditMoment/index.tsx
+++ b/TherrMobile/main/routes/EditMoment/index.tsx
@@ -49,7 +49,7 @@ import BaseStatusBar from '../../components/BaseStatusBar';
 import formatHashtags from '../../utilities/formatHashtags';
 import { getImagePreviewPath } from '../../utilities/areaUtils';
 import { getUserContentUri, signImageUrl } from '../../utilities/content';
-import { requestOSCameraPermissions } from '../../utilities/requestOSPermissions';
+import permissions from '../../utilities/permissionsOrchestrator';
 import { sendForegroundNotification, sendTriggerNotification } from '../../utilities/pushNotifications';
 import { SheetManager } from 'react-native-actions-sheet';
 import TherrIcon from '../../components/TherrIcon';
@@ -435,6 +435,15 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
                             category,
                         }).catch((err) => console.log(err));
 
+                        // Engagement-anchored soft-ask: a freshly published moment
+                        // is the strongest "you'll want to know when people react"
+                        // moment. No-op if already asked, granted, or blocked.
+                        if (!areaId && !isDraft) {
+                            permissions.requestIfAppropriate('notifications', {
+                                trigger: 'firstMomentPosted',
+                            });
+                        }
+
                         if (!shouldSkipNavigate) {
                             if (!isDraft) {
                                 this.setState({
@@ -566,10 +575,10 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
         // TODO: Store permissions in redux
         const storePermissions = () => {};
 
-        return requestOSCameraPermissions(storePermissions).then((response) => {
-            const permissionsDenied = Object.keys(response).some((key) => {
-                return response[key] !== 'granted';
-            });
+        return permissions.request('camera', {
+            trigger: 'capturePress',
+            storePermissionsResponse: storePermissions,
+        }).then((result) => {
             const pickerOptions: any = {
                 mediaType: 'photo',
                 includeBase64: false,
@@ -578,7 +587,7 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
                 multiple: false,
                 cropping: true,
             };
-            if (!permissionsDenied) {
+            if (result.status === 'granted') {
                 if (action === 'camera') {
                     return ImageCropPicker.openCamera(pickerOptions)
                         .then((cameraResponse) => this.handleImageSelect(cameraResponse));
@@ -587,14 +596,19 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
                         .then((cameraResponse) => this.handleImageSelect(cameraResponse));
                 }
             } else {
-                logEvent(getAnalytics(),'permissions_denied_issue', {
-                    platform: Platform.OS,
-                    userId: user?.details?.id,
-                }).catch((err) => console.log(err));
-                showToast.error({
-                    text1: this.translate('alertTitles.permissionsDenied'),
-                    text2: this.translate('alertMessages.cameraOrFilePermissionsDenied'),
-                });
+                // Soft-ask dismissals stay quiet — the user explicitly chose
+                // "Not now" and the toast would feel like a scolding. Only
+                // surface an error toast when the OS itself denied/blocked.
+                if (result.source === 'os' || result.status === 'blocked') {
+                    logEvent(getAnalytics(),'permissions_denied_issue', {
+                        platform: Platform.OS,
+                        userId: user?.details?.id,
+                    }).catch((err) => console.log(err));
+                    showToast.error({
+                        text1: this.translate('alertTitles.permissionsDenied'),
+                        text2: this.translate('alertMessages.cameraOrFilePermissionsDenied'),
+                    });
+                }
                 throw new Error('permissions denied');
             }
         }).catch((e) => {

--- a/TherrMobile/main/routes/Notifications/index.tsx
+++ b/TherrMobile/main/routes/Notifications/index.tsx
@@ -23,6 +23,7 @@ import translator from '../../utilities/translator';
 import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
 import Notification from './Notification';
 import ListEmpty from '../../components/ListEmpty';
+import permissions from '../../utilities/permissionsOrchestrator';
 import { GROUPS_CAROUSEL_TABS, PEOPLE_CAROUSEL_TABS } from '../../constants';
 
 interface INotificationsDispatchProps {
@@ -122,6 +123,15 @@ class Notifications extends React.Component<
             },
             user: user.details,
         });
+
+        // Engagement-anchored soft-ask: a freshly accepted connection is a
+        // strong signal the user wants to stay informed about that person's
+        // activity. No-op if already asked, granted, or blocked.
+        if (isAccepted) {
+            permissions.requestIfAppropriate('notifications', {
+                trigger: 'firstConnectionAccepted',
+            });
+        }
     };
 
     onNotificationPress = (event, notification, userConnection?: any, shouldNavigate = true) => {

--- a/TherrMobile/main/utilities/contacts.ts
+++ b/TherrMobile/main/utilities/contacts.ts
@@ -1,7 +1,7 @@
 import Contacts from 'react-native-contacts';
 import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
 import { UserConnectionsService } from 'therr-react/services';
-import { requestOSContactsPermissions } from './requestOSPermissions';
+import permissions from './permissionsOrchestrator';
 
 interface IMatchedUser {
     id: string;
@@ -20,11 +20,11 @@ interface ISyncResult {
 const synceMobileContacts = ({
     storePermissions,
     user,
-}): Promise<ISyncResult> => requestOSContactsPermissions(storePermissions).then((response) => {
-    const permissionsDenied = Object.keys(response).some((key) => {
-        return response[key] !== 'granted';
-    });
-    if (!permissionsDenied) {
+}): Promise<ISyncResult> => permissions.request('contacts', {
+    trigger: 'findFriendsTap',
+    storePermissionsResponse: storePermissions,
+}).then((result) => {
+    if (result.status === 'granted') {
         logEvent(getAnalytics(),'phone_contacts_perm_granted', {
             userId: user.details.id,
         }).catch((err) => console.log(err));

--- a/TherrMobile/main/utilities/permissionsOrchestrator.ts
+++ b/TherrMobile/main/utilities/permissionsOrchestrator.ts
@@ -1,0 +1,303 @@
+import { PermissionsAndroid, Platform } from 'react-native';
+import { check, PERMISSIONS, RESULTS } from 'react-native-permissions';
+import {
+    AuthorizationStatus,
+    getMessaging,
+    hasPermission,
+    requestPermission,
+} from '@react-native-firebase/messaging';
+import notifee from '@notifee/react-native';
+import DeviceInfo from 'react-native-device-info';
+import SecureStorage from './SecureStorage';
+import {
+    requestOSCameraPermissions,
+    requestOSContactsPermissions,
+} from './requestOSPermissions';
+
+export type PermType = 'notifications' | 'camera' | 'contacts';
+
+export type Trigger =
+    | 'capturePress'
+    | 'findFriendsTap'
+    | 'firstMomentPosted'
+    | 'firstMessageSent'
+    | 'firstConnectionAccepted'
+    | 'secondSession';
+
+type Status = 'granted' | 'denied' | 'blocked';
+
+export interface PermState {
+    softAskedAt?: number;
+    softAskDismissCount: number;
+    osAskedAt?: number;
+    lastStatus?: Status;
+    appVersionAtLastAsk?: string;
+}
+
+export interface RequestOptions {
+    trigger: Trigger;
+    storePermissionsResponse?: (perms: any) => void;
+    onGranted?: () => void;
+    onDenied?: (source: 'soft' | 'os') => void;
+}
+
+export interface RequestResult {
+    status: Status;
+    source: 'cached' | 'soft' | 'os';
+}
+
+interface PrimerRequest {
+    type: PermType;
+    resolve: (allowed: boolean) => void;
+}
+
+type PrimerListener = (req: PrimerRequest) => void;
+
+const STORAGE_KEY = 'therrPermissionPrompts';
+const SOFT_ASK_CAP = 2;
+const noopStore = () => {};
+
+let cache: Record<string, PermState> | null = null;
+let primerListener: PrimerListener | null = null;
+const grantedListeners: Record<PermType, Array<() => void>> = {
+    notifications: [],
+    camera: [],
+    contacts: [],
+};
+
+const loadState = async (): Promise<Record<string, PermState>> => {
+    if (cache) return cache;
+    try {
+        const raw = await SecureStorage.getItem(STORAGE_KEY);
+        cache = raw ? JSON.parse(raw) : {};
+    } catch {
+        cache = {};
+    }
+    return cache!;
+};
+
+const persistState = async (state: Record<string, PermState>) => {
+    cache = state;
+    try {
+        await SecureStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+        // Persist failure is non-fatal — caches stay in-memory until next launch.
+    }
+};
+
+const getStateFor = async (type: PermType): Promise<PermState> => {
+    const all = await loadState();
+    return all[type] || { softAskDismissCount: 0 };
+};
+
+const updateStateFor = async (type: PermType, patch: Partial<PermState>) => {
+    const all = await loadState();
+    const prev = all[type] || { softAskDismissCount: 0 };
+    const next = { ...all, [type]: { ...prev, ...patch } };
+    await persistState(next);
+};
+
+const checkNotifications = async (): Promise<Status> => {
+    try {
+        const status = await hasPermission(getMessaging());
+        const granted = status === AuthorizationStatus.AUTHORIZED
+            || status === AuthorizationStatus.PROVISIONAL;
+        if (granted) return 'granted';
+        if (status === AuthorizationStatus.DENIED) return 'denied';
+        return 'denied';
+    } catch {
+        return 'denied';
+    }
+};
+
+const checkRNPermission = async (
+    iosPerm: any,
+    androidPerm: any,
+): Promise<Status> => {
+    const perm = Platform.OS === 'ios' ? iosPerm : androidPerm;
+    if (!perm) return 'denied';
+    const result = await check(perm);
+    if (result === RESULTS.GRANTED) return 'granted';
+    if (result === RESULTS.BLOCKED) return 'blocked';
+    return 'denied';
+};
+
+const nativeCheck = async (type: PermType): Promise<Status> => {
+    if (type === 'notifications') return checkNotifications();
+    if (type === 'camera') {
+        return checkRNPermission(PERMISSIONS.IOS.CAMERA, PERMISSIONS.ANDROID.CAMERA);
+    }
+    if (type === 'contacts') {
+        return checkRNPermission(PERMISSIONS.IOS.CONTACTS, PERMISSIONS.ANDROID.READ_CONTACTS);
+    }
+    return 'denied';
+};
+
+const requestNotificationsOS = async (): Promise<Status> => {
+    // Mirrors the chain previously inlined in Layout.requestNotificationPermissions:
+    // Android 13+ POST_NOTIFICATIONS → notifee → Firebase messaging.
+    if (Platform.OS === 'android' && Number(Platform.Version) >= 33) {
+        try {
+            await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
+        } catch {
+            // Continue — notifee/FCM still need their prompts on iOS / older Android.
+        }
+    }
+    try {
+        await notifee.requestPermission();
+    } catch {
+        // Continue to FCM.
+    }
+    try {
+        await requestPermission(getMessaging());
+    } catch {
+        // Treated as denied below via the post-request check.
+    }
+    return checkNotifications();
+};
+
+const performOSRequest = async (
+    type: PermType,
+    storePermissionsResponse: (perms: any) => void,
+): Promise<Status> => {
+    if (type === 'notifications') return requestNotificationsOS();
+    if (type === 'camera') {
+        try {
+            await requestOSCameraPermissions(storePermissionsResponse);
+        } catch {
+            return 'denied';
+        }
+        return checkRNPermission(PERMISSIONS.IOS.CAMERA, PERMISSIONS.ANDROID.CAMERA);
+    }
+    if (type === 'contacts') {
+        try {
+            await requestOSContactsPermissions(storePermissionsResponse);
+        } catch {
+            return 'denied';
+        }
+        return checkRNPermission(PERMISSIONS.IOS.CONTACTS, PERMISSIONS.ANDROID.READ_CONTACTS);
+    }
+    return 'denied';
+};
+
+const showPrimer = (type: PermType): Promise<boolean> => new Promise((resolve) => {
+    if (!primerListener) {
+        // No subscriber mounted yet — treat as a soft "not now" so we never
+        // skip straight to the OS prompt without an explainer.
+        resolve(false);
+        return;
+    }
+    primerListener({ type, resolve });
+});
+
+const fireGrantedListeners = (type: PermType) => {
+    const fns = grantedListeners[type].slice();
+    fns.forEach((fn) => {
+        try {
+            fn();
+        } catch {
+            // Listener errors must not break the orchestrator flow.
+        }
+    });
+};
+
+const request = async (type: PermType, opts: RequestOptions): Promise<RequestResult> => {
+    const native = await nativeCheck(type);
+    if (native === 'granted') {
+        await updateStateFor(type, { lastStatus: 'granted' });
+        opts.onGranted?.();
+        fireGrantedListeners(type);
+        return { status: 'granted', source: 'cached' };
+    }
+    if (native === 'blocked') {
+        await updateStateFor(type, { lastStatus: 'blocked' });
+        opts.onDenied?.('os');
+        return { status: 'blocked', source: 'cached' };
+    }
+
+    const state = await getStateFor(type);
+    const currentVersion = DeviceInfo.getVersion();
+    const sameVersion = state.appVersionAtLastAsk === currentVersion;
+
+    if (sameVersion && (state.softAskDismissCount || 0) >= SOFT_ASK_CAP) {
+        return { status: 'denied', source: 'cached' };
+    }
+
+    if (!sameVersion && (state.softAskDismissCount || 0) > 0) {
+        await updateStateFor(type, {
+            softAskDismissCount: 0,
+            appVersionAtLastAsk: currentVersion,
+        });
+    }
+
+    const allowed = await showPrimer(type);
+    if (!allowed) {
+        const refreshed = await getStateFor(type);
+        await updateStateFor(type, {
+            softAskedAt: Date.now(),
+            softAskDismissCount: (refreshed.softAskDismissCount || 0) + 1,
+            appVersionAtLastAsk: currentVersion,
+        });
+        opts.onDenied?.('soft');
+        return { status: 'denied', source: 'soft' };
+    }
+
+    const status = await performOSRequest(type, opts.storePermissionsResponse || noopStore);
+    await updateStateFor(type, {
+        osAskedAt: Date.now(),
+        lastStatus: status,
+        appVersionAtLastAsk: currentVersion,
+    });
+    if (status === 'granted') {
+        opts.onGranted?.();
+        fireGrantedListeners(type);
+    } else {
+        opts.onDenied?.('os');
+    }
+    return { status, source: 'os' };
+};
+
+const requestIfAppropriate = async (type: PermType, opts: RequestOptions): Promise<void> => {
+    const native = await nativeCheck(type);
+    if (native === 'granted') {
+        await updateStateFor(type, { lastStatus: 'granted' });
+        fireGrantedListeners(type);
+        return;
+    }
+    const state = await getStateFor(type);
+    // Once the OS has been asked once, opportunistic triggers stop. A user who
+    // explicitly visits the relevant feature can still re-enter via request().
+    if (state.osAskedAt) return;
+    await request(type, opts);
+};
+
+const getStatus = (type: PermType): Promise<Status> => nativeCheck(type);
+
+const maybeShowSecondSessionFallback = async (
+    navigationTourCount: number | undefined,
+): Promise<void> => {
+    if ((navigationTourCount || 0) < 1) return;
+    await requestIfAppropriate('notifications', { trigger: 'secondSession' });
+};
+
+export const registerPrimerListener = (fn: PrimerListener | null) => {
+    primerListener = fn;
+};
+
+export const onGranted = (type: PermType, fn: () => void): (() => void) => {
+    grantedListeners[type].push(fn);
+    return () => {
+        grantedListeners[type] = grantedListeners[type].filter((f) => f !== fn);
+    };
+};
+
+const permissions = {
+    request,
+    requestIfAppropriate,
+    getStatus,
+    maybeShowSecondSessionFallback,
+    registerPrimerListener,
+    onGranted,
+};
+
+export default permissions;


### PR DESCRIPTION
## Summary

- Removes the auto-fire notification permission chain from `Layout.tsx` that surfaced 3 OS dialogs (Android `POST_NOTIFICATIONS` → notifee → Firebase) the moment a user logged in. Login is now silent.
- Adds `permissionsOrchestrator` (TherrMobile-only) — single entry point for `notifications`, `camera`, `contacts`. Shows an in-app primer modal first, only triggers the OS prompt if the user taps Allow, and tracks per-permission state in MMKV (`therrPermissionPrompts`) with a 2-dismissal cap that resets on app upgrade.
- Adds `PermissionPrimerModal` — generic Paper Dialog mounted once at the root in `Layout.render()`, mirroring the existing `LocationUseDisclosureModal` pattern.
- Wires engagement-anchored notification soft-asks: first moment posted (`EditMoment`), first DM sent (`DirectMessage`), first connection accepted (`Notifications/index.tsx`), with a second-session fallback in `Layout.componentDidMount` for users who never engage.
- Adds primers in front of the existing camera (`EditMoment.onAddImage`) and contacts (`utilities/contacts.ts`) flows; location continues to use its existing `LocationUseDisclosureModal`.
- Replaces the auto-fire FCM token registration with `tryRegisterDeviceTokenIfAuthorized()` (uses `messaging().hasPermission()`) plus an orchestrator `onGranted('notifications', …)` listener — already-granted users still get tokens registered transparently; new grants register via the same path. A synchronous `fcmRegistrationStarted` flag closes the double-subscribe race; the flag and subscription are reset on logout so re-login refreshes the token.
- Adds `permissions.primer.{notifications,camera,contacts}` plus `permissions.primer.shared.{allow,notNow}` keys in parallel to `en-us`, `es`, and `fr-ca` dictionaries.

Implements item #1 ("Soft opt-in UX") from `docs/PUSH_NOTIFICATIONS_ENGAGEMENT_ROADMAP.md`. Industry baseline iOS opt-in is ~50%; well-anchored soft-asks typically reach 70–80%. The TODO at the old `Layout.tsx:1705` is removed in this commit.

## Test plan

Run on both iOS simulator and Android emulator (API 33+ to exercise `POST_NOTIFICATIONS`).

- [ ] Fresh install + login: zero OS permission dialogs fire. Background geolocation startup unchanged.
- [ ] Tap Map: existing `LocationUseDisclosureModal` flow unchanged.
- [ ] Tap camera in EditMoment: primer appears → Allow → OS prompt → image picker opens.
- [ ] Tap camera, dismiss primer twice: third tap shows no primer until app upgrade. Verify `therrPermissionPrompts.camera.softAskDismissCount === 2` in MMKV storage.
- [ ] Tap Find Friends: contacts primer appears → Allow → OS prompt → contacts sync runs.
- [ ] Send first DM: notification primer appears once. Allow → 3 OS prompts → device token registers (verify axios `x-user-device-token` header is set on subsequent requests).
- [ ] Post a first moment (not a draft): notification primer appears (or no-ops if already asked from DM/Connect path).
- [ ] Accept a connection request from Notifications screen: notification primer appears (or no-ops if already asked).
- [ ] Second session without engagement: kill and relaunch the app while logged in. Primer appears at app launch (fallback path).
- [ ] Granted-state upgrader: install previous build, accept everything, upgrade to this build, relaunch — zero primers, zero OS dialogs, FCM token still registers.
- [ ] Logout + login again: FCM token re-registers (`x-user-device-token` header refreshed, no double-subscription).
- [ ] Locales: set device language to Spanish then to fr-CA, verify primer titles/bodies render in each.
- [ ] `npm run lint` clean on the changed TherrMobile files; `i18n-sync` skill confirms parity across the 3 locale dictionaries.

https://claude.ai/code/session_0195ftoR1iDtBE74rS2tsDKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_0195ftoR1iDtBE74rS2tsDKQ)_