### PR TITLE
fix(reactions): hide expired quick reports from activated areas list

### DIFF
--- a/therr-services/maps-service/src/handlers/moments.ts
+++ b/therr-services/maps-service/src/handlers/moments.ts
@@ -1247,6 +1247,7 @@ const findMoments: RequestHandler = async (req: any, res: any) => {
         lastContentCreatedAt,
         authorId,
         isDraft,
+        shouldHideExpired,
     } = req.body;
 
     return Store.moments.findMoments(req.headers, momentIds, {
@@ -1259,6 +1260,7 @@ const findMoments: RequestHandler = async (req: any, res: any) => {
         withMedia: !!withMedia,
         withUser: !!withUser,
         shouldHideMatureContent: true, // TODO: Check the user settings to determine if mature content should be hidden
+        shouldHideExpired: !!shouldHideExpired,
     })
         .then(({ moments, media }) => res.status(200).send({ moments, media }))
         .catch((err) => handleHttpError({ err, res, message: 'SQL:MOMENTS_ROUTES:ERROR' }));

--- a/therr-services/maps-service/src/store/MomentsStore.ts
+++ b/therr-services/maps-service/src/store/MomentsStore.ts
@@ -428,6 +428,14 @@ export default class MomentsStore {
             query = query.where({ isMatureContent: false });
         }
 
+        // Hide expired quick reports. Non-quick-report moments have expiresAt = NULL and pass through.
+        // Backed by the partial index on expiresAt added in 20260326000000_main.moments_quick_report_indexes.
+        if (options?.shouldHideExpired) {
+            query = query.andWhere(function () { // eslint-disable-line func-names
+                this.whereNull('expiresAt').orWhere('expiresAt', '>', new Date().toISOString());
+            });
+        }
+
         return this.db.read.query(query.toString()).then(async ({ rows: moments }) => {
             if (options.withMedia || options.withUser) {
                 const mediaIds: string[] = [];

--- a/therr-services/reactions-service/src/handlers/moments.ts
+++ b/therr-services/reactions-service/src/handlers/moments.ts
@@ -73,6 +73,7 @@ const searchActiveMoments = async (req: any, res: any) => {
                     lastContentCreatedAt,
                     authorId,
                     isDraft: false,
+                    shouldHideExpired: true,
                 },
             })
                 .then(async (response) => {
@@ -172,6 +173,7 @@ const searchActiveMomentsByIds = async (req: any, res: any) => {
                     withMedia,
                     withUser,
                     lastContentCreatedAt: new Date(),
+                    shouldHideExpired: true,
                 },
             });
         })


### PR DESCRIPTION
The mobile activated-areas screen is populated by reactions-service
searchActiveMoments / searchActiveMomentsByIds, which fetches the user's
activated reactions and then resolves them via maps-service /moments/find.
Reactions persist indefinitely, but quick-report moments carry an
expiresAt TTL — and findMoments did not filter on it, so expired quick
reports kept appearing in the list.

Add an opt-in shouldHideExpired flag to MomentsStore.findMoments and the
/moments/find handler (default false to preserve every existing internal
caller — drafts, detail views, etc.). Have searchActiveMoments and
searchActiveMomentsByIds pass shouldHideExpired: true so the activated
areas list filters expired rows at the SQL boundary.

The filter is backed by the existing partial index on expiresAt from
20260326000000_main.moments_quick_report_indexes, so no new DB work and
no measurable cost on the hot path. Non-quick-report moments have
expiresAt = NULL and are unaffected.