### PR TITLE
feat: add shared keep-alive HTTP/HTTPS agent pooling across gateway and services

### DIFF
--- a/therr-api-gateway/src/index.ts
+++ b/therr-api-gateway/src/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-import-module-exports */
 import tracing from './tracing'; // eslint-disable-line import/order
 import axios from 'axios';
+import { httpKeepAliveAgent, httpsKeepAliveAgent } from 'therr-js-utilities/http';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -19,6 +20,8 @@ tracing.start();
 
 // Axios defaults
 axios.defaults.timeout = 1000 * 30; // 30 Second Request timeout
+axios.defaults.httpAgent = httpKeepAliveAgent;
+axios.defaults.httpsAgent = httpsKeepAliveAgent;
 
 // NOTE: corsOptions commented out - mobile apps have no concept of CORS
 // const originWhitelist = (process.env.URI_WHITELIST || '').split(',');

--- a/therr-public-library/therr-js-utilities/src/http/agents.ts
+++ b/therr-public-library/therr-js-utilities/src/http/agents.ts
@@ -1,0 +1,18 @@
+import * as http from 'http';
+import * as https from 'https';
+
+// Shared keep-alive agents reuse TCP connections across requests to the same host,
+// avoiding repeated DNS lookups and TCP handshakes on every axios call.
+const httpKeepAliveAgent = new http.Agent({
+    keepAlive: true,
+    maxSockets: 50,
+    maxFreeSockets: 10,
+});
+
+const httpsKeepAliveAgent = new https.Agent({
+    keepAlive: true,
+    maxSockets: 25,
+    maxFreeSockets: 5,
+});
+
+export { httpKeepAliveAgent, httpsKeepAliveAgent };

--- a/therr-public-library/therr-js-utilities/src/http/index.ts
+++ b/therr-public-library/therr-js-utilities/src/http/index.ts
@@ -1,5 +1,6 @@
 import configureHandleHttpError, { IErrorArgs } from './configure-handle-http-error';
 import handleHttpError, { asyncHandler, HandleHttpError } from './async-handler';
+import { httpKeepAliveAgent, httpsKeepAliveAgent } from './agents';
 import getBrandContext, { IBrandContext } from './get-brand-context';
 import getSearchQueryArgs, { IReqQuery } from './get-search-query-args';
 import getSearchQueryString from './get-search-query-string';
@@ -12,6 +13,8 @@ export {
     HandleHttpError,
     IErrorArgs,
     IReqQuery,
+    httpKeepAliveAgent,
+    httpsKeepAliveAgent,
     getBrandContext,
     IBrandContext,
     getSearchQueryArgs,

--- a/therr-public-library/therr-js-utilities/src/internal-rest-request.ts
+++ b/therr-public-library/therr-js-utilities/src/internal-rest-request.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig } from 'axios';
+import { httpKeepAliveAgent, httpsKeepAliveAgent } from './http/agents';
 
 interface InternalConfigHeaders {
     authorization?: string;
@@ -38,6 +39,8 @@ const internalRestRequest = (internalConfig: IInternalConfig, axiosConfig: Axios
             sanitizedInternalConfigHeaders[header] = (internalConfig.headers as any)?.[header];
         });
     return axios({
+        httpAgent: httpKeepAliveAgent,
+        httpsAgent: httpsKeepAliveAgent,
         ...axiosConfig,
         headers: {
             ...axiosConfig.headers,


### PR DESCRIPTION
Wire a module-level http.Agent (keepAlive:true, maxSockets:50) and
https.Agent (keepAlive:true, maxSockets:25) into internalRestRequest so
every service-to-service call reuses pooled TCP connections instead of
paying a DNS lookup + TCP handshake on each request. Set the same agents
as axios.defaults in the API gateway, covering all gateway→service and
gateway→external HTTPS calls through the shared restRequest wrapper.