### PR TITLE
fix(mobile): add missing forms.editMoment.deleteConfirmation translation

### DIFF
--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -561,6 +561,7 @@
         "insufficientFundsMessage": "The owner of this Space has insufficient funds to send you TherrCoin. We have notified them for an update.",
         "insufficientFundsMessage2": "Continue creating content without rewards?"
       },
+      "deleteConfirmation": "Are you sure you want to delete this moment?",
       "backendSuccessMessage": "Your moment was successfully saved!",
       "backendErrorMessage": "Connection error. Please try again later."
     },

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -561,6 +561,7 @@
         "insufficientFundsMessage": "El propietario de este espacio no tiene fondos suficientes para enviarte TherrCoin. Les hemos notificado para una actualización.",
         "insufficientFundsMessage2": "¿Continuar creando contenido sin recompensas?"
       },
+      "deleteConfirmation": "¿Estás seguro de que quieres eliminar este momento?",
       "backendSuccessMessage": "¡Tu momento se guardó exitosamente!",
       "backendErrorMessage": "Error de conexión. Por favor, inténtalo de nuevo más tarde."
     },

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -561,6 +561,7 @@
         "insufficientFundsMessage": "Le propriétaire de cet espace n'a pas suffisamment de fonds pour vous envoyer des TherrCoin. Nous l'avons notifié.",
         "insufficientFundsMessage2": "Continuer la création de contenu sans récompenses?"
       },
+      "deleteConfirmation": "Êtes-vous sûr de vouloir supprimer ce moment?",
       "backendSuccessMessage": "Votre moment a été sauvegardé avec succès!",
       "backendErrorMessage": "Erreur de connexion. Veuillez réessayer plus tard."
     },


### PR DESCRIPTION
ViewMoment renders this key in the delete-confirmation modal but it
was absent from all three locale dictionaries, so users saw the raw
key. Mirrors the existing editEvent/editSpace/editThought entries.