### PR TITLE
fix(mobile): drop wrapper shadow on map FAB containers

### DIFF
--- a/TherrMobile/main/styles/buttons/index.ts
+++ b/TherrMobile/main/styles/buttons/index.ts
@@ -46,7 +46,6 @@ const getBtnGroupBtnStyles = (theme: ITherrTheme): any => ({
 
 const getFloatingBtnContainer = (_theme: ITherrTheme): any => ({
     position: 'absolute',
-    ...shadowSm,
     borderRadius: 100,
     padding: 0,
     alignItems: 'center',


### PR DESCRIPTION
The Phase 3 elevation refactor added shadowSm (which includes Android
elevation: 2) into getFloatingBtnContainer. The matchUp wrapper sets
both left: 0 and right: 0 to center the bonfire FAB, which makes that
View span the full screen width. With elevation on a no-background
View, Android painted a screen-wide rectangular shadow behind the row
of map action buttons.

The wrapper-level shadow is also redundant: react-native-paper's FAB
already renders its own per-button elevation/shadow. Removing the
spread leaves each FAB with its own shadow and eliminates the box
artifact.

Direct shadowSm usages on non-FAB elements (compass, recenter,
momentLayer*) are unchanged — they wrap their own surfaces and need
the explicit shadow.