### PR TITLE
feat(mobile): auto-swap Firebase config files in switch-brand.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,12 @@ terminals.sh
 # GCP
 google-service.json*
 
+# Per-brand Firebase config vault (secrets, populated by developers from
+# Firebase Console; copied into TherrMobile/{android,ios} by switch-brand.sh).
+# See _bin/firebase/README.md.
+_bin/firebase/**/google-services.json
+_bin/firebase/**/GoogleService-Info.plist
+
 # android
 bugreport-sdk*
 .aider*

--- a/TherrMobile/android/app/google-services.example.json
+++ b/TherrMobile/android/app/google-services.example.json
@@ -1,62 +1,13 @@
 {
-  "_comment_": "Sanitized template of the merged google-services.json used by the Android Gradle plugin. Real file lives at TherrMobile/android/app/google-services.json (gitignored). See docs/SECRETS_AND_LOCAL_BOOTSTRAP.md and docs/MULTI_BRAND_ARCHITECTURE.md.",
-  "_purpose_": "Use this file to verify your local google-services.json has client blocks for every active brand variant. If your real file is missing any package_name listed below, re-export from Firebase Console.",
-  "project_info": {
-    "project_number": "REPLACE_WITH_FIREBASE_PROJECT_NUMBER",
-    "project_id": "therr-app",
-    "storage_bucket": "therr-app.firebasestorage.app"
+  "_comment_": "This file used to be a sanitized template of a merged google-services.json with one client[] entry per brand. The active build now uses a per-brand vault — see _bin/firebase/README.md.",
+  "_per_brand_templates_": {
+    "therr":  "_bin/firebase/therr/google-services.example.json",
+    "habits": "_bin/firebase/habits/google-services.example.json"
   },
-  "client": [
-    {
-      "_comment_": "Therr — the default brand variant",
-      "client_info": {
-        "mobilesdk_app_id": "REPLACE_WITH_MOBILESDK_APP_ID",
-        "android_client_info": {
-          "package_name": "app.therrmobile"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "REPLACE_WITH_OAUTH_CLIENT_ID",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "app.therrmobile",
-            "certificate_hash": "REPLACE_WITH_SHA1_FINGERPRINT_LOWERCASE_NO_COLONS"
-          }
-        }
-      ],
-      "api_key": [
-        { "current_key": "REPLACE_WITH_FIREBASE_API_KEY" }
-      ],
-      "services": {
-        "appinvite_service": { "other_platform_oauth_client": [] }
-      }
-    },
-    {
-      "_comment_": "Friends with Habits — niche brand variant on niche/HABITS-general",
-      "client_info": {
-        "mobilesdk_app_id": "REPLACE_WITH_MOBILESDK_APP_ID",
-        "android_client_info": {
-          "package_name": "com.therr.habits"
-        }
-      },
-      "oauth_client": [
-        {
-          "client_id": "REPLACE_WITH_OAUTH_CLIENT_ID",
-          "client_type": 1,
-          "android_info": {
-            "package_name": "com.therr.habits",
-            "certificate_hash": "REPLACE_WITH_SHA1_FINGERPRINT_LOWERCASE_NO_COLONS"
-          }
-        }
-      ],
-      "api_key": [
-        { "current_key": "REPLACE_WITH_FIREBASE_API_KEY" }
-      ],
-      "services": {
-        "appinvite_service": { "other_platform_oauth_client": [] }
-      }
-    }
-  ],
-  "configuration_version": "1"
+  "_active_file_": "TherrMobile/android/app/google-services.json (gitignored; populated by _bin/switch-brand.sh <brand>)",
+  "_see_also_": [
+    "_bin/firebase/README.md",
+    "docs/SECRETS_AND_LOCAL_BOOTSTRAP.md",
+    "docs/MULTI_BRAND_ARCHITECTURE.md"
+  ]
 }

--- a/_bin/firebase/README.md
+++ b/_bin/firebase/README.md
@@ -1,0 +1,92 @@
+# Per-brand Firebase config vault
+
+This directory holds the **source of truth** for the Firebase mobile-client
+config files used by each brand variation. The actual files (the ones with
+secret payloads) are gitignored; this README is committed so the convention
+is discoverable.
+
+## Directory layout
+
+```
+_bin/firebase/
+├── README.md                      <-- this file (committed)
+├── therr/
+│   ├── google-services.json       <-- Android, package_name=app.therrmobile
+│   └── GoogleService-Info.plist   <-- iOS, BUNDLE_ID=app.therrmobile
+├── habits/
+│   ├── google-services.json       <-- Android, package_name=com.therr.habits
+│   └── GoogleService-Info.plist   <-- iOS (when Habits ships on iOS)
+└── teem/
+    └── (future, when TEEM is registered in Firebase)
+```
+
+Each Firebase config file is the **unmodified single-app export** from
+Firebase Console — no manual merging required.
+
+## How it gets used
+
+`_bin/switch-brand.sh <brand>` copies the matching files into the active
+build locations every time it runs:
+
+| Source (this dir)                                   | Destination (active build)                              |
+|-----------------------------------------------------|---------------------------------------------------------|
+| `_bin/firebase/<brand>/google-services.json`        | `TherrMobile/android/app/google-services.json`          |
+| `_bin/firebase/<brand>/GoogleService-Info.plist`    | `TherrMobile/ios/TherrMobile/GoogleService-Info.plist`  |
+
+After copying, the script validates that the Android JSON's `package_name`
+matches the expected `applicationId` for the brand and prints the registered
+SHA-1 fingerprint so you can eyeball it against your local debug keystore.
+
+**Do not edit the destination files directly.** The next `switch-brand.sh`
+run will overwrite them. Edit the vault copy here, then re-run the script.
+
+## Populating the vault
+
+1. Firebase Console → therr-app project → Project Settings → Your apps.
+2. For each Android app entry (one per `package_name`):
+   - Click "Download google-services.json".
+   - Save to `_bin/firebase/<brand>/google-services.json` (overwriting any
+     previous copy).
+3. For each iOS app entry (one per `BUNDLE_ID`):
+   - Click "Download GoogleService-Info.plist".
+   - Save to `_bin/firebase/<brand>/GoogleService-Info.plist`.
+
+Then run `./_bin/switch-brand.sh <brand>` to verify and apply.
+
+See `docs/SECRETS_AND_LOCAL_BOOTSTRAP.md` for the broader secret-recovery
+procedure (includes other gitignored credentials beyond Firebase).
+
+## SHA-1 fingerprints (must be registered upstream, not stored here)
+
+`google-services.json` embeds the SHA-1 fingerprints registered for that
+Android app in Firebase Console. If your local debug keystore changes, or
+you build from a new machine, the SHA-1 won't match and Google Sign-In will
+silently cancel. Print your local SHA-1 with:
+
+```bash
+keytool -list -v \
+    -keystore TherrMobile/android/app/debug.keystore \
+    -alias androiddebugkey \
+    -storepass android -keypass android | grep SHA1
+```
+
+If the printed value doesn't appear in the matching brand's
+`_bin/firebase/<brand>/google-services.json` (under
+`oauth_client[].android_info.certificate_hash`, lowercase, no colons),
+add it in Firebase Console under that Android app's "SHA certificate
+fingerprints" and re-download the JSON into the vault.
+
+## Shared Firebase project (today)
+
+All brand variants share **one** Firebase project, `therr-app`. They each
+have their own Android/iOS app entry within that project, which is what
+makes the per-brand-file split clean: each export contains only that
+brand's `client[]` (Android) or whole-file (iOS) config, but the
+`project_info.project_number` is the same across both — and that
+`project_number` is the prefix on the `googleOAuth2WebClientId*` values in
+`TherrMobile/env-config.js`. So the webClientId in env-config.js is the
+same for both brands and never needs to change when switching.
+
+If/when a brand splits into its own Firebase project, see
+`docs/MULTI_BRAND_ARCHITECTURE.md` "Migration path: when to split into
+per-brand Firebase projects" for the full procedure.

--- a/_bin/firebase/README.md
+++ b/_bin/firebase/README.md
@@ -9,19 +9,24 @@ is discoverable.
 
 ```
 _bin/firebase/
-├── README.md                      <-- this file (committed)
+├── README.md                              <-- this file (committed)
 ├── therr/
-│   ├── google-services.json       <-- Android, package_name=app.therrmobile
-│   └── GoogleService-Info.plist   <-- iOS, BUNDLE_ID=app.therrmobile
+│   ├── google-services.example.json       <-- committed sanitized template
+│   ├── google-services.json               <-- Android, package_name=app.therrmobile (gitignored)
+│   └── GoogleService-Info.plist           <-- iOS, BUNDLE_ID=app.therrmobile (gitignored)
 ├── habits/
-│   ├── google-services.json       <-- Android, package_name=com.therr.habits
-│   └── GoogleService-Info.plist   <-- iOS (when Habits ships on iOS)
+│   ├── google-services.example.json       <-- committed sanitized template
+│   ├── google-services.json               <-- Android, package_name=com.therr.habits (gitignored)
+│   └── GoogleService-Info.plist           <-- iOS, when Habits ships on iOS (gitignored)
 └── teem/
     └── (future, when TEEM is registered in Firebase)
 ```
 
-Each Firebase config file is the **unmodified single-app export** from
-Firebase Console — no manual merging required.
+Each `google-services.json` is the **unmodified single-app export** from
+Firebase Console — no manual merging required. The sibling
+`google-services.example.json` is a committed, sanitized template you can
+diff your real file against to confirm shape (one `client[]` entry,
+correct `package_name`).
 
 ## How it gets used
 

--- a/_bin/firebase/habits/google-services.example.json
+++ b/_bin/firebase/habits/google-services.example.json
@@ -1,0 +1,36 @@
+{
+  "_comment_": "Sanitized template of the Friends-with-Habits google-services.json placed under the per-brand vault at _bin/firebase/habits/. The real (gitignored) file with secrets sits next to it as google-services.json. _bin/switch-brand.sh habits copies the real file into TherrMobile/android/app/google-services.json. See _bin/firebase/README.md and docs/SECRETS_AND_LOCAL_BOOTSTRAP.md.",
+  "_purpose_": "Use this file to verify the shape of your local _bin/firebase/habits/google-services.json. It should contain exactly one client[] entry, with package_name == com.therr.habits. If your real file has more or different entries, re-export the Habits Android app from Firebase Console.",
+  "project_info": {
+    "project_number": "REPLACE_WITH_FIREBASE_PROJECT_NUMBER",
+    "project_id": "therr-app",
+    "storage_bucket": "therr-app.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "REPLACE_WITH_MOBILESDK_APP_ID",
+        "android_client_info": {
+          "package_name": "com.therr.habits"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "REPLACE_WITH_OAUTH_CLIENT_ID",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.therr.habits",
+            "certificate_hash": "REPLACE_WITH_SHA1_FINGERPRINT_LOWERCASE_NO_COLONS"
+          }
+        }
+      ],
+      "api_key": [
+        { "current_key": "REPLACE_WITH_FIREBASE_API_KEY" }
+      ],
+      "services": {
+        "appinvite_service": { "other_platform_oauth_client": [] }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/_bin/firebase/therr/google-services.example.json
+++ b/_bin/firebase/therr/google-services.example.json
@@ -1,0 +1,36 @@
+{
+  "_comment_": "Sanitized template of the Therr-brand google-services.json placed under the per-brand vault at _bin/firebase/therr/. The real (gitignored) file with secrets sits next to it as google-services.json. _bin/switch-brand.sh therr copies the real file into TherrMobile/android/app/google-services.json. See _bin/firebase/README.md and docs/SECRETS_AND_LOCAL_BOOTSTRAP.md.",
+  "_purpose_": "Use this file to verify the shape of your local _bin/firebase/therr/google-services.json. It should contain exactly one client[] entry, with package_name == app.therrmobile. If your real file has more or different entries, re-export the Therr Android app from Firebase Console.",
+  "project_info": {
+    "project_number": "REPLACE_WITH_FIREBASE_PROJECT_NUMBER",
+    "project_id": "therr-app",
+    "storage_bucket": "therr-app.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "REPLACE_WITH_MOBILESDK_APP_ID",
+        "android_client_info": {
+          "package_name": "app.therrmobile"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "REPLACE_WITH_OAUTH_CLIENT_ID",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "app.therrmobile",
+            "certificate_hash": "REPLACE_WITH_SHA1_FINGERPRINT_LOWERCASE_NO_COLONS"
+          }
+        }
+      ],
+      "api_key": [
+        { "current_key": "REPLACE_WITH_FIREBASE_API_KEY" }
+      ],
+      "services": {
+        "appinvite_service": { "other_platform_oauth_client": [] }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/_bin/switch-brand.sh
+++ b/_bin/switch-brand.sh
@@ -121,8 +121,19 @@ if [ -f "$ANDROID_GS_SRC" ]; then
     fi
 else
     printMessageWarning "No source file at $ANDROID_GS_SRC"
-    printMessageWarning "  Android build for $TARGET_LOWER will use whatever is currently at $ANDROID_GS_DST"
-    printMessageWarning "  See _bin/firebase/README.md and docs/SECRETS_AND_LOCAL_BOOTSTRAP.md to populate the vault."
+    if [ -f "$ANDROID_GS_DST" ] && command -v jq >/dev/null 2>&1; then
+        DEST_PKGS=$(jq -r '.client[].client_info.android_client_info.package_name' "$ANDROID_GS_DST" | tr '\n' ' ')
+        if echo " $DEST_PKGS " | grep -q " $EXPECTED_PKG "; then
+            printMessageWarning "  Existing $ANDROID_GS_DST already contains $EXPECTED_PKG — proceeding."
+        else
+            printMessageError "Existing $ANDROID_GS_DST has package_name(s) [$DEST_PKGS] but $TARGET_LOWER build expects [$EXPECTED_PKG]."
+            printMessageError "Populate $ANDROID_GS_SRC from Firebase Console (see _bin/firebase/README.md) before building."
+            exit 1
+        fi
+    else
+        printMessageWarning "  Android build for $TARGET_LOWER will use whatever is currently at $ANDROID_GS_DST"
+        printMessageWarning "  See _bin/firebase/README.md and docs/SECRETS_AND_LOCAL_BOOTSTRAP.md to populate the vault."
+    fi
 fi
 
 # 3b. iOS GoogleService-Info.plist (only Therr ships iOS today; absent for niches is OK)

--- a/_bin/switch-brand.sh
+++ b/_bin/switch-brand.sh
@@ -9,9 +9,15 @@
 #   1. Warns (does not block) if current git branch doesn't match target brand.
 #   2. Rewrites CURRENT_BRAND_VARIATION in TherrMobile/main/config/brandConfig.ts
 #      if it doesn't already match the target.
-#   3. Kills any running Metro bundler process.
-#   4. Clears Metro's temp caches.
-#   5. Prints next commands to run.
+#   3. Syncs Firebase config files for the target brand from the per-brand vault
+#      at _bin/firebase/<brand>/ into the active build locations
+#      (TherrMobile/android/app/google-services.json and
+#      TherrMobile/ios/TherrMobile/GoogleService-Info.plist), validates the
+#      Android JSON's package_name, and clears Gradle's generated
+#      google-services resource directory so the next build re-derives it.
+#   4. Kills any running Metro bundler process.
+#   5. Clears Metro's temp caches.
+#   6. Prints next commands to run.
 
 set -e
 
@@ -39,14 +45,17 @@ case "$TARGET_LOWER" in
     habits)
         EXPECTED_BRANCH="niche/HABITS-general"
         ENUM_KEY="HABITS"
+        EXPECTED_PKG="com.therr.habits"
         ;;
     therr)
         EXPECTED_BRANCH="general"
         ENUM_KEY="THERR"
+        EXPECTED_PKG="app.therrmobile"
         ;;
     teem)
         EXPECTED_BRANCH="niche/TEEM-general"
         ENUM_KEY="TEEM"
+        EXPECTED_PKG="com.therr.teem"
         ;;
     *)
         printMessageError "Unknown brand: $TARGET_RAW"
@@ -81,7 +90,58 @@ else
     sed -i '' -E "s/(export const CURRENT_BRAND_VARIATION = BrandVariations\.)[A-Z]+;/\1${ENUM_KEY};/" "$BRAND_CONFIG"
 fi
 
-# 3. Kill Metro (tolerant of no-match).
+# 3. Sync Firebase config files from the per-brand vault.
+#    Source of truth: _bin/firebase/<brand>/{google-services.json,GoogleService-Info.plist}
+#    See _bin/firebase/README.md for how to populate the vault.
+FIREBASE_VAULT="$REPO_ROOT/_bin/firebase/$TARGET_LOWER"
+ANDROID_GS_SRC="$FIREBASE_VAULT/google-services.json"
+ANDROID_GS_DST="$REPO_ROOT/TherrMobile/android/app/google-services.json"
+IOS_PLIST_SRC="$FIREBASE_VAULT/GoogleService-Info.plist"
+IOS_PLIST_DST="$REPO_ROOT/TherrMobile/ios/TherrMobile/GoogleService-Info.plist"
+
+# 3a. Android google-services.json
+if [ -f "$ANDROID_GS_SRC" ]; then
+    cp "$ANDROID_GS_SRC" "$ANDROID_GS_DST"
+    printMessageSuccess "Copied $TARGET_LOWER google-services.json → TherrMobile/android/app/"
+    if command -v jq >/dev/null 2>&1; then
+        ACTUAL_PKGS=$(jq -r '.client[].client_info.android_client_info.package_name' "$ANDROID_GS_DST" | tr '\n' ' ')
+        if echo " $ACTUAL_PKGS " | grep -q " $EXPECTED_PKG "; then
+            printMessageNeutral "  package_name OK: $EXPECTED_PKG present"
+            SHA1=$(jq -r --arg pkg "$EXPECTED_PKG" \
+                '.client[] | select(.client_info.android_client_info.package_name==$pkg) | .oauth_client[0].android_info.certificate_hash // "(none registered)"' \
+                "$ANDROID_GS_DST")
+            printMessageNeutral "  registered SHA-1: $SHA1"
+        else
+            printMessageError "google-services.json has package_name(s) [$ACTUAL_PKGS] but expected [$EXPECTED_PKG]"
+            printMessageError "Re-export the $TARGET_LOWER Android app from Firebase Console and save to $ANDROID_GS_SRC"
+            exit 1
+        fi
+    else
+        printMessageWarning "jq not installed — skipping google-services.json validation. Install jq to enable."
+    fi
+else
+    printMessageWarning "No source file at $ANDROID_GS_SRC"
+    printMessageWarning "  Android build for $TARGET_LOWER will use whatever is currently at $ANDROID_GS_DST"
+    printMessageWarning "  See _bin/firebase/README.md and docs/SECRETS_AND_LOCAL_BOOTSTRAP.md to populate the vault."
+fi
+
+# 3b. iOS GoogleService-Info.plist (only Therr ships iOS today; absent for niches is OK)
+if [ -f "$IOS_PLIST_SRC" ]; then
+    cp "$IOS_PLIST_SRC" "$IOS_PLIST_DST"
+    printMessageSuccess "Copied $TARGET_LOWER GoogleService-Info.plist → TherrMobile/ios/TherrMobile/"
+elif [ "$TARGET_LOWER" = "therr" ]; then
+    printMessageWarning "No source file at $IOS_PLIST_SRC — iOS Therr build will use whatever is currently at $IOS_PLIST_DST"
+fi
+
+# 3c. Invalidate Gradle's generated google-services resources so the next build
+#     re-derives strings.xml (default_web_client_id, etc.) from the new JSON.
+GRADLE_GEN_DIR="$REPO_ROOT/TherrMobile/android/app/build/generated/res/google-services"
+if [ -d "$GRADLE_GEN_DIR" ]; then
+    rm -rf "$GRADLE_GEN_DIR"
+    printMessageNeutral "Cleared Gradle's generated google-services resources."
+fi
+
+# 4. Kill Metro (tolerant of no-match).
 if pgrep -f "react-native.*start" >/dev/null 2>&1; then
     printMessageNeutral "Killing running Metro bundler..."
     pkill -f "react-native.*start" || true
@@ -90,7 +150,7 @@ else
     printMessageNeutral "No Metro bundler running."
 fi
 
-# 4. Clear Metro caches.
+# 5. Clear Metro caches.
 printMessageNeutral "Clearing Metro / Haste caches..."
 rm -rf "${TMPDIR}"metro-* 2>/dev/null || true
 rm -rf "${TMPDIR}"haste-map-* 2>/dev/null || true

--- a/docs/MULTI_BRAND_ARCHITECTURE.md
+++ b/docs/MULTI_BRAND_ARCHITECTURE.md
@@ -239,15 +239,29 @@ The mobile-client side of Firebase is structured differently from the
 backend push-notification service. Read this section before introducing a
 new brand or attempting to split projects.
 
-### Current state (as of 2026-04)
+### Current state (as of 2026-05)
 
 **Single shared Firebase project (`therr-app`) for all brand variants on the
-mobile client.** The Android client uses one merged `google-services.json`
-at `TherrMobile/android/app/google-services.json` containing one `client[]`
-entry per registered `applicationId`. Gradle's
-`com.google.gms.google-services` plugin selects the matching client block at
-build time based on the build's `applicationId` (e.g., `com.therr.habits`
-selects the HABITS client block).
+mobile client.** Per-brand Firebase config files live in a gitignored vault
+at `_bin/firebase/<brand>/`, and `_bin/switch-brand.sh <brand>` copies the
+matching files into the active build locations every time it runs:
+
+| Source                                              | Destination                                              |
+|-----------------------------------------------------|----------------------------------------------------------|
+| `_bin/firebase/<brand>/google-services.json`        | `TherrMobile/android/app/google-services.json`           |
+| `_bin/firebase/<brand>/GoogleService-Info.plist`    | `TherrMobile/ios/TherrMobile/GoogleService-Info.plist`   |
+
+Each vault file is the unmodified single-app export from Firebase Console —
+no manual merging. After copying, `switch-brand.sh` validates that the
+Android JSON's `package_name` matches the brand's expected `applicationId`
+and prints the registered SHA-1, failing loudly on mismatch. It also
+clears `TherrMobile/android/app/build/generated/res/google-services` so
+Gradle re-derives `default_web_client_id` strings.xml from the new JSON
+on the next build.
+
+The active build files are gitignored and treated as build artifacts; do
+not edit them by hand. See `_bin/firebase/README.md` for the vault
+convention and population procedure.
 
 The Android `namespace` stays `app.therrmobile` across all brands so Kotlin
 source paths don't change. Only the `applicationId` (defined in
@@ -292,27 +306,22 @@ This is **fine for MVP** but becomes painful once any brand needs:
 
 ### Risks of the current single-project model
 
-1. **Bus factor.** The active `google-services.json` is gitignored and
-   reconstructable only by re-exporting from Firebase Console for every
-   registered app and merging the `client[]` arrays manually. See
-   `docs/SECRETS_AND_LOCAL_BOOTSTRAP.md` for the recovery procedure.
-
-2. **Cross-brand contamination.** A noisy crash in Therr clutters HABITS'
+1. **Cross-brand contamination.** A noisy crash in Therr clutters HABITS'
    Crashlytics dashboard and vice versa. Alert rules on issue count get
    noisier as brand count grows.
 
-3. **No template-in-repo by default.** A new developer cloning the repo
-   cannot build until they obtain the file out-of-band. Mitigated by
-   `TherrMobile/android/app/google-services.example.json` (sanitized
-   template) — keep the example file's `package_name` list current as new
-   brands are added.
+2. **No template-in-repo by default.** A new developer cloning the repo
+   cannot build until they obtain the per-brand vault files out-of-band.
+   Mitigated by `_bin/firebase/README.md` (the populating procedure) and
+   `TherrMobile/android/app/google-services.example.json` (legacy sanitized
+   template — staged for replacement with per-brand examples; see
+   `docs/PEER_REVIEW_FOLLOWUP.md`).
 
-4. **iOS does not support the merged-file pattern.** Each `BUNDLE_ID`
+3. **iOS does not support a merged-file pattern.** Each `BUNDLE_ID`
    requires its own `GoogleService-Info.plist`. Today only the Therr
-   variant is configured for iOS. When HABITS iOS ships, the build
-   pipeline will need either Xcode build phase scheme switching or a
-   `_bin/switch-brand.sh` extension that copies the correct plist into
-   place.
+   variant is configured for iOS. When HABITS iOS ships, populate
+   `_bin/firebase/habits/GoogleService-Info.plist` and `switch-brand.sh`
+   will copy it on its own.
 
 ### Migration path: when to split into per-brand Firebase projects
 
@@ -332,13 +341,16 @@ Migration playbook (when a trigger fires):
 2. Register the brand's Android `applicationId` and iOS `BUNDLE_ID` in the
    new project; collect SHA-1 fingerprints from existing keystores and
    register them
-3. Extract the brand's `client[]` entry from the merged
-   `google-services.json` and replace it with the new project's exported
-   block; place the new file at `TherrMobile/android/app/src/<brand>/google-services.json`
-4. Convert `TherrMobile/android/app/build.gradle` to use Gradle product
-   flavors so the per-flavor `google-services.json` is selected
-   automatically; update `_bin/switch-brand.sh` to no longer copy the
-   merged file (it'll select via flavor)
+3. Replace the brand's vault entry at
+   `_bin/firebase/<brand>/google-services.json` with the new project's
+   exported block. (Optionally relocate the vault into Gradle's
+   per-flavor source-set path `TherrMobile/android/app/src/<brand>/google-services.json`
+   if migrating to product flavors at the same time.)
+4. Either keep the existing `_bin/switch-brand.sh` copy step (it works
+   unchanged for split projects, since the vault file is now from the
+   brand's own project) OR convert `TherrMobile/android/app/build.gradle`
+   to use Gradle product flavors so per-flavor `google-services.json` is
+   selected automatically without a copy step.
 5. Add a new `PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_<BRAND>` env var
    to the backend push service, populated with a service-account export
    from the new project
@@ -350,8 +362,9 @@ Migration playbook (when a trigger fires):
    once token refresh is statistically complete).
 7. Update `docs/SECRETS_AND_LOCAL_BOOTSTRAP.md` with the new project's
    recovery procedure.
-8. Update `TherrMobile/android/app/google-services.example.json` to remove
-   the brand's client entry (it's no longer in the merged file).
+8. Update `TherrMobile/android/app/google-services.example.json` (or its
+   per-brand replacements per `docs/PEER_REVIEW_FOLLOWUP.md`) to reflect
+   the brand's new project assignment.
 
 This work is meaningful (~1 week) and risky (FCM token transition window).
 Do not undertake it speculatively — wait for an actual trigger.

--- a/docs/MULTI_BRAND_ARCHITECTURE.md
+++ b/docs/MULTI_BRAND_ARCHITECTURE.md
@@ -313,9 +313,11 @@ This is **fine for MVP** but becomes painful once any brand needs:
 2. **No template-in-repo by default.** A new developer cloning the repo
    cannot build until they obtain the per-brand vault files out-of-band.
    Mitigated by `_bin/firebase/README.md` (the populating procedure) and
-   `TherrMobile/android/app/google-services.example.json` (legacy sanitized
-   template — staged for replacement with per-brand examples; see
-   `docs/PEER_REVIEW_FOLLOWUP.md`).
+   per-brand sanitized templates committed alongside the vault
+   (`_bin/firebase/<brand>/google-services.example.json`).
+   `TherrMobile/android/app/google-services.example.json` is retained as a
+   pointer file listing the per-brand template paths for discoverability
+   in the conventional location.
 
 3. **iOS does not support a merged-file pattern.** Each `BUNDLE_ID`
    requires its own `GoogleService-Info.plist`. Today only the Therr
@@ -362,9 +364,10 @@ Migration playbook (when a trigger fires):
    once token refresh is statistically complete).
 7. Update `docs/SECRETS_AND_LOCAL_BOOTSTRAP.md` with the new project's
    recovery procedure.
-8. Update `TherrMobile/android/app/google-services.example.json` (or its
-   per-brand replacements per `docs/PEER_REVIEW_FOLLOWUP.md`) to reflect
-   the brand's new project assignment.
+8. Update `_bin/firebase/<brand>/google-services.example.json` to reflect
+   the brand's new project assignment (and the pointer at
+   `TherrMobile/android/app/google-services.example.json` if the brand
+   list changes).
 
 This work is meaningful (~1 week) and risky (FCM token transition window).
 Do not undertake it speculatively — wait for an actual trigger.

--- a/docs/PEER_REVIEW_FOLLOWUP.md
+++ b/docs/PEER_REVIEW_FOLLOWUP.md
@@ -109,6 +109,33 @@ The baseline must monotonically decrease — never raise it without explicit jus
 
 ---
 
+### Replace `google-services.example.json` with per-brand sanitized examples
+
+**Status**: Open
+**Origin**: Per-brand Firebase config vault rollout (2026-05, on `general`)
+
+`TherrMobile/android/app/google-services.example.json` was originally written
+to demonstrate the merged-file shape (multiple `client[]` entries across both
+`app.therrmobile` and `com.therr.habits`). With the per-brand vault pattern
+in `_bin/firebase/<brand>/`, the active build file holds exactly one
+`client[]` entry, so the legacy template is misleading.
+
+**Steps**:
+
+1. Generate sanitized per-brand templates committed alongside the vault, e.g.
+   `_bin/firebase/therr/google-services.example.json` and
+   `_bin/firebase/habits/google-services.example.json` (single `client[]`
+   each, secrets scrubbed).
+2. Either delete `TherrMobile/android/app/google-services.example.json` or
+   rewrite it to reference the per-brand templates.
+3. Update `_bin/firebase/README.md` and
+   `docs/SECRETS_AND_LOCAL_BOOTSTRAP.md` to point at the new templates.
+
+Low priority — the vault README already explains the populating procedure;
+the legacy template is a sanity-check aid, not a build-blocking artifact.
+
+---
+
 ## Done
 
 _Move entries here with the merge SHA when complete; trim periodically._

--- a/docs/PEER_REVIEW_FOLLOWUP.md
+++ b/docs/PEER_REVIEW_FOLLOWUP.md
@@ -109,36 +109,21 @@ The baseline must monotonically decrease — never raise it without explicit jus
 
 ---
 
-### Replace `google-services.example.json` with per-brand sanitized examples
-
-**Status**: Open
-**Origin**: Per-brand Firebase config vault rollout (2026-05, on `general`)
-
-`TherrMobile/android/app/google-services.example.json` was originally written
-to demonstrate the merged-file shape (multiple `client[]` entries across both
-`app.therrmobile` and `com.therr.habits`). With the per-brand vault pattern
-in `_bin/firebase/<brand>/`, the active build file holds exactly one
-`client[]` entry, so the legacy template is misleading.
-
-**Steps**:
-
-1. Generate sanitized per-brand templates committed alongside the vault, e.g.
-   `_bin/firebase/therr/google-services.example.json` and
-   `_bin/firebase/habits/google-services.example.json` (single `client[]`
-   each, secrets scrubbed).
-2. Either delete `TherrMobile/android/app/google-services.example.json` or
-   rewrite it to reference the per-brand templates.
-3. Update `_bin/firebase/README.md` and
-   `docs/SECRETS_AND_LOCAL_BOOTSTRAP.md` to point at the new templates.
-
-Low priority — the vault README already explains the populating procedure;
-the legacy template is a sanity-check aid, not a build-blocking artifact.
-
----
-
 ## Done
 
 _Move entries here with the merge SHA when complete; trim periodically._
+
+### 2. Replace `google-services.example.json` with per-brand sanitized examples (2026-05-10, pending merge to `general`)
+
+Added committed sanitized templates at
+`_bin/firebase/therr/google-services.example.json` and
+`_bin/firebase/habits/google-services.example.json` — one `client[]` entry
+each, secrets scrubbed. Rewrote
+`TherrMobile/android/app/google-services.example.json` as a pointer file
+listing the per-brand template paths (kept for discoverability in the
+conventional location). Updated `_bin/firebase/README.md`,
+`docs/SECRETS_AND_LOCAL_BOOTSTRAP.md`, and `docs/MULTI_BRAND_ARCHITECTURE.md`
+to reference the new templates.
 
 ### 1. Unify `BrandScopedStore.ts` across services (2026-04-28, on `general`)
 

--- a/docs/SECRETS_AND_LOCAL_BOOTSTRAP.md
+++ b/docs/SECRETS_AND_LOCAL_BOOTSTRAP.md
@@ -35,16 +35,23 @@ document and have a working build.
 ### `TherrMobile/android/app/google-services.json`
 
 **What it is:** Firebase configuration for the Android client. Defines the
-Firebase project and a `client[]` entry per registered `applicationId`. Read
-by Gradle's `com.google.gms.google-services` plugin at build time, which
-selects the matching client block from the build's `applicationId`.
+Firebase project and a `client[]` entry for the build's `applicationId`. Read
+by Gradle's `com.google.gms.google-services` plugin at build time.
 
-**Current contents (as of 2026-04-23):**
+**Source of truth:** Per-brand vault at `_bin/firebase/<brand>/google-services.json`
+(also gitignored). The active build file at
+`TherrMobile/android/app/google-services.json` is **populated by
+`_bin/switch-brand.sh <brand>`** — it is treated as a build artifact, not a
+hand-edited file. Editing it directly will be overwritten by the next
+`switch-brand.sh` run. See `_bin/firebase/README.md` for the vault convention.
+
+**Current contents (as of 2026-05-10):**
 - Project: `therr-app` (single Firebase project shared by all brand variants)
-- Registered `package_name`s:
-  - `app.therrmobile` (Therr — the default brand)
+- Active file contains exactly one `client[]` entry — the brand currently
+  selected by the most recent `switch-brand.sh` invocation:
+  - `app.therrmobile` (Therr — default brand)
   - `com.therr.habits` (Friends with Habits)
-  - Future TEEM `package_name` should be added here when introduced
+  - Future TEEM `package_name` will be added when registered in Firebase.
 
 **Why gitignored:** Contains an OAuth client ID and API key. Even though both
 are scoped (the OAuth client is restricted to the registered SHA-1
@@ -53,25 +60,27 @@ of the repo reduces the blast radius of an accidental public repo flip.
 
 **Regenerate from upstream if lost:**
 1. Sign in to https://console.firebase.google.com/project/therr-app/settings/general
-2. Under "Your apps", click each Android app entry
-3. Click "Download google-services.json" — repeat for each registered app
-4. The downloaded files each contain the full project config and a single
-   `client[]` entry for that app
-5. Manually merge: take any one as the base, then copy the `client[]` array
-   entries from the others into the base's `client[]` array
-6. Save the merged file at `TherrMobile/android/app/google-services.json`
-7. Verify by building both Therr (`switch-brand.sh therr`) and Habits
-   (`switch-brand.sh habits`) — both should succeed without the
-   "No matching client found" Gradle error
+2. Under "Your apps", for **each** registered Android app, click "Download
+   google-services.json".
+3. Save each download to `_bin/firebase/<brand>/google-services.json` —
+   `therr/` for `app.therrmobile`, `habits/` for `com.therr.habits`. No
+   manual merging required; each file holds exactly one `client[]` entry.
+4. Run `./_bin/switch-brand.sh <brand>` to copy the matching file into
+   `TherrMobile/android/app/google-services.json` and validate it. The
+   script will fail loudly if the JSON's `package_name` doesn't match the
+   brand's expected `applicationId`.
+5. Verify by building (`cd TherrMobile && npm run android:<brand>`) — should
+   succeed without the "No matching client found" Gradle error.
 
 **Sanity-check template:** `TherrMobile/android/app/google-services.example.json`
-shows the expected shape (with secrets scrubbed). Compare your real file's
-`client[].client_info.android_client_info.package_name` list to the example;
-if the real file is missing entries listed in the example, you have a stale
-copy and need to re-export from Firebase Console.
+shows the expected shape (with secrets scrubbed). NOTE: that template still
+shows the legacy merged-file shape (multiple `client[]` entries); the active
+file under the per-brand-vault pattern will have exactly one. The template
+is staged for replacement — see `docs/PEER_REVIEW_FOLLOWUP.md`.
 
 **See also:** `docs/MULTI_BRAND_ARCHITECTURE.md` for the brand-flag-driven
-build behavior; `TherrMobile/CLAUDE.md` for module-resolution gotchas.
+build behavior; `_bin/firebase/README.md` for the vault layout and
+populating procedure; `TherrMobile/CLAUDE.md` for module-resolution gotchas.
 
 ---
 
@@ -84,15 +93,21 @@ Firebase iOS SDK at runtime (not build time).
 Android counterpart, this is per-Firebase-project. iOS does NOT support the
 merged-file pattern — each `BUNDLE_ID` requires its own plist.
 
-**Per-brand handling:** Currently the iOS build serves only Therr. When
-HABITS iOS ships, the build pipeline will need either Xcode build phase
-schemes that swap the plist or an `_bin/switch-brand.sh` extension that
-copies from `_bin/firebase/<brand>/GoogleService-Info.plist`.
+**Source of truth:** Per-brand vault at
+`_bin/firebase/<brand>/GoogleService-Info.plist`. `_bin/switch-brand.sh
+<brand>` copies the matching file into
+`TherrMobile/ios/TherrMobile/GoogleService-Info.plist` on every run.
+Currently only `_bin/firebase/therr/GoogleService-Info.plist` is populated
+because Therr is the only brand shipping iOS today; switching to a niche
+brand without a vault plist leaves the Therr plist in place and prints a
+non-fatal warning.
 
 **Regenerate from upstream if lost:**
-1. Firebase Console → therr-app project → iOS app entry
-2. Download `GoogleService-Info.plist`
-3. Place at `TherrMobile/ios/TherrMobile/GoogleService-Info.plist`
+1. Firebase Console → therr-app project → iOS app entry for the brand.
+2. Download `GoogleService-Info.plist`.
+3. Save to `_bin/firebase/<brand>/GoogleService-Info.plist`.
+4. Run `./_bin/switch-brand.sh <brand>` to copy it into
+   `TherrMobile/ios/TherrMobile/GoogleService-Info.plist`.
 
 ---
 

--- a/docs/SECRETS_AND_LOCAL_BOOTSTRAP.md
+++ b/docs/SECRETS_AND_LOCAL_BOOTSTRAP.md
@@ -72,11 +72,18 @@ of the repo reduces the blast radius of an accidental public repo flip.
 5. Verify by building (`cd TherrMobile && npm run android:<brand>`) — should
    succeed without the "No matching client found" Gradle error.
 
-**Sanity-check template:** `TherrMobile/android/app/google-services.example.json`
-shows the expected shape (with secrets scrubbed). NOTE: that template still
-shows the legacy merged-file shape (multiple `client[]` entries); the active
-file under the per-brand-vault pattern will have exactly one. The template
-is staged for replacement — see `docs/PEER_REVIEW_FOLLOWUP.md`.
+**Sanity-check templates:** Each brand has a committed sanitized template
+next to its vault entry, with secrets scrubbed:
+- `_bin/firebase/therr/google-services.example.json` — one `client[]` entry,
+  `package_name == app.therrmobile`.
+- `_bin/firebase/habits/google-services.example.json` — one `client[]` entry,
+  `package_name == com.therr.habits`.
+
+Diff your real `_bin/firebase/<brand>/google-services.json` against the
+matching template to confirm shape; if your file has extra or different
+`client[]` entries, re-export the matching Android app from Firebase
+Console. `TherrMobile/android/app/google-services.example.json` is kept as
+a pointer that lists the per-brand template paths above.
 
 **See also:** `docs/MULTI_BRAND_ARCHITECTURE.md` for the brand-flag-driven
 build behavior; `_bin/firebase/README.md` for the vault layout and


### PR DESCRIPTION
Adds a per-brand Firebase config vault under _bin/firebase/<brand>/ as the
source of truth for google-services.json (Android) and GoogleService-Info.plist
(iOS). _bin/switch-brand.sh now copies the matching files into the active
build locations on every run, validates the Android JSON's package_name
against the brand's expected applicationId via jq, prints the registered
SHA-1, and clears Gradle's generated google-services resources so the next
build re-derives strings.xml from the new config.

This fixes the silent Google Sign-In failure that occurs when a re-export
from Firebase Console for one brand overwrites the merged
google-services.json: with the per-brand vault, brand selection happens at
script time (by file copy) rather than at gradle time (by applicationId
matching), so each Firebase Console export drops straight into
_bin/firebase/<brand>/ with no manual merging.

Updates SECRETS_AND_LOCAL_BOOTSTRAP.md, MULTI_BRAND_ARCHITECTURE.md, and
PEER_REVIEW_FOLLOWUP.md to reflect the new pattern. Adds .gitignore entries
so vault payload files stay out of git while the README convention stays
in.

https://claude.ai/code/session_0125bAZajKkrMYjFdnNFA85N