### PR TITLE
fix(mobile): unblock EAS Android build (monorepo prep + node-builtin bundle leak)

### DIFF
--- a/therr-public-library/therr-react/src/services/CampaignsService.ts
+++ b/therr-public-library/therr-react/src/services/CampaignsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import { getSearchQueryString } from 'therr-js-utilities/http';
+import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
 import { ISearchQuery } from '../types';
 
 class CampaignsService {

--- a/therr-public-library/therr-react/src/services/ForumsService.ts
+++ b/therr-public-library/therr-react/src/services/ForumsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import { getSearchQueryString } from 'therr-js-utilities/http';
+import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
 import { ISearchQuery } from '../types';
 import { ICreateEventBody } from './MapsService';
 

--- a/therr-public-library/therr-react/src/services/MapsService.ts
+++ b/therr-public-library/therr-react/src/services/MapsService.ts
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
 import uuid from 'react-native-uuid';
-import { getSearchQueryString } from 'therr-js-utilities/http';
+import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
 import { IAreaType } from 'therr-js-utilities/types';
 import { ISearchQuery } from '../types';
 

--- a/therr-public-library/therr-react/src/services/MessagesService.ts
+++ b/therr-public-library/therr-react/src/services/MessagesService.ts
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
 import { ILogLevel } from 'therr-js-utilities/constants';
-import { getSearchQueryString } from 'therr-js-utilities/http';
+import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
 import { ISearchQuery } from '../types';
 
 class MessagesService {

--- a/therr-public-library/therr-react/src/services/NotificationsService.ts
+++ b/therr-public-library/therr-react/src/services/NotificationsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import { getSearchQueryString } from 'therr-js-utilities/http';
+import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
 import { ISearchQuery } from '../types';
 
 class NotificationsService {

--- a/therr-public-library/therr-react/src/services/UserConnectionsService.ts
+++ b/therr-public-library/therr-react/src/services/UserConnectionsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import { getSearchQueryString } from 'therr-js-utilities/http';
+import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
 import { ISearchQuery } from '../types';
 
 interface ICreateConnectionBody {

--- a/therr-public-library/therr-react/src/services/UsersService.ts
+++ b/therr-public-library/therr-react/src/services/UsersService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import { getSearchQueryString } from 'therr-js-utilities/http';
+import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
 import {
     IAccess,
     AccessCheckType,


### PR DESCRIPTION
## Problem

The EAS Android cloud build (`therr-internal` profile, kicked off by CircleCI's `eas_build_therr_android` job) failed during Metro bundling with two successive errors.

### 1. `TypeError: Cannot read properties of undefined (reading 'end')`

The real cause was hidden above it:

```
Failed to construct transformer: Error: ENOENT: no such file or directory,
stat '/home/expo/workingdir/build/node_modules'
   at verifyRootExists (.../metro/src/DeltaBundler/Transformer.js)
```

EAS uploads the whole monorepo but only runs `npm install` inside `TherrMobile/`. The metro config's `watchFolders`/`extraNodeModules` point at the monorepo-parent `../node_modules` and the shared-library `lib/` build outputs (`therr-js-utilities`, `therr-styles`, `therr-react`) — none of which exist in the EAS builder (root `node_modules` and those `lib/` dirs are gitignored). Metro stats every watch-folder root on `Transformer` construction and crashes with `ENOENT`.

### 2. `Unable to resolve module https from .../therr-react/lib/services.js`

Once the monorepo was prepared, Metro got further and hit a second issue. The `therr-react` service files imported `getSearchQueryString` from the `therr-js-utilities/http` **barrel**, which statically re-exports the backend-only `httpKeepAliveAgent`/`httpsKeepAliveAgent` from `agents.ts`. That module imports node's `http`/`https` and constructs `Agent`s at load time, so webpack baked `require('https')` into the compiled `services.js`. Web consumers stub node builtins via their browser webpack config; React Native's Metro cannot.

## Fix

**1. `eas-build-post-install` hook (`TherrMobile/package.json`)** — prepares the monorepo inside the EAS builder so it mirrors a local dev checkout: installs root deps, then builds the shared libs in dependency order (`therr-js-utilities` + `therr-styles` before `therr-react`, which bundles both). `HUSKY=0` skips the git-hook install (no `.git` in the EAS archive); `--include=dev` guards against the production environment dropping `webpack`.

**2. Direct submodule import (`therr-react` services)** — the 7 service files now import `getSearchQueryString` from `therr-js-utilities/http/get-search-query-string` instead of the barrel, so the node-only agent code is never pulled into the frontend bundle. Fixes mobile and removes the latent node-builtin leak from the web bundle too.

## Notes / verification

- Commits are split per the repo's commit-separation rule: one app-specific (`TherrMobile/package.json`), one shared-library (`therr-react`). Targeting `general` so it flows `general → stage → main` and triggers the EAS build.
- Could not run the actual EAS build from here — the next `stage → main` merge (or a manual `eas build --profile therr-internal`) will exercise the full path. Locally verified: no other frontend code imports the `therr-js-utilities/http` barrel or root barrel, so `agents.ts` has no remaining path into the RN bundle; the deep import resolves via both the `therr-js-utilities/*` tsconfig path mapping and the webpack alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxJXDZxxKXiAjr1TZPoxNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxJXDZxxKXiAjr1TZPoxNY)_