### PR TITLE
feat(gateway): allow API-key auth to create thoughts and thought-reactions

### DIFF
--- a/therr-api-gateway/src/middleware/restrictApiKeyAccess.ts
+++ b/therr-api-gateway/src/middleware/restrictApiKeyAccess.ts
@@ -27,8 +27,18 @@ const ALLOWED_PATTERNS: { method: string; pattern: RegExp }[] = [
     { method: 'GET', pattern: /^\/v1\/users-service\/users\/[0-9a-f-]+$/ },
     { method: 'GET', pattern: /^\/v1\/users-service\/interests$/ },
 
+    // Users service - create a thought/reply as the key's own user. Posting content
+    // (including replies, which notify the parent author) is already permitted via JWT;
+    // this lets server-side automation (e.g. therr-ai-automator) post on the bot's own
+    // behalf without minting a JWT. Account management/auth/payments remain blocked.
+    { method: 'POST', pattern: /^\/v1\/users-service\/thoughts$/ },
+
     // Reactions service - read
     { method: 'GET', pattern: /^\/v1\/reactions-service\// },
+
+    // Reactions service - react to a thought as the key's own user (like/activate).
+    // Scoped to the thought-reactions write path only; other reaction writes stay blocked.
+    { method: 'POST', pattern: /^\/v1\/reactions-service\/thought-reactions\// },
 
     // User metrics
     { method: 'GET', pattern: /^\/v1\/users-service\/metrics\// },

--- a/therr-api-gateway/tests/unit/middleware/restrictApiKeyAccess.test.ts
+++ b/therr-api-gateway/tests/unit/middleware/restrictApiKeyAccess.test.ts
@@ -160,10 +160,25 @@ describe('restrictApiKeyAccess middleware', () => {
             expect(next.calledOnce).to.be.eq(true);
         });
 
+        // Users service - create thought/reply as the key's own user
+        it('should allow POST to create a thought/reply', () => {
+            req.method = 'POST';
+            req.path = '/v1/users-service/thoughts';
+            restrictApiKeyAccess(req, res, next);
+            expect(next.calledOnce).to.be.eq(true);
+        });
+
         // Reactions service
         it('should allow GET reactions', () => {
             req.method = 'GET';
             req.path = '/v1/reactions-service/some-resource';
+            restrictApiKeyAccess(req, res, next);
+            expect(next.calledOnce).to.be.eq(true);
+        });
+
+        it('should allow POST to react to a thought', () => {
+            req.method = 'POST';
+            req.path = '/v1/reactions-service/thought-reactions/abc-123';
             restrictApiKeyAccess(req, res, next);
             expect(next.calledOnce).to.be.eq(true);
         });
@@ -266,6 +281,22 @@ describe('restrictApiKeyAccess middleware', () => {
         it('should block POST reactions (write)', () => {
             req.method = 'POST';
             req.path = '/v1/reactions-service/some-resource';
+            restrictApiKeyAccess(req, res, next);
+
+            expect(res.status.calledWith(403)).to.be.eq(true);
+        });
+
+        it('should block POST moment-reactions (only thought-reactions writes allowed)', () => {
+            req.method = 'POST';
+            req.path = '/v1/reactions-service/moment-reactions/abc-123';
+            restrictApiKeyAccess(req, res, next);
+
+            expect(res.status.calledWith(403)).to.be.eq(true);
+        });
+
+        it('should block POST to thoughts sub-paths (only exact /thoughts allowed)', () => {
+            req.method = 'POST';
+            req.path = '/v1/users-service/thoughts/some-id/delete';
             restrictApiKeyAccess(req, res, next);
 
             expect(res.status.calledWith(403)).to.be.eq(true);


### PR DESCRIPTION
Adds POST /v1/users-service/thoughts and POST /v1/reactions-service/
thought-reactions/* to the API-key allowlist in restrictApiKeyAccess.
Posting content (including replies, which notify the parent author) is
already permitted via JWT; this lets server-side automation post on its
own bot account's behalf via x-api-key without minting a JWT. Account
management, auth, payments, and other reaction writes remain blocked.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EMbmG8rsiRgn48ds5j53dE