### PR TITLE
fix(mobile): use Lexend font and tighten header title style

### DIFF
--- a/TherrMobile/main/styles/index.ts
+++ b/TherrMobile/main/styles/index.ts
@@ -373,15 +373,15 @@ const buildStyles = (themeName?: IMobileThemeName) => {
         },
         headerTitleStyle: {
             fontSize: 20,
-            fontFamily: Platform.OS === 'ios' ? 'Lexend-Regular' : 'monospace',
+            fontFamily: therrFontFamily,
             alignSelf: 'center',
             textAlign: 'center',
             justifyContent: 'center',
             flex: 1,
-            letterSpacing: Platform.OS === 'ios' ? 1 : 2,
+            letterSpacing: 0,
             lineHeight: HEADER_HEIGHT,
             overflow: 'hidden',
-            fontWeight: 'bold',
+            fontWeight: '600',
         },
         headerTitleLogoText: {
             ...headerTitleStyles,


### PR DESCRIPTION
Android was falling back to monospace with double letter-spacing,
making headers look out of place. Unify fontFamily to therrFontFamily,
remove artificial letter-spacing, and soften weight from bold to 600.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CLJJ4uHbwyWUdjbrmtz51E