### PR TITLE
fix(mobile): close delete dialog on success and lighten content options sheet

### DIFF
--- a/TherrMobile/main/components/ActionSheet/ContentOptionsSheet.tsx
+++ b/TherrMobile/main/components/ActionSheet/ContentOptionsSheet.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { View } from 'react-native';
+import React, { useMemo } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import ActionSheet, { SheetManager, SheetProps } from 'react-native-actions-sheet';
-import { List } from 'react-native-paper';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import spacingStyles from '../../styles/layouts/spacing';
 import { bottomSafeAreaInset } from '../../styles/navigation/buttonMenu';
@@ -14,30 +13,24 @@ interface IContentOption {
     type: IContentSelectionType;
 }
 
-const ContentOptionIcon = ({ iconName, iconColor, style }: { iconName: string; iconColor: string | undefined; style: any }) => (
-    <MaterialIcon
-        name={iconName}
-        size={22}
-        color={iconColor}
-        style={style}
-    />
-);
+const ANDROID_RIPPLE = { color: 'rgba(0,0,0,0.08)' };
 
 const ContentOptionsSheet = (props: SheetProps<'content-options-sheet'>) => {
     const { payload } = props;
     const contentType = payload?.contentType;
+    const shouldIncludeShareButton = !!payload?.shouldIncludeShareButton;
 
-    const allOptions: (IContentOption | false)[] = [
+    const options = useMemo<IContentOption[]>(() => ([
         contentType === 'area' && { icon: 'directions', title: 'getDirections', type: 'getDirections' as const },
-        contentType === 'area' && !!payload?.shouldIncludeShareButton && { icon: 'share', title: 'shareALink', type: 'shareALink' as const },
+        contentType === 'area' && shouldIncludeShareButton && { icon: 'share', title: 'shareALink', type: 'shareALink' as const },
         { icon: 'thumb-up', title: 'superLike', type: 'superLike' as const },
         { icon: 'thumb-down', title: 'dislike', type: 'dislike' as const },
         { icon: 'thumb-down', title: 'superDislike', type: 'superDislike' as const },
         { icon: 'report-problem', title: 'report', type: 'report' as const },
-    ];
+    ].filter(Boolean) as IContentOption[]), [contentType, shouldIncludeShareButton]);
 
-    const options = allOptions.filter(Boolean) as IContentOption[];
     const iconColor = payload?.themeForms.colors.primary3;
+    const titleStyle = useMemo(() => [localStyles.title, { color: iconColor }], [iconColor]);
 
     return (
         <ActionSheet id={props.sheetId}>
@@ -48,22 +41,47 @@ const ContentOptionsSheet = (props: SheetProps<'content-options-sheet'>) => {
                 { paddingBottom: bottomSafeAreaInset },
             ]}>
                 {options.map((option) => (
-                    <List.Item
+                    <Pressable
                         key={option.type}
-                        title={payload?.translate(`modals.contentOptions.buttons.${option.title}`)}
-                        titleStyle={{ color: iconColor }}
-                        left={(listProps) => (
-                            <ContentOptionIcon iconName={option.icon} iconColor={iconColor} style={listProps.style} />
-                        )}
+                        style={localStyles.row}
+                        android_ripple={ANDROID_RIPPLE}
                         onPress={() => {
                             SheetManager.hide('content-options-sheet');
                             payload?.onSelect(option.type);
                         }}
-                    />
+                    >
+                        <MaterialIcon
+                            name={option.icon}
+                            size={22}
+                            color={iconColor}
+                            style={localStyles.icon}
+                        />
+                        <Text style={titleStyle}>
+                            {payload?.translate(`modals.contentOptions.buttons.${option.title}`)}
+                        </Text>
+                    </Pressable>
                 ))}
             </View>
         </ActionSheet>
     );
 };
+
+const localStyles = StyleSheet.create({
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: 14,
+        paddingHorizontal: 16,
+    },
+    icon: {
+        width: 40,
+        textAlign: 'center',
+    },
+    title: {
+        fontSize: 16,
+        marginLeft: 4,
+        flexShrink: 1,
+    },
+});
 
 export default ContentOptionsSheet;

--- a/TherrMobile/main/routes/ViewEvent/index.tsx
+++ b/TherrMobile/main/routes/ViewEvent/index.tsx
@@ -292,6 +292,8 @@ const ViewEvent = ({
         if (checkIsMyEvent(event, user)) {
             deleteEvent({ ids: [event.id] })
                 .then(() => {
+                    setIsDeleting(false);
+                    setIsDeleteDialogVisible(false);
                     navigation.navigate('Map', { shouldShowPreview: false });
                 })
                 .catch((err) => {

--- a/TherrMobile/main/routes/ViewMoment/index.tsx
+++ b/TherrMobile/main/routes/ViewMoment/index.tsx
@@ -205,6 +205,10 @@ export class ViewMoment extends React.Component<IViewMomentProps, IViewMomentSta
         if (checkIsMyMoment(moment, user)) {
             deleteMoment({ ids: [moment.id] })
                 .then(() => {
+                    this.setState({
+                        isDeleting: false,
+                        isDeleteDialogVisible: false,
+                    });
                     navigation.navigate('Map', {
                         shouldShowPreview: false,
                     });

--- a/TherrMobile/main/routes/ViewSpace/index.tsx
+++ b/TherrMobile/main/routes/ViewSpace/index.tsx
@@ -450,6 +450,8 @@ const ViewSpace = ({
         if (checkIsMySpace(fetchedSpace, user)) {
             deleteSpace({ ids: [fetchedSpace.id] })
                 .then(() => {
+                    setIsDeleting(false);
+                    setIsDeleteDialogVisible(false);
                     navigation.navigate('Map', { shouldShowPreview: false });
                 })
                 .catch((err) => {

--- a/TherrMobile/main/routes/ViewThought/index.tsx
+++ b/TherrMobile/main/routes/ViewThought/index.tsx
@@ -237,6 +237,8 @@ const ViewThought = ({
         if (checkIsMyContent(thought, user)) {
             deleteThought({ ids: [thought.id] })
                 .then(() => {
+                    setIsDeleting(false);
+                    setIsDeleteDialogVisible(false);
                     const isAreasEnabled = getConfig().featureFlags?.[FeatureFlags.ENABLE_AREAS] === true;
                     if (isAreasEnabled) {
                         navigation.navigate('Areas');


### PR DESCRIPTION
Two bugs in the area-card content flow on TherrMobile:

1. Tapping Delete on a single-area view (Space/Moment/Event/Thought) navigated
   to the map but left the confirmation modal open with the spinner stuck on
   the confirm button. The success branch never reset isDeleting/
   isDeleteDialogVisible — it relied on the screen unmounting, but the modal
   sits in a portal and stays mounted across navigation. Reset both flags in
   the .then() before navigating, mirroring the existing .catch() handling.

2. Pressing the 3-dot menu on an area card felt very slow to open the bottom
   sheet. ContentOptionsSheet rendered six react-native-paper List.Item rows,
   each of which pulls in Surface, TouchableRipple, and theme-context lookups
   — a meaningful render cost that runs synchronously when the sheet mounts.
   Replace with lightweight Pressable + MaterialIcon + Text rows (matching
   the pattern already used in ListPickerSheet) and memoize the options
   array and title style so the rows render cheaply.

https://claude.ai/code/session_01RDyJvtATnhbmYnUyGBbzAv