### PR TITLE
Add Claude Code memory system (Hermes + MemSearch)

### DIFF
--- a/.claude/hooks/transcript-capture.js
+++ b/.claude/hooks/transcript-capture.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+// Stop hook: captures first 500 chars of assistant response to daily transcript file
+const input = JSON.parse(fs.readFileSync('/dev/stdin', 'utf8'));
+
+if (input.stop_reason === 'end_turn' && input.response) {
+  const today = new Date().toISOString().slice(0, 10);
+  const dir = path.join(process.env.CLAUDE_PROJECT_DIR || '.', 'context', 'transcripts');
+  const file = path.join(dir, `${today}.md`);
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const summary = input.response.slice(0, 500).replace(/\n{3,}/g, '\n\n');
+    const timestamp = new Date().toISOString().slice(11, 19);
+    const entry = `\n## ${timestamp}\n${summary}\n`;
+    fs.appendFileSync(file, entry);
+  } catch (e) {
+    // Fire and forget — don't break the session
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,14 @@
 {
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "node .claude/hooks/transcript-capture.js"
+        }
+      ]
+    }
+  ],
   "SessionStart": [
     {
       "matcher": {},

--- a/.claude/skills/memory-write/SKILL.md
+++ b/.claude/skills/memory-write/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: memory-write
+description: >
+  Saves durable facts to context/MEMORY.md. Triggers on "remember this",
+  "note that", "update memory", "save this", "forget about". Three actions:
+  add (append under correct section), replace (substring match + swap),
+  remove (confirm with user first). Enforces 2,500 char cap with dedup guard.
+---
+
+# Memory Write
+
+## Outcome
+- Fact added to, updated in, or removed from `context/MEMORY.md`
+- Character cap enforced (2,500 chars)
+- Confirmation message: "Saved — will be active from next session."
+
+## Steps
+1. Read `context/MEMORY.md` in full
+2. Determine action: add, replace, or remove
+3. **Dedup check**: scan for substring match — if the fact already exists, skip or update
+4. **Cap check**: run `wc -c < context/MEMORY.md` — if over 2,500, consolidate before adding
+5. Write the change
+6. Confirm: "Saved — will be active from next session."
+
+For **remove**: always confirm with the user before deleting.
+
+## Sections in MEMORY.md
+- `## Active Threads` — current work, open questions
+- `## Environment Notes` — URLs, API keys (names only), tool versions, project structure
+- `## Pending Decisions` — decisions that need to be made
+
+## Rules
+- Never exceed 2,500 characters
+- Always check for duplicates before adding
+- Replace is preferred over add when updating existing facts

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ _bin/firebase/**/GoogleService-Info.plist
 # android
 bugreport-sdk*
 .aider*
+
+# Claude Code memory system
+context/transcripts/
+.memsearch/

--- a/.memsearch.toml
+++ b/.memsearch.toml
@@ -1,0 +1,3 @@
+[embedding]
+provider = "local"
+model = "all-MiniLM-L6-v2"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,3 +435,51 @@ See `docs/OFFLINE_FIRST_PLAN.md` for the full phased roadmap (Phases 2-5 cover w
 - Most npm deps are in root `package.json` (shared across packages)
 - TherrMobile has its own `package.json` with React Native specific deps
 - Always use `--legacy-peer-deps` flag when installing
+
+## Session Startup (silent — do not output anything)
+
+On every session start, read these files silently:
+1. Read `context/USER.md` (~1.4 KB max)
+2. Read `context/MEMORY.md` (~2.5 KB max, curated working scratchpad)
+3. Read `context/memory/{today's date in YYYY-MM-DD}.md` if it exists
+4. If today's memory file has no prior sessions, also read yesterday's
+
+These files are your "frozen snapshot" — loaded once at session start. Mid-session writes persist to disk but take effect next session.
+
+Total injected: ~3,000 tokens. Do not load more than this at startup.
+
+### Memory Budget
+- `context/MEMORY.md`: 2,500 character cap. Before writing, check `wc -c`. If over cap, consolidate existing entries before adding.
+- `context/USER.md`: 1,375 character cap. Same rule.
+- Mid-session writes to these files persist to disk but only appear in context next session (frozen snapshot pattern — preserves prefix cache).
+
+### Memory Write
+When the user says "remember this", "note that", "update memory", "save this", or "forget about":
+1. Read `context/MEMORY.md` in full
+2. Check for duplicates (scan for substring match)
+3. Check character count: `wc -c < context/MEMORY.md`
+4. If under 2,500 chars: append the new fact under the appropriate section
+5. If over cap: consolidate — merge similar entries, remove stale ones, then add
+6. Actions: add (append), replace (find substring + swap), remove (confirm with user first)
+7. After writing: "Saved — will be active from next session."
+
+### Memory Retrieval
+When the user asks about past context, conversations, or decisions:
+1. **Tier 0**: Check `context/MEMORY.md` and today's daily log — already in context, zero cost
+2. **L1**: Run `memsearch search "query" --top-k 5` — hybrid vector + keyword search
+3. **L2**: Run `memsearch expand <chunk_hash>` — full markdown section around the match
+4. **L3**: Run `memsearch transcript <session_id>` — raw dialogue, last resort
+5. **Fallback**: "I don't have a record of that."
+
+Only escalate if the previous tier didn't find the answer.
+
+### Daily Log
+Track session activity in `context/memory/{YYYY-MM-DD}.md`. One file per day, numbered session blocks:
+
+#### Session N
+**Goal**: [one line, filled when user states their goal]
+**Deliverables**: [files created/modified]
+**Decisions**: [key decisions and rationale]
+**Open threads**: [anything unfinished]
+
+Log these silently as they happen. Never announce "I've logged that."

--- a/context/MEMORY.md
+++ b/context/MEMORY.md
@@ -1,0 +1,8 @@
+<!-- Cap: 2,500 chars. Agent maintains via memory-write instructions. -->
+# Working Memory
+
+## Active Threads
+
+## Environment Notes
+
+## Pending Decisions

--- a/context/USER.md
+++ b/context/USER.md
@@ -1,0 +1,9 @@
+<!-- Cap: 1,375 chars. Updated by the agent when it learns preferences. -->
+# User Profile
+
+## About
+- Email: zack.anselm@gmail.com
+
+## Preferences
+
+## Working Style

--- a/cron/jobs/daily-memory-distill.md
+++ b/cron/jobs/daily-memory-distill.md
@@ -1,0 +1,13 @@
+---
+name: Daily Memory Distillation
+time: '23:00'
+days: daily
+active: 'true'
+model: haiku
+notify: on_failure
+description: 'Extracts durable facts from daily log into MEMORY.md'
+timeout: 5m
+retry: '0'
+---
+
+Read today's `context/memory/{today}.md`. Extract any durable facts (URLs, decisions, preferences, project structure) that aren't already in `context/MEMORY.md`. Add them under the appropriate section (`## Active Threads`, `## Environment Notes`, `## Pending Decisions`). Enforce the 2,500 char cap — consolidate before adding if needed.

--- a/cron/jobs/nightly-memsearch-index.md
+++ b/cron/jobs/nightly-memsearch-index.md
@@ -1,0 +1,13 @@
+---
+name: Nightly MemSearch Index
+time: '02:00'
+days: daily
+active: 'true'
+model: haiku
+notify: on_failure
+description: 'Re-indexes memory and transcript files for vector search'
+timeout: 5m
+retry: '1'
+---
+
+Run `memsearch index` to update the vector database with any new content from today's memory and transcript files.

--- a/cron/jobs/weekly-memory-curator.md
+++ b/cron/jobs/weekly-memory-curator.md
@@ -1,0 +1,18 @@
+---
+name: Weekly Memory Curator
+time: '09:00'
+days: sun
+active: 'true'
+model: sonnet
+notify: on_finish
+description: 'Prunes, merges, and consolidates MEMORY.md entries'
+timeout: 10m
+retry: '0'
+---
+
+Read `context/MEMORY.md`. For each entry:
+1. Is it still relevant? Remove if stale.
+2. Are there duplicates? Merge them.
+3. Can entries be consolidated? Combine related facts.
+
+Keep under 2,500 chars. Log what was changed.


### PR DESCRIPTION
Implements the full memory system from the Memory-System-Improvements-Plan:

Store layer:
- context/MEMORY.md — curated working scratchpad (2,500 char cap)
- context/USER.md — user profile/preferences (1,375 char cap)
- context/memory/ — daily session logs (YYYY-MM-DD.md)
- .claude/hooks/transcript-capture.js — Stop hook writes first 500 chars of each response to context/transcripts/

Inject layer:
- CLAUDE.md — Session Startup section: silently loads USER.md + MEMORY.md + today's daily log as a ~3,000-token frozen snapshot each session

Recall layer:
- CLAUDE.md — Memory Retrieval section: tiered Tier 0 → L1 memsearch → L2 expand → L3 transcript
- .memsearch.toml — project config using local sentence-transformers embedder
- cron/jobs/ — daily distill, nightly reindex, weekly curator job definitions

Tooling:
- .claude/settings.json — registers Stop hook alongside existing SessionStart hooks
- .claude/skills/memory-write/SKILL.md — already present, wires "remember this" trigger
- .gitignore — excludes context/transcripts/ and .memsearch/ from version control

https://claude.ai/code/session_01VqbbSnPNEtX9E7hxEHQ2dj