### PR TITLE
fix(web): stop marking optional onboarding name fields as required

### DIFF
--- a/therr-client-web/src/components/forms/CreateProfileForm.tsx
+++ b/therr-client-web/src/components/forms/CreateProfileForm.tsx
@@ -150,6 +150,9 @@ export class CreateProfileFormComponent extends React.Component<ICreateProfileFo
                             label={this.props.translate('components.createProfileForm.labels.userName')}
                         />
 
+                        {/* First/last name are optional during onboarding (see isFormDisabled).
+                            Do not mark them isRequired or the input renders a misleading
+                            "required" error once touched, contradicting the deferred-name flow. */}
                         <MantineInput
                             type="text"
                             id="first_name"
@@ -158,7 +161,7 @@ export class CreateProfileFormComponent extends React.Component<ICreateProfileFo
                             onChange={this.onInputChange}
                             onEnter={this.onSubmit}
                             translateFn={this.props.translate}
-                            validations={['isRequired']}
+                            validations={[]}
                             label={isBusiness
                                 ? this.props.translate('components.createProfileForm.labels.businessName')
                                 : this.props.translate('components.createProfileForm.labels.firstName')}
@@ -173,7 +176,7 @@ export class CreateProfileFormComponent extends React.Component<ICreateProfileFo
                                 onChange={this.onInputChange}
                                 onEnter={this.onSubmit}
                                 translateFn={this.props.translate}
-                                validations={['isRequired']}
+                                validations={[]}
                                 label={this.props.translate('components.createProfileForm.labels.lastName')}
                             />
                         )}


### PR DESCRIPTION
The create-profile form defers first/last name to reduce onboarding
friction (only userName + a valid phone are required, enforced by
isFormDisabled). The firstName/lastName inputs still carried
validations={['isRequired']}, which rendered a misleading 'required'
error once the field was touched, contradicting the deferred-name flow
that the mobile client already adopted. Make the validation match the
documented intent.

https://claude.ai/code/session_01PtEzQyHfwmzB5z8vRKrFCv