### PR TITLE
fix(users): stop People discovery list going empty for email-verified users

### DIFF
--- a/therr-services/users-service/src/store/UsersStore.ts
+++ b/therr-services/users-service/src/store/UsersStore.ts
@@ -221,7 +221,16 @@ export default class UsersStore {
             .andWhereNot('id', requestingUserId);
 
         if (onlyVerified) {
-            queryString = queryString.andWhere(knexBuilder.raw(`"accessLevels" \\? '${AccessLevels.MOBILE_VERIFIED}'`));
+            // Discovery surfaces any verified account — email OR mobile. Requiring
+            // MOBILE_VERIFIED alone silently emptied the People list once onboarding
+            // stopped forcing phone verification (feat(users): reduce onboarding
+            // friction): most users now carry EMAIL_VERIFIED but never complete mobile
+            // verification, so the single-level `?` filter matched nobody. The jsonb
+            // `?|` operator matches when accessLevels contains ANY of the listed levels.
+            // AccessLevels values are trusted enum constants, so inlining them is safe.
+            queryString = queryString.andWhere(knexBuilder.raw(
+                `"accessLevels" \\?| ARRAY['${AccessLevels.MOBILE_VERIFIED}', '${AccessLevels.EMAIL_VERIFIED}']::text[]`,
+            ));
         }
 
         queryString = queryString

--- a/therr-services/users-service/tests/unit/UsersStore.test.ts
+++ b/therr-services/users-service/tests/unit/UsersStore.test.ts
@@ -119,6 +119,49 @@ describe('UsersStore', () => {
         });
     });
 
+    describe('searchUsers', () => {
+        // Regression: the People discovery list (Connect route) went empty ("no users
+        // found") because onlyVerified filtered candidates by MOBILE_VERIFIED alone. After
+        // onboarding stopped forcing phone verification, most users carry EMAIL_VERIFIED but
+        // not MOBILE_VERIFIED, so the single-level jsonb `?` filter matched nobody. The fix
+        // widens it to match EITHER verified level via the jsonb `?|` any-of operator.
+        it('surfaces email- OR mobile-verified accounts when onlyVerified is set', () => {
+            const mockStore = {
+                read: {
+                    query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
+                },
+            };
+            const store = new UsersStore(mockStore);
+            store.searchUsers('user-1', {
+                query: '',
+                limit: 50,
+                offset: 0,
+            }, false, true);
+
+            const sql = mockStore.read.query.args[0][0];
+            expect(sql).to.contain(`"accessLevels" ?| ARRAY['user.verified.mobile', 'user.verified.email']::text[]`);
+            // Must NOT fall back to the mobile-only single-key form that emptied the list.
+            expect(sql).to.not.contain(`"accessLevels" ? 'user.verified.mobile'`);
+        });
+
+        it('omits the verified filter entirely when onlyVerified is false', () => {
+            const mockStore = {
+                read: {
+                    query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
+                },
+            };
+            const store = new UsersStore(mockStore);
+            store.searchUsers('user-1', {
+                query: '',
+                limit: 50,
+                offset: 0,
+            }, false, false);
+
+            const sql = mockStore.read.query.args[0][0];
+            expect(sql).to.not.contain('accessLevels');
+        });
+    });
+
     // Should not allow updating email (for security purposes)
     describe('deleteUsers', () => {
         it('requires email or id', () => {


### PR DESCRIPTION
## Summary

The TherrMobile **People list** (Connect route) rendered **"no users found"**, and the **DMs** tab was empty, while the **Connections** tab kept working. This PR fixes the People-list root cause and documents the DMs finding.

## Root cause (People list) — fixed here

`user.users` was genuinely empty (confirmed against FlashList 1.8.3 internals: `ListEmptyComponent` renders only when `dataProvider.getSize() === 0`; the list root already self-applies `flex:1`). So the recent `FlatList → FlashList` migration was a red herring — it never touched the data flow.

The empty data comes from the users-service discovery query:

```
UsersStore.searchUsers(userId, {...}, withConnections=true, onlyVerified=true)
```

With `onlyVerified=true` it filtered candidates using a **single-key** jsonb match:

```sql
"accessLevels" ? 'user.verified.mobile'   -- MOBILE_VERIFIED only
```

After onboarding was relaxed (`feat(users): reduce onboarding friction`), users reach the app with just phone + username and typically carry `EMAIL_VERIFIED` but **never complete mobile verification**. So the filter matched nobody and the list came back empty — "no users found."

The **Connections** tab was unaffected because `searchUserConnections` derives the user id from the request body and applies no verified filter — which is exactly why it kept working.

## Fix

Widen the discovery filter to match **either** verified level via the jsonb `?|` any-of operator (mirrors the existing `ThoughtsStore`/`SpacesStore` interest-key pattern):

```sql
"accessLevels" ?| ARRAY['user.verified.mobile', 'user.verified.email']::text[]
```

`AccessLevels` values are trusted enum constants, so inlining them stays injection-safe.

## Tests

Adds `UsersStore.searchUsers` unit regression tests:
- asserts the widened `?|` any-of filter is emitted when `onlyVerified` is set (and the mobile-only single-key form is **not**),
- asserts no `accessLevels` filter is emitted when `onlyVerified` is false.

## DMs tab — separate cause, not a code bug (no change in this PR)

The DMs emptiness is **not** a code defect:
- New DMs are correctly stamped with `brandVariation` (`createDirectMessage` → `scopedInsert`), and the DM-list read filters by brand exactly like the canonical `NotificationsStore` — the established brand-scoping pattern.
- The migration `20260425000004_main.directMessages.brandVariation` **already exists** and backfills all legacy rows to `'therr'` so they stay visible to Therr users; its header documents that cross-brand DM isolation is **by design**.
- `docs/WORK_IN_PROGRESS.md` already tracks the open ops step: *run that migration on the messages-service* — without the column, `searchLatestDMs`/`searchDirectMessages` fail and DMs come back empty.

So for a same-brand user, empty DMs = that migration hasn't been run (operational), intended cross-brand isolation, or genuinely no threads. Forcing DMs to show across brands in code would break the deliberate multi-brand isolation, so it's intentionally left out here. If you'd prefer DMs to render regardless of migration state during the shadow-rollout window, the follow-up would be to make `DirectMessagesStore` reads observe-only while `mode === 'shadow'` — happy to do that as a separate change.

## Deploy notes

- Backend-only change under `therr-services/`; lands on `general`.
- Operational follow-up for DMs: run `20260425000004_main.directMessages.brandVariation` on the messages-service (`npm run migrations:run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJzumC8ixK9nFcJD2B88XC)_