### PR TITLE
fix(shared): un-break EAS build — keep node http/https agents out of the isomorphic http barrel

### DIFF
--- a/therr-api-gateway/src/index.ts
+++ b/therr-api-gateway/src/index.ts
@@ -1,7 +1,8 @@
 /* eslint-disable import/no-import-module-exports */
 import tracing from './tracing'; // eslint-disable-line import/order
 import axios from 'axios';
-import { httpKeepAliveAgent, httpsKeepAliveAgent } from 'therr-js-utilities/http';
+import * as http from 'http';
+import * as https from 'https';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -20,8 +21,20 @@ tracing.start();
 
 // Axios defaults
 axios.defaults.timeout = 1000 * 30; // 30 Second Request timeout
-axios.defaults.httpAgent = httpKeepAliveAgent;
-axios.defaults.httpsAgent = httpsKeepAliveAgent;
+// Shared keep-alive agents reuse TCP connections across requests to the same host,
+// avoiding repeated DNS lookups and TCP handshakes on every axios call. Defined here
+// (rather than imported from therr-js-utilities/http) so the isomorphic http barrel stays
+// free of node-only `http`/`https`, which would otherwise break the React Native bundle.
+axios.defaults.httpAgent = new http.Agent({
+    keepAlive: true,
+    maxSockets: 50,
+    maxFreeSockets: 10,
+});
+axios.defaults.httpsAgent = new https.Agent({
+    keepAlive: true,
+    maxSockets: 25,
+    maxFreeSockets: 5,
+});
 
 // Mobile apps send no Origin header, so passing `!origin` through is safe and required.
 // Web clients are restricted to the URI_WHITELIST in production so any other browser origin

--- a/therr-public-library/therr-js-utilities/src/http/index.ts
+++ b/therr-public-library/therr-js-utilities/src/http/index.ts
@@ -1,10 +1,17 @@
 import configureHandleHttpError, { IErrorArgs } from './configure-handle-http-error';
 import handleHttpError, { asyncHandler, HandleHttpError } from './async-handler';
-import { httpKeepAliveAgent, httpsKeepAliveAgent } from './agents';
 import getBrandContext, { IBrandContext } from './get-brand-context';
 import getSearchQueryArgs, { IReqQuery } from './get-search-query-args';
 import getSearchQueryString from './get-search-query-string';
 import parseHeaders from './parse-headers';
+
+// NOTE: The node keep-alive agents (httpKeepAliveAgent/httpsKeepAliveAgent) intentionally
+// live in './agents' and are NOT re-exported here. They statically import node's `http`/`https`
+// and construct Agents at module load, which would drag node-only code into this isomorphic
+// barrel — and from there into the frontend bundle (therr-react/lib/services.js), breaking the
+// React Native (Metro) build, which cannot resolve `https`. The agents stay an internal module:
+// './internal-rest-request' bundles them for inter-service calls, and other backend consumers
+// (e.g. the API gateway) construct their own node agents directly.
 
 export {
     configureHandleHttpError,
@@ -13,8 +20,6 @@ export {
     HandleHttpError,
     IErrorArgs,
     IReqQuery,
-    httpKeepAliveAgent,
-    httpsKeepAliveAgent,
     getBrandContext,
     IBrandContext,
     getSearchQueryArgs,

--- a/therr-public-library/therr-react/src/services/CampaignsService.ts
+++ b/therr-public-library/therr-react/src/services/CampaignsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
+import { getSearchQueryString } from 'therr-js-utilities/http';
 import { ISearchQuery } from '../types';
 
 class CampaignsService {

--- a/therr-public-library/therr-react/src/services/ForumsService.ts
+++ b/therr-public-library/therr-react/src/services/ForumsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
+import { getSearchQueryString } from 'therr-js-utilities/http';
 import { ISearchQuery } from '../types';
 import { ICreateEventBody } from './MapsService';
 

--- a/therr-public-library/therr-react/src/services/MapsService.ts
+++ b/therr-public-library/therr-react/src/services/MapsService.ts
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
 import uuid from 'react-native-uuid';
-import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
+import { getSearchQueryString } from 'therr-js-utilities/http';
 import { IAreaType } from 'therr-js-utilities/types';
 import { ISearchQuery } from '../types';
 

--- a/therr-public-library/therr-react/src/services/MessagesService.ts
+++ b/therr-public-library/therr-react/src/services/MessagesService.ts
@@ -1,7 +1,7 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
 import { ILogLevel } from 'therr-js-utilities/constants';
-import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
+import { getSearchQueryString } from 'therr-js-utilities/http';
 import { ISearchQuery } from '../types';
 
 class MessagesService {

--- a/therr-public-library/therr-react/src/services/NotificationsService.ts
+++ b/therr-public-library/therr-react/src/services/NotificationsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
+import { getSearchQueryString } from 'therr-js-utilities/http';
 import { ISearchQuery } from '../types';
 
 class NotificationsService {

--- a/therr-public-library/therr-react/src/services/UserConnectionsService.ts
+++ b/therr-public-library/therr-react/src/services/UserConnectionsService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
+import { getSearchQueryString } from 'therr-js-utilities/http';
 import { ISearchQuery } from '../types';
 
 interface ICreateConnectionBody {

--- a/therr-public-library/therr-react/src/services/UsersService.ts
+++ b/therr-public-library/therr-react/src/services/UsersService.ts
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
-import getSearchQueryString from 'therr-js-utilities/http/get-search-query-string';
+import { getSearchQueryString } from 'therr-js-utilities/http';
 import {
     IAccess,
     AccessCheckType,


### PR DESCRIPTION
## Context

Follow-up to #2573 (merged into `main`). That PR's second fix imported `getSearchQueryString` from a deep submodule path (`therr-js-utilities/http/get-search-query-string`) to keep node `http`/`https` out of the React Native bundle. But the **built** `therr-js-utilities/lib` only emits per-barrel bundles (`lib/http.js`), not a 1:1 source mirror, so the `therr-react` webpack build (run inside the EAS `eas-build-post-install` hook) now fails:

```
ERROR in ./src/services/CampaignsService.ts
Module not found: Error: Can't resolve 'therr-js-utilities/http/get-search-query-string'
... (7 service files)
npm run eas-build-post-install exited with non-zero code: 1
```

## Root cause

The real problem is that the isomorphic `therr-js-utilities/http` barrel re-exports the **backend-only** `httpKeepAliveAgent`/`httpsKeepAliveAgent` from `agents.ts`, which statically imports node's `http`/`https` and constructs `Agent`s at module load. That dragged `require('https')` into the compiled `lib/http.js`, and from there into `therr-react/lib/services.js` — which Metro (React Native) cannot resolve. Importing a deep path was the wrong workaround; it doesn't exist in the built lib.

## Fix (at the source)

- **`therr-js-utilities/src/http/index.ts`** — stop re-exporting the node agents from the barrel, so `lib/http.js` is node-free and safe for the frontend bundle. (Aligns with the package's "isomorphic, no side effects" guidance.)
- **`therr-api-gateway/src/index.ts`** — the agents' only external consumer now constructs its own node `http`/`https` agents directly (same keep-alive tuning). The internal `internal-rest-request` helper keeps importing them from `./http/agents` (backend-only, never bundled into the frontend).
- **`therr-react` services (7 files)** — revert to the now node-free barrel import `import { getSearchQueryString } from 'therr-js-utilities/http'`, which resolves correctly in both the webpack build (alias → `lib/http.js`) and Metro.

## Why this works end-to-end

The `eas-build-post-install` hook builds `therr-js-utilities` before `therr-react`, so `therr-react`'s webpack resolves `therr-js-utilities/http` → the freshly-built node-free `lib/http.js`, bundling no `require('https')` into `services.js`; Metro then bundles cleanly. Verified locally that the frontend imports neither `internal-rest-request` nor any other module that reaches `agents.ts`, so there's no remaining node-builtin leak into the RN bundle.

## Notes

- Targets `main` to directly un-break the build introduced by #2573 (which merged there). Per CLAUDE.md these shared/backend paths normally flow `general → stage → main`; flagging the divergence.
- Single atomic commit: the barrel change, its sole consumer (api-gateway), and the service reverts must land together — splitting would leave a transiently-broken intermediate build.
- Could not run the EAS cloud build from here; the next `stage → main` EAS job (or a manual `eas build --profile therr-internal`) exercises the full path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxJXDZxxKXiAjr1TZPoxNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxJXDZxxKXiAjr1TZPoxNY)_