### PR TITLE
feat(mobile): add Android app shortcuts for Create Moment / Create Thought

### DIFF
--- a/TherrMobile/android/app/src/main/AndroidManifest.xml
+++ b/TherrMobile/android/app/src/main/AndroidManifest.xml
@@ -138,6 +138,20 @@
         <action android:name="app.therrmobile.INVITE_FRIENDS_REMINDER" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
+
+      <!-- App shortcuts (long-press launcher icon). See res/xml/shortcuts.xml -->
+      <intent-filter>
+        <action android:name="app.therrmobile.QUICK_CREATE_MOMENT" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="app.therrmobile.QUICK_CREATE_THOUGHT" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+
+      <meta-data
+        android:name="android.app.shortcuts"
+        android:resource="@xml/shortcuts" />
     </activity>
 
     <meta-data

--- a/TherrMobile/android/app/src/main/java/app/therrmobile/MainApplication.kt
+++ b/TherrMobile/android/app/src/main/java/app/therrmobile/MainApplication.kt
@@ -2,6 +2,7 @@ package app.therrmobile
 
 import android.app.Application
 import app.therrmobile.modules.EdgeToEdgePackage
+import app.therrmobile.modules.InitialIntentPackage
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
@@ -15,7 +16,7 @@ class MainApplication : Application(), ReactApplication {
   override val reactHost: ReactHost
     get() = getDefaultReactHost(
         context = applicationContext,
-        packageList = PackageList(this).packages + listOf(EdgeToEdgePackage()),
+        packageList = PackageList(this).packages + listOf(EdgeToEdgePackage(), InitialIntentPackage()),
         jsMainModulePath = "index",
         useDevSupport = BuildConfig.DEBUG,
     )

--- a/TherrMobile/android/app/src/main/java/app/therrmobile/modules/InitialIntentModule.kt
+++ b/TherrMobile/android/app/src/main/java/app/therrmobile/modules/InitialIntentModule.kt
@@ -1,0 +1,43 @@
+package app.therrmobile.modules
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+/**
+ * Exposes the launch Intent's action to JS for the cold-start case.
+ *
+ * Warm/background taps on an app shortcut (long-press launcher menu) arrive
+ * via MainActivity.onNewIntent, which already emits a "new-intent-action"
+ * event. But a shortcut tapped while the app is killed goes through onCreate,
+ * not onNewIntent, so nothing pushes that action to JS. Layout reads it once
+ * on mount via getInitialAction().
+ *
+ * The action is cleared after the first read so subsequent Layout remounts
+ * (e.g. the login/logout cycle) don't re-trigger navigation from a stale
+ * launch intent.
+ */
+class InitialIntentModule(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext) {
+
+    override fun getName(): String = NAME
+
+    @ReactMethod
+    fun getInitialAction(promise: Promise) {
+        val activity = reactApplicationContext.currentActivity
+        if (activity == null) {
+            promise.resolve(null)
+            return
+        }
+        val intent = activity.intent
+        val action = intent?.action
+        // Consume it so a Layout remount doesn't re-navigate from the same launch.
+        intent?.action = null
+        promise.resolve(action)
+    }
+
+    companion object {
+        const val NAME = "InitialIntent"
+    }
+}

--- a/TherrMobile/android/app/src/main/java/app/therrmobile/modules/InitialIntentPackage.kt
+++ b/TherrMobile/android/app/src/main/java/app/therrmobile/modules/InitialIntentPackage.kt
@@ -1,0 +1,14 @@
+package app.therrmobile.modules
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class InitialIntentPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+        listOf(InitialIntentModule(reactContext))
+
+    override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+        emptyList()
+}

--- a/TherrMobile/android/app/src/main/res/drawable/ic_shortcut_moment.xml
+++ b/TherrMobile/android/app/src/main/res/drawable/ic_shortcut_moment.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="#0f7b82"
+        android:pathData="M24,24m-24,0a24,24 0,1 1,48 0a24,24 0,1 1,-48 0" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M24,11c-4.97,0 -9,4.03 -9,9 0,6.75 9,16 9,16s9,-9.25 9,-16c0,-4.97 -4.03,-9 -9,-9zM24,23.5c-1.93,0 -3.5,-1.57 -3.5,-3.5s1.57,-3.5 3.5,-3.5 3.5,1.57 3.5,3.5 -1.57,3.5 -3.5,3.5z" />
+</vector>

--- a/TherrMobile/android/app/src/main/res/drawable/ic_shortcut_thought.xml
+++ b/TherrMobile/android/app/src/main/res/drawable/ic_shortcut_thought.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+    <path
+        android:fillColor="#0f7b82"
+        android:pathData="M24,24m-24,0a24,24 0,1 1,48 0a24,24 0,1 1,-48 0" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M33,13H15c-1.65,0 -3,1.35 -3,3v12c0,1.65 1.35,3 3,3h4l5,5 5,-5h4c1.65,0 3,-1.35 3,-3V16c0,-1.65 -1.35,-3 -3,-3zM19,23c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM24,23c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM29,23c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2z" />
+</vector>

--- a/TherrMobile/android/app/src/main/res/values/strings.xml
+++ b/TherrMobile/android/app/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="appCenterCrashes_whenToSendCrashes" moduleConfig="true" translatable="false">DO_NOT_ASK_JAVASCRIPT</string>
     <string name="appCenterAnalytics_whenToEnableAnalytics" moduleConfig="true" translatable="false">ALWAYS_SEND</string>
     <string name="default_notification_channel_id">reminders</string>
+    <string name="shortcut_create_moment_short">Moment</string>
+    <string name="shortcut_create_moment_long">Create a Moment</string>
+    <string name="shortcut_create_thought_short">Thought</string>
+    <string name="shortcut_create_thought_long">Create a Thought</string>
 </resources>

--- a/TherrMobile/android/app/src/main/res/xml/shortcuts.xml
+++ b/TherrMobile/android/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Static app shortcuts (long-press the launcher icon). Each fires an implicit
+  intent whose action matches an <intent-filter> on MainActivity in
+  AndroidManifest.xml. MainActivity.onNewIntent forwards the action to JS as a
+  "new-intent-action" event (warm start); Layout reads it from the launch
+  intent via the InitialIntent native module on cold start. Layout maps the
+  action suffix to the create routes.
+
+  Actions use the Therr binary prefix (app.therrmobile.*). Niche variants that
+  inherit this file must add filters/shortcuts under their own prefix (see the
+  brand-scoped enums in therr-js-utilities PushNotifications.ts).
+-->
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="create_moment"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_moment"
+        android:shortcutShortLabel="@string/shortcut_create_moment_short"
+        android:shortcutLongLabel="@string/shortcut_create_moment_long">
+        <intent
+            android:action="app.therrmobile.QUICK_CREATE_MOMENT" />
+    </shortcut>
+    <shortcut
+        android:shortcutId="create_thought"
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_thought"
+        android:shortcutShortLabel="@string/shortcut_create_thought_short"
+        android:shortcutLongLabel="@string/shortcut_create_thought_long">
+        <intent
+            android:action="app.therrmobile.QUICK_CREATE_THOUGHT" />
+    </shortcut>
+</shortcuts>

--- a/TherrMobile/main/components/Layout.tsx
+++ b/TherrMobile/main/components/Layout.tsx
@@ -4,6 +4,7 @@ import qs from 'qs';
 import {
     Image,
     Linking,
+    NativeModules,
     PermissionsAndroid,
     Platform,
 } from 'react-native';
@@ -84,6 +85,15 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import { buildGroupUrl } from '../utilities/shareUrls';
 
 const preLoadImageList = [background1, background2, background3];
+
+// Android app-shortcut intent-action suffixes (long-press launcher icon).
+// Matched by suffix so the same JS handles every brand binary regardless of
+// its package prefix (app.therrmobile.* / com.therr.mobile.* / ...). See
+// android/app/src/main/res/xml/shortcuts.xml.
+const QUICK_ACTION_SUFFIXES = {
+    CREATE_MOMENT: '.QUICK_CREATE_MOMENT',
+    CREATE_THOUGHT: '.QUICK_CREATE_THOUGHT',
+};
 
 const Stack = createNativeStackNavigator<ParamListBase, undefined>();
 
@@ -234,6 +244,16 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
 
         if (Platform.OS === 'android') {
             Linking.getInitialURL().then(this.handleAppUniversalLinkURL);
+            // App-shortcut cold-start: a shortcut tapped while the app is killed
+            // launches via onCreate (not onNewIntent), so read the launch intent's
+            // action once and route it through the same handler as the warm path.
+            NativeModules.InitialIntent?.getInitialAction?.()
+                .then((action: string | null) => {
+                    if (action) {
+                        this.handleFirebasePushNotificationEvent({ action });
+                    }
+                })
+                .catch((err) => console.log('INITIAL_INTENT_ACTION_ERROR', err));
         }
         // (Firebase) Push Notifications Click Handler (Android intent-filter path)
         this.nativeEventListener = PlatformNativeEventEmitter?.addListener('new-intent-action', this.handleFirebasePushNotificationEvent);
@@ -907,6 +927,21 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
                 targetRouteView = 'BookMarked';
             } else if (data.action === brandIntents.REPORT_CONFIRMED) {
                 targetRouteView = 'Notifications';
+            } else if (data.action?.endsWith(QUICK_ACTION_SUFFIXES.CREATE_MOMENT)) {
+                // App-shortcut: jump straight into moment creation. EditMoment
+                // destructures route.params (and calls nearbySpaces.find), so we
+                // must pass a non-empty param object. Seed the location from the
+                // user's last-known coords, matching the in-app create button.
+                targetRouteView = 'EditMoment';
+                targetRouteParams = {
+                    imageDetails: {},
+                    nearbySpaces: [],
+                    latitude: user?.details?.lastKnownLatitude,
+                    longitude: user?.details?.lastKnownLongitude,
+                };
+            } else if (data.action?.endsWith(QUICK_ACTION_SUFFIXES.CREATE_THOUGHT)) {
+                // App-shortcut: jump straight into thought creation (no location).
+                targetRouteView = 'EditThought';
             }
         }
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -101,6 +101,7 @@
 - **Nearby content carousels** — swipeable tabs for discoveries, events, thoughts, news
 - **Draft management** — save and resume content drafts
 - **Animated onboarding** — landing page with background carousel
+- **Android app shortcuts** — long-press the launcher icon for quick links straight into Create Moment / Create Thought
 
 ---
 


### PR DESCRIPTION
Long-pressing the launcher icon now surfaces quick links that jump straight
into the create flows, reusing the existing intent-action routing that push
notifications already use.

- res/xml/shortcuts.xml: two static shortcuts firing implicit actions
  (QUICK_CREATE_MOMENT / QUICK_CREATE_THOUGHT) matched by new MainActivity
  intent-filters; icons + labels added.
- InitialIntentModule/Package (native): expose the launch intent action so a
  shortcut tapped while the app is killed (cold start via onCreate, not
  onNewIntent) still routes. Action is consumed after first read so Layout
  remounts don't re-navigate.
- Layout: route the quick actions to EditMoment (seeded with last-known
  coords + safe params) and EditThought, matched by action suffix so every
  brand binary works regardless of package prefix. Warm-start taps continue
  through the existing new-intent-action listener.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0126DBpFdSS3Ai4puUjMZfHM