### PR TITLE
fix(users-service): brand-scope the People discovery list

### DIFF
--- a/docs/NICHE_APP_DATABASE_GUIDELINES.md
+++ b/docs/NICHE_APP_DATABASE_GUIDELINES.md
@@ -12,7 +12,7 @@ All brand variants share the same PostgreSQL database infrastructure and **singl
 
 | Archetype | Definition | Storage | Enforcement | Default for existing rows |
 |-----------|------------|---------|-------------|---------------------------|
-| **Identity-shared** | One row per human regardless of brand. The data is about the person, not the app they used. | `main.*`, **no brand column** | None at row level. Brand only used when UX is conditional on enrollment (`brandVariations @> '["habits"]'`). | n/a — no schema change needed |
+| **Identity-shared** | One row per human regardless of brand. The data is about the person, not the app they used. | `main.*`, **no brand column** | None at row level. Brand only used when UX is conditional on enrollment. `main.users.brandVariations` stores an **array of objects** (`[{ brand, firstSeenAt, lastSeenAt, isActive }]`), so containment is `brandVariations @> '[{"brand":"habits"}]'` — NOT `@> '["habits"]'` (the column is not an array of strings). | n/a — no schema change needed |
 | **Brand-scoped** | Same row shape, must be partitioned per brand so a user signed into multiple apps does not see leaked data. | `main.*` with `brandVariation TEXT NOT NULL DEFAULT 'therr'` column + composite index `(userId, brandVariation, ...)` | `BrandScopedStore` base class in each service's `src/store/` directory. Handlers cannot omit brand because the store method signatures require it. | Backfill `'therr'` in the same migration that adds the column (every row created before this work was created by the original Therr app) |
 | **Brand-only / niche** | Only exists for one brand. | Dedicated `<niche>.*` schema (e.g. `habits.*`), FK to `main.users(id)`. | Schema name is the boundary; no row-level filter needed. | n/a — only ever populated by the niche app |
 
@@ -376,7 +376,9 @@ The base class accepts a third constructor argument: `'shadow'` (default) or `'e
 
 ### When to use brand-conditional logic in a handler instead
 
-Some flows are genuinely brand-conditional even when the data is identity-shared (e.g. achievements list filtering). Continue to do that with `getBrandContext` at the handler level — the BrandScopedStore pattern is only required for tables in the **Brand-scoped** archetype.
+Some flows are genuinely brand-conditional even when the data is identity-shared (e.g. achievements list filtering, **user discovery / the People list**). Continue to do that with `getBrandContext` at the handler level — the BrandScopedStore pattern is only required for tables in the **Brand-scoped** archetype.
+
+> **User discovery is one of these flows.** `main.users` has no brand column, but the People/Connect list must only surface users enrolled in the requesting brand. `UsersStore.searchUsers` takes a `brandVariation` and filters `brandVariations @> '[{"brand":"<brand>"}]'`. Omitting that filter leaks the full cross-brand user list into every niche app. No backfill is needed for legacy accounts — the `brandVariations` column default already stamps every pre-existing row with a `therr` entry.
 
 ```typescript
 import { getBrandContext } from 'therr-js-utilities/http';

--- a/therr-services/users-service/src/handlers/users.ts
+++ b/therr-services/users-service/src/handlers/users.ts
@@ -3,7 +3,7 @@ import {
     AccessLevels, COIN_PACKAGE_IDS, ErrorCodes, ReferralRewards, UserConnectionTypes,
 } from 'therr-js-utilities/constants';
 import logSpan from 'therr-js-utilities/log-or-update-span';
-import { parseHeaders } from 'therr-js-utilities/http';
+import { getBrandContext, parseHeaders } from 'therr-js-utilities/http';
 import handleHttpError from '../utilities/handleHttpError';
 import Store from '../store';
 import translate from '../utilities/translator';
@@ -476,6 +476,10 @@ const findUsers: RequestHandler = (req: any, res: any) => Store.users.findUsers(
 
 const searchUsers: RequestHandler = (req: any, res: any) => {
     const userId = req.headers['x-userid']; // undefined if user is not logged in
+    // Discovery is brand-scoped: identity-shared main.users has no brand column, so we
+    // filter on brandVariations enrollment. getBrandContext defaults to THERR for legacy
+    // tokens with no x-brand-variation header, matching the column's default membership.
+    const { brandVariation } = getBrandContext(req.headers);
 
     const {
         ids,
@@ -503,6 +507,7 @@ const searchUsers: RequestHandler = (req: any, res: any) => {
         queryColumnName,
         limit: actualLimit,
         offset: actualOffset,
+        brandVariation,
     }, true, true);
 
     return Promise.all([mightKnowPromise, searchPromise])

--- a/therr-services/users-service/src/store/UsersStore.ts
+++ b/therr-services/users-service/src/store/UsersStore.ts
@@ -51,6 +51,10 @@ interface ISearchUsersArgs {
     queryColumnName?: string;
     limit?: number;
     offset?: number;
+    // When set, discovery is scoped to users enrolled in this brand (identity-shared
+    // pattern: main.users has no brand column, membership lives in the brandVariations
+    // JSONB array). See docs/NICHE_APP_DATABASE_GUIDELINES.md.
+    brandVariation?: string;
 }
 
 export interface IFindUsersByContactInfo {
@@ -207,6 +211,7 @@ export default class UsersStore {
             queryColumnName,
             limit,
             offset,
+            brandVariation,
         }: ISearchUsersArgs,
         withConnections = false,
         onlyVerified = false,
@@ -219,6 +224,19 @@ export default class UsersStore {
             .whereNotNull('userName')
             .andWhere('settingsIsProfilePublic', true)
             .andWhereNot('id', requestingUserId);
+
+        if (brandVariation) {
+            // Scope discovery to users enrolled in the requesting brand. main.users is
+            // identity-shared (no brand column); brand membership is an entry in the
+            // brandVariations JSONB array, e.g. [{ brand: 'habits', ... }]. The @>
+            // containment check is backed by the GIN index added in brandVariations_v2.
+            // Legacy rows carry the column's default 'therr' entry, so Therr discovery
+            // still returns pre-existing accounts without a separate backfill.
+            queryString = queryString.andWhere(knexBuilder.raw(
+                '"brandVariations" @> ?::jsonb',
+                [JSON.stringify([{ brand: brandVariation }])],
+            ));
+        }
 
         if (onlyVerified) {
             // "Verified for discovery" means the current onboarding baseline: an email-verified

--- a/therr-services/users-service/tests/unit/UsersStore.test.ts
+++ b/therr-services/users-service/tests/unit/UsersStore.test.ts
@@ -45,6 +45,42 @@ describe('UsersStore', () => {
             expect(generatedSql).to.contain(`"accessLevels" ?| ARRAY['user.verified.email', 'user.verified.mobile']::text[]`);
         });
 
+        // Regression: discovery must be brand-scoped. main.users is identity-shared (no brand
+        // column); enrollment lives in the brandVariations JSONB array. Without this filter,
+        // every niche app leaked the full cross-brand user list (e.g. Habits showed Therr users).
+        it('scopes results to the requesting brand when brandVariation is provided', () => {
+            const mockStore = {
+                read: {
+                    query: sinon.stub().callsFake(() => Promise.resolve({})),
+                },
+            };
+            const store = new UsersStore(mockStore);
+            store.searchUsers('req-user-1', {
+                limit: 50,
+                offset: 0,
+                brandVariation: 'habits',
+            }, false, true);
+
+            const generatedSql = mockStore.read.query.args[0][0];
+            expect(generatedSql).to.contain(`"brandVariations" @> '[{"brand":"habits"}]'::jsonb`);
+        });
+
+        it('omits the brand filter when brandVariation is not provided', () => {
+            const mockStore = {
+                read: {
+                    query: sinon.stub().callsFake(() => Promise.resolve({})),
+                },
+            };
+            const store = new UsersStore(mockStore);
+            store.searchUsers('req-user-1', {
+                limit: 50,
+                offset: 0,
+            }, false, true);
+
+            const generatedSql = mockStore.read.query.args[0][0];
+            expect(generatedSql).to.not.contain('brandVariations');
+        });
+
         it('omits the verification filter when onlyVerified is false', () => {
             const mockStore = {
                 read: {


### PR DESCRIPTION
User discovery leaked across brands: because searchUsers applied no brand filter, every niche app showed the full cross-brand user list (e.g. logging into Friends with Habits surfaced all Therr users). main.users is identity- shared with no brand column — enrollment lives in the brandVariations JSONB array — so discovery must filter on that array at the handler level, per docs/NICHE_APP_DATABASE_GUIDELINES.md.

- searchUsers now accepts brandVariation and filters brandVariations @> '[{"brand":"<brand>"}]' (GIN-indexed via brandVariations_v2).
- searchUsers handler resolves the brand with getBrandContext, which defaults to THERR for legacy tokens with no x-brand-variation header.

No backfill is required: the brandVariations column default already stamps every pre-existing account with a 'therr' membership entry, so Therr discovery keeps returning legacy users while niche apps only see their own enrollees.

Also correct the identity-shared containment example in the guidelines — the column is an array of objects, so the query is @> '[{"brand":"habits"}]', not @> '["habits"]' — and document discovery as a brand-conditional flow.

Add UsersStore regression tests for the brand filter (present when scoped, absent when not).


Claude-Session: https://claude.ai/code/session_01H5pHTaSMAziuH7xyTBHKsP