### PR TITLE
fix: mobile "request a space" hangs on submit

### DIFF
--- a/TherrMobile/main/routes/EditSpace/index.tsx
+++ b/TherrMobile/main/routes/EditSpace/index.tsx
@@ -515,23 +515,28 @@ export class EditSpace extends React.PureComponent<IEditSpaceProps, IEditSpaceSt
                     })
                     .catch((error: any) => {
                         // TODO: Delete uploaded file on failure to create
+                        let errorMsg: string;
                         if (
                             error.statusCode === 400 ||
                             error.statusCode === 401 ||
                             error.statusCode === 404
                         ) {
-                            this.setState({
-                                errorMsg: `${error.message}${
-                                    error.parameters
-                                        ? '(' + error.parameters.toString() + ')'
-                                        : ''
-                                }`,
-                            });
-                        } else if (error.statusCode >= 500) {
-                            this.setState({
-                                errorMsg: this.translate('forms.editSpace.backendErrorMessage'),
-                            });
+                            errorMsg = `${error.message}${
+                                error.parameters
+                                    ? '(' + error.parameters.toString() + ')'
+                                    : ''
+                            }`;
+                        } else {
+                            // Covers 5xx and errors with no statusCode (network
+                            // failure / timeout). Without an explicit reset here the
+                            // submit button spinner stayed active indefinitely on any
+                            // non-4xx failure, which presented as the form "hanging".
+                            errorMsg = this.translate('forms.editSpace.backendErrorMessage');
                         }
+                        this.setState({
+                            isSubmitting: false,
+                            errorMsg,
+                        });
                     })
                     .finally(() => {
                         Keyboard.dismiss();

--- a/therr-services/users-service/src/handlers/users.ts
+++ b/therr-services/users-service/src/handlers/users.ts
@@ -1164,16 +1164,25 @@ const requestSpace: RequestHandler = (req: any, res: any) => {
 
             redactUserCreds(users[0]);
 
-            return Promise.all([
+            const user = users[0];
+
+            // Fire-and-forget the claim-request notification emails. These are
+            // best-effort admin/business notifications and must NOT gate the HTTP
+            // response. Previously they were awaited via Promise.all before the
+            // 200 was sent, so any AWS SES latency (slow/unreachable endpoint, SDK
+            // retry backoff) blocked the response. With no client-side request
+            // timeout on mobile, that surfaced as the "request a space" submit
+            // hanging indefinitely. Respond immediately; log email failures.
+            Promise.all([
                 sendClaimPendingReviewEmail({
                     subject: 'Business Space Request in Review',
                     locale,
-                    toAddresses: [users[0].email],
+                    toAddresses: [user.email],
                     agencyDomainName: whiteLabelOrigin,
                     brandVariation,
                     recipientIdentifiers: {
-                        id: users[0].id,
-                        accountEmail: users[0].email,
+                        id: user.id,
+                        accountEmail: user.email,
                     },
                 }, {
                     spaceName: title || notificationMsg,
@@ -1191,16 +1200,27 @@ const requestSpace: RequestHandler = (req: any, res: any) => {
                     description,
                     userId,
                 }),
-            ]).then(() => users[0]);
+            ]).catch((err) => {
+                logSpan({
+                    level: 'error',
+                    messageOrigin: 'API_SERVER',
+                    messages: ['Failed to send space claim request emails'],
+                    traceArgs: {
+                        'error.message': err?.message,
+                        'user.id': userId,
+                    },
+                });
+            });
+
+            return res.status(200).send({
+                message: 'Request sent to admin',
+                user: {
+                    accessLevels: user.accessLevels,
+                    isBusinessAccount: user.isBusinessAccount,
+                    email: user.email,
+                },
+            });
         })
-        .then((user) => res.status(200).send({
-            message: 'Request sent to admin',
-            user: {
-                accessLevels: user.accessLevels,
-                isBusinessAccount: user.isBusinessAccount,
-                email: user.email,
-            },
-        }))
         .catch((err) => handleHttpError({
             err,
             res,


### PR DESCRIPTION
## Summary

Requesting a space from the mobile app would hang on submit. Root cause is a backend request that blocks on email delivery, made worse by a mobile submit handler that never cleared its loading state on failure.

## Root cause

The non-business "request a space" flow (`EditSpace` → `MapsService.requestClaim` → `POST /maps-service/spaces/request-claim`) resolves, backend-side, to `users-service`'s `requestSpace` handler. That handler `await`ed **both** claim-notification emails via `Promise.all` before sending its `200`, and the maps-service handler in turn awaits that call.

`sendEmail` never rejects, but the underlying AWS SES SDK call (`awsSES.sendEmail`) can block for a long time when SES is slow, unreachable, or misconfigured (connection stall + SDK retry backoff). The mobile axios client sets **no request timeout** (`_timeout` in `interceptors.ts` is only a loader-debounce delay), so a slow response has nothing to abort it — the submit spinner spins indefinitely.

Separately, the mobile submit handler set `isSubmitting = true` but only ever reset it in the image-upload `catch`. On a request/update failure it set an `errorMsg` for 4xx/5xx but never reset `isSubmitting`, and errors with **no** `statusCode` (network failure / timeout) matched neither branch — leaving the button stuck with no message even once the request did fail.

## Changes

**Backend (`therr-services/users-service` — deploys via `general → stage → main`)**
- `requestSpace` now sends the two claim-notification emails **fire-and-forget** (best-effort, failures logged via `logSpan`) and responds as soon as the requesting user is resolved. The email content and recipients are unchanged.
- Collapsed the response into a single `.then`, which also fixes a latent double-`res.send` in the user-not-found path.

**Mobile (`TherrMobile`)**
- `onSubmitWithIncentives` now always resets `isSubmitting` and surfaces a message on the error path, falling back to the generic backend-error copy for 5xx and errors that carry no `statusCode`.

## Notes
- Two commits, split backend vs. mobile per the repo's commit-separation rule; both are appropriate for `general`.
- No schema, locale, or public-API surface changes. Reuses the existing `forms.editSpace.backendErrorMessage` string.

## Testing
- Dependencies are not installed in this environment, so linters/tsc/tests could not be run here. Changes were reviewed against surrounding style and the existing fire-and-forget email pattern already used elsewhere in `users.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198R8GhVeNd2cPMrieLdeb2

---
_Generated by [Claude Code](https://claude.ai/code/session_0198R8GhVeNd2cPMrieLdeb2)_