### PR TITLE
fix(mobile): bypass Paper TextInput for header search inputs

### DIFF
--- a/TherrMobile/main/components/Input/HeaderSearchInput.tsx
+++ b/TherrMobile/main/components/Input/HeaderSearchInput.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import { Platform, StyleSheet, TextInput as RNTextInput, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, TextInput as RNTextInput, TextInputProps, View } from 'react-native';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Badge } from 'react-native-paper';
-import { TextInputProps } from 'react-native';
 import 'react-native-gesture-handler';
 import { MapActions } from 'therr-react/redux/actions';
 import { IContentState, IMapState as IMapReduxState } from 'therr-react/types';
 import { FeatureFlags } from 'therr-js-utilities/constants';
-import RoundInput from './';
 import translator from '../../utilities/translator';
 import { ITherrThemeColors, ITherrThemeColorVariations } from '../../styles/themes';
 import TherrIcon from '../TherrIcon';
@@ -132,9 +130,6 @@ export class HeaderSearchInput extends React.Component<IHeaderSearchInputProps, 
     render() {
         const { inputText } = this.state;
         const { content, isAdvancedSearch, map, theme, themeForms, placeholderText } = this.props;
-        const textStyle = !inputText?.length
-            ? [themeForms.styles.placeholderText, { fontSize: 16 }]
-            : [themeForms.styles.inputText, { fontSize: 16 }];
         const mapFilters = {
             filtersAuthor: map.filtersAuthor,
             filtersCategory: map.filtersCategory,
@@ -150,49 +145,64 @@ export class HeaderSearchInput extends React.Component<IHeaderSearchInputProps, 
             filterCount += 1;
         }
 
+        const inputContainerStyle = [
+            themeForms.styles.inputContainerRound,
+            theme.styles.headerSearchInputContainer,
+            localStyles.row,
+        ];
+
+        const textInputStyle = [
+            Platform.OS !== 'ios' ? themeForms.styles.input : themeForms.styles.inputAlt,
+            localStyles.flex,
+            localStyles.textInputBase,
+            Platform.OS !== 'ios' ? localStyles.fontSizeDefault : localStyles.fontSizeIos,
+        ];
+
         return (
             <>
-                <RoundInput
-                    errorStyle={localStyles.hidden}
-                    style={textStyle}
-                    containerStyle={theme.styles.headerSearchContainer}
-                    inputStyle={
-                        [
-                            Platform.OS !== 'ios'
-                                ? themeForms.styles.input
-                                : themeForms.styles.inputAlt,
-                            Platform.OS !== 'ios'
-                                ? localStyles.fontSizeDefault
-                                : localStyles.fontSizeIos,
-                        ]
-                    }
-                    inputContainerStyle={[themeForms.styles.inputContainerRound, theme.styles.headerSearchInputContainer]}
-                    roundness={18}
-                    onChangeText={this.onInputChange}
-                    onFocus={() => this.handlePress('onfocus')}
-                    placeholder={placeholderText}
-                    placeholderTextColor={theme.colorVariations.textGrayFade}
-                    render={(inputProps) => (
+                <View style={[theme.styles.headerSearchContainer, inputContainerStyle]}>
+                    {isAdvancedSearch ? (
+                        // Areas screen: tapping the field navigates to AdvancedSearch instead of
+                        // accepting input in place. Wrap the input area in a Pressable so taps on
+                        // the text region (not just the icon) still trigger the navigation, and
+                        // make the inner field non-editable to suppress the keyboard.
+                        <Pressable
+                            style={localStyles.flexRow}
+                            onPress={() => this.handlePress('onpress')}
+                        >
+                            <RNTextInput
+                                editable={false}
+                                pointerEvents="none"
+                                placeholder={placeholderText}
+                                placeholderTextColor={theme.colorVariations.textGrayFade}
+                                style={textInputStyle}
+                                value={inputText}
+                            />
+                        </Pressable>
+                    ) : (
                         <RNTextInput
-                            {...inputProps}
+                            onChangeText={this.onInputChange}
+                            onFocus={() => this.handlePress('onfocus')}
                             placeholder={placeholderText}
                             placeholderTextColor={theme.colorVariations.textGrayFade}
+                            selectionColor={themeForms.colors.selectionColor as unknown as string}
+                            cursorColor={themeForms.colors.selectionColor as unknown as string}
+                            style={textInputStyle}
+                            value={inputText}
                         />
                     )}
-                    underlineColor="transparent"
-                    activeUnderlineColor="transparent"
-                    dense
-                    rightIcon={
+                    <Pressable
+                        onPress={() => this.handlePress('onpress')}
+                        hitSlop={8}
+                        style={localStyles.iconButton}
+                    >
                         <TherrIcon
                             name={isAdvancedSearch ? 'filters' : 'search'}
                             size={18}
                             color={theme.colors.primary3}
-                            onPress={() => this.handlePress('onpress')}
                         />
-                    }
-                    themeForms={themeForms}
-                    value={inputText}
-                />
+                    </Pressable>
+                </View>
                 {
                     isAdvancedSearch && filterCount > 0 &&
                     <View style={themeForms.styles.headerInputBadgeContainer}>
@@ -207,8 +217,30 @@ export class HeaderSearchInput extends React.Component<IHeaderSearchInputProps, 
 }
 
 const localStyles = StyleSheet.create({
-    hidden: {
-        display: 'none',
+    flex: {
+        flex: 1,
+    },
+    flexRow: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 12,
+    },
+    iconButton: {
+        paddingHorizontal: 4,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    textInputBase: {
+        margin: 0,
+        padding: 0,
+        paddingVertical: 0,
+        paddingHorizontal: 0,
+        backgroundColor: 'transparent',
     },
     fontSizeDefault: {
         fontSize: 16,

--- a/TherrMobile/main/components/Input/HeaderSearchUsersInput.tsx
+++ b/TherrMobile/main/components/Input/HeaderSearchUsersInput.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Platform, StyleSheet, TextInput as RNTextInput, TextInputProps } from 'react-native';
+import { Platform, StyleSheet, TextInput as RNTextInput, TextInputProps, View } from 'react-native';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import 'react-native-gesture-handler';
 import { IMapState as IMapReduxState } from 'therr-react/types';
-import RoundInput from '.';
 import translator from '../../utilities/translator';
 import { ITherrThemeColors, ITherrThemeColorVariations } from '../../styles/themes';
 import UsersActions from '../../redux/actions/UsersActions';
@@ -96,58 +95,64 @@ export class HeaderSearchUsersInput extends React.Component<IHeaderSearchUsersIn
     render() {
         const { inputText } = this.state;
         const { theme, themeForms } = this.props;
-        const textStyle = !inputText?.length
-            ? [themeForms.styles.placeholderText, { fontSize: 16 }]
-            : [themeForms.styles.inputText, { fontSize: 16 }];
         const placeholderText = this.translate('components.header.searchUsersInput.placeholder');
+
+        const inputContainerStyle = [
+            themeForms.styles.inputContainerRound,
+            theme.styles.headerSearchInputContainer,
+            localStyles.row,
+        ];
+
+        const textInputStyle = [
+            Platform.OS !== 'ios' ? themeForms.styles.input : themeForms.styles.inputAlt,
+            localStyles.flex,
+            localStyles.textInputBase,
+            Platform.OS !== 'ios' ? localStyles.fontSizeDefault : localStyles.fontSizeIos,
+        ];
+
         return (
-            <>
-                <RoundInput
-                    errorStyle={localStyles.hidden}
-                    style={textStyle}
-                    containerStyle={theme.styles.headerSearchContainer}
-                    inputStyle={
-                        [
-                            Platform.OS !== 'ios'
-                                ? themeForms.styles.input
-                                : themeForms.styles.inputAlt,
-                            Platform.OS !== 'ios'
-                                ? localStyles.fontSizeDefault
-                                : localStyles.fontSizeIos,
-                        ]
-                    }
-                    inputContainerStyle={[themeForms.styles.inputContainerRound, theme.styles.headerSearchInputContainer]}
-                    roundness={18}
+            <View style={[theme.styles.headerSearchContainer, inputContainerStyle]}>
+                <RNTextInput
                     onChangeText={this.onInputChange}
                     placeholder={placeholderText}
                     placeholderTextColor={theme.colorVariations.textGrayFade}
-                    render={(inputProps) => (
-                        <RNTextInput
-                            {...inputProps}
-                            placeholder={placeholderText}
-                            placeholderTextColor={theme.colorVariations.textGrayFade}
-                        />
-                    )}
-                    underlineColor="transparent"
-                    activeUnderlineColor="transparent"
-                    rightIcon={
-                        <TherrIcon
-                            name={'search'}
-                            size={18}
-                            color={theme.colors.primary3}
-                        />
-                    }
-                    themeForms={themeForms}
+                    selectionColor={themeForms.colors.selectionColor as unknown as string}
+                    cursorColor={themeForms.colors.selectionColor as unknown as string}
+                    style={textInputStyle}
                     value={inputText}
                 />
-            </>
+                <View style={localStyles.iconButton}>
+                    <TherrIcon
+                        name={'search'}
+                        size={18}
+                        color={theme.colors.primary3}
+                    />
+                </View>
+            </View>
         );
     }
 }
 
 const localStyles = StyleSheet.create({
-    hidden: {
-        display: 'none',
+    flex: {
+        flex: 1,
+    },
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 12,
+    },
+    iconButton: {
+        paddingHorizontal: 4,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    textInputBase: {
+        margin: 0,
+        padding: 0,
+        paddingVertical: 0,
+        paddingHorizontal: 0,
+        backgroundColor: 'transparent',
     },
     fontSizeDefault: {
         fontSize: 16,


### PR DESCRIPTION
The header search inputs (Map, Areas, Connect) were using a heavyweight
PaperTextInput with a `render` override (added in 5dd2c02 to work around
Paper's deferred placeholder state) on top of BaseInput's variant API.
Phase 5b's BaseInput refactor (2e67813, committed without lint/tsc
verification) reshuffled the destructuring and explicit-vs-spread prop
order around `value` / `placeholderTextColor` / `selectionColor`, leaving
the typing flow brittle and effectively non-functional in practice.

Bypass Paper entirely for these two inputs. They are visually just a
rounded box with a text field and a trailing icon — none of Paper's
animated label, focus ripple, or internal state machinery is needed.
Render a plain RNTextInput inside a styled View, with a sibling Pressable
for the icon. For the Areas screen (`isAdvancedSearch=true`) the field is
non-editable and wrapped in a Pressable that navigates to AdvancedSearch
on tap, matching the prior `onFocus -> navigate` behavior more reliably.

This also removes the placeholder race condition the original render
override was patching around.

https://claude.ai/code/session_01B3JHu1bq5hV3aH1pdCqtTj