### PR TITLE
chore(mobile): bump Android versionName to 3.7.0

### DIFF
--- a/TherrMobile/android/app/build.gradle
+++ b/TherrMobile/android/app/build.gradle
@@ -93,7 +93,7 @@ android {
         applicationId "app.therrmobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 433
+        versionCode 434
         versionName "3.7.0"
         manifestPlaceholders = [GOOGLE_APIS_ANDROID_KEY: "${System.getenv("GOOGLE_APIS_ANDROID_KEY")}"]
         vectorDrawables.useSupportLibrary = true

--- a/TherrMobile/android/app/build.gradle
+++ b/TherrMobile/android/app/build.gradle
@@ -94,7 +94,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 433
-        versionName "3.6.20"
+        versionName "3.7.0"
         manifestPlaceholders = [GOOGLE_APIS_ANDROID_KEY: "${System.getenv("GOOGLE_APIS_ANDROID_KEY")}"]
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
## Summary
- Bumps `TherrMobile` Android `versionName` from `3.6.20` to `3.7.0` (minor version bump) in `TherrMobile/android/app/build.gradle`.

## Notes
- `versionCode` (433) was left unchanged since the request was scoped to the minor version. If this build is intended for a Play Store release, `versionCode` should also be incremented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)