### PR TITLE
fix(mobile): prepare monorepo in EAS build via eas-build-post-install

### DIFF
--- a/TherrMobile/package.json
+++ b/TherrMobile/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "eas-build-pre-install": "if [ -n \"$GOOGLE_SERVICES_JSON\" ]; then cp \"$GOOGLE_SERVICES_JSON\" android/app/google-services.json && echo 'eas-build-pre-install: copied google-services.json into android/app'; else echo 'eas-build-pre-install: WARNING GOOGLE_SERVICES_JSON not set — Android build will fail at :app:processReleaseGoogleServices'; fi",
+    "eas-build-post-install": "echo 'eas-build-post-install: preparing monorepo (root node_modules + compiled shared libs that Metro bundles)' && cd .. && HUSKY=0 npm install --legacy-peer-deps --include=dev && npm --prefix therr-public-library/therr-js-utilities run build && npm --prefix therr-public-library/therr-styles run build && npm --prefix therr-public-library/therr-react run build && echo 'eas-build-post-install: monorepo prepared (../node_modules + therr-js-utilities/lib + therr-styles/lib + therr-react/lib)'",
     "android": "export $(cat .env | xargs) && ./node_modules/.bin/react-native run-android",
     "android:clean": "pushd android && rm -rf app/.cxx app/build app/build/generated/autolinking .gradle build && ./gradlew clean; popd",
     "android:clean:cache": "pushd android && rm -rf app/.cxx app/build/generated/autolinking app/build/intermediates/cxx app/build/intermediates/cmake; popd",


### PR DESCRIPTION
EAS cloud builds run `npm install` only inside TherrMobile/, so the monorepo root node_modules and the compiled shared-library lib/ dirs (therr-js-utilities, therr-styles, therr-react) never exist in the builder. Metro's watchFolders/extraNodeModules point at those absent paths, so Transformer.verifyRootExists stat()s
/home/expo/workingdir/build/node_modules, throws ENOENT, and the bundle crashes with "Cannot read properties of undefined (reading 'end')".

Add an eas-build-post-install hook that installs the root dependencies and builds the shared libs in dependency order (js-utilities + styles before therr-react, which bundles both), so the EAS builder mirrors a local dev checkout before Metro bundles.


Claude-Session: https://claude.ai/code/session_01XxJXDZxxKXiAjr1TZPoxNY