### PR TITLE
feat(eas): enable autoSubmit to push builds to Google Play Store

### DIFF
--- a/TherrMobile/eas.json
+++ b/TherrMobile/eas.json
@@ -12,7 +12,8 @@
         "buildType": "app-bundle",
         "gradleCommand": ":app:bundleRelease",
         "credentialsSource": "remote"
-      }
+      },
+      "autoSubmit": true
     }
   },
   "submit": {


### PR DESCRIPTION
Adds autoSubmit: true to the therr-internal build profile so EAS
automatically runs submission to the Play Store (internal track, draft)
after each successful build, using the existing submit profile and
service account credentials stored in EAS secrets.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JfZA7D7aXx2zuuP4tohYaj