### PR TITLE
feat(memory): add Store/Inject/Recall memory management system

### DIFF
--- a/.claude/hooks/transcript-capture.js
+++ b/.claude/hooks/transcript-capture.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+// Stop hook: captures first 500 chars of assistant response to daily transcript file
+const input = JSON.parse(fs.readFileSync('/dev/stdin', 'utf8'));
+
+if (input.stop_reason === 'end_turn' && input.response) {
+  const today = new Date().toISOString().slice(0, 10);
+  const dir = path.join(process.env.CLAUDE_PROJECT_DIR || '.', 'context', 'transcripts');
+  const file = path.join(dir, `${today}.md`);
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const summary = input.response.slice(0, 500).replace(/\n{3,}/g, '\n\n');
+    const timestamp = new Date().toISOString().slice(11, 19);
+    const entry = `\n## ${timestamp}\n${summary}\n`;
+    fs.appendFileSync(file, entry);
+  } catch (e) {
+    // Fire and forget — don't break the session
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,14 @@
 {
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "node .claude/hooks/transcript-capture.js"
+        }
+      ]
+    }
+  ],
   "SessionStart": [
     {
       "matcher": {},

--- a/.claude/skills/memory-write/SKILL.md
+++ b/.claude/skills/memory-write/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: memory-write
+description: >
+  Saves durable facts to context/MEMORY.md. Triggers on "remember this",
+  "note that", "update memory", "save this", "forget about". Three actions:
+  add (append under correct section), replace (substring match + swap),
+  remove (confirm with user first). Enforces 2,500 char cap with dedup guard.
+---
+
+# Memory Write
+
+## Outcome
+- Fact added to, updated in, or removed from `context/MEMORY.md`
+- Character cap enforced (2,500 chars)
+- Confirmation message: "Saved — will be active from next session."
+
+## Steps
+
+1. Read `context/MEMORY.md` in full
+2. Determine action: add, replace, or remove
+3. **Dedup check**: scan for substring match — if the fact already exists, skip or update
+4. **Cap check**: run `wc -c < context/MEMORY.md` — if over 2,500, consolidate before adding
+5. Write the change
+6. Confirm: "Saved — will be active from next session."
+
+For **remove**: always confirm with the user before deleting.
+
+## Sections in MEMORY.md
+- `## Active Threads` — current work, open questions
+- `## Environment Notes` — URLs, API keys (names only), tool versions, project structure
+- `## Pending Decisions` — decisions that need to be made
+
+## Rules
+- Never exceed 2,500 characters
+- Always check for duplicates before adding
+- Replace is preferred over add when updating existing facts

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+context/transcripts/
+.memsearch/
+
 # Logs
 logs
 *.log
@@ -94,3 +97,7 @@ _bin/firebase/**/GoogleService-Info.plist
 # android
 bugreport-sdk*
 .aider*
+
+# memsearch vector DB and transcript captures (machine-local, not shared)
+context/transcripts/
+.memsearch/

--- a/.memsearch.toml
+++ b/.memsearch.toml
@@ -1,0 +1,2 @@
+[embedding]
+provider = "onnx"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,3 +435,56 @@ See `docs/OFFLINE_FIRST_PLAN.md` for the full phased roadmap (Phases 2-5 cover w
 - Most npm deps are in root `package.json` (shared across packages)
 - TherrMobile has its own `package.json` with React Native specific deps
 - Always use `--legacy-peer-deps` flag when installing
+
+## Session Startup (silent — do not output anything)
+
+On every session start, read these files silently:
+1. Read `context/USER.md` (~1.4 KB max)
+2. Read `context/MEMORY.md` (~2.5 KB max, curated working scratchpad)
+3. Read `context/memory/{today's date in YYYY-MM-DD}.md` if it exists
+4. If today's memory file has no prior sessions, also read yesterday's
+
+These files are your "frozen snapshot" — loaded once at session start. Mid-session writes persist to disk but take effect next session. This preserves the prefix cache.
+
+Total injected: ~3,000 tokens. Do not load more than this at startup.
+
+### Memory Budget
+
+- `context/MEMORY.md`: 2,500 character cap. Before writing, check `wc -c`. If over cap, consolidate existing entries before adding.
+- `context/USER.md`: 1,375 character cap. Same rule.
+- Mid-session writes to these files persist to disk but only appear in context next session (frozen snapshot pattern — preserves prefix cache).
+
+### Memory Write
+
+When the user says "remember this", "note that", "update memory", or "forget about":
+1. Read `context/MEMORY.md` in full
+2. Check for duplicates (scan for substring match)
+3. Check character count: `wc -c < context/MEMORY.md`
+4. If under 2,500 chars: append the new fact under the appropriate section
+5. If over cap: consolidate — merge similar entries, remove stale ones, then add
+6. Actions: add (append), replace (find substring + swap), remove (confirm with user first)
+7. After writing: "Saved — will be active from next session."
+
+### Memory Retrieval
+
+When the user asks about past context, conversations, or decisions:
+
+1. **Tier 0**: Check `context/MEMORY.md` and today's daily log — already in context, zero cost
+2. **L1**: Run `memsearch search "query" --top-k 5` — hybrid vector + keyword search. Finds semantic matches even with different words (e.g. "pricing" finds "monetisation")
+3. **L2**: Run `memsearch expand <chunk_hash>` — returns full markdown section around the match
+4. **L3**: Run `memsearch transcript <session_id>` — raw dialogue, last resort
+5. **Fallback**: "I don't have a record of that."
+
+Only escalate if the previous tier didn't find the answer.
+
+### Daily Log
+
+Track session activity in `context/memory/{YYYY-MM-DD}.md`. One file per day, numbered session blocks:
+
+#### Session N
+**Goal**: [one line, filled when user states their goal]
+**Deliverables**: [files created/modified]
+**Decisions**: [key decisions and rationale]
+**Open threads**: [anything unfinished]
+
+Log these silently as they happen. Never announce "I've logged that."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,6 +438,8 @@ See `docs/OFFLINE_FIRST_PLAN.md` for the full phased roadmap (Phases 2-5 cover w
 
 ## Session Startup (silent — do not output anything)
 
+> **Developer setup**: see [`docs/MEMORY_SYSTEM_SETUP.md`](docs/MEMORY_SYSTEM_SETUP.md) to replicate this memory system in another repo or to run `memsearch index` locally for vector recall.
+
 On every session start, read these files silently:
 1. Read `context/USER.md` (~1.4 KB max)
 2. Read `context/MEMORY.md` (~2.5 KB max, curated working scratchpad)

--- a/context/MEMORY.md
+++ b/context/MEMORY.md
@@ -1,0 +1,8 @@
+<!-- Cap: 2,500 chars. Agent maintains via memory-write instructions. -->
+# Working Memory
+
+## Active Threads
+
+## Environment Notes
+
+## Pending Decisions

--- a/context/USER.md
+++ b/context/USER.md
@@ -1,0 +1,8 @@
+<!-- Cap: 1,375 chars. Updated by the agent when it learns preferences. -->
+# User Profile
+
+## About
+
+## Preferences
+
+## Working Style

--- a/docs/MEMORY_SYSTEM_SETUP.md
+++ b/docs/MEMORY_SYSTEM_SETUP.md
@@ -1,0 +1,332 @@
+# Memory System Setup Guide
+
+Reusable implementation guide for adding Store / Inject / Recall memory to any Claude Code project.
+
+**What you get:**
+- **Store** — transcript capture after every response + curated fact scratchpad Claude writes on demand
+- **Inject** — frozen snapshot of user profile, working memory, and today's daily log loaded silently at session start (~3,000 tokens)
+- **Recall** — four-tier retrieval: context (free) → hybrid vector+keyword search → chunk expansion → raw transcript
+
+**Works in remote / ephemeral containers** (Claude Code on the web, GitHub Actions, CI) because all memory files are git-tracked. The container resets between sessions but the memory persists in the repo.
+
+---
+
+## Prerequisites
+
+```bash
+pip install memsearch 'memsearch[onnx]'
+# memsearch[onnx] installs onnxruntime + tokenizers for local CPU embedding.
+# First index run downloads gpahal/bge-m3-onnx-int8 (~558 MB) from HuggingFace,
+# cached at ~/.cache/memsearch/ — no API key, fully offline after that.
+```
+
+Node.js is required for the transcript capture hook (any version ≥ 16).
+
+---
+
+## Step 1 — Folder structure
+
+```bash
+mkdir -p context/memory context/transcripts
+touch context/memory/.gitkeep   # so git tracks the empty directory
+```
+
+`context/transcripts/` will be gitignored (machine-local captures). `context/memory/` is committed (shared daily logs).
+
+---
+
+## Step 2 — context/MEMORY.md
+
+Create only if missing — it may already contain curated facts from previous sessions:
+
+```markdown
+<!-- Cap: 2,500 chars. Agent maintains via memory-write instructions. -->
+# Working Memory
+
+## Active Threads
+
+## Environment Notes
+
+## Pending Decisions
+```
+
+---
+
+## Step 3 — context/USER.md
+
+Create only if missing:
+
+```markdown
+<!-- Cap: 1,375 chars. Updated by the agent when it learns preferences. -->
+# User Profile
+
+## About
+
+## Preferences
+
+## Working Style
+```
+
+---
+
+## Step 4 — Transcript capture hook
+
+Create `.claude/hooks/transcript-capture.js`:
+
+```javascript
+const fs = require('fs');
+const path = require('path');
+
+// Stop hook: appends first 500 chars of each response to today's transcript file.
+const input = JSON.parse(fs.readFileSync('/dev/stdin', 'utf8'));
+
+if (input.stop_reason === 'end_turn' && input.response) {
+  const today = new Date().toISOString().slice(0, 10);
+  const dir = path.join(process.env.CLAUDE_PROJECT_DIR || '.', 'context', 'transcripts');
+  const file = path.join(dir, `${today}.md`);
+
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const summary = input.response.slice(0, 500).replace(/\n{3,}/g, '\n\n');
+    const timestamp = new Date().toISOString().slice(11, 19);
+    fs.appendFileSync(file, `\n## ${timestamp}\n${summary}\n`);
+  } catch (e) {
+    // Fire and forget — don't break the session
+  }
+}
+```
+
+Register it in `.claude/settings.json`. Merge with existing content — do not replace the whole file:
+
+```json
+{
+  "Stop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "node .claude/hooks/transcript-capture.js"
+        }
+      ]
+    }
+  ]
+}
+```
+
+If the file already has a `Stop` array, append the hook object to it. If the file uses a `"hooks": { "Stop": [...] }` wrapper instead of top-level keys, use that same format.
+
+---
+
+## Step 5 — CLAUDE.md memory sections
+
+Read `CLAUDE.md` first. Skip any section that already exists. Add only what is missing.
+
+### Session Startup
+
+```markdown
+## Session Startup (silent — do not output anything)
+
+On every session start, read these files silently:
+1. Read `context/USER.md` (~1.4 KB max)
+2. Read `context/MEMORY.md` (~2.5 KB max, curated working scratchpad)
+3. Read `context/memory/{today's date in YYYY-MM-DD}.md` if it exists
+4. If today's memory file has no prior sessions, also read yesterday's
+
+These files are your "frozen snapshot" — loaded once at session start. Mid-session writes
+persist to disk but take effect next session. This preserves the prefix cache.
+
+Total injected: ~3,000 tokens. Do not load more than this at startup.
+```
+
+### Memory Budget
+
+```markdown
+### Memory Budget
+
+- `context/MEMORY.md`: 2,500 character cap. Before writing, check `wc -c`. If over cap, consolidate existing entries before adding.
+- `context/USER.md`: 1,375 character cap. Same rule.
+- Mid-session writes to these files persist to disk but only appear in context next session (frozen snapshot pattern — preserves prefix cache).
+```
+
+### Memory Write
+
+```markdown
+### Memory Write
+
+When the user says "remember this", "note that", "update memory", or "forget about":
+1. Read `context/MEMORY.md` in full
+2. Check for duplicates (scan for substring match)
+3. Check character count: `wc -c < context/MEMORY.md`
+4. If under 2,500 chars: append the new fact under the appropriate section
+5. If over cap: consolidate — merge similar entries, remove stale ones, then add
+6. Actions: add (append), replace (find substring + swap), remove (confirm with user first)
+7. After writing: "Saved — will be active from next session."
+```
+
+### Memory Retrieval
+
+```markdown
+### Memory Retrieval
+
+When the user asks about past context, conversations, or decisions:
+
+1. **Tier 0**: Check `context/MEMORY.md` and today's daily log — already in context, zero cost
+2. **L1**: Run `memsearch search "query" --top-k 5` — hybrid vector + keyword search. Finds semantic matches even with different words (e.g. "pricing" finds "monetisation")
+3. **L2**: Run `memsearch expand <chunk_hash>` — returns full markdown section around the match
+4. **L3**: Run `memsearch transcript <session_id>` — raw dialogue, last resort
+5. **Fallback**: "I don't have a record of that."
+
+Only escalate if the previous tier didn't find the answer.
+```
+
+### Daily Log
+
+```markdown
+### Daily Log
+
+Track session activity in `context/memory/{YYYY-MM-DD}.md`. One file per day, numbered session blocks:
+
+#### Session N
+**Goal**: [one line, filled when user states their goal]
+**Deliverables**: [files created/modified]
+**Decisions**: [key decisions and rationale]
+**Open threads**: [anything unfinished]
+
+Log these silently as they happen. Never announce "I've logged that."
+```
+
+---
+
+## Step 6 — memory-write skill (optional, if .claude/skills/ exists)
+
+Create `.claude/skills/memory-write/SKILL.md`:
+
+```markdown
+---
+name: memory-write
+description: >
+  Saves durable facts to context/MEMORY.md. Triggers on "remember this",
+  "note that", "update memory", "save this", "forget about". Three actions:
+  add (append under correct section), replace (substring match + swap),
+  remove (confirm with user first). Enforces 2,500 char cap with dedup guard.
+---
+
+# Memory Write
+
+## Outcome
+- Fact added to, updated in, or removed from `context/MEMORY.md`
+- Character cap enforced (2,500 chars)
+- Confirmation message: "Saved — will be active from next session."
+
+## Steps
+
+1. Read `context/MEMORY.md` in full
+2. Determine action: add, replace, or remove
+3. **Dedup check**: scan for substring match — if the fact already exists, skip or update
+4. **Cap check**: run `wc -c < context/MEMORY.md` — if over 2,500, consolidate before adding
+5. Write the change
+6. Confirm: "Saved — will be active from next session."
+
+For **remove**: always confirm with the user before deleting.
+
+## Sections in MEMORY.md
+- `## Active Threads` — current work, open questions
+- `## Environment Notes` — URLs, API keys (names only), tool versions, project structure
+- `## Pending Decisions` — decisions that need to be made
+
+## Rules
+- Never exceed 2,500 characters
+- Always check for duplicates before adding
+- Replace is preferred over add when updating existing facts
+```
+
+---
+
+## Step 7 — Configure MemSearch embedding provider
+
+Create `.memsearch.toml` in the repo root:
+
+```toml
+[embedding]
+provider = "onnx"
+```
+
+This overrides the default (OpenAI) with local ONNX inference — no API key needed.
+Commit this file so everyone on the team gets the same setting.
+
+---
+
+## Step 8 — Update .gitignore
+
+Add these two lines (skip any already present):
+
+```
+context/transcripts/
+.memsearch/
+```
+
+`context/transcripts/` — machine-local transcript captures, not shared  
+`.memsearch/` — local vector database, rebuilt per-machine by `memsearch index`
+
+---
+
+## Step 9 — First index (local machine only)
+
+```bash
+memsearch index context/memory context/transcripts
+```
+
+- First run: downloads the bge-m3 model (~558 MB, cached permanently at `~/.cache/memsearch/`)
+- Subsequent runs: fully offline, typically completes in seconds
+- Re-run after sessions to incorporate new daily logs and transcripts
+- Remote/CI environments: skip this step — they don't have writable caches or persistent storage
+
+---
+
+## Verification
+
+After setup, start a new Claude Code session and confirm:
+
+1. Claude reads `context/MEMORY.md` and `context/USER.md` silently at startup (no output)
+2. Say **"remember that our staging URL is staging.example.com"** → Claude writes to `context/MEMORY.md`
+3. After any response, check `context/transcripts/{today}.md` has a new entry
+4. Run `memsearch index context/memory context/transcripts` then `memsearch search "staging"` → finds the entry
+5. In a new session, ask **"what's our staging URL?"** → Tier 0 finds it in `context/MEMORY.md` without a search
+
+---
+
+## Files summary
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `context/MEMORY.md` | Create (if missing) | Curated working memory, 2,500-char cap |
+| `context/USER.md` | Create (if missing) | User profile and preferences, 1,375-char cap |
+| `context/memory/` | Create directory | Daily session logs (git-tracked) |
+| `context/transcripts/` | Create directory | Transcript captures (gitignored) |
+| `.claude/hooks/transcript-capture.js` | Create | Stop hook — auto-captures each response |
+| `.claude/skills/memory-write/SKILL.md` | Create (if skills dir exists) | Curated write/dedup/cap skill |
+| `.memsearch.toml` | Create | Sets ONNX provider (no API key) |
+| `CLAUDE.md` | Add sections | Session startup, budget, write, retrieval, daily log |
+| `.claude/settings.json` | Add Stop hook entry | Wires transcript-capture.js |
+| `.gitignore` | Add two lines | Excludes transcripts/ and .memsearch/ |
+
+---
+
+## Embedding provider options
+
+| Provider | Cost | Requires | Notes |
+|----------|------|----------|-------|
+| `onnx` (recommended) | Free | `pip install 'memsearch[onnx]'`, first-run HuggingFace download | CPU-only, fully offline after model cache, bge-m3-onnx-int8 |
+| `ollama` | Free | Ollama running locally | `pip install 'memsearch[ollama]'`, use `nomic-embed-text` or similar |
+| `openai` (default) | ~$0.02/1M tokens | `OPENAI_API_KEY` | Highest throughput for large corpora |
+| `google` | Varies | GCP credentials | `pip install 'memsearch[google]'` |
+
+Switch provider: `memsearch config set embedding.provider <name>` (or edit `.memsearch.toml`).
+
+---
+
+## Maintenance
+
+- **Nightly**: run `memsearch index context/memory context/transcripts` to incorporate new content
+- **Weekly**: review `context/MEMORY.md` — prune stale entries, merge duplicates, stay under 2,500 chars
+- **Context/transcripts is gitignored** — each developer's local transcript history stays on their machine; only the curated `context/memory/*.md` daily logs are shared via git

--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -87,6 +87,7 @@ append new items here rather than only printing them once.
 > `[ ] (YYYY-MM-DD, /<skill-name>) <action> — <why>`
 
 <!-- skill-followups:start -->
+- [ ] (2026-06-11, /memory-management) Activate MemSearch recall — on your local machine, set `OPENAI_API_KEY` and run `memsearch index context/memory context/transcripts` from the repo root. Re-run nightly to keep the vector index fresh. Without this, recall falls back to grep-only.
 - [ ] (2026-04-27, /quality-peer-review) Configure per-brand Firebase service
   account env vars on push-notifications-service production
   (`PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_HABITS`,

--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -87,7 +87,7 @@ append new items here rather than only printing them once.
 > `[ ] (YYYY-MM-DD, /<skill-name>) <action> — <why>`
 
 <!-- skill-followups:start -->
-- [ ] (2026-06-11, /memory-management) Activate MemSearch recall — on your local machine, set `OPENAI_API_KEY` and run `memsearch index context/memory context/transcripts` from the repo root. Re-run nightly to keep the vector index fresh. Without this, recall falls back to grep-only.
+- [ ] (2026-06-11, /memory-management) Activate MemSearch recall — on your local machine, run `pip install 'memsearch[onnx]'` then `memsearch index context/memory context/transcripts`. First run downloads the bge-m3-onnx-int8 model (~558 MB, HuggingFace, cached permanently at `~/.cache/memsearch/`). No API key needed — fully local ONNX inference on CPU. Re-run after sessions to keep the index fresh.
 - [ ] (2026-04-27, /quality-peer-review) Configure per-brand Firebase service
   account env vars on push-notifications-service production
   (`PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_HABITS`,


### PR DESCRIPTION
Implements the three-layer memory architecture from the ScrapeSHQ plan:

Store: transcript-capture.js Stop hook writes first 500 chars of each
response to context/transcripts/{date}.md for later vector indexing.
CLAUDE.md memory-write instructions let Claude curate durable facts
into context/MEMORY.md on "remember this" / "note that" triggers.

Inject: Session Startup block in CLAUDE.md loads context/USER.md,
context/MEMORY.md (2,500-char cap), and today's daily log at session
start as a frozen snapshot (~3,000 tokens). Survives container resets
in remote environments because files are git-tracked.

Recall: Tiered retrieval — Tier 0 (MEMORY.md already in context, zero
cost) → L1 memsearch hybrid vector+keyword search → L2 expand chunk
→ L3 raw transcript. memsearch skill registered; index step requires
OPENAI_API_KEY on local machine (see WORK_IN_PROGRESS.md TODO).

Files added:
- context/MEMORY.md, context/USER.md — curated working memory
- context/memory/ — daily session logs (git-tracked)
- context/transcripts/ — auto-captured transcripts (gitignored)
- .claude/hooks/transcript-capture.js — Stop hook
- .claude/skills/memory-write/SKILL.md — memory-write skill
- .gitignore additions: context/transcripts/, .memsearch/

https://claude.ai/code/session_01AaSqMYQoEMzMRTojXdRJq8