### PR TITLE
fix: moment creation stuck in infinite loading state

### DIFF
--- a/TherrMobile/main/routes/EditMoment/index.tsx
+++ b/TherrMobile/main/routes/EditMoment/index.tsx
@@ -410,7 +410,7 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
 
                         if (isDraft && Platform.OS !== 'android') {
                             const nowPlus = new Date();
-                            nowPlus.setHours(nowPlus.getMinutes() + 1);
+                            nowPlus.setMinutes(nowPlus.getMinutes() + 1);
                             sendTriggerNotification(nowPlus, {
                                 title: this.translate('alertTitles.draftReminder'),
                                 body: this.translate('alertMessages.draftReminder'),
@@ -482,15 +482,16 @@ export class EditMoment extends React.Component<IEditMomentProps, IEditMomentSta
                             if (error.errorCode === ErrorCodes.INSUFFICIENT_THERR_COIN_FUNDS) {
                                 this.toggleInfoModal();
                             }
-                        } else if (error.statusCode >= 500) {
+                        } else {
                             this.setState({
                                 errorMsg: this.translate('forms.editMoment.backendErrorMessage'),
                             });
                         }
                     })
                     .finally(() => {
+                        this.setState({ isSubmitting: false });
                         Keyboard.dismiss();
-                        this.scrollViewRef.scrollToEnd({ animated: true });
+                        this.scrollViewRef?.scrollToEnd({ animated: true });
                     });
             }).catch((err) => {
                 console.log(err);

--- a/therr-public-library/therr-react/src/redux/actions/Maps.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Maps.ts
@@ -204,6 +204,11 @@ const Maps = {
                     ...data,
                 }, // server doesn't return changes, so use request data
             });
+
+            return {
+                ...response.data,
+                ...data,
+            };
         }),
     getMomentDetails: (id: number, data: any) => (dispatch: any) => MapsService.getMomentDetails(id, data)
         .then((response: any) => {


### PR DESCRIPTION
Three bugs caused the submit button to spin forever with no error shown:

1. The .catch() block never reset isSubmitting — moved reset to .finally()
   so it runs on both success and failure paths.

2. 429 rate-limit responses fell through all branches in the catch handler
   (not 400/401/404, not >=500), leaving the form silently locked.
   Collapsed the else-if to a plain else so any unhandled status code
   shows the generic backend error message.

3. updateMoment Redux action had no return value — the UI's .then() tried
   response.id on undefined, threw a TypeError, and the catch caught it
   with no statusCode match so nothing was displayed and isSubmitting
   stayed true indefinitely. Added return matching the updateEvent/
   updateSpace pattern.

Also fixes draft reminder scheduling using setHours(getMinutes()+1)
instead of setMinutes(getMinutes()+1), which set the wrong clock field.

https://claude.ai/code/session_014XBjeH4WhYc1zyLLskG6kQ