### PR TITLE
fix(habits/mobile): improve footer menu spacing on profile and pacts tabs

### DIFF
--- a/TherrMobile/main/components/ButtonMenu/HabitsButtonMenu.tsx
+++ b/TherrMobile/main/components/ButtonMenu/HabitsButtonMenu.tsx
@@ -43,6 +43,7 @@ const ViewProfileButton = ({
         <Button
             buttonStyle={themeMenu.styles.buttons}
             containerStyle={themeMenu.styles.buttonContainerUserProfile}
+            iconContainerStyle={{ marginRight: 6 }}
             titleStyle={themeMenu.styles.buttonsTitle}
             icon={
                 isUserAuthenticated(user) ?
@@ -249,8 +250,8 @@ class HabitsButtonMenu extends ButtonMenu {
                         <View
                             style={{
                                 position: 'absolute',
-                                top: 4,
-                                right: buttonWidth / 2 - 24,
+                                top: 7,
+                                right: buttonWidth / 2 - 20,
                                 minWidth: 18,
                                 height: 18,
                                 borderRadius: 9,


### PR DESCRIPTION
- Add 6px right margin on the profile tab icon so the avatar image
  is no longer flush against the "Profile" label text
- Move the pacts badge 3px down (top: 4 → 7) and 4px toward the right
  edge (right offset − 4) so it clears the active top-border indicator

https://claude.ai/code/session_014mcoKrVy4QzeuhessjDkKW