### PR TITLE
Return a nested reply count per reply from getThoughtDetails

### DIFF
--- a/TherrMobile/main/components/UserContent/ThoughtDisplay.tsx
+++ b/TherrMobile/main/components/UserContent/ThoughtDisplay.tsx
@@ -45,6 +45,12 @@ interface IThoughtDisplayProps {
     thought: any;
     topReply?: any;
     replyCount?: number;
+    /**
+     * Renders a standalone reply-count icon/count for content that is not itself repliable
+     * (ie. replies rendered within the thought details view). Pressing it inspects the nested
+     * thought. Off by default so feed/carousel displays are unaffected.
+     */
+    showReplyCount?: boolean;
     goToViewUser: Function;
     updateThoughtReaction: Function;
     user: IUserState;
@@ -144,6 +150,7 @@ class ThoughtDisplay extends React.Component<IThoughtDisplayProps, IThoughtDispl
             thought,
             topReply,
             replyCount,
+            showReplyCount,
             goToViewUser,
             contentUserDetails,
             theme,
@@ -234,10 +241,12 @@ class ThoughtDisplay extends React.Component<IThoughtDisplayProps, IThoughtDispl
                                     onLikePress={this.onLikePress}
                                     goToViewUser={goToViewUser}
                                     replyCount={replyCount}
+                                    showReplyCount={showReplyCount}
                                     theme={theme}
                                     themeForms={themeForms}
                                     themeViewContent={themeViewContent}
                                     thought={thought}
+                                    translate={translate}
                                 />
                         }
                     </View>
@@ -273,10 +282,12 @@ class ThoughtDisplay extends React.Component<IThoughtDisplayProps, IThoughtDispl
                                 onLikePress={this.onLikePress}
                                 goToViewUser={goToViewUser}
                                 replyCount={replyCount}
+                                showReplyCount={showReplyCount}
                                 theme={theme}
                                 themeForms={themeForms}
                                 themeViewContent={themeViewContent}
                                 thought={thought}
+                                translate={translate}
                             />
                         </View>
                 }
@@ -351,13 +362,19 @@ const ThoughtContent = ({
     onLikePress,
     goToViewUser,
     replyCount,
+    showReplyCount,
     theme,
     themeForms,
     themeViewContent,
     thought,
+    translate,
 }) => {
-    const totalReplies = replyCount ?? thought.replies?.length;
+    const totalReplies = replyCount ?? thought.replyCount ?? thought.replies?.length;
     const onMentionPress = (username: string) => handleMentionPress(username, goToViewUser);
+    const hasRepliableActions = !thought.isDraft && isRepliable;
+    // The repliable action row already renders a reply icon/count, so this only fills the gap
+    // for non-repliable content (replies within the thought details view).
+    const shouldShowStandaloneReplyCount = !hasRepliableActions && !thought.isDraft && showReplyCount;
 
     return (
         <Pressable style={themeViewContent.styles.thoughtContentContainer} onPress={() => inspectThought(thought)}>
@@ -381,7 +398,30 @@ const ThoughtContent = ({
                 </View>
                 <View style={isExpanded ? themeViewContent.styles.thoughtReactionsContainerExpanded : themeViewContent.styles.thoughtReactionsContainer}>
                     {
-                        !thought.isDraft && isRepliable &&
+                        shouldShowStandaloneReplyCount &&
+                        <Button
+                            containerStyle={themeViewContent.styles.thoughtReactionButtonContainer}
+                            buttonStyle={themeViewContent.styles.thoughtReactionButton}
+                            icon={
+                                <TherrIcon
+                                    name="chat"
+                                    size={22}
+                                    color={isDarkMode ? theme.colors.textWhite : theme.colors.tertiary}
+                                />
+                            }
+                            onPress={() => inspectThought(thought)}
+                            type="clear"
+                            title={`${totalReplies || 0}`}
+                            titleStyle={[
+                                themeViewContent.styles.thoughtReactionButtonTitle,
+                                { color: isDarkMode ? theme.colors.textWhite : theme.colors.tertiary },
+                            ]}
+                            accessibilityLabel={translate('components.thoughtDisplay.viewReplies', { count: totalReplies || 0 })}
+                            TouchableComponent={TouchableWithoutFeedbackComponent}
+                        />
+                    }
+                    {
+                        hasRepliableActions &&
                         <>
                             <Button
                                 containerStyle={themeViewContent.styles.thoughtReactionButtonContainer}

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -392,7 +392,8 @@
       }
     },
     "thoughtDisplay": {
-      "viewAllReplies": "View all {count} replies"
+      "viewAllReplies": "View all {count} replies",
+      "viewReplies": "View {count} replies"
     },
     "userMenu": {
       "buttons": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -392,7 +392,8 @@
       }
     },
     "thoughtDisplay": {
-      "viewAllReplies": "Ver las {count} respuestas"
+      "viewAllReplies": "Ver las {count} respuestas",
+      "viewReplies": "Ver {count} respuestas"
     },
     "userMenu": {
       "buttons": {

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -392,7 +392,8 @@
       }
     },
     "thoughtDisplay": {
-      "viewAllReplies": "Voir les {count} réponses"
+      "viewAllReplies": "Voir les {count} réponses",
+      "viewReplies": "Voir {count} réponses"
     },
     "userMenu": {
       "buttons": {

--- a/TherrMobile/main/routes/ViewThought/index.tsx
+++ b/TherrMobile/main/routes/ViewThought/index.tsx
@@ -387,6 +387,7 @@ const ViewThought = ({
                                     isDarkMode={isDarkMode}
                                     isExpanded={false}
                                     inspectThought={handleGoToContent}
+                                    showReplyCount={true}
                                     thought={reply}
                                     goToViewUser={handleGoToViewUser}
                                     updateThoughtReaction={handleUpdateThoughtReaction}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -42,6 +42,7 @@
 - **Thoughts** — micro-posts with categories, reply threads, mentions, hashtags
 - **Ranked social feed (mobile)** — Discoveries/Thoughts tabs ordered by engagement score (recency decay × likes/replies/views × category affinity from the user's own reactions); backend stream activation ranks candidates by reply-count hot score
 - **Auto-expanded thread previews (mobile)** — engaging thought threads show their top reply inline with a "View all N replies" link (Twitter-style)
+- **Nested reply counts (mobile & web)** — in the thought details view only, each reply renders a reply icon with its own nested reply count; tapping it opens that reply's details view so threads can be walked one level at a time
 - **Content categories** — 20+ categories (food, music, nature, art, gaming, etc.)
 - **Media uploads** — image upload with CDN (ImageKit), YouTube video embedding
 

--- a/therr-client-web/src/locales/en-us/dictionary.json
+++ b/therr-client-web/src/locales/en-us/dictionary.json
@@ -431,7 +431,8 @@
       "replyError": "Failed to post reply. Please try again.",
       "loginToReply": "Log in to reply",
       "loginToView": "Log in to view this post and join the conversation",
-      "backToThoughts": "Back to Thoughts"
+      "backToThoughts": "Back to Thoughts",
+      "viewReplies": "View {count} replies"
     },
     "explorePeople": {
       "pageTitle": "Search People",

--- a/therr-client-web/src/locales/es/dictionary.json
+++ b/therr-client-web/src/locales/es/dictionary.json
@@ -431,7 +431,8 @@
       "replyError": "No se pudo publicar la respuesta. Por favor, inténtalo de nuevo.",
       "loginToReply": "Inicia sesión para responder",
       "loginToView": "Inicia sesión para ver esta publicación y unirte a la conversación",
-      "backToThoughts": "Volver a Pensamientos"
+      "backToThoughts": "Volver a Pensamientos",
+      "viewReplies": "Ver {count} respuestas"
     },
     "explorePeople": {
       "pageTitle": "Buscar personas",

--- a/therr-client-web/src/locales/fr-ca/dictionary.json
+++ b/therr-client-web/src/locales/fr-ca/dictionary.json
@@ -438,7 +438,8 @@
       "replyError": "Échec de la publication de la réponse. Veuillez réessayer.",
       "loginToReply": "Connectez-vous pour répondre",
       "loginToView": "Connectez-vous pour voir cette publication et rejoindre la conversation",
-      "backToThoughts": "Retour aux pensées"
+      "backToThoughts": "Retour aux pensées",
+      "viewReplies": "Voir {count} réponses"
     },
     "chatForum": {
       "pageTitle": "Clavardage hébergé",

--- a/therr-client-web/src/routes/ViewThought.tsx
+++ b/therr-client-web/src/routes/ViewThought.tsx
@@ -187,6 +187,11 @@ const ViewThought: React.FC = () => {
         navigate(`/users/${userId}`);
     }, [navigate]);
 
+    // Drills into a reply's own details view, where its nested replies become the thread
+    const handleInspectReply = useCallback((replyId: string) => {
+        navigate(`/thoughts/${replyId}`);
+    }, [navigate]);
+
     const breadcrumbs = [
         <Anchor component={Link} to="/" key="home" size="sm">{translate('pages.navigation.home')}</Anchor>,
         <Anchor component={Link} to="/posts/thoughts" key="thoughts" size="sm">{translate('pages.navigation.thoughts')}</Anchor>,
@@ -315,6 +320,8 @@ const ViewThought: React.FC = () => {
                             {replies.map((reply) => {
                                 const replyHashtags = reply.hashTags ? reply.hashTags.split(',').filter(Boolean) : [];
                                 const replyIsLiked = reply.reaction?.userHasLiked;
+                                const replyReplyCount = reply.replyCount || 0;
+                                const viewRepliesLabel = translate('pages.viewThought.viewReplies', { count: replyReplyCount });
                                 return (
                                     <div key={reply.id} className="thought-card">
                                         <div className="thought-card-content">
@@ -346,8 +353,8 @@ const ViewThought: React.FC = () => {
                                                 </Group>
                                             )}
 
-                                            {user?.isAuthenticated && (
-                                                <Group gap="md" className="thought-card-reactions">
+                                            <Group gap="md" className="thought-card-reactions">
+                                                {user?.isAuthenticated && (
                                                     <Tooltip label={replyIsLiked ? 'Unlike' : 'Like'}>
                                                         <ActionIcon
                                                             variant="subtle"
@@ -361,8 +368,23 @@ const ViewThought: React.FC = () => {
                                                             />
                                                         </ActionIcon>
                                                     </Tooltip>
-                                                </Group>
-                                            )}
+                                                )}
+                                                <Tooltip label={viewRepliesLabel}>
+                                                    <Button
+                                                        variant="subtle"
+                                                        size="compact-xs"
+                                                        color="gray"
+                                                        aria-label={viewRepliesLabel}
+                                                        onClick={() => handleInspectReply(reply.id)}
+                                                        leftSection={(
+                                                            <InlineSvg name="forum" className="discovered-tile-icon" />
+                                                        )}
+                                                        className="thought-card-reply-count"
+                                                    >
+                                                        {replyReplyCount}
+                                                    </Button>
+                                                </Tooltip>
+                                            </Group>
                                         </div>
                                     </div>
                                 );

--- a/therr-client-web/src/styles/pages/explore.scss
+++ b/therr-client-web/src/styles/pages/explore.scss
@@ -167,6 +167,23 @@
   padding-top: 4px;
 }
 
+// Reply-count control on nested replies (thought details view only)
+.thought-card-reply-count {
+  padding-left: 4px;
+  padding-right: 6px;
+
+  .inline-svg {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  svg {
+    width: 1rem;
+    height: 1rem;
+    fill: currentColor;
+  }
+}
+
 .thought-card-clickable {
   cursor: pointer;
   transition: background 0.15s ease;

--- a/therr-services/users-service/src/store/ThoughtsStore.ts
+++ b/therr-services/users-service/src/store/ThoughtsStore.ts
@@ -223,6 +223,16 @@ export default class ThoughtsStore {
             const repliesJoinClause = readable === 'all'
                 ? undefined
                 : `replies."brandVariation" IN (${readable.map((b) => `'${b}'`).join(',')})`;
+
+            // Nested reply count powers the reply-count icon in the thought details view (mobile + web).
+            // The brand restriction is mirrored from the reply join so the count can never advertise
+            // replies the caller would not be allowed to open. It is deliberately a correlated
+            // subquery rather than a second join: the details view loads one parent, so this is a
+            // handful of index probes on the parentId index, and a GROUP BY join would aggregate
+            // every reply row in the table.
+            const nestedRepliesBrandClause = readable === 'all'
+                ? ''
+                : ` AND nested."brandVariation" IN (${readable.map((b) => `'${b}'`).join(',')})`;
             query = query
                 .leftJoin(`${THOUGHTS_TABLE_NAME} as replies`, function joinReplies() {
                     this.on('replies.parentId', '=', `${THOUGHTS_TABLE_NAME}.id`);
@@ -232,6 +242,10 @@ export default class ThoughtsStore {
                 })
                 .columns([
                     `${THOUGHTS_TABLE_NAME}.*`,
+                    knexBuilder.raw(
+                        `(SELECT COUNT(*) FROM ${THOUGHTS_TABLE_NAME} AS nested `
+                        + `WHERE nested."parentId" = replies.id${nestedRepliesBrandClause}) AS "replies[].replyCount"`,
+                    ),
                     'replies.id as replies[].id',
                     'replies.fromUserId as replies[].fromUserId',
                     'replies.parentId as replies[].parentId',
@@ -261,6 +275,17 @@ export default class ThoughtsStore {
 
         return this.db.read.query(query.toString()).then(async ({ rows }) => {
             const thoughts = formatSQLJoinAsJSON(rows, [{ propKey: 'replies', propId: 'id' }]);
+
+            if (options.withReplies) {
+                // pg returns COUNT(*) as a bigint string; clients render/compare it as a number
+                thoughts.forEach((thought) => {
+                    (thought.replies || []).forEach((reply) => {
+                        const modifiedReply = reply;
+                        modifiedReply.replyCount = parseInt(modifiedReply.replyCount || 0, 10);
+                    });
+                });
+            }
+
             if (options.withUser) {
                 const userIds: string[] = [];
                 const thoughtDetailsPromises: Promise<any>[] = [];

--- a/therr-services/users-service/tests/unit/ThoughtsStore.test.ts
+++ b/therr-services/users-service/tests/unit/ThoughtsStore.test.ts
@@ -237,6 +237,47 @@ describe('ThoughtsStore brand filtering', () => {
             const sql = readStub.args[0][0] as string;
             expect(sql).to.not.include('brandVariation');
         });
+
+        it('selects a nested reply count per reply, brand-restricted to match the reply join', () => {
+            const { connection, readStub } = buildMockConnection();
+            const store = new ThoughtsStore(connection, stubUsersStore);
+            store.getById(BrandVariations.HABITS, 'thought-1', {}, { withReplies: true });
+
+            const sql = readStub.args[0][0] as string;
+            expect(sql).to.include('SELECT COUNT(*) FROM main.thoughts AS nested WHERE nested."parentId" = replies.id');
+            expect(sql).to.include(`nested."brandVariation" IN ('habits')`);
+            expect(sql).to.include('"replies[].replyCount"');
+        });
+
+        it('does not select a nested reply count when replies are not requested', () => {
+            const { connection, readStub } = buildMockConnection();
+            const store = new ThoughtsStore(connection, stubUsersStore);
+            store.getById(BrandVariations.THERR, 'thought-1', {}, {});
+
+            const sql = readStub.args[0][0] as string;
+            expect(sql).to.not.include('replyCount');
+        });
+
+        it('coerces the nested reply count from a pg bigint string to a number', async () => {
+            const { connection, readStub } = buildMockConnection();
+            readStub.callsFake(() => Promise.resolve({
+                rows: [{
+                    id: 'thought-1',
+                    'replies[].id': 'reply-1',
+                    'replies[].replyCount': '3',
+                }, {
+                    id: 'thought-1',
+                    'replies[].id': 'reply-2',
+                    'replies[].replyCount': '0',
+                }],
+            }));
+            const store = new ThoughtsStore(connection, stubUsersStore);
+
+            const { thoughts } = await store.getById(BrandVariations.THERR, 'thought-1', {}, { withReplies: true });
+
+            expect(thoughts[0].replies[0].replyCount).to.equal(3);
+            expect(thoughts[0].replies[1].replyCount).to.equal(0);
+        });
     });
 
     describe('create', () => {


### PR DESCRIPTION
The thought details view needs to show, for each reply, how many replies
that reply itself has. ThoughtsStore.getById already self-joins replies but
reported nothing about their own threads.

Adds a correlated COUNT(*) subquery selected as "replies[].replyCount", with
the same brandVariation restriction the reply join uses so the count can never
advertise replies the caller would not be allowed to open. Correlated rather
than a GROUP BY join because the details view loads a single parent, making
this a handful of probes on the parentId index.

pg returns COUNT(*) as a bigint string, so the value is coerced to a number
before it leaves the store (matching how find() already normalizes replyCount).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017ux6cbYS6UxSZupimCVx7t