### PR TITLE
fix: stop niche apps leaking cross-brand users in discovery/search

### DIFF
--- a/TherrMobile/android/app/build.gradle
+++ b/TherrMobile/android/app/build.gradle
@@ -93,8 +93,8 @@ android {
         applicationId "app.therrmobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 432
-        versionName "3.6.19"
+        versionCode 433
+        versionName "3.6.20"
         manifestPlaceholders = [GOOGLE_APIS_ANDROID_KEY: "${System.getenv("GOOGLE_APIS_ANDROID_KEY")}"]
         vectorDrawables.useSupportLibrary = true
     }

--- a/therr-public-library/therr-react/src/redux/reducers/__tests__/user.test.ts
+++ b/therr-public-library/therr-react/src/redux/reducers/__tests__/user.test.ts
@@ -49,6 +49,23 @@ describe('user reducer', () => {
         expect(result.usersMightKnow.u3).toBeDefined();
     });
 
+    it('handles GET_USERS (replaces stale results, does not accumulate)', () => {
+        // Regression: discovery must evict prior entries so cross-brand users cached before
+        // brand-scoping (and rehydrated from redux-persist) cannot survive a fresh fetch.
+        const populated = reducer(initialState, {
+            type: UserActionTypes.GET_USERS,
+            data: { results: [{ id: 'stale-1' }, { id: 'stale-2' }], mightKnowResults: [{ id: 'mk-stale' }] },
+        });
+        const result = reducer(populated, {
+            type: UserActionTypes.GET_USERS,
+            data: { results: [{ id: 'fresh-1' }], mightKnowResults: [] },
+        });
+        expect(result.users['stale-1']).toBeUndefined();
+        expect(result.users['stale-2']).toBeUndefined();
+        expect(result.users['fresh-1']).toBeDefined();
+        expect(result.usersMightKnow['mk-stale']).toBeUndefined();
+    });
+
     it('handles GET_USERS_REFETCH (clears stale results)', () => {
         const populated = reducer(initialState, {
             type: UserActionTypes.GET_USERS,

--- a/therr-public-library/therr-react/src/redux/reducers/user.ts
+++ b/therr-public-library/therr-react/src/redux/reducers/user.ts
@@ -55,16 +55,22 @@ const getUserReducer = (socketIO) => produce((draft: IUserState, action: any) =>
 
     switch (action.type) {
         case UserActionTypes.GET_USERS:
-            // Convert array to object for faster lookup and de-duping
+            // Replace (not merge) so stale entries from a prior fetch are evicted. Merging into
+            // `modifiedUsers` kept cross-brand users that were cached before discovery became
+            // brand-scoped — and because the `user` slice is persisted (redux-persist), those
+            // leaked rows were rehydrated on every launch and never cleared, so a backend fix
+            // alone could not remove them from the client. Discovery pagination is page-replace
+            // (web ExplorePeople) or unwired (mobile), so nothing relies on accumulation. The
+            // query path (GET_USERS_REFETCH) already clears the same way.
             draft.users = action.data.results
                 .reduce((acc, item) => ({
                     ...acc,
                     [item.id]: item,
-                }), modifiedUsers);
+                }), {});
             draft.usersMightKnow = action.data?.mightKnowResults?.reduce((acc, item) => ({
                 ...acc,
                 [item.id]: item,
-            }), {});
+            }), {}) || {};
             break;
         case UserActionTypes.GET_USERS_REFETCH:
             // Convert array to object for faster lookup and de-duping


### PR DESCRIPTION
## Summary

User search on niche apps (e.g. Friends with Habits) showed an inverted result: the main People list returned nothing while "People You May Know" surfaced pre-existing Therr accounts that shouldn't appear. Root cause was a chain of gaps across backend and client:

1. **Backend leak** — brand-scoping was applied to `searchUsers` (the `results` query) but **not** to the parallel discovery paths feeding the same screen. `findUsers` (the mightKnow read) and `findUsersByContactInfo` (contact matching) ran with no brand filter, so contact-matched Therr users leaked into Habits.
2. **Malformed data** — some `main.users.brandVariations` rows were stored in shapes (object / scalar / array-of-strings / empty) that silently fail the `@> '[{"brand":"..."}]'` containment check, so even Therr users could vanish from Therr search.
3. **Client cache** — the `user` slice is persisted via redux-persist, and the `GET_USERS` reducer *merged* results into existing state instead of replacing, so users leaked before the backend fix were rehydrated on every launch and never evicted.

## Changes

**Backend (`therr-services/users-service`)**
- Added a shared `brandContainment` predicate; `searchUsers` reuses it (SQL unchanged — existing test still passes).
- `findUsers` takes an optional `brandVariation`, passed from the searchUsers handler's mightKnow branch. Brand-agnostic callers (thought authors, group members) omit it and are unchanged.
- `findUsersByContactInfo` is brand-scoped, with the email/phone `OR` grouped so the brand filter ANDs correctly. `findPeopleYouMayKnow` derives brand via `getBrandContext`, so cross-brand MIGHT_KNOW edges are no longer seeded or returned. The invite-list caller omits brand and is unchanged.

**Migration (`20260719000001_main.users.brandVariations_backfill.js`)**
- Idempotent backfill normalizing every non-canonical `brandVariations` shape (SQL NULL / JSON null, single object, scalar string, array of strings, junk / brand-less elements, empty array) to the array-of-objects form the containment filter requires. Existing brand memberships preserved; only unknowable rows fall back to the legacy Therr default. The `WHERE` guard matches only non-canonical rows, so re-runs update zero rows. Verified against Postgres 16 driving `up()` twice (state unchanged on the 2nd pass) across all shapes. The JSONB key-existence operator is escaped `\?` because Knex.raw otherwise parses a bare `?` as a bind placeholder.

**Client (`therr-react`)**
- `GET_USERS` now replaces (seeds the reduce from `{}`) instead of merging, mirroring `GET_USERS_REFETCH`, so stale/cross-brand entries are evicted on the next discovery refresh. Discovery pagination is page-replace on web (ExplorePeople) and unwired on mobile, so nothing relied on accumulation. Guards `usersMightKnow` against an undefined `mightKnowResults`.

**Version**
- Bumped mobile app `3.6.19 → 3.6.20` (versionCode `432 → 433`).

## Tests

- New regression tests for `findUsers` and `findUsersByContactInfo` brand scoping in `UsersStore.test.ts`.
- New reducer test asserting `GET_USERS` evicts prior entries.
- Migration validated end-to-end against a live Postgres 16 (normalization correctness + idempotency + per-brand containment).

## Notes / follow-ups

- `therr-react` is consumed as a compiled lib, so web/mobile pick up the reducer change only after `build:all` runs in the `general → stage` pipeline.
- Already-affected installs also self-heal on logout (`persistor.purge`) or app-data reset; the reducer change removes the leak on the next refresh without requiring that.
- Backfill migration has already been deployed/run per the reporter; re-running is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BV4TFGcfUtwFjnWHyV7WQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BV4TFGcfUtwFjnWHyV7WQZ)_