### PR TITLE
feat(memory): add team-sharing index script and optional external doc…

### DIFF
--- a/docs/MEMORY_SYSTEM_SETUP.md
+++ b/docs/MEMORY_SYSTEM_SETUP.md
@@ -27,11 +27,16 @@ Node.js is required for the transcript capture hook (any version ≥ 16).
 ## Step 1 — Folder structure
 
 ```bash
-mkdir -p context/memory context/transcripts
+mkdir -p context/memory context/transcripts context/external
 touch context/memory/.gitkeep   # so git tracks the empty directory
+touch context/external/.gitkeep
 ```
 
-`context/transcripts/` will be gitignored (machine-local captures). `context/memory/` is committed (shared daily logs).
+| Directory | Git-tracked | Purpose |
+|-----------|-------------|---------|
+| `context/memory/` | ✅ Yes | Daily session logs — shared across the team |
+| `context/external/` | ✅ Yes | Markdown exports from Notion/Confluence/local docs — shared |
+| `context/transcripts/` | ❌ Gitignored | Machine-local transcript captures |
 
 ---
 
@@ -270,16 +275,38 @@ context/transcripts/
 
 ---
 
-## Step 9 — First index (local machine only)
+## Step 9 — Indexing scripts
+
+Copy `scripts/memsearch-index.sh` and `scripts/fetch-external-docs.py` from this repo (or scaffold them — see below).
+
+**`scripts/memsearch-index.sh`** — rebuilds the local vector index from all sources:
 
 ```bash
-memsearch index context/memory context/transcripts
+scripts/memsearch-index.sh           # index memory + external docs
+scripts/memsearch-index.sh --fetch   # fetch external docs first, then index
+scripts/memsearch-index.sh --force   # re-embed everything (ignore cache)
 ```
 
-- First run: downloads the bge-m3 model (~558 MB, cached permanently at `~/.cache/memsearch/`)
-- Subsequent runs: fully offline, typically completes in seconds
-- Re-run after sessions to incorporate new daily logs and transcripts
-- Remote/CI environments: skip this step — they don't have writable caches or persistent storage
+**`scripts/fetch-external-docs.py`** — pulls external docs into `context/external/` as markdown. All sources are opt-in via env vars — set only what you have:
+
+| Source | Required env vars |
+|--------|-------------------|
+| Notion | `NOTION_API_KEY`, `NOTION_DATABASE_IDS` (comma-separated) |
+| Confluence | `CONFLUENCE_URL`, `CONFLUENCE_EMAIL`, `CONFLUENCE_API_TOKEN`, `CONFLUENCE_SPACE_KEYS` |
+| Local folder | `LOCAL_DOCS_PATH` (absolute path to any local docs directory) |
+
+Unset sources are silently skipped. The script prints which were active and which were skipped on each run.
+
+**First run (local machine only):**
+
+```bash
+pip install 'memsearch[onnx]'
+scripts/memsearch-index.sh
+```
+
+First run downloads the bge-m3 model (~558 MB, cached permanently at `~/.cache/memsearch/`). Subsequent runs are fully offline and complete in seconds.
+
+Remote/CI environments: skip indexing — they lack writable caches and persistent storage. The markdown source files in `context/` are what CI needs; the vector index is a local dev tool.
 
 ---
 
@@ -290,7 +317,7 @@ After setup, start a new Claude Code session and confirm:
 1. Claude reads `context/MEMORY.md` and `context/USER.md` silently at startup (no output)
 2. Say **"remember that our staging URL is staging.example.com"** → Claude writes to `context/MEMORY.md`
 3. After any response, check `context/transcripts/{today}.md` has a new entry
-4. Run `memsearch index context/memory context/transcripts` then `memsearch search "staging"` → finds the entry
+4. Run `scripts/memsearch-index.sh` then `memsearch search "staging"` → finds the entry
 5. In a new session, ask **"what's our staging URL?"** → Tier 0 finds it in `context/MEMORY.md` without a search
 
 ---
@@ -301,8 +328,11 @@ After setup, start a new Claude Code session and confirm:
 |------|--------|---------|
 | `context/MEMORY.md` | Create (if missing) | Curated working memory, 2,500-char cap |
 | `context/USER.md` | Create (if missing) | User profile and preferences, 1,375-char cap |
-| `context/memory/` | Create directory | Daily session logs (git-tracked) |
-| `context/transcripts/` | Create directory | Transcript captures (gitignored) |
+| `context/memory/` | Create directory | Daily session logs (git-tracked, shared) |
+| `context/external/` | Create directory | External doc exports (git-tracked, shared) |
+| `context/transcripts/` | Create directory | Transcript captures (gitignored, machine-local) |
+| `scripts/memsearch-index.sh` | Create | Rebuilds vector index from all sources |
+| `scripts/fetch-external-docs.py` | Create | Pulls Notion/Confluence/local docs → markdown |
 | `.claude/hooks/transcript-capture.js` | Create | Stop hook — auto-captures each response |
 | `.claude/skills/memory-write/SKILL.md` | Create (if skills dir exists) | Curated write/dedup/cap skill |
 | `.memsearch.toml` | Create | Sets ONNX provider (no API key) |
@@ -325,8 +355,63 @@ Switch provider: `memsearch config set embedding.provider <name>` (or edit `.mem
 
 ---
 
+## Team sharing
+
+The vector index itself (`.memsearch/`, gitignored) is a derived artifact — each developer builds it locally. What gets shared via git is the **source**:
+
+| Shared via git (source) | Machine-local (derived) |
+|-------------------------|------------------------|
+| `context/memory/*.md` — daily logs | `.memsearch/` — vector DB |
+| `context/external/**/*.md` — doc exports | `context/transcripts/` — transcripts |
+| `context/MEMORY.md`, `context/USER.md` | `~/.cache/memsearch/` — ONNX model |
+
+**After `git pull`**, any developer rebuilds their index in one command:
+
+```bash
+scripts/memsearch-index.sh
+```
+
+This avoids committing binary database blobs (which generate unreadable diffs and balloon git history). The tradeoff: a ~seconds rebuild step after pulling instead of instant search. For most teams this is the right call.
+
+> **Why not commit the `.db` file?** Milvus-lite stores data as a binary SQLite blob. Every re-index produces a completely different binary diff — git can't compress or diff it. A 500-doc index is ~10–30 MB of opaque binary per commit. Git LFS solves this but adds infrastructure. The markdown-as-source-of-truth approach avoids the problem entirely.
+
+## External docs ingestion
+
+`scripts/fetch-external-docs.py` writes markdown files into `context/external/`, which are then committed and shared. Teammates get new docs on `git pull` without running the fetch script themselves.
+
+**Recommended workflow for the person who owns doc syncing:**
+
+```bash
+# Pull latest docs from all configured sources
+NOTION_API_KEY=... NOTION_DATABASE_IDS=page-id-1,page-id-2 \
+  scripts/memsearch-index.sh --fetch
+
+# Commit the updated markdown exports
+git add context/external/
+git commit -m "docs(memory): refresh external docs from Notion"
+git push
+```
+
+**Or automate with a GitHub Action** (cron, nightly):
+
+```yaml
+- name: Fetch and commit external docs
+  env:
+    NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+    NOTION_DATABASE_IDS: ${{ vars.NOTION_DATABASE_IDS }}
+  run: |
+    pip install memsearch 'memsearch[onnx]' notion-client
+    python3 scripts/fetch-external-docs.py
+    git add context/external/
+    git diff --cached --quiet || git commit -m "chore: refresh external docs"
+    git push
+```
+
+Note: the GitHub Action only fetches and commits the markdown. It does **not** run `memsearch index` — that stays local per developer.
+
 ## Maintenance
 
-- **Nightly**: run `memsearch index context/memory context/transcripts` to incorporate new content
+- **After `git pull`**: run `scripts/memsearch-index.sh` to incorporate new daily logs and external docs
 - **Weekly**: review `context/MEMORY.md` — prune stale entries, merge duplicates, stay under 2,500 chars
-- **Context/transcripts is gitignored** — each developer's local transcript history stays on their machine; only the curated `context/memory/*.md` daily logs are shared via git
+- **When adding a new external source**: set the relevant env vars, run `scripts/memsearch-index.sh --fetch`, commit `context/external/`
+- **Context/transcripts is gitignored** — each developer's local transcript history stays on their machine

--- a/docs/MEMORY_SYSTEM_SETUP.md
+++ b/docs/MEMORY_SYSTEM_SETUP.md
@@ -331,6 +331,7 @@ After setup, start a new Claude Code session and confirm:
 | `context/memory/` | Create directory | Daily session logs (git-tracked, shared) |
 | `context/external/` | Create directory | External doc exports (git-tracked, shared) |
 | `context/transcripts/` | Create directory | Transcript captures (gitignored, machine-local) |
+| `scripts/memory-stats.sh` | Create | Health dashboard — utilization, cadence, token cost |
 | `scripts/memsearch-index.sh` | Create | Rebuilds vector index from all sources |
 | `scripts/fetch-external-docs.py` | Create | Pulls Notion/Confluence/local docs → markdown |
 | `.claude/hooks/transcript-capture.js` | Create | Stop hook — auto-captures each response |
@@ -352,6 +353,52 @@ After setup, start a new Claude Code session and confirm:
 | `google` | Varies | GCP credentials | `pip install 'memsearch[google]'` |
 
 Switch provider: `memsearch config set embedding.provider <name>` (or edit `.memsearch.toml`).
+
+---
+
+## Monitoring
+
+Run `scripts/memory-stats.sh` at any time for a health dashboard:
+
+```
+=== Memory System Health ===
+
+Working memory
+  MEMORY.md     847 / 2500 chars  ######..............  34%
+  USER.md       312 / 1375 chars  ####................  23%
+
+Session logs
+  Daily logs: 12 file(s)  (2026-05-28 → 2026-06-14)
+  Last log:   2026-06-14 — 42 line(s)
+
+Transcripts (machine-local, gitignored)
+  Captures:  8 file(s), 24 KB total
+  Latest:    2026-06-14
+
+External docs (context/external/, git-tracked)
+  notion: 14 file(s)
+
+Vector index (machine-local, .memsearch/)
+  Chunks indexed: 312
+  Last indexed:   2026-06-14 09:30
+
+Estimated inject cost per session
+  MEMORY.md:   ~212 tokens
+  USER.md:     ~78 tokens
+  Today's log: ~105 tokens
+  ─────────────────────────────
+  Total inject: ~395 tokens  (chars ÷ 4, rough estimate)
+
+  Budget: 3,000 tokens target. Claude's context window: 200k tokens.
+  Memory overhead: ~0% of available context.
+```
+
+**What to watch:**
+- `MEMORY.md` bar hitting yellow (70%) or red (90%) → time to consolidate entries
+- Session logs cadence → confirms Claude is writing daily logs each session
+- Total inject staying well under 3,000 tokens → healthy; if it creeps up, trim USER.md or MEMORY.md
+
+**Exact token counts** aren't exposed by Claude Code, so the estimate uses `chars ÷ 4` (conservative; real tokenization is closer to `chars ÷ 3.5` for mixed code/prose). Directionally accurate — good enough for budget monitoring.
 
 ---
 

--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -87,7 +87,7 @@ append new items here rather than only printing them once.
 > `[ ] (YYYY-MM-DD, /<skill-name>) <action> — <why>`
 
 <!-- skill-followups:start -->
-- [ ] (2026-06-11, /memory-management) Activate MemSearch recall — on your local machine, run `pip install 'memsearch[onnx]'` then `memsearch index context/memory context/transcripts`. First run downloads the bge-m3-onnx-int8 model (~558 MB, HuggingFace, cached permanently at `~/.cache/memsearch/`). No API key needed — fully local ONNX inference on CPU. Re-run after sessions to keep the index fresh.
+- [ ] (2026-06-11, /memory-management) Activate MemSearch recall — on your local machine, run `pip install 'memsearch[onnx]'` then `scripts/memsearch-index.sh`. First run downloads the bge-m3-onnx-int8 model (~558 MB, HuggingFace, cached permanently at `~/.cache/memsearch/`). No API key needed — fully local ONNX inference on CPU. Re-run after `git pull` to pick up new session logs and external docs. See `docs/MEMORY_SYSTEM_SETUP.md` for team-sharing and Notion/Confluence ingestion setup.
 - [ ] (2026-04-25, manual) Run `20260425000004_main.directMessages.brandVariation`
   migration on production messages-service (`npm run migrations:run`). Without it
   the `brandVariation` column does not exist, `searchDirectMessages` fails with a

--- a/scripts/fetch-external-docs.py
+++ b/scripts/fetch-external-docs.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+fetch-external-docs.py — pull external documentation into context/external/
+for memsearch indexing.
+
+Sources are opt-in: set the relevant env vars to activate each one.
+Output is plain markdown committed to git, so the team shares it via git pull.
+
+Supported sources:
+  Notion    — set NOTION_API_KEY + NOTION_DATABASE_IDS (comma-separated page/db IDs)
+  Confluence — set CONFLUENCE_URL + CONFLUENCE_EMAIL + CONFLUENCE_API_TOKEN +
+               CONFLUENCE_SPACE_KEYS (comma-separated space keys, e.g. "ENG,PROD")
+
+Run manually:
+  python3 scripts/fetch-external-docs.py
+
+Or via the index script:
+  scripts/memsearch-index.sh --fetch
+
+Add to a nightly cron / GitHub Action for automatic refresh:
+  0 2 * * * cd /path/to/repo && python3 scripts/fetch-external-docs.py && scripts/memsearch-index.sh
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+EXTERNAL_DIR = REPO_ROOT / "context" / "external"
+EXTERNAL_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def slug(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")[:80]
+
+
+def write_page(dest_dir: Path, filename: str, title: str, body: str) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    path = dest_dir / filename
+    path.write_text(f"# {title}\n\n{body}\n", encoding="utf-8")
+    print(f"  ✓ {path.relative_to(REPO_ROOT)}")
+
+
+# ---------------------------------------------------------------------------
+# Notion
+# ---------------------------------------------------------------------------
+
+def fetch_notion() -> bool:
+    api_key = os.environ.get("NOTION_API_KEY", "")
+    db_ids_raw = os.environ.get("NOTION_DATABASE_IDS", "")
+
+    if not api_key:
+        print("  Notion: skipped (NOTION_API_KEY not set)")
+        return False
+    if not db_ids_raw:
+        print("  Notion: skipped (NOTION_DATABASE_IDS not set)")
+        return False
+
+    # TODO: install notion-client → pip install notion-client
+    try:
+        from notion_client import Client  # type: ignore
+    except ImportError:
+        print("  Notion: skipped (pip install notion-client)")
+        return False
+
+    notion = Client(auth=api_key)
+    dest = EXTERNAL_DIR / "notion"
+    db_ids = [d.strip() for d in db_ids_raw.split(",") if d.strip()]
+
+    print(f"  Notion: fetching {len(db_ids)} database(s)...")
+    fetched = 0
+
+    for db_id in db_ids:
+        try:
+            results = notion.databases.query(database_id=db_id).get("results", [])
+            for page in results:
+                title_prop = next(
+                    (v for v in page.get("properties", {}).values()
+                     if v.get("type") == "title"),
+                    None,
+                )
+                title = (
+                    title_prop["title"][0]["plain_text"]
+                    if title_prop and title_prop.get("title")
+                    else page["id"]
+                )
+                # Fetch page blocks and convert to plain text
+                blocks = notion.blocks.children.list(block_id=page["id"]).get("results", [])
+                lines = []
+                for b in blocks:
+                    btype = b.get("type", "")
+                    rich = b.get(btype, {}).get("rich_text", [])
+                    text = "".join(r.get("plain_text", "") for r in rich)
+                    if text:
+                        lines.append(text)
+                body = "\n\n".join(lines) if lines else "_No content_"
+                write_page(dest, f"{slug(title)}.md", title, body)
+                fetched += 1
+        except Exception as exc:
+            print(f"  Notion: error on db {db_id}: {exc}")
+
+    print(f"  Notion: wrote {fetched} page(s) → context/external/notion/")
+    return fetched > 0
+
+
+# ---------------------------------------------------------------------------
+# Confluence
+# ---------------------------------------------------------------------------
+
+def fetch_confluence() -> bool:
+    base_url = os.environ.get("CONFLUENCE_URL", "")          # e.g. https://myorg.atlassian.net
+    email = os.environ.get("CONFLUENCE_EMAIL", "")
+    token = os.environ.get("CONFLUENCE_API_TOKEN", "")
+    space_keys_raw = os.environ.get("CONFLUENCE_SPACE_KEYS", "")
+
+    if not all([base_url, email, token]):
+        print("  Confluence: skipped (CONFLUENCE_URL / CONFLUENCE_EMAIL / CONFLUENCE_API_TOKEN not set)")
+        return False
+    if not space_keys_raw:
+        print("  Confluence: skipped (CONFLUENCE_SPACE_KEYS not set)")
+        return False
+
+    # TODO: install requests → pip install requests (usually already present)
+    try:
+        import requests  # type: ignore
+    except ImportError:
+        print("  Confluence: skipped (pip install requests)")
+        return False
+
+    from requests.auth import HTTPBasicAuth
+
+    auth = HTTPBasicAuth(email, token)
+    headers = {"Accept": "application/json"}
+    dest = EXTERNAL_DIR / "confluence"
+    space_keys = [s.strip() for s in space_keys_raw.split(",") if s.strip()]
+
+    print(f"  Confluence: fetching {len(space_keys)} space(s)...")
+    fetched = 0
+
+    for space_key in space_keys:
+        start = 0
+        limit = 50
+        while True:
+            url = (
+                f"{base_url.rstrip('/')}/wiki/rest/api/content"
+                f"?spaceKey={space_key}&type=page&expand=body.storage"
+                f"&start={start}&limit={limit}"
+            )
+            try:
+                resp = requests.get(url, headers=headers, auth=auth, timeout=30)
+                resp.raise_for_status()
+                data = resp.json()
+            except Exception as exc:
+                print(f"  Confluence: error fetching space {space_key}: {exc}")
+                break
+
+            pages = data.get("results", [])
+            for page in pages:
+                title = page.get("title", page["id"])
+                # Strip HTML tags from Confluence storage format
+                html = page.get("body", {}).get("storage", {}).get("value", "")
+                text = re.sub(r"<[^>]+>", " ", html)
+                text = re.sub(r"\s{2,}", "\n\n", text).strip()
+                body = text if text else "_No content_"
+                write_page(dest / space_key.lower(), f"{slug(title)}.md", title, body)
+                fetched += 1
+
+            if data.get("size", 0) < limit:
+                break
+            start += limit
+
+    print(f"  Confluence: wrote {fetched} page(s) → context/external/confluence/")
+    return fetched > 0
+
+
+# ---------------------------------------------------------------------------
+# Local markdown folder (no credentials needed)
+# ---------------------------------------------------------------------------
+
+def fetch_local_folder() -> bool:
+    """
+    Copy markdown files from a local docs folder into context/external/local/.
+    Set LOCAL_DOCS_PATH to the absolute path of any local documentation folder.
+    Example: LOCAL_DOCS_PATH=/Users/you/company-wiki
+    """
+    local_path_raw = os.environ.get("LOCAL_DOCS_PATH", "")
+    if not local_path_raw:
+        print("  Local folder: skipped (LOCAL_DOCS_PATH not set)")
+        return False
+
+    local_path = Path(local_path_raw).expanduser()
+    if not local_path.is_dir():
+        print(f"  Local folder: skipped ({local_path} does not exist)")
+        return False
+
+    dest = EXTERNAL_DIR / "local"
+    md_files = list(local_path.rglob("*.md"))
+    print(f"  Local folder: copying {len(md_files)} files from {local_path}...")
+
+    for src_file in md_files:
+        rel = src_file.relative_to(local_path)
+        dest_file = dest / rel
+        dest_file.parent.mkdir(parents=True, exist_ok=True)
+        dest_file.write_bytes(src_file.read_bytes())
+        print(f"  ✓ context/external/local/{rel}")
+
+    print(f"  Local folder: copied {len(md_files)} file(s) → context/external/local/")
+    return bool(md_files)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    print("=== fetch-external-docs ===")
+    print(f"Output: {EXTERNAL_DIR.relative_to(REPO_ROOT)}/")
+    print()
+
+    results = {
+        "notion": fetch_notion(),
+        "confluence": fetch_confluence(),
+        "local": fetch_local_folder(),
+    }
+
+    active = [k for k, v in results.items() if v]
+    skipped = [k for k, v in results.items() if not v]
+
+    print()
+    if active:
+        print(f"✓ Fetched: {', '.join(active)}")
+    if skipped:
+        print(f"  Skipped: {', '.join(skipped)} (env vars not set)")
+    print()
+    print("Next: run scripts/memsearch-index.sh to rebuild the search index")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/memory-stats.sh
+++ b/scripts/memory-stats.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# memory-stats.sh — health dashboard for the Claude Code memory system.
+#
+# Usage: scripts/memory-stats.sh
+#
+# Shows memory utilization, session log cadence, external doc coverage,
+# vector index size, and estimated token cost injected at each session start.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Colours (disabled when not a TTY)
+if [[ -t 1 ]]; then
+  BOLD="\033[1m"; RESET="\033[0m"; GREEN="\033[32m"; YELLOW="\033[33m"; RED="\033[31m"; DIM="\033[2m"
+else
+  BOLD=""; RESET=""; GREEN=""; YELLOW=""; RED=""; DIM=""
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+chars_of() { wc -c < "$1" 2>/dev/null || echo 0; }
+lines_of() { wc -l < "$1" 2>/dev/null || echo 0; }
+
+bar() {
+  local used=$1 cap=$2 width=20
+  local filled=$(( used * width / (cap > 0 ? cap : 1) ))
+  [[ $filled -gt $width ]] && filled=$width
+  local empty=$(( width - filled ))
+  local pct=$(( used * 100 / (cap > 0 ? cap : 1) ))
+  local colour="$GREEN"
+  [[ $pct -ge 70 ]] && colour="$YELLOW"
+  [[ $pct -ge 90 ]] && colour="$RED"
+  local bar_filled="" bar_empty=""
+  [[ $filled -gt 0 ]] && bar_filled="$(printf '#%.0s' $(seq 1 $filled))"
+  [[ $empty  -gt 0 ]] && bar_empty="$(printf  '.%.0s' $(seq 1 $empty))"
+  printf "${colour}%s${RESET}%s  %d%%" "$bar_filled" "$bar_empty" "$pct"
+}
+
+# ---------------------------------------------------------------------------
+# Section 1 — Working memory
+# ---------------------------------------------------------------------------
+
+echo ""
+echo -e "${BOLD}=== Memory System Health ===${RESET}"
+echo ""
+echo -e "${BOLD}Working memory${RESET}"
+
+MEMORY_FILE="context/MEMORY.md"
+USER_FILE="context/USER.md"
+MEMORY_CAP=2500
+USER_CAP=1375
+
+if [[ -f "$MEMORY_FILE" ]]; then
+  MEMORY_CHARS=$(chars_of "$MEMORY_FILE")
+  printf "  MEMORY.md   %5d / %d chars  " "$MEMORY_CHARS" "$MEMORY_CAP"
+  bar "$MEMORY_CHARS" "$MEMORY_CAP"
+  echo ""
+else
+  echo -e "  MEMORY.md   ${RED}missing${RESET} — run setup from docs/MEMORY_SYSTEM_SETUP.md"
+fi
+
+if [[ -f "$USER_FILE" ]]; then
+  USER_CHARS=$(chars_of "$USER_FILE")
+  printf "  USER.md     %5d / %d chars  " "$USER_CHARS" "$USER_CAP"
+  bar "$USER_CHARS" "$USER_CAP"
+  echo ""
+else
+  echo -e "  USER.md     ${RED}missing${RESET}"
+fi
+
+# ---------------------------------------------------------------------------
+# Section 2 — Session logs
+# ---------------------------------------------------------------------------
+
+echo ""
+echo -e "${BOLD}Session logs${RESET}"
+
+LOG_DIR="context/memory"
+if [[ -d "$LOG_DIR" ]]; then
+  LOG_COUNT=$(find "$LOG_DIR" -name "*.md" | wc -l)
+  if [[ $LOG_COUNT -gt 0 ]]; then
+    OLDEST=$(find "$LOG_DIR" -name "*.md" | sort | head -1 | xargs basename .md 2>/dev/null || echo "unknown")
+    NEWEST=$(find "$LOG_DIR" -name "*.md" | sort | tail -1 | xargs basename .md 2>/dev/null || echo "unknown")
+    NEWEST_LINES=$(find "$LOG_DIR" -name "*.md" | sort | tail -1 | xargs lines_of)
+    echo "  Daily logs: ${LOG_COUNT} file(s)  (${OLDEST} → ${NEWEST})"
+    echo "  Last log:   ${NEWEST} — ${NEWEST_LINES} line(s)"
+  else
+    echo -e "  Daily logs: ${DIM}none yet — logs appear after first session${RESET}"
+  fi
+else
+  echo -e "  ${RED}context/memory/ missing${RESET}"
+fi
+
+# ---------------------------------------------------------------------------
+# Section 3 — Transcripts (machine-local)
+# ---------------------------------------------------------------------------
+
+echo ""
+echo -e "${BOLD}Transcripts${RESET} ${DIM}(machine-local, gitignored)${RESET}"
+
+TRANSCRIPT_DIR="context/transcripts"
+if [[ -d "$TRANSCRIPT_DIR" ]]; then
+  T_COUNT=$(find "$TRANSCRIPT_DIR" -name "*.md" | wc -l)
+  if [[ $T_COUNT -gt 0 ]]; then
+    T_LATEST=$(find "$TRANSCRIPT_DIR" -name "*.md" | sort | tail -1 | xargs basename .md 2>/dev/null || echo "unknown")
+    T_TOTAL_KB=$(du -sk "$TRANSCRIPT_DIR" 2>/dev/null | awk '{print $1}' || echo 0)
+    echo "  Captures:  ${T_COUNT} file(s), ${T_TOTAL_KB} KB total"
+    echo "  Latest:    ${T_LATEST}"
+  else
+    echo -e "  ${DIM}None yet — transcripts appear after first session response${RESET}"
+  fi
+else
+  echo -e "  ${DIM}Directory not created yet${RESET}"
+fi
+
+# ---------------------------------------------------------------------------
+# Section 4 — External docs
+# ---------------------------------------------------------------------------
+
+echo ""
+echo -e "${BOLD}External docs${RESET} ${DIM}(context/external/, git-tracked)${RESET}"
+
+EXT_DIR="context/external"
+if [[ -d "$EXT_DIR" ]]; then
+  EXT_TOTAL=$(find "$EXT_DIR" -name "*.md" ! -name ".gitkeep" | wc -l)
+  if [[ $EXT_TOTAL -gt 0 ]]; then
+    for source_dir in "$EXT_DIR"/*/; do
+      [[ -d "$source_dir" ]] || continue
+      source_name=$(basename "$source_dir")
+      count=$(find "$source_dir" -name "*.md" | wc -l)
+      echo "  ${source_name}: ${count} file(s)"
+    done
+  else
+    echo -e "  ${DIM}No external docs yet${RESET}"
+    echo -e "  ${DIM}Run: scripts/memsearch-index.sh --fetch  (after configuring env vars)${RESET}"
+    echo -e "  ${DIM}See: docs/MEMORY_SYSTEM_SETUP.md → External docs ingestion${RESET}"
+  fi
+else
+  echo -e "  ${RED}context/external/ missing${RESET}"
+fi
+
+# ---------------------------------------------------------------------------
+# Section 5 — Vector index
+# ---------------------------------------------------------------------------
+
+echo ""
+echo -e "${BOLD}Vector index${RESET} ${DIM}(machine-local, .memsearch/)${RESET}"
+
+STATS_OUTPUT=$(memsearch stats 2>/dev/null || echo "")
+if echo "$STATS_OUTPUT" | grep -q "^Total indexed chunks:"; then
+  CHUNK_COUNT=$(echo "$STATS_OUTPUT" | grep "^Total indexed chunks:" | awk '{print $NF}')
+  echo "  Chunks indexed: ${CHUNK_COUNT}"
+  # Show last-modified time of the milvus DB file if it exists
+  DB_FILE=$(python3 -c "
+import os, pathlib
+p = pathlib.Path('~/.memsearch/milvus.db').expanduser()
+if p.exists():
+    import datetime
+    mtime = datetime.datetime.fromtimestamp(p.stat().st_mtime)
+    print(mtime.strftime('%Y-%m-%d %H:%M'))
+" 2>/dev/null || echo "")
+  [[ -n "$DB_FILE" ]] && echo "  Last indexed:   ${DB_FILE}"
+else
+  echo -e "  ${DIM}Not indexed yet — run: scripts/memsearch-index.sh${RESET}"
+fi
+
+# ---------------------------------------------------------------------------
+# Section 6 — Estimated inject cost
+# ---------------------------------------------------------------------------
+
+echo ""
+echo -e "${BOLD}Estimated inject cost per session${RESET}"
+
+TOTAL_CHARS=0
+BREAKDOWN=""
+
+if [[ -f "$MEMORY_FILE" ]]; then
+  C=$(chars_of "$MEMORY_FILE")
+  TOTAL_CHARS=$(( TOTAL_CHARS + C ))
+  BREAKDOWN+="  MEMORY.md:   ~$(( C / 4 )) tokens\n"
+fi
+
+if [[ -f "$USER_FILE" ]]; then
+  C=$(chars_of "$USER_FILE")
+  TOTAL_CHARS=$(( TOTAL_CHARS + C ))
+  BREAKDOWN+="  USER.md:     ~$(( C / 4 )) tokens\n"
+fi
+
+TODAY=$(date +%Y-%m-%d)
+TODAY_LOG="context/memory/${TODAY}.md"
+if [[ -f "$TODAY_LOG" ]]; then
+  C=$(chars_of "$TODAY_LOG")
+  TOTAL_CHARS=$(( TOTAL_CHARS + C ))
+  BREAKDOWN+="  Today's log: ~$(( C / 4 )) tokens\n"
+fi
+
+if [[ $TOTAL_CHARS -gt 0 ]]; then
+  echo -e "$BREAKDOWN"
+  echo "  ─────────────────────────────"
+  printf "  Total inject: ~%d tokens  (chars ÷ 4, rough estimate)\n" "$(( TOTAL_CHARS / 4 ))"
+  echo ""
+  echo -e "  ${DIM}Budget: 3,000 tokens target. Claude's context window: 200k tokens.${RESET}"
+  echo -e "  ${DIM}Memory overhead: ~$(( TOTAL_CHARS * 100 / 800000 ))% of available context.${RESET}"
+else
+  echo -e "  ${DIM}No memory files found — nothing injected yet${RESET}"
+fi
+
+echo ""

--- a/scripts/memsearch-index.sh
+++ b/scripts/memsearch-index.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# memsearch-index.sh — rebuild the local vector index from all memory sources.
+#
+# Usage:
+#   scripts/memsearch-index.sh              # index memory + external docs
+#   scripts/memsearch-index.sh --fetch      # fetch external docs first, then index
+#   scripts/memsearch-index.sh --force      # re-embed everything (ignore cache)
+#
+# Run this after `git pull` to incorporate new session logs and external docs.
+# The index lives at ~/.memsearch/milvus.db (machine-local, gitignored).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FETCH=false
+FORCE_FLAG=""
+
+for arg in "$@"; do
+  case $arg in
+    --fetch) FETCH=true ;;
+    --force) FORCE_FLAG="--force" ;;
+  esac
+done
+
+echo "=== memsearch index ==="
+echo "Repo: $REPO_ROOT"
+cd "$REPO_ROOT"
+
+# --- optional: fetch external docs first ---
+if [[ "$FETCH" == "true" ]]; then
+  if [[ ! -f "scripts/fetch-external-docs.py" ]]; then
+    echo "⚠  --fetch requested but scripts/fetch-external-docs.py not found — skipping"
+  else
+    echo ""
+    echo "Fetching external docs..."
+    python3 scripts/fetch-external-docs.py
+  fi
+fi
+
+# --- build index path list ---
+PATHS=()
+
+# Always index committed session memory
+if [[ -d "context/memory" ]]; then
+  PATHS+=("context/memory")
+fi
+
+# Index transcripts if present (gitignored, machine-local)
+if [[ -d "context/transcripts" ]] && compgen -G "context/transcripts/*.md" > /dev/null 2>&1; then
+  PATHS+=("context/transcripts")
+fi
+
+# Index external docs if any markdown files exist
+if [[ -d "context/external" ]] && compgen -G "context/external/**/*.md" "context/external/*.md" > /dev/null 2>&1; then
+  PATHS+=("context/external")
+fi
+
+if [[ ${#PATHS[@]} -eq 0 ]]; then
+  echo "Nothing to index yet — add markdown files to context/memory/ or context/external/"
+  exit 0
+fi
+
+echo ""
+echo "Indexing:"
+for p in "${PATHS[@]}"; do
+  echo "  • $p"
+done
+echo ""
+
+memsearch index $FORCE_FLAG "${PATHS[@]}"
+
+echo ""
+echo "✓ Index updated. Test with: memsearch search \"your query\""


### PR DESCRIPTION
… ingestion

scripts/memsearch-index.sh — single command to rebuild the local vector index from all sources (context/memory, context/transcripts, context/external). Supports --fetch (run fetch script first) and --force (re-embed everything). Replaces the manual memsearch index command in WORK_IN_PROGRESS.md.

scripts/fetch-external-docs.py — pulls external docs into context/external/ as committed markdown. All three sources (Notion, Confluence, local folder) are opt-in via env vars; unset sources are silently skipped. The script prints what ran and what was skipped on each invocation.

context/external/ — new git-tracked directory for markdown exports. Shared via git pull so teammates get updated docs without running the fetch script. The vector DB (.memsearch/) stays gitignored; each dev rebuilds from source in seconds with scripts/memsearch-index.sh after a pull.

docs/MEMORY_SYSTEM_SETUP.md — expanded with team-sharing architecture explanation, external docs ingestion workflow, optional GitHub Action for nightly doc refresh, and updated files summary table.

https://claude.ai/code/session_01AaSqMYQoEMzMRTojXdRJq8