### PR TITLE
fix(ci): install TherrMobile isolated deps before linting it

### DIFF
--- a/_bin/cicd/lint-changed-files.sh
+++ b/_bin/cicd/lint-changed-files.sh
@@ -85,12 +85,25 @@ for PKG in "${PACKAGES[@]}"; do
   PKG_FILE_COUNT=$(echo "$PKG_FILES" | wc -l | tr -d ' ')
   printMessageNeutral "=== Linting ${PKG_FILE_COUNT} file(s) in ${PKG} ==="
 
+  # TherrMobile keeps its React Native toolchain in an isolated package.json that the
+  # root `npm ci` above does not install. Its .eslintrc.js does `extends: ['@react-native']`,
+  # which resolves @react-native/eslint-config from TherrMobile/node_modules — so without
+  # this install eslint fails with "couldn't find the config @react-native to extend from".
+  # Install (deps only; --ignore-scripts skips native postinstall) before linting it.
+  # Other packages resolve their eslint config/plugins from the hoisted root install.
+  if [ "${PKG}" = "TherrMobile" ]; then
+    printMessageNeutral "Installing TherrMobile isolated dependencies for linting..."
+    (cd TherrMobile && npm ci --legacy-peer-deps --ignore-scripts)
+    printMessageSuccess "TherrMobile dependencies installed"
+  fi
+
   # Convert package-relative paths for eslint (strip package prefix)
   # Use newline-safe conversion to space-separated args
   ESLINT_ARGS=$(echo "$PKG_FILES" | sed "s|^${PKG}/||")
 
-  # Run eslint from the package directory so .eslintrc.js resolves correctly
-  # node_modules are in the repo root (hoisted), eslint plugins resolve from there
+  # Run eslint from the package directory so .eslintrc.js resolves correctly.
+  # For most packages node_modules are in the repo root (hoisted) and eslint plugins
+  # resolve from there; TherrMobile additionally uses its own install (see above).
   (cd "${PKG}" && npx eslint $ESLINT_ARGS) || {
     printMessageError "Lint errors found in ${PKG}"
     LINT_ERRORS=$((LINT_ERRORS + 1))


### PR DESCRIPTION
## Why

The `lint_changed_files` CI job fails for **any** branch that changes a TherrMobile source file:

```
ESLint couldn't find the config "@react-native" to extend from.
The config "@react-native" was referenced from the config file in
".../TherrMobile/.eslintrc.js".
```

`_bin/cicd/lint-changed-files.sh` runs `npm ci` only at the **repo root**, then runs `npx eslint` inside each package directory. That works for the backend/web packages (their eslint plugins are hoisted to root `node_modules`), but **TherrMobile has an isolated `package.json`** and its `.eslintrc.js` does `extends: ['@react-native']`. `@react-native/eslint-config` lives in **TherrMobile's own** dependencies, which the root install never pulls in — so eslint can't resolve the extended config and the job fails.

The script's existing comment ("node_modules are in the repo root (hoisted)") simply doesn't hold for TherrMobile.

## What changed

In the per-package lint loop, when the package being linted is `TherrMobile`, install its isolated deps first:

```bash
if [ "${PKG}" = "TherrMobile" ]; then
  (cd TherrMobile && npm ci --legacy-peer-deps --ignore-scripts)
fi
```

- Gated on `PKG == TherrMobile`, which only runs when TherrMobile actually has changed files — **no install cost added to backend-only changes.**
- `--legacy-peer-deps` matches the repo's required install flag; `--ignore-scripts` skips native/postinstall steps that aren't needed for linting.
- `TherrMobile/package-lock.json` is present, so `npm ci` is valid.

Verified `bash -n` passes on the script.

## Context

Surfaced while shipping the HABITS `READ_MEDIA_IMAGES` Play-policy fix (#2578) — that PR's only TS change tripped this pre-existing infra failure. This belongs on `general` (root `_bin/**` is shared infrastructure), so it's split out as its own PR per the branch strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H388sL7ZNMjSq8Yxtm8AvT

---
_Generated by [Claude Code](https://claude.ai/code/session_01H388sL7ZNMjSq8Yxtm8AvT)_