### PR TITLE
feat(js-utilities): add short-lived phone-ownership token helper

### DIFF
--- a/TherrMobile/__tests__/components/LoginForm.test.tsx
+++ b/TherrMobile/__tests__/components/LoginForm.test.tsx
@@ -6,7 +6,7 @@ import LoginForm from '../../main/routes/Login/LoginForm';
 import renderer, { act } from 'react-test-renderer';
 
 // Note: import explicitly to use the types shiped with jest.
-import {it} from '@jest/globals';
+import {it, expect} from '@jest/globals';
 
 // The shared Button reads the active theme via useSelector. This test renders
 // the form with explicit props (no <Provider>), so stub useSelector to resolve
@@ -14,6 +14,14 @@ import {it} from '@jest/globals';
 jest.mock('react-redux', () => ({
     ...jest.requireActual('react-redux'),
     useSelector: (selector: (state: any) => any) => selector({ user: { settings: {} } }),
+}));
+
+// The form reads remembered profiles on mount. Stub the module so the test does not
+// depend on device storage and so each case controls its own pre-fill.
+jest.mock('../../main/utilities/rememberedProfiles', () => ({
+    getRememberedProfiles: jest.fn(() => Promise.resolve([])),
+    rememberCurrentUser: jest.fn(() => Promise.resolve()),
+    forgetProfile: jest.fn(() => Promise.resolve([])),
 }));
 
 beforeEach(() => {
@@ -31,27 +39,61 @@ const mockStyles = {
     },
 };
 
-describe('LoginForm', () => {
-    beforeEach(() => {
+// `await act(async ...)` so the remembered-profiles read that fires on mount settles
+// before assertions — otherwise React warns about an unwrapped state update.
+const renderLoginForm = async (props: any = {}) => {
+    let component!: renderer.ReactTestRenderer;
+    await act(async () => {
+        component = renderer.create(
+            <LoginForm navigation={{ navigate: jest.fn() }}
+                login={jest.fn()}
+                loginWithPhone={jest.fn()}
+                selectPhoneLoginAccount={jest.fn()}
+                userSettings={{ mobileThemeName: 'retro' }}
+                themeAuthForm={{ styles: mockStyles }}
+                themeAlerts={{ styles: mockStyles, colors: {} as any }}
+                themeForms={{ styles: mockStyles, colors: {} as any }}
+                {...props}
+            />
+        );
     });
 
-    it('renders correctly', () => {
-        const mockNavigation = {
-            navigate: jest.fn(),
-        };
-        const mockLogin = jest.fn();
-        let component: renderer.ReactTestRenderer;
+    return component;
+};
+
+describe('LoginForm', () => {
+    it('renders correctly', async () => {
+        const component = await renderLoginForm();
+
+        expect(component.getInstance()).toBeTruthy();
+    });
+
+    it('starts on the password step for an email identifier', async () => {
+        const component = await renderLoginForm({ prefillIdentifier: 'jane@example.com' });
+        const instance: any = component.getInstance();
+
+        expect(instance.isPhoneModeActive()).toEqual(false);
+        expect(component.root.findAllByProps({ testID: 'login-password' }).length).toBeGreaterThan(0);
+    });
+
+    it('switches to the SMS step when the identifier is a phone number', async () => {
+        const component = await renderLoginForm({ prefillIdentifier: '+13175551234' });
+        const instance: any = component.getInstance();
+
+        expect(instance.isPhoneModeActive()).toEqual(true);
+        // The password field is replaced by the "text me a code" action.
+        expect(component.root.findAllByProps({ testID: 'login-password' }).length).toEqual(0);
+    });
+
+    it('drops back to the password step when the identifier stops looking like a phone number', async () => {
+        const component = await renderLoginForm({ prefillIdentifier: '+13175551234' });
+        const instance: any = component.getInstance();
+
         act(() => {
-            component = renderer.create(
-                <LoginForm navigation={mockNavigation}
-                    login={mockLogin}
-                    userSettings={{ mobileThemeName: 'retro' }}
-                    themeAuthForm={{ styles: mockStyles }}
-                    themeAlerts={{ styles: mockStyles, colors: {} as any }}
-                    themeForms={{ styles: mockStyles, colors: {} as any }}
-                />
-            );
+            instance.onInputChange('userName', 'jane@example.com');
         });
-        expect(component!.getInstance()?.isLoginFormDisabled()).toEqual(true);
+
+        expect(instance.isPhoneModeActive()).toEqual(false);
+        expect(component.root.findAllByProps({ testID: 'login-password' }).length).toBeGreaterThan(0);
     });
 });

--- a/TherrMobile/__tests__/routes/Login.test.tsx
+++ b/TherrMobile/__tests__/routes/Login.test.tsx
@@ -18,6 +18,14 @@ jest.mock('react-redux', () => ({
     useSelector: (selector: (state: any) => any) => selector({ user: { settings: {} } }),
 }));
 
+// The form reads remembered profiles on mount. Stub the module so these tests neither touch
+// device storage nor get a surprise pre-filled identifier.
+jest.mock('../../main/utilities/rememberedProfiles', () => ({
+    getRememberedProfiles: jest.fn(() => Promise.resolve([])),
+    rememberCurrentUser: jest.fn(() => Promise.resolve()),
+    forgetProfile: jest.fn(() => Promise.resolve([])),
+}));
+
 jest.mock('react-native-toast-message', () => {
     const MockToast = () => null;
     MockToast.show = jest.fn();
@@ -79,6 +87,8 @@ const defaultProps = {
         navigate: jest.fn(),
     },
     login: jest.fn(),
+    loginWithPhone: jest.fn(),
+    selectPhoneLoginAccount: jest.fn(),
     userSettings: { mobileThemeName: 'light' },
     themeAuthForm: { styles: mockStyles },
     themeAlerts: {

--- a/TherrMobile/__tests__/utilities/authIdentifier.test.ts
+++ b/TherrMobile/__tests__/utilities/authIdentifier.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+    getIdentifierType,
+    isLikelyPhoneNumber,
+    maskEmail,
+    maskIdentifier,
+    maskPhoneNumber,
+    toDialableNumber,
+} from '../../main/utilities/authIdentifier';
+
+describe('isLikelyPhoneNumber', () => {
+    it('accepts the formats people actually type', () => {
+        expect(isLikelyPhoneNumber('+13175551234')).toEqual(true);
+        expect(isLikelyPhoneNumber('317-555-1234')).toEqual(true);
+        expect(isLikelyPhoneNumber('(317) 555 1234')).toEqual(true);
+        expect(isLikelyPhoneNumber('+44 20 7946 0958')).toEqual(true);
+    });
+
+    it('rejects emails and usernames', () => {
+        expect(isLikelyPhoneNumber('jane@example.com')).toEqual(false);
+        expect(isLikelyPhoneNumber('jane_doe')).toEqual(false);
+        // An email whose local part is all digits must not be mistaken for a number.
+        expect(isLikelyPhoneNumber('3175551234@example.com')).toEqual(false);
+    });
+
+    it('rejects digit strings outside the E.164 length range', () => {
+        // A short numeric username, not a phone number.
+        expect(isLikelyPhoneNumber('1234')).toEqual(false);
+        expect(isLikelyPhoneNumber('12345678901234567890')).toEqual(false);
+    });
+
+    it('rejects empty and whitespace-only input', () => {
+        expect(isLikelyPhoneNumber('')).toEqual(false);
+        expect(isLikelyPhoneNumber('   ')).toEqual(false);
+        expect(isLikelyPhoneNumber(undefined)).toEqual(false);
+    });
+});
+
+describe('toDialableNumber', () => {
+    it('strips display formatting but keeps an explicit country code', () => {
+        expect(toDialableNumber('+1 (317) 555-1234')).toEqual('+13175551234');
+        expect(toDialableNumber('317-555-1234')).toEqual('3175551234');
+    });
+});
+
+describe('getIdentifierType', () => {
+    it('classifies each identifier kind', () => {
+        expect(getIdentifierType('jane@example.com')).toEqual('email');
+        expect(getIdentifierType('+13175551234')).toEqual('phone');
+        expect(getIdentifierType('jane_doe')).toEqual('userName');
+    });
+});
+
+describe('masking', () => {
+    it('keeps enough of an email to recognize your own account', () => {
+        expect(maskEmail('jane.doe@example.com')).toEqual('ja•••@example.com');
+    });
+
+    it('returns the input unchanged when it is not an email', () => {
+        expect(maskEmail('not-an-email')).toEqual('not-an-email');
+    });
+
+    it('shows only the last four digits of a phone number', () => {
+        expect(maskPhoneNumber('+13175551234')).toEqual('•••• 1234');
+    });
+
+    it('dispatches on identifier type', () => {
+        expect(maskIdentifier('jane@example.com')).toEqual('ja•••@example.com');
+        expect(maskIdentifier('+13175551234')).toEqual('•••• 1234');
+        expect(maskIdentifier('jane_doe')).toEqual('jane_doe');
+    });
+});

--- a/TherrMobile/main/components/Input/VerificationCodeInput.tsx
+++ b/TherrMobile/main/components/Input/VerificationCodeInput.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import {
+    Pressable,
+    StyleSheet,
+    Text,
+    TextInput,
+    View,
+} from 'react-native';
+import { ITherrThemeColors } from '../../styles/themes';
+import { radius } from '../../styles/radii';
+import { space } from '../../styles/layouts/spacing';
+import { fontSizes, fontWeights } from '../../styles/text';
+
+interface IVerificationCodeInputProps {
+    value: string;
+    onChangeText: (value: string) => void;
+    /** Fired once the final digit is entered, so the user never hunts for a submit button. */
+    onComplete?: (value: string) => void;
+    length?: number;
+    autoFocus?: boolean;
+    disabled?: boolean;
+    hasError?: boolean;
+    themeForms: {
+        colors: ITherrThemeColors;
+        styles: any;
+    };
+}
+
+/**
+ * Segmented one-time-code entry.
+ *
+ * A single hidden `TextInput` owns the value and the keyboard; the visible cells are plain
+ * views that mirror it. This is the standard approach for OTP fields — one input per cell
+ * fights the platform (backspace on an empty cell, paste of a full code, and autofill all
+ * break), whereas one input keeps `oneTimeCode` / `sms-otp` autofill working, which is the
+ * feature users actually notice.
+ */
+const VerificationCodeInput = ({
+    value,
+    onChangeText,
+    onComplete,
+    length = 6,
+    autoFocus = true,
+    disabled = false,
+    hasError = false,
+    themeForms,
+}: IVerificationCodeInputProps) => {
+    const inputRef = React.useRef<TextInput>(null);
+    const [isFocused, setIsFocused] = React.useState(autoFocus);
+
+    const handleChange = (text: string) => {
+        const digits = text.replace(/\D/g, '').slice(0, length);
+        onChangeText(digits);
+
+        if (digits.length === length) {
+            onComplete?.(digits);
+        }
+    };
+
+    const focusInput = () => {
+        if (!disabled) {
+            inputRef.current?.focus();
+        }
+    };
+
+    const characters = value.split('');
+    // The caret sits on the first empty cell, or stays on the last one when full.
+    const activeIndex = Math.min(characters.length, length - 1);
+
+    return (
+        <Pressable onPress={focusInput} accessibilityRole="none">
+            <View style={localStyles.cellRow}>
+                {Array.from({ length }).map((_, index) => {
+                    const isActive = isFocused && index === activeIndex && !disabled;
+                    const cellBorderColor = (() => {
+                        if (hasError) return themeForms.colors.alertError;
+                        if (isActive) return themeForms.colors.brand;
+                        return themeForms.colors.border;
+                    })();
+
+                    return (
+                        <View
+                            key={index}
+                            style={[
+                                localStyles.cell,
+                                {
+                                    borderColor: cellBorderColor,
+                                    backgroundColor: themeForms.colors.surfaceAlt,
+                                    borderWidth: isActive || hasError ? 2 : 1,
+                                },
+                            ]}
+                        >
+                            <Text style={[localStyles.cellText, { color: themeForms.colors.onSurface }]}>
+                                {characters[index] || ''}
+                            </Text>
+                        </View>
+                    );
+                })}
+            </View>
+            <TextInput
+                ref={inputRef}
+                value={value}
+                onChangeText={handleChange}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+                keyboardType="number-pad"
+                textContentType="oneTimeCode"
+                autoComplete="sms-otp"
+                autoFocus={autoFocus}
+                editable={!disabled}
+                maxLength={length}
+                caretHidden
+                style={localStyles.hiddenInput}
+                testID="verification-code-input"
+            />
+        </Pressable>
+    );
+};
+
+const localStyles = StyleSheet.create({
+    cellRow: {
+        flexDirection: 'row',
+        justifyContent: 'center',
+        gap: space.sm,
+    },
+    cell: {
+        width: 46,
+        height: 58,
+        borderRadius: radius.lg,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    cellText: {
+        fontSize: fontSizes.xxl,
+        fontWeight: fontWeights.bold,
+    },
+    // Stretched over the cells rather than `display: none` so taps land on it and the
+    // keyboard opens; `opacity: 0` keeps the native caret and selection invisible.
+    hiddenInput: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        opacity: 0,
+    },
+});
+
+export default VerificationCodeInput;

--- a/TherrMobile/main/components/Modals/AccountPickerModal.tsx
+++ b/TherrMobile/main/components/Modals/AccountPickerModal.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+import {
+    Pressable,
+    StyleSheet,
+    Text,
+    View,
+} from 'react-native';
+import { useSelector } from 'react-redux';
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
+import BaseModal from './BaseModal';
+import { Image } from '../BaseImage';
+import { getTheme } from '../../styles/themes';
+import { getUserImageUri } from '../../utilities/content';
+import { maskIdentifier } from '../../utilities/authIdentifier';
+import { radius } from '../../styles/radii';
+import { space } from '../../styles/layouts/spacing';
+import { fontSizes, fontWeights } from '../../styles/text';
+import { therrFontFamily } from '../../styles/font';
+
+export interface IPickableAccount {
+    id: string;
+    /** Identifier to pre-fill on selection. Absent for accounts returned by the server. */
+    identifier?: string;
+    userName?: string;
+    firstName?: string;
+    lastName?: string;
+    media?: any;
+    isBusinessAccount?: boolean;
+    isCreatorAccount?: boolean;
+}
+
+interface IAccountPickerModalProps {
+    isVisible: boolean;
+    accounts: IPickableAccount[];
+    /** Highlights the row that is currently in play. */
+    selectedAccountId?: string;
+    headerText: string;
+    onSelect: (account: IPickableAccount) => void;
+    onClose: () => void;
+    /** Omit to hide the per-row remove control (e.g. the post-SMS account picker). */
+    onForget?: (account: IPickableAccount) => void;
+    /** Omit to hide the "use another account" row. */
+    onUseAnotherAccount?: () => void;
+    translate: Function;
+}
+
+const getDisplayName = (account: IPickableAccount) => {
+    const fullName = [account.firstName, account.lastName].filter(Boolean).join(' ');
+
+    return fullName || account.userName || account.identifier || '';
+};
+
+/**
+ * Account switcher shown from the chevron on the sign-in field, and reused as the picker when
+ * a phone number turns out to be attached to more than one account.
+ *
+ * Both cases are the same interaction — "which of these is you?" — so they share one surface
+ * rather than two near-identical sheets. The only difference is which optional affordances
+ * the caller passes (`onForget` / `onUseAnotherAccount`).
+ */
+const AccountPickerModal = ({
+    isVisible,
+    accounts,
+    selectedAccountId,
+    headerText,
+    onSelect,
+    onClose,
+    onForget,
+    onUseAnotherAccount,
+    translate,
+}: IAccountPickerModalProps) => {
+    const themeName = useSelector((state: any) => state?.user?.settings?.mobileThemeName);
+    const therrTheme = getTheme(themeName);
+
+    return (
+        <BaseModal
+            isVisible={isVisible}
+            onDismiss={onClose}
+            headerText={headerText}
+            width="88%"
+        >
+            <View>
+                {accounts.map((account) => {
+                    const isSelected = !!selectedAccountId && selectedAccountId === account.id;
+
+                    return (
+                        <View key={account.id} style={localStyles.row}>
+                            <Pressable
+                                accessibilityRole="button"
+                                accessibilityLabel={getDisplayName(account)}
+                                onPress={() => onSelect(account)}
+                                style={({ pressed }) => [
+                                    localStyles.accountButton,
+                                    {
+                                        backgroundColor: isSelected || pressed
+                                            ? therrTheme.colors.surfaceAlt
+                                            : 'transparent',
+                                        borderColor: isSelected ? therrTheme.colors.brand : 'transparent',
+                                    },
+                                ]}
+                            >
+                                <Image
+                                    source={{ uri: getUserImageUri({ details: account }, 100) }}
+                                    style={localStyles.avatar}
+                                />
+                                <View style={localStyles.accountText}>
+                                    <Text
+                                        numberOfLines={1}
+                                        style={[localStyles.accountName, { color: therrTheme.colors.onSurface }]}
+                                    >
+                                        {getDisplayName(account)}
+                                    </Text>
+                                    {
+                                        account.identifier
+                                            ? (
+                                                <Text
+                                                    numberOfLines={1}
+                                                    style={[localStyles.accountIdentifier, { color: therrTheme.colors.onSurfaceMuted }]}
+                                                >
+                                                    {maskIdentifier(account.identifier)}
+                                                </Text>
+                                            )
+                                            : null
+                                    }
+                                </View>
+                                {
+                                    isSelected
+                                        ? <MaterialIcon name="check-circle" size={20} color={therrTheme.colors.brand} />
+                                        : null
+                                }
+                            </Pressable>
+                            {
+                                onForget
+                                    ? (
+                                        <Pressable
+                                            accessibilityRole="button"
+                                            accessibilityLabel={translate('modals.accountPicker.removeAccount')}
+                                            hitSlop={8}
+                                            onPress={() => onForget(account)}
+                                            style={localStyles.forgetButton}
+                                        >
+                                            <MaterialIcon name="close" size={18} color={therrTheme.colors.onSurfaceMuted} />
+                                        </Pressable>
+                                    )
+                                    : null
+                            }
+                        </View>
+                    );
+                })}
+                {
+                    onUseAnotherAccount
+                        ? (
+                            <Pressable
+                                accessibilityRole="button"
+                                onPress={onUseAnotherAccount}
+                                style={({ pressed }) => [
+                                    localStyles.accountButton,
+                                    localStyles.useAnotherRow,
+                                    {
+                                        borderTopColor: therrTheme.colors.border,
+                                        backgroundColor: pressed ? therrTheme.colors.surfaceAlt : 'transparent',
+                                    },
+                                ]}
+                            >
+                                <View style={[localStyles.addIconCircle, { borderColor: therrTheme.colors.brand }]}>
+                                    <MaterialIcon name="add" size={20} color={therrTheme.colors.brand} />
+                                </View>
+                                <Text style={[localStyles.accountName, { color: therrTheme.colors.brand }]}>
+                                    {translate('modals.accountPicker.useAnotherAccount')}
+                                </Text>
+                            </Pressable>
+                        )
+                        : null
+                }
+            </View>
+        </BaseModal>
+    );
+};
+
+const localStyles = StyleSheet.create({
+    row: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    accountButton: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingVertical: space.md,
+        paddingHorizontal: space.sm,
+        borderRadius: radius.lg,
+        borderWidth: 1,
+        gap: space.md,
+    },
+    avatar: {
+        width: 40,
+        height: 40,
+        borderRadius: radius.circle,
+    },
+    accountText: {
+        flex: 1,
+    },
+    accountName: {
+        fontFamily: therrFontFamily,
+        fontSize: fontSizes.md,
+        fontWeight: fontWeights.semibold,
+    },
+    accountIdentifier: {
+        fontFamily: therrFontFamily,
+        fontSize: fontSizes.sm,
+        marginTop: 2,
+    },
+    forgetButton: {
+        paddingHorizontal: space.sm,
+        paddingVertical: space.sm,
+    },
+    useAnotherRow: {
+        marginTop: space.xs,
+        paddingTop: space.md,
+        borderTopWidth: StyleSheet.hairlineWidth,
+        borderRadius: 0,
+        borderWidth: 0,
+    },
+    addIconCircle: {
+        width: 40,
+        height: 40,
+        borderRadius: radius.circle,
+        borderWidth: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+});
+
+export default AccountPickerModal;

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -70,7 +70,9 @@
     "waitlistSuccess": "Registration Success!",
     "reactionSent": "Reaction Sent!",
     "reactionFailed": "Reaction Failed",
-    "mediaUploadFailed": "Image Upload Failed"
+    "mediaUploadFailed": "Image Upload Failed",
+    "tooManyAttempts": "Too Many Attempts",
+    "registerSuccess": "Account Created"
   },
   "alertMessages": {
     "activityCreated": "A new group and event was created. Invites sent to each group member.",
@@ -107,7 +109,9 @@
     "draftReminder": "Did you remember to finish your drafted post?",
     "requestClaimSent": "Check your e-mail for confirmation and next steps",
     "waitlistSuccess": "Check your e-mail to verify your account",
-    "mediaUploadFailed": "Your image could not be uploaded. Please try again."
+    "mediaUploadFailed": "Your image could not be uploaded. Please try again.",
+    "tooManyAttempts": "Please wait a few minutes before trying again.",
+    "phoneRegisterSuccess": "Your phone is verified. Check your e-mail to confirm your address."
   },
   "dateTime": {
     "lessThanHours": "< 1h",
@@ -478,12 +482,18 @@
       "buttons": {
         "login": "Sign In",
         "signUp": "Create an Account?",
-        "forgotPassword": "Forgot Password?"
+        "forgotPassword": "Forgot Password?",
+        "sendCode": "Text Me a Code",
+        "verifyAndSignIn": "Verify & Sign In",
+        "resendCode": "Resend Code?",
+        "usePasswordInstead": "Use a password instead"
       },
       "defaultTitle": "Login",
       "labels": {
         "password": "Password",
-        "userName": "Email/Phone/Username"
+        "userName": "Email/Phone/Username",
+        "enterCode": "Enter your code",
+        "switchAccount": "Switch account"
       },
       "backendErrorMessage": "Connection error. Please try again later.",
       "invalidUsernamePassword": "Invalid username/password combination.",
@@ -493,7 +503,13 @@
         "appleButtonTitle": "Sign in with Apple",
         "googleButtonTitleContinue": "Continue with Google",
         "googleButtonTitleSignIn": "Sign in with Google"
-      }
+      },
+      "subtitles": {
+        "codeSentTo": "We sent a 6-digit code to {phoneNumber}",
+        "phoneSignInHint": "We'll text you a 6-digit code — no password needed."
+      },
+      "invalidCode": "That code is invalid or expired.",
+      "invalidPhoneNumber": "Please enter a valid phone number."
     },
     "nearbyForm": {
       "buttons": {
@@ -887,6 +903,29 @@
     "myQRCodeDetail": {
       "share": "Share Link",
       "copy": "Copy Link"
+    },
+    "phoneSignupForm": {
+      "labels": {
+        "enterPhone": "What's your number?",
+        "enterCode": "Enter your code",
+        "enterEmail": "Add your e-mail",
+        "optionalPassword": "Password (optional)"
+      },
+      "subtitles": {
+        "enterPhone": "We'll text you a code to verify it's you.",
+        "enterEmail": "We use it for receipts, password resets, and account recovery.",
+        "optionalPassword": "Skip it — you can always sign in with a texted code."
+      },
+      "buttons": {
+        "sendCode": "Send Code",
+        "verify": "Verify",
+        "changeNumber": "Use a different number",
+        "useEmailInstead": "Sign up with e-mail instead",
+        "usePhoneInstead": "Sign up with your phone instead"
+      },
+      "errorMessages": {
+        "accountExists": "An account already uses this number. Try signing in."
+      }
     }
   },
   "interests": {
@@ -1516,7 +1555,8 @@
       "pageTitle": "Welcome",
       "pageSubtitle": "Sign in to Therr to see what you missed",
       "userAlerts": {
-        "registerSuccess": "Registration success! Check your e-mail for verification."
+        "registerSuccess": "Registration success! Check your e-mail for verification.",
+        "phoneRegisterSuccess": "Account created! Sign in with a code sent to your phone."
       }
     },
     "map": {
@@ -1958,6 +1998,12 @@
         "header": "Achievement Earned!",
         "message": "Share your achievement with friends!"
       }
+    },
+    "accountPicker": {
+      "switchHeader": "Switch account",
+      "chooseHeader": "Choose an account",
+      "useAnotherAccount": "Use another account",
+      "removeAccount": "Remove saved account"
     }
   },
   "permissions": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -70,7 +70,9 @@
     "waitlistSuccess": "¡Registro exitoso!",
     "reactionSent": "¡Reacción enviada!",
     "reactionFailed": "Reacción fallida",
-    "mediaUploadFailed": "Error al cargar imagen"
+    "mediaUploadFailed": "Error al cargar imagen",
+    "tooManyAttempts": "Demasiados intentos",
+    "registerSuccess": "Cuenta creada"
   },
   "alertMessages": {
     "activityCreated": "Se creó un nuevo grupo y evento. Se enviaron invitaciones a cada miembro del grupo.",
@@ -107,7 +109,9 @@
     "draftReminder": "¿Recordaste terminar tu publicación en borrador?",
     "requestClaimSent": "Revisa tu correo electrónico para confirmación y próximos pasos",
     "waitlistSuccess": "Revisa tu correo electrónico para verificar tu cuenta",
-    "mediaUploadFailed": "No se pudo cargar tu imagen. Por favor, inténtalo de nuevo."
+    "mediaUploadFailed": "No se pudo cargar tu imagen. Por favor, inténtalo de nuevo.",
+    "tooManyAttempts": "Espera unos minutos antes de volver a intentarlo.",
+    "phoneRegisterSuccess": "Tu teléfono está verificado. Revisa tu correo para confirmar tu dirección."
   },
   "dateTime": {
     "lessThanHours": "< 1h",
@@ -478,12 +482,18 @@
       "buttons": {
         "login": "Iniciar sesión",
         "signUp": "¿Crear una cuenta?",
-        "forgotPassword": "¿Olvidaste tu contraseña?"
+        "forgotPassword": "¿Olvidaste tu contraseña?",
+        "sendCode": "Enviarme un código",
+        "verifyAndSignIn": "Verificar e iniciar sesión",
+        "resendCode": "¿Reenviar código?",
+        "usePasswordInstead": "Usar una contraseña"
       },
       "defaultTitle": "Iniciar sesión",
       "labels": {
         "password": "Contraseña",
-        "userName": "Correo/Teléfono/Usuario"
+        "userName": "Correo/Teléfono/Usuario",
+        "enterCode": "Ingresa tu código",
+        "switchAccount": "Cambiar de cuenta"
       },
       "backendErrorMessage": "Error de conexión. Por favor, inténtalo de nuevo más tarde.",
       "invalidUsernamePassword": "Combinación de usuario/contraseña inválida.",
@@ -493,7 +503,13 @@
         "appleButtonTitle": "Iniciar sesión con Apple",
         "googleButtonTitleContinue": "Continuar con Google",
         "googleButtonTitleSignIn": "Iniciar sesión con Google"
-      }
+      },
+      "subtitles": {
+        "codeSentTo": "Enviamos un código de 6 dígitos a {phoneNumber}",
+        "phoneSignInHint": "Te enviaremos un código de 6 dígitos: no necesitas contraseña."
+      },
+      "invalidCode": "Ese código no es válido o ha expirado.",
+      "invalidPhoneNumber": "Ingresa un número de teléfono válido."
     },
     "nearbyForm": {
       "buttons": {
@@ -887,6 +903,29 @@
     "myQRCodeDetail": {
       "share": "Compartir enlace",
       "copy": "Copiar enlace"
+    },
+    "phoneSignupForm": {
+      "labels": {
+        "enterPhone": "¿Cuál es tu número?",
+        "enterCode": "Ingresa tu código",
+        "enterEmail": "Agrega tu correo",
+        "optionalPassword": "Contraseña (opcional)"
+      },
+      "subtitles": {
+        "enterPhone": "Te enviaremos un código para verificar que eres tú.",
+        "enterEmail": "Lo usamos para recibos, restablecer contraseñas y recuperar tu cuenta.",
+        "optionalPassword": "Puedes omitirla: siempre puedes iniciar sesión con un código."
+      },
+      "buttons": {
+        "sendCode": "Enviar código",
+        "verify": "Verificar",
+        "changeNumber": "Usar otro número",
+        "useEmailInstead": "Registrarse con correo",
+        "usePhoneInstead": "Registrarse con tu teléfono"
+      },
+      "errorMessages": {
+        "accountExists": "Ya existe una cuenta con este número. Intenta iniciar sesión."
+      }
     }
   },
   "interests": {
@@ -1516,7 +1555,8 @@
       "pageTitle": "Bienvenido",
       "pageSubtitle": "Inicia sesión en Therr para ver lo que te perdiste",
       "userAlerts": {
-        "registerSuccess": "¡Registro exitoso! Revisa tu correo electrónico para la verificación."
+        "registerSuccess": "¡Registro exitoso! Revisa tu correo electrónico para la verificación.",
+        "phoneRegisterSuccess": "¡Cuenta creada! Inicia sesión con un código enviado a tu teléfono."
       }
     },
     "map": {
@@ -1958,6 +1998,12 @@
         "header": "¡Logro obtenido!",
         "message": "¡Comparte tu logro con amigos!"
       }
+    },
+    "accountPicker": {
+      "switchHeader": "Cambiar de cuenta",
+      "chooseHeader": "Elige una cuenta",
+      "useAnotherAccount": "Usar otra cuenta",
+      "removeAccount": "Quitar cuenta guardada"
     }
   },
   "permissions": {

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -70,7 +70,9 @@
     "waitlistSuccess": "Inscription réussie!",
     "reactionSent": "Réaction envoyée!",
     "reactionFailed": "Échec de la réaction",
-    "mediaUploadFailed": "Échec du téléversement de l'image"
+    "mediaUploadFailed": "Échec du téléversement de l'image",
+    "tooManyAttempts": "Trop de tentatives",
+    "registerSuccess": "Compte créé"
   },
   "alertMessages": {
     "activityCreated": "Un nouveau groupe et événement ont été créés. Des invitations ont été envoyées à chaque membre du groupe.",
@@ -107,7 +109,9 @@
     "draftReminder": "Avez-vous pensé à terminer votre brouillon?",
     "requestClaimSent": "Vérifiez votre courriel pour la confirmation et les prochaines étapes",
     "waitlistSuccess": "Vérifiez votre courriel pour confirmer votre compte",
-    "mediaUploadFailed": "Votre image n'a pas pu être téléversée. Veuillez réessayer."
+    "mediaUploadFailed": "Votre image n'a pas pu être téléversée. Veuillez réessayer.",
+    "tooManyAttempts": "Veuillez patienter quelques minutes avant de réessayer.",
+    "phoneRegisterSuccess": "Votre téléphone est vérifié. Consultez vos courriels pour confirmer votre adresse."
   },
   "dateTime": {
     "lessThanHours": "< 1h",
@@ -478,12 +482,18 @@
       "buttons": {
         "login": "Se connecter",
         "signUp": "Créer un compte?",
-        "forgotPassword": "Mot de passe oublié?"
+        "forgotPassword": "Mot de passe oublié?",
+        "sendCode": "M’envoyer un code",
+        "verifyAndSignIn": "Vérifier et se connecter",
+        "resendCode": "Renvoyer le code?",
+        "usePasswordInstead": "Utiliser un mot de passe"
       },
       "defaultTitle": "Connexion",
       "labels": {
         "password": "Mot de passe",
-        "userName": "Courriel/Téléphone/Nom d'utilisateur"
+        "userName": "Courriel/Téléphone/Nom d'utilisateur",
+        "enterCode": "Entrez votre code",
+        "switchAccount": "Changer de compte"
       },
       "backendErrorMessage": "Erreur de connexion. Veuillez réessayer plus tard.",
       "invalidUsernamePassword": "Combinaison nom d'utilisateur/mot de passe invalide.",
@@ -493,7 +503,13 @@
         "appleButtonTitle": "Se connecter avec Apple",
         "googleButtonTitleContinue": "Continuer avec Google",
         "googleButtonTitleSignIn": "Se connecter avec Google"
-      }
+      },
+      "subtitles": {
+        "codeSentTo": "Nous avons envoyé un code à 6 chiffres au {phoneNumber}",
+        "phoneSignInHint": "Nous vous enverrons un code à 6 chiffres — aucun mot de passe requis."
+      },
+      "invalidCode": "Ce code est invalide ou expiré.",
+      "invalidPhoneNumber": "Veuillez entrer un numéro de téléphone valide."
     },
     "nearbyForm": {
       "buttons": {
@@ -887,6 +903,29 @@
     "myQRCodeDetail": {
       "share": "Partager le lien",
       "copy": "Copier le lien"
+    },
+    "phoneSignupForm": {
+      "labels": {
+        "enterPhone": "Quel est votre numéro?",
+        "enterCode": "Entrez votre code",
+        "enterEmail": "Ajoutez votre courriel",
+        "optionalPassword": "Mot de passe (facultatif)"
+      },
+      "subtitles": {
+        "enterPhone": "Nous vous enverrons un code pour vérifier que c’est bien vous.",
+        "enterEmail": "Il sert aux reçus, à la réinitialisation du mot de passe et à la récupération du compte.",
+        "optionalPassword": "Vous pouvez l’ignorer : un code texte suffit pour vous connecter."
+      },
+      "buttons": {
+        "sendCode": "Envoyer le code",
+        "verify": "Vérifier",
+        "changeNumber": "Utiliser un autre numéro",
+        "useEmailInstead": "S’inscrire avec un courriel",
+        "usePhoneInstead": "S’inscrire avec votre téléphone"
+      },
+      "errorMessages": {
+        "accountExists": "Un compte utilise déjà ce numéro. Essayez de vous connecter."
+      }
     }
   },
   "interests": {
@@ -1516,7 +1555,8 @@
       "pageTitle": "Bienvenue",
       "pageSubtitle": "Connectez-vous à Therr pour voir ce que vous avez manqué",
       "userAlerts": {
-        "registerSuccess": "Inscription réussie! Vérifiez votre courriel pour la confirmation."
+        "registerSuccess": "Inscription réussie! Vérifiez votre courriel pour la confirmation.",
+        "phoneRegisterSuccess": "Compte créé! Connectez-vous avec un code envoyé à votre téléphone."
       }
     },
     "map": {
@@ -1958,6 +1998,12 @@
         "header": "Réalisation obtenue!",
         "message": "Partagez votre réalisation avec des amis!"
       }
+    },
+    "accountPicker": {
+      "switchHeader": "Changer de compte",
+      "chooseHeader": "Choisissez un compte",
+      "useAnotherAccount": "Utiliser un autre compte",
+      "removeAccount": "Retirer le compte enregistré"
     }
   },
   "permissions": {

--- a/TherrMobile/main/routes/Login/LoginForm.tsx
+++ b/TherrMobile/main/routes/Login/LoginForm.tsx
@@ -1,20 +1,38 @@
 import * as React from 'react';
-import { Platform, View } from 'react-native';
+import {
+    Platform,
+    Pressable,
+    StyleSheet,
+    Text,
+    View,
+} from 'react-native';
 import { Button } from '../../components/BaseButton';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome5';
 import { appleAuth, AppleButton } from '@invertase/react-native-apple-authentication';
+import { ApiService } from 'therr-react/services';
+import { ErrorCodes } from 'therr-js-utilities/constants';
 import { showToast } from '../../utilities/toasts';
 import translator from '../../utilities/translator';
 import { addMargins } from '../../styles';
-import spacingStyles from '../../styles/layouts/spacing';
+import spacingStyles, { space } from '../../styles/layouts/spacing';
+import { fontSizes } from '../../styles/text';
 import Alert from '../../components/Alert';
 import RoundInput from '../../components/Input/Round';
+import VerificationCodeInput from '../../components/Input/VerificationCodeInput';
 import AppleSignInButton from '../../components/LoginButtons/AppleSignInButton';
 import GoogleSignInButton from '../../components/LoginButtons/GoogleSignInButton';
+import AccountPickerModal, { IPickableAccount } from '../../components/Modals/AccountPickerModal';
 import { ITherrThemeColors } from '../../styles/themes';
 import OrDivider from '../../components/Input/OrDivider';
 import TherrIcon from '../../components/TherrIcon';
+import { isLikelyPhoneNumber, toDialableNumber } from '../../utilities/authIdentifier';
+import {
+    forgetProfile,
+    getRememberedProfiles,
+    rememberCurrentUser,
+    IRememberedProfile,
+} from '../../utilities/rememberedProfiles';
 
 export interface ISSOUserDetails {
     isSSO: boolean;
@@ -28,11 +46,25 @@ export interface ISSOUserDetails {
     userEmail: string;
 }
 
+/**
+ * Which step of the passwordless flow is on screen. `password` is the default and covers
+ * email/username sign-in; the two `code` states are only reachable from a phone number.
+ */
+type LoginMode = 'password' | 'awaitingCode' | 'selectingAccount';
+
 // Regular component props
 interface ILoginFormProps {
     alert?: string;
     login: Function;
+    loginWithPhone: Function;
+    selectPhoneLoginAccount: Function;
     navigation: any;
+    /**
+     * Identifier to seed the field with, ahead of any remembered profile. Set by the sign-up
+     * screens so a brand-new account — which has no remembered profile yet, having never
+     * signed in — doesn't land on an empty form.
+     */
+    prefillIdentifier?: string;
     userMessage?: string;
     userSettings: any;
     themeAlerts: {
@@ -53,10 +85,27 @@ interface ILoginFormState {
     inputs: any;
     isSubmitting: boolean;
     prevLoginError: string;
+    mode: LoginMode;
+    verificationCode: string;
+    hasCodeError: boolean;
+    /** Phone number the code was actually texted to, echoed back by the server. */
+    codeSentToPhoneNumber: string;
+    rememberedProfiles: IRememberedProfile[];
+    isProfileSwitcherVisible: boolean;
+    /** Accounts to choose between when one phone number has several. */
+    selectableAccounts: IPickableAccount[];
+    phoneVerificationToken: string;
+    activeProfileId: string;
 }
 
 /**
  * LoginForm
+ *
+ * One identifier field drives two flows. Typing an email or username keeps the classic
+ * password form; typing something that looks like a phone number swaps the password field for
+ * "text me a code", because a phone-first user very likely has no password at all (see the
+ * passwordless sign-up flow). The switch is reversible — `usePasswordInstead` is always one
+ * tap away for people who registered by phone but later set a password.
  */
 export class LoginFormComponent extends React.Component<
     ILoginFormProps,
@@ -68,20 +117,48 @@ export class LoginFormComponent extends React.Component<
         super(props);
 
         this.state = {
-            inputs: {},
+            inputs: props.prefillIdentifier ? { userName: props.prefillIdentifier } : {},
             isSubmitting: false,
             prevLoginError: '',
+            mode: 'password',
+            verificationCode: '',
+            hasCodeError: false,
+            codeSentToPhoneNumber: '',
+            rememberedProfiles: [],
+            isProfileSwitcherVisible: false,
+            selectableAccounts: [],
+            phoneVerificationToken: '',
+            activeProfileId: '',
         };
 
         // Read from `this.props` so labels re-translate when the pre-login locale changes.
-        this.translate = (key: string, params: any) =>
+        this.translate = (key: string, params?: any) =>
             translator(this.props.userSettings?.locale || 'en-us', key, params);
     }
 
-    isLoginFormDisabled = () => {
-        const { inputs, isSubmitting } = this.state;
-        return !inputs.userName || !inputs.password || isSubmitting;
-    };
+    componentDidMount() {
+        this.loadRememberedProfiles();
+    }
+
+    /**
+     * Pre-fills the identifier with the account last used on this device. Only seeds the field
+     * when it is still empty so a returning render never clobbers typing in progress.
+     */
+    loadRememberedProfiles = () => getRememberedProfiles()
+        .then((rememberedProfiles) => {
+            const mostRecent = rememberedProfiles[0];
+
+            this.setState((prevState) => ({
+                rememberedProfiles,
+                activeProfileId: mostRecent && !prevState.inputs.userName ? mostRecent.id : prevState.activeProfileId,
+                inputs: (mostRecent && !prevState.inputs.userName)
+                    ? { ...prevState.inputs, userName: mostRecent.identifier }
+                    : prevState.inputs,
+            }));
+        })
+        .catch(() => { /* a missing cache just means no pre-fill */ });
+
+    isPhoneModeActive = () => isLikelyPhoneNumber(this.state.inputs.userName);
 
     isLoginButtonLoading() {
         return this.state.isSubmitting;
@@ -136,6 +213,36 @@ export class LoginFormComponent extends React.Component<
         }
     };
 
+    /** Shared error mapping for every sign-in path so the messaging never diverges. */
+    onLoginError = (error: any) => {
+        if (
+            error.statusCode === 400 ||
+            error.statusCode === 401 ||
+            error.statusCode === 404
+        ) {
+            const msg = this.translate(
+                'forms.loginForm.invalidUsernamePassword'
+            );
+            this.setState({ prevLoginError: msg });
+            showToast.error({
+                text1: this.translate('alertTitles.loginError'),
+                text2: msg,
+            });
+        } else if (error.statusCode >= 500) {
+            const msg = this.translate(
+                'forms.loginForm.backendErrorMessage'
+            );
+            this.setState({ prevLoginError: msg });
+            showToast.error({
+                text1: this.translate('alertTitles.backendErrorMessage'),
+                text2: msg,
+            });
+        }
+        this.setState({
+            isSubmitting: false,
+        });
+    };
+
     onSubmit = (ssoUserDetails?: ISSOUserDetails) => {
         const { password, rememberMe, userName } = this.state.inputs;
 
@@ -176,52 +283,415 @@ export class LoginFormComponent extends React.Component<
             .login(loginArgs, {
                 googleSSOIdToken: ssoUserDetails?.idToken,
             })
+            .then(() => rememberCurrentUser(ssoUserDetails ? ssoUserDetails.userEmail : userName))
+            .catch(this.onLoginError);
+    };
+
+    // PASSWORDLESS SIGN-IN
+
+    /**
+     * Requests an SMS code. The response is deliberately the same whether or not an account
+     * exists for the number, so we always advance to the code step — a wrong number simply
+     * fails at the next step instead of telling a stranger which numbers are registered.
+     */
+    onRequestVerificationCode = () => {
+        const phoneNumber = toDialableNumber(this.state.inputs.userName);
+
+        if (!isLikelyPhoneNumber(phoneNumber)) {
+            showToast.error({
+                text1: this.translate('alertTitles.loginError'),
+                text2: this.translate('forms.loginForm.invalidPhoneNumber'),
+            });
+            return;
+        }
+
+        this.setState({
+            isSubmitting: true,
+            prevLoginError: '',
+        });
+
+        ApiService.startPhoneLogin(phoneNumber)
+            .then(() => {
+                this.setState({
+                    mode: 'awaitingCode',
+                    codeSentToPhoneNumber: phoneNumber,
+                    verificationCode: '',
+                    hasCodeError: false,
+                });
+                showToast.success({
+                    text1: this.translate('alertTitles.codeSent'),
+                    text2: this.translate('alertMessages.codeSent'),
+                });
+            })
             .catch((error: any) => {
-                if (
-                    error.statusCode === 400 ||
-                    error.statusCode === 401 ||
-                    error.statusCode === 404
-                ) {
-                    const msg = this.translate(
-                        'forms.loginForm.invalidUsernamePassword'
-                    );
-                    this.setState({ prevLoginError: msg });
+                if (error?.errorCode === ErrorCodes.INVALID_REGION) {
                     showToast.error({
-                        text1: this.translate('alertTitles.loginError'),
-                        text2: msg,
+                        text1: this.translate('alertTitles.invalidRegionCode'),
+                        text2: this.translate('alertMessages.invalidRegionCode'),
                     });
-                } else if (error.statusCode >= 500) {
-                    const msg = this.translate(
-                        'forms.loginForm.backendErrorMessage'
-                    );
-                    this.setState({ prevLoginError: msg });
+                } else if (error?.statusCode === 429) {
+                    showToast.error({
+                        text1: this.translate('alertTitles.tooManyAttempts'),
+                        text2: this.translate('alertMessages.tooManyAttempts'),
+                    });
+                } else {
                     showToast.error({
                         text1: this.translate('alertTitles.backendErrorMessage'),
-                        text2: msg,
+                        text2: this.translate('alertMessages.backendErrorMessage'),
                     });
                 }
-                this.setState({
-                    isSubmitting: false,
-                });
+            })
+            .finally(() => this.setState({ isSubmitting: false }));
+    };
+
+    onSubmitVerificationCode = () => {
+        const { codeSentToPhoneNumber, verificationCode } = this.state;
+
+        if (verificationCode.length !== 6) {
+            return;
+        }
+
+        this.setState({
+            isSubmitting: true,
+            hasCodeError: false,
+        });
+
+        this.props
+            .loginWithPhone({
+                phoneNumber: codeSentToPhoneNumber,
+                verificationCode,
+                rememberMe: this.state.inputs.rememberMe,
+            })
+            .then((result: any) => {
+                // One phone number, several accounts (personal / creator / business). We are
+                // not signed in yet — the user has to say which one they meant.
+                if (result?.requiresAccountSelection) {
+                    this.setState({
+                        mode: 'selectingAccount',
+                        selectableAccounts: result.accounts || [],
+                        phoneVerificationToken: result.phoneVerificationToken,
+                        isSubmitting: false,
+                    });
+                    return undefined;
+                }
+
+                return rememberCurrentUser(codeSentToPhoneNumber);
+            })
+            .catch((error: any) => {
+                // A rejected code is the common case here, so call it out precisely rather
+                // than falling through to the generic credential message.
+                if (error?.statusCode === 400) {
+                    this.setState({
+                        hasCodeError: true,
+                        verificationCode: '',
+                        isSubmitting: false,
+                        prevLoginError: this.translate('forms.loginForm.invalidCode'),
+                    });
+                    showToast.error({
+                        text1: this.translate('alertTitles.invalidCode'),
+                        text2: this.translate('alertMessages.invalidCode'),
+                    });
+                    return;
+                }
+
+                this.onLoginError(error);
             });
     };
 
-    onInputChange = (name: string, value: string) => {
-        const newInputChanges = {
-            [name]: value,
-        };
+    onSelectPhoneAccount = (account: IPickableAccount) => {
+        this.setState({ isSubmitting: true });
 
+        this.props
+            .selectPhoneLoginAccount({
+                phoneVerificationToken: this.state.phoneVerificationToken,
+                userId: account.id,
+                rememberMe: this.state.inputs.rememberMe,
+            })
+            .then(() => rememberCurrentUser(this.state.codeSentToPhoneNumber))
+            .catch(this.onLoginError);
+    };
+
+    /** Abandons the SMS flow and returns to the identifier + password form. */
+    onUsePasswordInstead = () => {
         this.setState({
-            inputs: {
-                ...this.state.inputs,
-                ...newInputChanges,
-            },
+            mode: 'password',
+            verificationCode: '',
+            hasCodeError: false,
             prevLoginError: '',
         });
     };
 
+    // REMEMBERED PROFILES
+
+    toggleProfileSwitcher = () => {
+        this.setState((prevState) => ({
+            isProfileSwitcherVisible: !prevState.isProfileSwitcherVisible,
+        }));
+    };
+
+    onSelectRememberedProfile = (account: IPickableAccount) => {
+        this.setState((prevState) => ({
+            inputs: {
+                ...prevState.inputs,
+                userName: account.identifier || '',
+                // Never carry one account's password over to another.
+                password: '',
+            },
+            activeProfileId: account.id,
+            isProfileSwitcherVisible: false,
+            mode: 'password',
+            prevLoginError: '',
+        }));
+    };
+
+    onForgetRememberedProfile = (account: IPickableAccount) => {
+        forgetProfile(account.id).then((rememberedProfiles) => {
+            this.setState((prevState) => {
+                const wasActive = prevState.activeProfileId === account.id;
+
+                return {
+                    rememberedProfiles,
+                    isProfileSwitcherVisible: rememberedProfiles.length > 0,
+                    activeProfileId: wasActive ? '' : prevState.activeProfileId,
+                    inputs: wasActive
+                        ? { ...prevState.inputs, userName: '', password: '' }
+                        : prevState.inputs,
+                };
+            });
+        });
+    };
+
+    onUseAnotherAccount = () => {
+        this.setState((prevState) => ({
+            inputs: { ...prevState.inputs, userName: '', password: '' },
+            activeProfileId: '',
+            isProfileSwitcherVisible: false,
+            mode: 'password',
+            prevLoginError: '',
+        }));
+    };
+
+    onInputChange = (name: string, value: string) => {
+        const isIdentifierChange = name === 'userName';
+
+        this.setState((prevState) => ({
+            inputs: {
+                ...prevState.inputs,
+                [name]: value,
+            },
+            prevLoginError: '',
+            // Editing the identifier detaches it from the remembered profile it came from and
+            // invalidates any code already in flight.
+            activeProfileId: isIdentifierChange ? '' : prevState.activeProfileId,
+            mode: isIdentifierChange ? 'password' : prevState.mode,
+        }));
+    };
+
+    /**
+     * The SMS step: six-digit entry, resend, and an escape hatch back to the password form.
+     */
+    renderVerificationCodeStep() {
+        const { themeAuthForm, themeForms } = this.props;
+        const {
+            codeSentToPhoneNumber,
+            hasCodeError,
+            isSubmitting,
+            verificationCode,
+        } = this.state;
+
+        return (
+            <>
+                <Text style={[localStyles.codeHeading, { color: themeForms.colors.onSurface }]}>
+                    {this.translate('forms.loginForm.labels.enterCode')}
+                </Text>
+                <Text style={[localStyles.codeSubheading, { color: themeForms.colors.onSurfaceMuted }]}>
+                    {this.translate('forms.loginForm.subtitles.codeSentTo', { phoneNumber: codeSentToPhoneNumber })}
+                </Text>
+                <VerificationCodeInput
+                    value={verificationCode}
+                    onChangeText={(value) => this.setState({ verificationCode: value, hasCodeError: false })}
+                    onComplete={() => this.onSubmitVerificationCode()}
+                    disabled={isSubmitting}
+                    hasError={hasCodeError}
+                    themeForms={themeForms}
+                />
+                <View style={[themeAuthForm.styles.submitButtonContainer, spacingStyles.marginTopMd]}>
+                    <Button
+                        variant="primary"
+                        size="lg"
+                        shape="rounded"
+                        disabledTitleStyle={themeForms.styles.buttonTitleDisabled}
+                        disabledStyle={themeForms.styles.buttonDisabled}
+                        title={this.translate('forms.loginForm.buttons.verifyAndSignIn')}
+                        onPress={() => this.onSubmitVerificationCode()}
+                        disabled={isSubmitting || verificationCode.length !== 6}
+                        loading={isSubmitting}
+                    />
+                </View>
+                <View style={themeForms.styles.moreLinksContainer}>
+                    <Button
+                        type="clear"
+                        titleStyle={themeForms.styles.buttonLink}
+                        title={this.translate('forms.loginForm.buttons.resendCode')}
+                        onPress={this.onRequestVerificationCode}
+                        disabled={isSubmitting}
+                    />
+                </View>
+                <View style={themeForms.styles.moreLinksContainer}>
+                    <Button
+                        type="clear"
+                        titleStyle={themeForms.styles.buttonLink}
+                        title={this.translate('forms.loginForm.buttons.usePasswordInstead')}
+                        onPress={this.onUsePasswordInstead}
+                        disabled={isSubmitting}
+                    />
+                </View>
+            </>
+        );
+    }
+
+    /**
+     * The default step: identifier (with the remembered-profile chevron) plus either a
+     * password field or the "text me a code" button, depending on what was typed.
+     */
+    renderIdentifierStep() {
+        const { isSubmitting, rememberedProfiles } = this.state;
+        const { themeAlerts, themeAuthForm, themeForms } = this.props;
+        const isPhoneMode = this.isPhoneModeActive();
+        const hasRememberedProfiles = rememberedProfiles.length > 0;
+
+        return (
+            <>
+                <RoundInput
+                    autoCapitalize="none"
+                    autoComplete={isPhoneMode ? 'tel' : 'email'}
+                    autoCorrect={false}
+                    keyboardType={isPhoneMode ? 'phone-pad' : 'default'}
+                    placeholder={this.translate(
+                        'forms.loginForm.labels.userName'
+                    )}
+                    value={this.state.inputs.userName}
+                    onChangeText={(text) =>
+                        this.onInputChange('userName', text)
+                    }
+                    rightIcon={
+                        hasRememberedProfiles
+                            ? (
+                                <Pressable
+                                    accessibilityRole="button"
+                                    accessibilityLabel={this.translate('forms.loginForm.labels.switchAccount')}
+                                    hitSlop={12}
+                                    onPress={this.toggleProfileSwitcher}
+                                    testID="login-profile-switcher"
+                                >
+                                    <MaterialIcon
+                                        name="expand-more"
+                                        size={26}
+                                        color={themeAlerts.colors.placeholderTextColorAlt}
+                                    />
+                                </Pressable>
+                            )
+                            : (
+                                <MaterialIcon
+                                    name={isPhoneMode ? 'smartphone' : 'person'}
+                                    size={24}
+                                    color={themeAlerts.colors.placeholderTextColorAlt}
+                                />
+                            )
+                    }
+                    themeForms={themeForms}
+                    containerStyle={{ marginBottom: 14 }}
+                    testID="login-username"
+                    inputStyle={{ fontSize: 17 }}
+                />
+                {
+                    isPhoneMode
+                        ? (
+                            <>
+                                <Text style={[localStyles.phoneHint, { color: themeForms.colors.onSurfaceMuted }]}>
+                                    {this.translate('forms.loginForm.subtitles.phoneSignInHint')}
+                                </Text>
+                                <View style={themeAuthForm.styles.submitButtonContainer}>
+                                    <Button
+                                        variant="primary"
+                                        size="lg"
+                                        shape="rounded"
+                                        disabledTitleStyle={themeForms.styles.buttonTitleDisabled}
+                                        disabledStyle={themeForms.styles.buttonDisabled}
+                                        title={this.translate('forms.loginForm.buttons.sendCode')}
+                                        onPress={this.onRequestVerificationCode}
+                                        disabled={isSubmitting}
+                                        loading={isSubmitting}
+                                        icon={
+                                            <MaterialIcon
+                                                name="sms"
+                                                size={18}
+                                                style={themeForms.styles.buttonIcon}
+                                            />
+                                        }
+                                        iconRight
+                                    />
+                                </View>
+                            </>
+                        )
+                        : (
+                            <>
+                                <RoundInput
+                                    autoCapitalize="none"
+                                    autoCorrect={false}
+                                    autoComplete="password"
+                                    placeholder={this.translate(
+                                        'forms.loginForm.labels.password'
+                                    )}
+                                    value={this.state.inputs.password}
+                                    onChangeText={(text) =>
+                                        this.onInputChange('password', text)
+                                    }
+                                    onSubmitEditing={() => this.onSubmit()}
+                                    secureTextEntry={true}
+                                    rightIcon={
+                                        <TherrIcon
+                                            name="key"
+                                            size={24}
+                                            color={themeAlerts.colors.placeholderTextColorAlt}
+                                        />
+                                    }
+                                    themeForms={themeForms}
+                                    testID="login-password"
+                                    inputStyle={{ fontSize: 17 }}
+                                />
+                                <View style={themeAuthForm.styles.submitButtonContainer}>
+                                    <Button
+                                        variant="primary"
+                                        size="lg"
+                                        shape="rounded"
+                                        disabledTitleStyle={themeForms.styles.buttonTitleDisabled}
+                                        disabledStyle={themeForms.styles.buttonDisabled}
+                                        title={this.translate(
+                                            'forms.loginForm.buttons.login'
+                                        )}
+                                        onPress={() => this.onSubmit()}
+                                        disabled={this.isLoginButtonLoading()}
+                                        loading={isSubmitting}
+                                        icon={
+                                            <FontAwesomeIcon
+                                                name="sign-in-alt"
+                                                size={18}
+                                                style={themeForms.styles.buttonIcon}
+                                            />
+                                        }
+                                        iconRight
+                                    />
+                                </View>
+                            </>
+                        )
+                }
+            </>
+        );
+    }
+
     public render() {
-        const { isSubmitting } = this.state;
+        const { isSubmitting, mode, rememberedProfiles, selectableAccounts } = this.state;
         const {
             navigation,
             themeAlerts,
@@ -229,6 +699,7 @@ export class LoginFormComponent extends React.Component<
             themeForms,
             userMessage,
         } = this.props;
+        const isCodeStep = mode === 'awaitingCode';
 
         return (
             <>
@@ -241,127 +712,105 @@ export class LoginFormComponent extends React.Component<
                     type={'success'}
                     themeAlerts={themeAlerts}
                 />
-                <RoundInput
-                    autoCapitalize="none"
-                    autoComplete="email"
-                    autoCorrect={false}
-                    placeholder={this.translate(
-                        'forms.loginForm.labels.userName'
-                    )}
-                    value={this.state.inputs.userName}
-                    onChangeText={(text) =>
-                        this.onInputChange('userName', text)
-                    }
-                    rightIcon={
-                        <MaterialIcon
-                            name="person"
-                            size={24}
-                            color={themeAlerts.colors.placeholderTextColorAlt}
-                        />
-                    }
-                    themeForms={themeForms}
-                    containerStyle={{ marginBottom: 14 }}
-                    testID="login-username"
-                    inputStyle={{ fontSize: 17 }}
-                />
-                <RoundInput
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                    autoComplete="password"
-                    placeholder={this.translate(
-                        'forms.loginForm.labels.password'
-                    )}
-                    value={this.state.inputs.password}
-                    onChangeText={(text) =>
-                        this.onInputChange('password', text)
-                    }
-                    onSubmitEditing={() => this.onSubmit()}
-                    secureTextEntry={true}
-                    rightIcon={
-                        <TherrIcon
-                            name="key"
-                            size={24}
-                            color={themeAlerts.colors.placeholderTextColorAlt}
-                        />
-                    }
-                    themeForms={themeForms}
-                    testID="login-password"
-                    inputStyle={{ fontSize: 17 }}
-                />
-                <View style={themeAuthForm.styles.submitButtonContainer}>
-                    <Button
-                        variant="primary"
-                        size="lg"
-                        shape="rounded"
-                        disabledTitleStyle={themeForms.styles.buttonTitleDisabled}
-                        disabledStyle={themeForms.styles.buttonDisabled}
-                        title={this.translate(
-                            'forms.loginForm.buttons.login'
-                        )}
-                        onPress={() => this.onSubmit()}
-                        disabled={this.isLoginButtonLoading()}
-                        loading={isSubmitting}
-                        icon={
-                            <FontAwesomeIcon
-                                name="sign-in-alt"
-                                size={18}
-                                style={themeForms.styles.buttonIcon}
-                            />
-                        }
-                        iconRight
-                    />
-                </View>
-                <OrDivider
-                    translate={this.translate}
-                    themeForms={themeForms}
-                    containerStyle={{ marginBottom: 20 }}
-                />
-                <View style={themeAuthForm.styles.submitButtonContainer}>
-                    <GoogleSignInButton
-                        disabled={isSubmitting}
-                        buttonTitle={this.translate('forms.loginForm.sso.googleButtonTitleSignIn')}
-                        onLoginError={this.onSSOLoginError}
-                        onLoginSuccess={this.onSSOLoginSuccess}
-                        themeForms={themeForms}
-                    />
-                </View>
+                {isCodeStep ? this.renderVerificationCodeStep() : this.renderIdentifierStep()}
                 {
-                    Platform.OS === 'ios' && appleAuth.isSupported &&
-                    appleAuth.isSupported &&
-                    <View style={themeAuthForm.styles.submitButtonContainer}>
-                        <AppleSignInButton
-                            disabled={isSubmitting}
-                            buttonTitle={this.translate('forms.loginForm.sso.appleButtonTitle')}
-                            onLoginError={this.onSSOLoginError}
-                            onLoginSuccess={this.onSSOLoginSuccess}
-                            themeForms={themeForms}
-                            type={AppleButton.Type.SIGN_IN}
-                        />
-                    </View>
+                    // SSO and the sign-up/forgot-password links are noise mid-code-entry:
+                    // the user is three taps from being signed in and needs no alternatives.
+                    isCodeStep
+                        ? null
+                        : (
+                            <>
+                                <OrDivider
+                                    translate={this.translate}
+                                    themeForms={themeForms}
+                                    containerStyle={{ marginBottom: 20 }}
+                                />
+                                <View style={themeAuthForm.styles.submitButtonContainer}>
+                                    <GoogleSignInButton
+                                        disabled={isSubmitting}
+                                        buttonTitle={this.translate('forms.loginForm.sso.googleButtonTitleSignIn')}
+                                        onLoginError={this.onSSOLoginError}
+                                        onLoginSuccess={this.onSSOLoginSuccess}
+                                        themeForms={themeForms}
+                                    />
+                                </View>
+                                {
+                                    Platform.OS === 'ios' && appleAuth.isSupported &&
+                                    <View style={themeAuthForm.styles.submitButtonContainer}>
+                                        <AppleSignInButton
+                                            disabled={isSubmitting}
+                                            buttonTitle={this.translate('forms.loginForm.sso.appleButtonTitle')}
+                                            onLoginError={this.onSSOLoginError}
+                                            onLoginSuccess={this.onSSOLoginSuccess}
+                                            themeForms={themeForms}
+                                            type={AppleButton.Type.SIGN_IN}
+                                        />
+                                    </View>
+                                }
+                                <View style={[themeForms.styles.moreLinksContainer, spacingStyles.marginBotMd]}>
+                                    <Button
+                                        type="clear"
+                                        titleStyle={themeForms.styles.buttonLink}
+                                        title={this.translate(
+                                            'forms.loginForm.buttons.signUp'
+                                        )}
+                                        onPress={() => navigation.navigate('Register')}
+                                    />
+                                </View>
+                                <View style={[themeForms.styles.moreLinksContainer, spacingStyles.marginBotMd, spacingStyles.marginTopMd]}>
+                                    <Button
+                                        type="clear"
+                                        titleStyle={themeForms.styles.buttonLink}
+                                        title={this.translate(
+                                            'forms.loginForm.buttons.forgotPassword'
+                                        )}
+                                        onPress={() => navigation.navigate('ForgotPassword')}
+                                    />
+                                </View>
+                            </>
+                        )
                 }
-                <View style={[themeForms.styles.moreLinksContainer, spacingStyles.marginBotMd]}>
-                    <Button
-                        type="clear"
-                        titleStyle={themeForms.styles.buttonLink}
-                        title={this.translate(
-                            'forms.loginForm.buttons.signUp'
-                        )}
-                        onPress={() => navigation.navigate('Register')}
-                    />
-                </View>
-                <View style={[themeForms.styles.moreLinksContainer, spacingStyles.marginBotMd, spacingStyles.marginTopMd]}>
-                    <Button
-                        type="clear"
-                        titleStyle={themeForms.styles.buttonLink}
-                        title={this.translate(
-                            'forms.loginForm.buttons.forgotPassword'
-                        )}
-                        onPress={() => navigation.navigate('ForgotPassword')}
-                    />
-                </View>
+                <AccountPickerModal
+                    isVisible={this.state.isProfileSwitcherVisible}
+                    accounts={rememberedProfiles}
+                    selectedAccountId={this.state.activeProfileId}
+                    headerText={this.translate('modals.accountPicker.switchHeader')}
+                    onSelect={this.onSelectRememberedProfile}
+                    onClose={this.toggleProfileSwitcher}
+                    onForget={this.onForgetRememberedProfile}
+                    onUseAnotherAccount={this.onUseAnotherAccount}
+                    translate={this.translate}
+                />
+                <AccountPickerModal
+                    isVisible={mode === 'selectingAccount'}
+                    accounts={selectableAccounts}
+                    headerText={this.translate('modals.accountPicker.chooseHeader')}
+                    onSelect={this.onSelectPhoneAccount}
+                    onClose={this.onUsePasswordInstead}
+                    translate={this.translate}
+                />
             </>
         );
     }
 }
+
+const localStyles = StyleSheet.create({
+    codeHeading: {
+        fontSize: fontSizes.xl,
+        fontWeight: '600',
+        textAlign: 'center',
+        marginBottom: space.xs,
+    },
+    codeSubheading: {
+        fontSize: fontSizes.sm,
+        textAlign: 'center',
+        marginBottom: space.lg,
+    },
+    phoneHint: {
+        fontSize: fontSizes.sm,
+        textAlign: 'center',
+        marginBottom: space.md,
+    },
+});
 
 export default LoginFormComponent;

--- a/TherrMobile/main/routes/Login/LoginForm.tsx
+++ b/TherrMobile/main/routes/Login/LoginForm.tsx
@@ -148,6 +148,12 @@ export class LoginFormComponent extends React.Component<
         .then((rememberedProfiles) => {
             const mostRecent = rememberedProfiles[0];
 
+            // First run on a device: nothing to pre-fill and nothing to switch between, so
+            // skip the re-render entirely rather than storing an empty list over an empty one.
+            if (!mostRecent) {
+                return;
+            }
+
             this.setState((prevState) => ({
                 rememberedProfiles,
                 activeProfileId: mostRecent && !prevState.inputs.userName ? mostRecent.id : prevState.activeProfileId,
@@ -160,9 +166,23 @@ export class LoginFormComponent extends React.Component<
 
     isPhoneModeActive = () => isLikelyPhoneNumber(this.state.inputs.userName);
 
-    isLoginButtonLoading() {
-        return this.state.isSubmitting;
-    }
+    /**
+     * Whether the primary action is unavailable. Mode-aware: in SMS mode there is no password
+     * to check, so an identifier alone is enough to request a code.
+     */
+    isLoginFormDisabled = () => {
+        const { inputs, isSubmitting } = this.state;
+
+        if (isSubmitting) {
+            return true;
+        }
+
+        if (this.isPhoneModeActive()) {
+            return !inputs.userName;
+        }
+
+        return !inputs.userName || !inputs.password;
+    };
 
     onSSOLoginError = (err) => {
         this.setState({
@@ -620,7 +640,7 @@ export class LoginFormComponent extends React.Component<
                                         disabledStyle={themeForms.styles.buttonDisabled}
                                         title={this.translate('forms.loginForm.buttons.sendCode')}
                                         onPress={this.onRequestVerificationCode}
-                                        disabled={isSubmitting}
+                                        disabled={this.isLoginFormDisabled()}
                                         loading={isSubmitting}
                                         icon={
                                             <MaterialIcon
@@ -671,7 +691,7 @@ export class LoginFormComponent extends React.Component<
                                             'forms.loginForm.buttons.login'
                                         )}
                                         onPress={() => this.onSubmit()}
-                                        disabled={this.isLoginButtonLoading()}
+                                        disabled={this.isLoginFormDisabled()}
                                         loading={isSubmitting}
                                         icon={
                                             <FontAwesomeIcon
@@ -770,25 +790,41 @@ export class LoginFormComponent extends React.Component<
                             </>
                         )
                 }
-                <AccountPickerModal
-                    isVisible={this.state.isProfileSwitcherVisible}
-                    accounts={rememberedProfiles}
-                    selectedAccountId={this.state.activeProfileId}
-                    headerText={this.translate('modals.accountPicker.switchHeader')}
-                    onSelect={this.onSelectRememberedProfile}
-                    onClose={this.toggleProfileSwitcher}
-                    onForget={this.onForgetRememberedProfile}
-                    onUseAnotherAccount={this.onUseAnotherAccount}
-                    translate={this.translate}
-                />
-                <AccountPickerModal
-                    isVisible={mode === 'selectingAccount'}
-                    accounts={selectableAccounts}
-                    headerText={this.translate('modals.accountPicker.chooseHeader')}
-                    onSelect={this.onSelectPhoneAccount}
-                    onClose={this.onUsePasswordInstead}
-                    translate={this.translate}
-                />
+                {
+                    // Mounted only while open. BaseModal renders through a react-native-paper
+                    // `Portal`, which attaches to the Provider as soon as it mounts — keeping
+                    // two of them permanently mounted costs teardown work on every render and
+                    // makes the form unrenderable outside a PaperProvider.
+                    this.state.isProfileSwitcherVisible
+                        ? (
+                            <AccountPickerModal
+                                isVisible
+                                accounts={rememberedProfiles}
+                                selectedAccountId={this.state.activeProfileId}
+                                headerText={this.translate('modals.accountPicker.switchHeader')}
+                                onSelect={this.onSelectRememberedProfile}
+                                onClose={this.toggleProfileSwitcher}
+                                onForget={this.onForgetRememberedProfile}
+                                onUseAnotherAccount={this.onUseAnotherAccount}
+                                translate={this.translate}
+                            />
+                        )
+                        : null
+                }
+                {
+                    mode === 'selectingAccount'
+                        ? (
+                            <AccountPickerModal
+                                isVisible
+                                accounts={selectableAccounts}
+                                headerText={this.translate('modals.accountPicker.chooseHeader')}
+                                onSelect={this.onSelectPhoneAccount}
+                                onClose={this.onUsePasswordInstead}
+                                translate={this.translate}
+                            />
+                        )
+                        : null
+                }
             </>
         );
     }

--- a/TherrMobile/main/routes/Login/index.tsx
+++ b/TherrMobile/main/routes/Login/index.tsx
@@ -23,6 +23,8 @@ import { getUserImageUri } from '../../utilities/content';
 
 interface ILoginDispatchProps {
     login: Function;
+    loginWithPhone: Function;
+    selectPhoneLoginAccount: Function;
     setPreLoginLocale: Function;
 }
 
@@ -48,6 +50,8 @@ const mapDispatchToProps = (dispatch: any) =>
     bindActionCreators(
         {
             login: UsersActions.login,
+            loginWithPhone: UsersActions.loginWithPhone,
+            selectPhoneLoginAccount: UsersActions.selectPhoneLoginAccount,
             setPreLoginLocale,
         },
         dispatch
@@ -140,10 +144,13 @@ class LoginComponent extends React.Component<ILoginProps, ILoginState> {
                             }
                             <LoginForm
                                 login={this.props.login}
+                                loginWithPhone={this.props.loginWithPhone}
+                                selectPhoneLoginAccount={this.props.selectPhoneLoginAccount}
                                 navigation={this.props.navigation}
                                 themeAlerts={this.themeAlerts}
                                 themeAuthForm={this.themeAuthForm}
                                 themeForms={this.themeForms}
+                                prefillIdentifier={route?.params?.prefillIdentifier}
                                 userMessage={userMessage}
                                 userSettings={user?.settings || {}} />
                             <LanguageSelector

--- a/TherrMobile/main/routes/Register/PhoneSignupForm.tsx
+++ b/TherrMobile/main/routes/Register/PhoneSignupForm.tsx
@@ -1,0 +1,582 @@
+import * as React from 'react';
+import {
+    Linking,
+    Pressable,
+    StyleSheet,
+    Text,
+    View,
+} from 'react-native';
+import DatePicker from 'react-native-date-picker';
+import { ApiService } from 'therr-react/services';
+import { ErrorCodes, PasswordRegex } from 'therr-js-utilities/constants';
+import isValidSignupAge, { MINIMUM_SIGNUP_AGE } from 'therr-js-utilities/is-valid-signup-age';
+import { Button } from '../../components/BaseButton';
+import { showToast } from '../../utilities/toasts';
+import translator from '../../utilities/translator';
+import RoundInput from '../../components/Input/Round';
+import PhoneNumberInput from '../../components/Input/PhoneNumberInput';
+import VerificationCodeInput from '../../components/Input/VerificationCodeInput';
+import PasswordRequirements from '../../components/Input/PasswordRequirements';
+import TherrIcon from '../../components/TherrIcon';
+import Alert from '../../components/Alert';
+import { addMargins } from '../../styles';
+import spacingStyles, { space } from '../../styles/layouts/spacing';
+import { fontSizes } from '../../styles/text';
+import { ITherrThemeColors, ITherrThemeColorVariations, isDarkTheme } from '../../styles/themes';
+
+/**
+ * Three steps, in order. The account row is not created until `details` is submitted, so an
+ * abandoned sign-up leaves nothing behind — only a spent SMS code and an expired token.
+ */
+type PhoneSignupStep = 'phone' | 'code' | 'details';
+
+interface IPhoneSignupFormProps {
+    register: Function;
+    onSuccess: (args: { email: string; phoneNumber: string }) => void;
+    onSwitchToEmailSignup: () => void;
+    onSwitchToSignIn: () => void;
+    toggleEULA: Function;
+    userSettings: any;
+    theme: {
+        colors: ITherrThemeColors;
+        styles: any;
+    };
+    themeAlerts: {
+        colors: ITherrThemeColors;
+        colorVariations: ITherrThemeColorVariations;
+        styles: any;
+    };
+    themeAuthForm: {
+        styles: any;
+    };
+    themeForms: {
+        colors: ITherrThemeColors;
+        styles: any;
+    };
+}
+
+interface IPhoneSignupFormState {
+    step: PhoneSignupStep;
+    phoneNumber: string;
+    isPhoneNumberValid: boolean;
+    verificationCode: string;
+    hasCodeError: boolean;
+    /** Signed proof of phone ownership; expires ~20 minutes after the code is accepted. */
+    phoneVerificationToken: string;
+    email: string;
+    password: string;
+    settingsBirthdate: string;
+    isBirthdatePickerOpen: boolean;
+    isPasswordEntryDirty: boolean;
+    isSubmitting: boolean;
+    errorMessage: string;
+}
+
+/**
+ * Phone-first sign-up: verify the handset, then collect an email.
+ *
+ * Deliberately inverted from the classic form. The first screen asks for one thing the user
+ * already knows by heart, and the code they get back does double duty — it proves the number
+ * and doubles as their sign-in method from then on, so a password is genuinely optional. The
+ * email step still exists (accounts need a recoverable address and it is how we reach people)
+ * but it now happens *after* the user is invested, not before.
+ */
+export class PhoneSignupFormComponent extends React.Component<
+    IPhoneSignupFormProps,
+    IPhoneSignupFormState
+> {
+    private translate: Function;
+
+    constructor(props: IPhoneSignupFormProps) {
+        super(props);
+
+        this.state = {
+            step: 'phone',
+            phoneNumber: '',
+            isPhoneNumberValid: false,
+            verificationCode: '',
+            hasCodeError: false,
+            phoneVerificationToken: '',
+            email: '',
+            password: '',
+            settingsBirthdate: '',
+            isBirthdatePickerOpen: false,
+            isPasswordEntryDirty: false,
+            isSubmitting: false,
+            errorMessage: '',
+        };
+
+        // Read from `this.props` so labels re-translate when the pre-login locale changes.
+        this.translate = (key: string, params?: any) =>
+            translator(this.props.userSettings?.locale || 'en-us', key, params);
+    }
+
+    getDefaultBirthdate = () => {
+        const d = new Date();
+        d.setFullYear(d.getFullYear() - MINIMUM_SIGNUP_AGE);
+        return d;
+    };
+
+    onPhoneInputChange = (value: string, isValid: boolean) => {
+        this.setState({
+            phoneNumber: value,
+            isPhoneNumberValid: isValid,
+            errorMessage: '',
+        });
+    };
+
+    onRequestCode = () => {
+        const { phoneNumber } = this.state;
+
+        this.setState({ isSubmitting: true, errorMessage: '' });
+
+        ApiService.startPhoneRegistration(phoneNumber)
+            .then(() => {
+                this.setState({
+                    step: 'code',
+                    verificationCode: '',
+                    hasCodeError: false,
+                });
+                showToast.success({
+                    text1: this.translate('alertTitles.codeSent'),
+                    text2: this.translate('alertMessages.codeSent'),
+                });
+            })
+            .catch((error: any) => {
+                // Unlike sign-in, this endpoint does tell us the number is taken — surface it
+                // and point at sign-in rather than leaving the user stuck on a dead form.
+                if (error?.errorCode === ErrorCodes.USER_EXISTS) {
+                    this.setState({
+                        errorMessage: this.translate('forms.phoneSignupForm.errorMessages.accountExists'),
+                    });
+                    showToast.error({
+                        text1: this.translate('alertTitles.phoneNumberAlreadyInUse'),
+                        text2: this.translate('alertMessages.phoneNumberAlreadyInUse'),
+                    });
+                } else if (error?.errorCode === ErrorCodes.INVALID_REGION) {
+                    showToast.error({
+                        text1: this.translate('alertTitles.invalidRegionCode'),
+                        text2: this.translate('alertMessages.invalidRegionCode'),
+                    });
+                } else if (error?.statusCode === 429) {
+                    showToast.error({
+                        text1: this.translate('alertTitles.tooManyAttempts'),
+                        text2: this.translate('alertMessages.tooManyAttempts'),
+                    });
+                } else {
+                    showToast.error({
+                        text1: this.translate('alertTitles.backendErrorMessage'),
+                        text2: this.translate('alertMessages.backendErrorMessage'),
+                    });
+                }
+            })
+            .finally(() => this.setState({ isSubmitting: false }));
+    };
+
+    onSubmitCode = () => {
+        const { phoneNumber, verificationCode } = this.state;
+
+        if (verificationCode.length !== 6) {
+            return;
+        }
+
+        this.setState({ isSubmitting: true, hasCodeError: false });
+
+        ApiService.verifyPhoneRegistration({ phoneNumber, verificationCode })
+            .then((response: any) => {
+                this.setState({
+                    step: 'details',
+                    phoneVerificationToken: response?.data?.phoneVerificationToken || '',
+                });
+            })
+            .catch((error: any) => {
+                if (error?.statusCode === 400) {
+                    this.setState({ hasCodeError: true, verificationCode: '' });
+                    showToast.error({
+                        text1: this.translate('alertTitles.invalidCode'),
+                        text2: this.translate('alertMessages.invalidCode'),
+                    });
+                    return;
+                }
+                showToast.error({
+                    text1: this.translate('alertTitles.backendErrorMessage'),
+                    text2: this.translate('alertMessages.backendErrorMessage'),
+                });
+            })
+            .finally(() => this.setState({ isSubmitting: false }));
+    };
+
+    onBirthdateConfirm = (date: Date) => {
+        this.setState({ isBirthdatePickerOpen: false });
+
+        if (!isValidSignupAge(date)) {
+            showToast.error({
+                text1: this.translate('alertTitles.registrationError'),
+                text2: this.translate('forms.registerForm.errorMessages.birthdateTooYoung', { minAge: `${MINIMUM_SIGNUP_AGE}` }),
+            });
+            return;
+        }
+
+        this.setState({ settingsBirthdate: date.toISOString() });
+    };
+
+    isDetailsStepDisabled = () => {
+        const { email, isSubmitting, settingsBirthdate } = this.state;
+
+        return !email || !settingsBirthdate || !isValidSignupAge(settingsBirthdate) || isSubmitting;
+    };
+
+    onSubmitDetails = () => {
+        const {
+            email,
+            password,
+            phoneNumber,
+            phoneVerificationToken,
+            settingsBirthdate,
+        } = this.state;
+
+        if (!email) {
+            showToast.error({
+                text1: this.translate('alertTitles.registrationError'),
+                text2: this.translate('forms.registerForm.missingEmail'),
+            });
+            return;
+        }
+        // Password is optional here — but if one was typed it still has to be a real one.
+        if (password && !PasswordRegex.test(password)) {
+            this.setState({
+                errorMessage: this.translate('forms.registerForm.errorMessages.passwordInsecure'),
+            });
+            return;
+        }
+        if (!settingsBirthdate || !isValidSignupAge(settingsBirthdate)) {
+            showToast.error({
+                text1: this.translate('alertTitles.registrationError'),
+                text2: this.translate('forms.registerForm.errorMessages.birthdateTooYoung', { minAge: `${MINIMUM_SIGNUP_AGE}` }),
+            });
+            return;
+        }
+
+        this.setState({ isSubmitting: true, errorMessage: '' });
+
+        this.props
+            .register({
+                email: email.trim(),
+                password: password || undefined,
+                phoneNumber,
+                phoneVerificationToken,
+                settingsBirthdate,
+                settingsLocale: this.props.userSettings?.locale || 'en-us',
+            })
+            .then(() => this.props.onSuccess({ email: email.trim(), phoneNumber }))
+            .catch((error: any) => {
+                this.setState({
+                    isSubmitting: false,
+                    errorMessage: error?.statusCode === 400
+                        ? `${error.message}`
+                        : this.translate('forms.registerForm.backendErrorMessage'),
+                });
+            });
+    };
+
+    openPrivacyPolicy = () => {
+        Linking.openURL('https://www.therr.app/privacy-policy.html');
+    };
+
+    renderPhoneStep() {
+        const { theme, themeAuthForm, themeForms } = this.props;
+        const { isPhoneNumberValid, isSubmitting } = this.state;
+
+        return (
+            <>
+                <Text style={[localStyles.stepHeading, { color: themeForms.colors.onSurface }]}>
+                    {this.translate('forms.phoneSignupForm.labels.enterPhone')}
+                </Text>
+                <Text style={[localStyles.stepSubheading, { color: themeForms.colors.onSurfaceMuted }]}>
+                    {this.translate('forms.phoneSignupForm.subtitles.enterPhone')}
+                </Text>
+                <PhoneNumberInput
+                    onChangeText={this.onPhoneInputChange}
+                    onSubmit={this.onRequestCode}
+                    placeholder={this.translate('forms.settings.labels.phoneNumber')}
+                    translate={this.translate}
+                    theme={theme}
+                    themeForms={themeForms}
+                />
+                <View style={[themeAuthForm.styles.submitButtonContainer, spacingStyles.marginTopLg]}>
+                    <Button
+                        variant="primary"
+                        size="lg"
+                        shape="rounded"
+                        disabledTitleStyle={themeForms.styles.buttonTitleDisabled}
+                        disabledStyle={themeForms.styles.buttonDisabled}
+                        title={this.translate('forms.phoneSignupForm.buttons.sendCode')}
+                        onPress={this.onRequestCode}
+                        disabled={!isPhoneNumberValid || isSubmitting}
+                        loading={isSubmitting}
+                    />
+                </View>
+            </>
+        );
+    }
+
+    renderCodeStep() {
+        const { themeAuthForm, themeForms } = this.props;
+        const {
+            hasCodeError,
+            isSubmitting,
+            phoneNumber,
+            verificationCode,
+        } = this.state;
+
+        return (
+            <>
+                <Text style={[localStyles.stepHeading, { color: themeForms.colors.onSurface }]}>
+                    {this.translate('forms.phoneSignupForm.labels.enterCode')}
+                </Text>
+                <Text style={[localStyles.stepSubheading, { color: themeForms.colors.onSurfaceMuted }]}>
+                    {this.translate('forms.loginForm.subtitles.codeSentTo', { phoneNumber })}
+                </Text>
+                <VerificationCodeInput
+                    value={verificationCode}
+                    onChangeText={(value) => this.setState({ verificationCode: value, hasCodeError: false })}
+                    onComplete={this.onSubmitCode}
+                    disabled={isSubmitting}
+                    hasError={hasCodeError}
+                    themeForms={themeForms}
+                />
+                <View style={[themeAuthForm.styles.submitButtonContainer, spacingStyles.marginTopMd]}>
+                    <Button
+                        variant="primary"
+                        size="lg"
+                        shape="rounded"
+                        disabledTitleStyle={themeForms.styles.buttonTitleDisabled}
+                        disabledStyle={themeForms.styles.buttonDisabled}
+                        title={this.translate('forms.phoneSignupForm.buttons.verify')}
+                        onPress={this.onSubmitCode}
+                        disabled={isSubmitting || verificationCode.length !== 6}
+                        loading={isSubmitting}
+                    />
+                </View>
+                <View style={themeForms.styles.moreLinksContainer}>
+                    <Button
+                        type="clear"
+                        titleStyle={themeForms.styles.buttonLink}
+                        title={this.translate('forms.loginForm.buttons.resendCode')}
+                        onPress={this.onRequestCode}
+                        disabled={isSubmitting}
+                    />
+                </View>
+                <View style={themeForms.styles.moreLinksContainer}>
+                    <Button
+                        type="clear"
+                        titleStyle={themeForms.styles.buttonLink}
+                        title={this.translate('forms.phoneSignupForm.buttons.changeNumber')}
+                        onPress={() => this.setState({ step: 'phone', verificationCode: '', hasCodeError: false })}
+                        disabled={isSubmitting}
+                    />
+                </View>
+            </>
+        );
+    }
+
+    renderDetailsStep() {
+        const { theme, themeAlerts, themeAuthForm, themeForms, toggleEULA } = this.props;
+        const {
+            email,
+            isBirthdatePickerOpen,
+            isPasswordEntryDirty,
+            isSubmitting,
+            password,
+            settingsBirthdate,
+        } = this.state;
+
+        return (
+            <>
+                <Text style={[localStyles.stepHeading, { color: themeForms.colors.onSurface }]}>
+                    {this.translate('forms.phoneSignupForm.labels.enterEmail')}
+                </Text>
+                <Text style={[localStyles.stepSubheading, { color: themeForms.colors.onSurfaceMuted }]}>
+                    {this.translate('forms.phoneSignupForm.subtitles.enterEmail')}
+                </Text>
+                <RoundInput
+                    autoCapitalize="none"
+                    autoComplete="email"
+                    autoCorrect={false}
+                    keyboardType="email-address"
+                    placeholder={this.translate('forms.registerForm.labels.email')}
+                    value={email}
+                    onChangeText={(text) => this.setState({ email: text, errorMessage: '' })}
+                    rightIcon={
+                        <TherrIcon
+                            name="mail"
+                            size={24}
+                            color={themeAlerts.colors.placeholderTextColorAlt}
+                        />
+                    }
+                    themeForms={themeForms}
+                    containerStyle={{ marginBottom: 14 }}
+                    testID="phone-signup-email"
+                />
+                <Pressable onPress={() => this.setState({ isBirthdatePickerOpen: true })}>
+                    <View pointerEvents="none">
+                        <RoundInput
+                            editable={false}
+                            placeholder={this.translate('forms.registerForm.labels.birthdate')}
+                            value={
+                                settingsBirthdate
+                                    ? new Date(settingsBirthdate)
+                                        .toLocaleDateString(this.props.userSettings?.locale || 'en-us')
+                                    : ''
+                            }
+                            rightIcon={
+                                <TherrIcon
+                                    name="calendar"
+                                    size={24}
+                                    color={themeAlerts.colors.placeholderTextColorAlt}
+                                />
+                            }
+                            themeForms={themeForms}
+                        />
+                    </View>
+                </Pressable>
+                <Text style={[theme.styles.sectionDescription, localStyles.hint]}>
+                    {this.translate('forms.registerForm.subtitles.birthdateHint', { minAge: `${MINIMUM_SIGNUP_AGE}` })}
+                </Text>
+                <DatePicker
+                    modal
+                    mode="date"
+                    open={isBirthdatePickerOpen}
+                    date={settingsBirthdate ? new Date(settingsBirthdate) : this.getDefaultBirthdate()}
+                    maximumDate={new Date()}
+                    onConfirm={this.onBirthdateConfirm}
+                    onCancel={() => this.setState({ isBirthdatePickerOpen: false })}
+                    theme={isDarkTheme(this.props.userSettings?.mobileThemeName) ? 'dark' : 'light'}
+                />
+                {
+                    isPasswordEntryDirty &&
+                        <PasswordRequirements translate={this.translate} password={password} themeForms={themeForms} />
+                }
+                <RoundInput
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    placeholder={this.translate('forms.phoneSignupForm.labels.optionalPassword')}
+                    value={password}
+                    onChangeText={(text) => this.setState({
+                        password: text,
+                        isPasswordEntryDirty: true,
+                        errorMessage: '',
+                    })}
+                    secureTextEntry={true}
+                    rightIcon={
+                        <TherrIcon
+                            name="key"
+                            size={24}
+                            color={themeAlerts.colors.placeholderTextColorAlt}
+                        />
+                    }
+                    themeForms={themeForms}
+                    containerStyle={{ marginBottom: 6 }}
+                    testID="phone-signup-password"
+                />
+                <Text style={[theme.styles.sectionDescription, localStyles.hint]}>
+                    {this.translate('forms.phoneSignupForm.subtitles.optionalPassword')}
+                </Text>
+                <Text style={[theme.styles.sectionDescription, localStyles.disclaimer]}>
+                    {this.translate('forms.registerForm.subtitles.disclaimer')}
+                    <Text
+                        style={themeForms.styles.buttonLink}
+                        onPress={() => toggleEULA()}>{this.translate('forms.registerForm.buttons.eula')}</Text>
+                    {this.translate('forms.registerForm.subtitles.and')}
+                    <Text
+                        style={themeForms.styles.buttonLink}
+                        onPress={this.openPrivacyPolicy}>{this.translate('forms.registerForm.buttons.privacyPolicy')}</Text>
+                </Text>
+                <View style={themeAuthForm.styles.submitButtonContainer}>
+                    <Button
+                        variant="primary"
+                        size="lg"
+                        shape="rounded"
+                        disabledTitleStyle={themeForms.styles.buttonTitleDisabled}
+                        disabledStyle={themeForms.styles.buttonDisabled}
+                        title={this.translate('forms.registerForm.buttons.register')}
+                        onPress={this.onSubmitDetails}
+                        disabled={this.isDetailsStepDisabled()}
+                        loading={isSubmitting}
+                    />
+                </View>
+            </>
+        );
+    }
+
+    public render() {
+        const { themeAlerts, themeForms } = this.props;
+        const { errorMessage, step } = this.state;
+
+        return (
+            <>
+                <Alert
+                    containerStyles={addMargins({ marginBottom: 16 })}
+                    isVisible={!!errorMessage}
+                    message={errorMessage}
+                    type={'error'}
+                    themeAlerts={themeAlerts}
+                />
+                {step === 'phone' && this.renderPhoneStep()}
+                {step === 'code' && this.renderCodeStep()}
+                {step === 'details' && this.renderDetailsStep()}
+                {
+                    // Only offered before the SMS is sent — once a code is in flight, an escape
+                    // hatch that discards it is a way to lose progress, not a convenience.
+                    step === 'phone'
+                        ? (
+                            <>
+                                <View style={[themeForms.styles.moreLinksContainer, spacingStyles.marginTopMd]}>
+                                    <Button
+                                        type="clear"
+                                        titleStyle={themeForms.styles.buttonLink}
+                                        title={this.translate('forms.phoneSignupForm.buttons.useEmailInstead')}
+                                        onPress={this.props.onSwitchToEmailSignup}
+                                    />
+                                </View>
+                                <View style={themeForms.styles.moreLinksContainer}>
+                                    <Button
+                                        type="clear"
+                                        titleStyle={themeForms.styles.buttonLink}
+                                        title={this.translate('forms.registerForm.buttons.backToLogin')}
+                                        onPress={this.props.onSwitchToSignIn}
+                                    />
+                                </View>
+                            </>
+                        )
+                        : null
+                }
+            </>
+        );
+    }
+}
+
+const localStyles = StyleSheet.create({
+    stepHeading: {
+        fontSize: fontSizes.xl,
+        fontWeight: '600',
+        textAlign: 'center',
+        marginBottom: space.xs,
+    },
+    stepSubheading: {
+        fontSize: fontSizes.sm,
+        textAlign: 'center',
+        marginBottom: space.lg,
+    },
+    hint: {
+        fontSize: fontSizes.xs,
+        textAlign: 'center',
+        marginTop: space.xs,
+        marginBottom: space.lg,
+    },
+    disclaimer: {
+        marginBottom: space.xl,
+    },
+});
+
+export default PhoneSignupFormComponent;

--- a/TherrMobile/main/routes/Register/RegisterForm.tsx
+++ b/TherrMobile/main/routes/Register/RegisterForm.tsx
@@ -23,6 +23,8 @@ import spacingStyles from '../../styles/layouts/spacing';
 interface IRegisterFormProps {
     alert?: string;
     onSuccess: Function;
+    /** Omitted when the phone path isn't offered (e.g. arriving via a magic invite link). */
+    onSwitchToPhoneSignup?: () => void;
     register: Function;
     login: Function;
     title?: string;
@@ -558,6 +560,20 @@ export class RegisterFormComponent extends React.Component<
                         themeForms={themeForms}
                         containerStyle={spacingStyles.marginVertXLg}
                     />
+                    {
+                        this.props.onSwitchToPhoneSignup
+                            ? (
+                                <View style={themeForms.styles.moreLinksContainer}>
+                                    <Button
+                                        type="clear"
+                                        titleStyle={themeForms.styles.buttonLink}
+                                        title={this.translate('forms.phoneSignupForm.buttons.usePhoneInstead')}
+                                        onPress={this.props.onSwitchToPhoneSignup}
+                                    />
+                                </View>
+                            )
+                            : null
+                    }
                     <View style={themeAuthForm.styles.submitButtonContainer}>
                         <GoogleSignInButton
                             disabled={this.state.isSubmitting}

--- a/TherrMobile/main/routes/Register/index.tsx
+++ b/TherrMobile/main/routes/Register/index.tsx
@@ -15,6 +15,7 @@ import { buildStyles as buildButtonsStyles } from '../../styles/buttons';
 import { buildStyles as buildConfirmModalStyles } from '../../styles/modal/confirmModal';
 import { buildStyles as buildFTUIStyles } from '../../styles/first-time-ui';
 import RegisterForm from './RegisterForm';
+import PhoneSignupForm from './PhoneSignupForm';
 import { bindActionCreators } from 'redux';
 import UsersActions from '../../redux/actions/UsersActions';
 import setPreLoginLocale from '../../redux/actions/setPreLoginLocale';
@@ -44,6 +45,13 @@ interface IRegisterState {
     isEULAVisible: boolean;
     prefillEmail: string;
     inviterName: string;
+    /**
+     * Which sign-up path is on screen. Phone-first is the default because it asks for one
+     * thing the user knows by heart and gets them a working sign-in method immediately; the
+     * classic email + password form is one tap away and is forced for invite links, whose
+     * whole premise is a specific email address.
+     */
+    signupMethod: 'phone' | 'email';
 }
 
 const mapStateToProps = (state: any) => ({
@@ -77,6 +85,9 @@ class RegisterComponent extends React.Component<IRegisterProps, IRegisterState> 
             isEULAVisible: false,
             prefillEmail: '',
             inviterName: '',
+            // An invite link carries the invitee's email and grants verified access on that
+            // channel — routing them through phone verification would throw that away.
+            signupMethod: props.route?.params?.inviteToken ? 'email' : 'phone',
         };
 
         this.theme = buildStyles(props.user.settings?.mobileThemeName);
@@ -136,6 +147,33 @@ class RegisterComponent extends React.Component<IRegisterProps, IRegisterState> 
         });
     };
 
+    /**
+     * Phone-first signups land on the sign-in screen already able to get in — their number is
+     * verified, so a texted code works right away. The message therefore nudges them to
+     * confirm the email they just entered rather than implying they are locked out.
+     */
+    onPhoneSignupSuccess = ({ phoneNumber }: { phoneNumber: string }) => {
+        showToast.success({
+            text1: this.translate('alertTitles.registerSuccess'),
+            text2: this.translate('alertMessages.phoneRegisterSuccess'),
+        });
+        this.props.navigation.navigate('Login', {
+            userMessage: this.translate('pages.login.userAlerts.phoneRegisterSuccess'),
+            // The account has never signed in, so there is no remembered profile to pre-fill
+            // from. Hand the number over directly, which also puts the sign-in form straight
+            // into its SMS mode — one tap from a code.
+            prefillIdentifier: phoneNumber,
+        });
+    };
+
+    setSignupMethod = (signupMethod: 'phone' | 'email') => {
+        this.setState({ signupMethod });
+    };
+
+    goToLogin = () => {
+        this.props.navigation.navigate('Login');
+    };
+
     goToMap = () => {
         this.props.navigation.navigate('Map');
     };
@@ -148,7 +186,7 @@ class RegisterComponent extends React.Component<IRegisterProps, IRegisterState> 
     };
 
     render() {
-        const { isEULAVisible } = this.state;
+        const { isEULAVisible, signupMethod } = this.state;
         const pageTitle = this.translate('pages.register.pageTitle');
         const pageSubtitle = this.translate('pages.register.pageSubtitle');
         const pageSubtitleMapPreviewLink = this.translate('pages.register.pageSubtitleMapPreviewLink');
@@ -177,20 +215,40 @@ class RegisterComponent extends React.Component<IRegisterProps, IRegisterState> 
                                 theme={this.theme}
                                 containerStyle={this.theme.styles.sectionContainerWide}
                             />
-                            <RegisterForm
-                                login={this.props.login}
-                                register={this.props.register}
-                                onSuccess={this.onSuccess}
-                                theme={this.theme}
-                                themeAlerts={this.themeAlerts}
-                                themeAuthForm={this.themeAuthForm}
-                                themeForms={this.themeForms}
-                                toggleEULA={this.toggleEULA}
-                                userSettings={this.props.user?.settings || {}}
-                                inviteToken={this.props.route?.params?.inviteToken}
-                                prefillEmail={this.state.prefillEmail}
-                                inviterName={this.state.inviterName}
-                            />
+                            {
+                                signupMethod === 'phone'
+                                    ? (
+                                        <PhoneSignupForm
+                                            register={this.props.register}
+                                            onSuccess={this.onPhoneSignupSuccess}
+                                            onSwitchToEmailSignup={() => this.setSignupMethod('email')}
+                                            onSwitchToSignIn={this.goToLogin}
+                                            theme={this.theme}
+                                            themeAlerts={this.themeAlerts}
+                                            themeAuthForm={this.themeAuthForm}
+                                            themeForms={this.themeForms}
+                                            toggleEULA={this.toggleEULA}
+                                            userSettings={this.props.user?.settings || {}}
+                                        />
+                                    )
+                                    : (
+                                        <RegisterForm
+                                            login={this.props.login}
+                                            register={this.props.register}
+                                            onSuccess={this.onSuccess}
+                                            onSwitchToPhoneSignup={() => this.setSignupMethod('phone')}
+                                            theme={this.theme}
+                                            themeAlerts={this.themeAlerts}
+                                            themeAuthForm={this.themeAuthForm}
+                                            themeForms={this.themeForms}
+                                            toggleEULA={this.toggleEULA}
+                                            userSettings={this.props.user?.settings || {}}
+                                            inviteToken={this.props.route?.params?.inviteToken}
+                                            prefillEmail={this.state.prefillEmail}
+                                            inviterName={this.state.inviterName}
+                                        />
+                                    )
+                            }
                         </View>
                     </KeyboardAwareScrollView>
                 </SafeAreaView>

--- a/TherrMobile/main/utilities/SecureStorage.ts
+++ b/TherrMobile/main/utilities/SecureStorage.ts
@@ -1,8 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { MMKV } from 'react-native-mmkv';
 
-// Keys that contain sensitive data and should use secure storage when available
-const SECURE_KEYS = ['therrRefreshToken', 'therrUser'];
+// Keys that contain sensitive data and should use secure storage when available.
+// `therrKnownProfiles` holds no credentials, but it does hold contact info for every account
+// that has signed in on this device, so it gets the same protection.
+const SECURE_KEYS = ['therrRefreshToken', 'therrUser', 'therrKnownProfiles'];
 
 let Keychain: any = null;
 

--- a/TherrMobile/main/utilities/authIdentifier.ts
+++ b/TherrMobile/main/utilities/authIdentifier.ts
@@ -1,0 +1,106 @@
+/**
+ * Helpers for the single "email / phone / username" field on the sign-in screen.
+ *
+ * The classification here is deliberately loose: it only decides which UI to show (password
+ * field vs. "text me a code"). The API gateway does the authoritative parse with
+ * `awesome-phonenumber` and rejects anything that isn't E.164, so a false positive costs the
+ * user one tap on "use password instead", never a failed account lookup.
+ *
+ * `awesome-phonenumber` is intentionally NOT imported here: it is not in TherrMobile's own
+ * package.json, and pulling it through Metro's monorepo resolution for a cosmetic decision
+ * would be a poor trade.
+ */
+
+// Digits plus the punctuation people actually type into a phone field.
+const PHONE_ALLOWED_CHARS = /^[+()\-.\s\d]+$/;
+
+/**
+ * True when the input looks like a phone number rather than an email or username.
+ *
+ * Requires 7–15 digits, matching the E.164 range, so a short numeric username ("1234") and a
+ * long digit string are both correctly rejected.
+ */
+export const isLikelyPhoneNumber = (value?: string): boolean => {
+    const trimmed = (value || '').trim();
+
+    if (!trimmed || trimmed.includes('@')) {
+        return false;
+    }
+
+    if (!PHONE_ALLOWED_CHARS.test(trimmed)) {
+        return false;
+    }
+
+    const digitCount = trimmed.replace(/\D/g, '').length;
+
+    return digitCount >= 7 && digitCount <= 15;
+};
+
+/**
+ * Strips display formatting so the value can be sent to the API. A leading `+` is preserved
+ * because it is the only reliable signal of an explicit country code; without it the server
+ * falls back to its default region.
+ */
+export const toDialableNumber = (value?: string): string => {
+    const trimmed = (value || '').trim();
+    const hasPlus = trimmed.startsWith('+');
+
+    return `${hasPlus ? '+' : ''}${trimmed.replace(/\D/g, '')}`;
+};
+
+/**
+ * Best-effort classification of a saved credential, used to label remembered profiles.
+ */
+export const getIdentifierType = (value?: string): 'email' | 'phone' | 'userName' => {
+    if ((value || '').includes('@')) {
+        return 'email';
+    }
+
+    return isLikelyPhoneNumber(value) ? 'phone' : 'userName';
+};
+
+/**
+ * Partially hides an email for display in the account switcher — enough to recognize your own
+ * account, not enough to be useful to someone glancing at your screen.
+ * `jane.doe@example.com` -> `ja•••@example.com`
+ */
+export const maskEmail = (email?: string): string => {
+    const [localPart, domain] = (email || '').split('@');
+
+    if (!localPart || !domain) {
+        return email || '';
+    }
+
+    const visible = localPart.slice(0, Math.min(2, localPart.length));
+
+    return `${visible}•••@${domain}`;
+};
+
+/**
+ * Shows only the last four digits of a phone number: `+13175551234` -> `•••• 1234`.
+ */
+export const maskPhoneNumber = (phoneNumber?: string): string => {
+    const digits = (phoneNumber || '').replace(/\D/g, '');
+
+    if (digits.length < 4) {
+        return phoneNumber || '';
+    }
+
+    return `•••• ${digits.slice(-4)}`;
+};
+
+/**
+ * Display string for whatever kind of identifier a remembered profile holds.
+ */
+export const maskIdentifier = (identifier?: string): string => {
+    const type = getIdentifierType(identifier);
+
+    if (type === 'email') {
+        return maskEmail(identifier);
+    }
+    if (type === 'phone') {
+        return maskPhoneNumber(identifier);
+    }
+
+    return identifier || '';
+};

--- a/TherrMobile/main/utilities/rememberedProfiles.ts
+++ b/TherrMobile/main/utilities/rememberedProfiles.ts
@@ -1,0 +1,139 @@
+import SecureStorage from './SecureStorage';
+import { getIdentifierType } from './authIdentifier';
+
+/**
+ * Locally remembered accounts, so the sign-in screen can pre-fill the last identifier used on
+ * this device and offer a one-tap switch between accounts (personal / creator / business, or a
+ * shared handset).
+ *
+ * This is a convenience cache, never a credential: it holds no password, token, or session.
+ * It survives sign-out on purpose — that is the entire point — and is stored through
+ * `SecureStorage` (Keychain-backed where available) because it contains contact info.
+ */
+
+const STORAGE_KEY = 'therrKnownProfiles';
+
+// Enough for a family handset or someone juggling a personal + business account, small enough
+// that the switcher stays a glanceable list rather than something you scroll.
+const MAX_REMEMBERED_PROFILES = 5;
+
+export interface IRememberedProfile {
+    /** User id, the identity key for de-duplication. */
+    id: string;
+    /** Exactly what should be typed back into the sign-in field (email, phone, or username). */
+    identifier: string;
+    identifierType: 'email' | 'phone' | 'userName';
+    userName?: string;
+    firstName?: string;
+    lastName?: string;
+    /** Profile media blob, in the shape `getUserImageUri` expects under `details`. */
+    media?: any;
+    /** Epoch ms, used to order the switcher most-recent-first. */
+    lastLoginAt: number;
+}
+
+const parseProfiles = (raw: string | null): IRememberedProfile[] => {
+    if (!raw) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(raw);
+        // Tolerate a corrupt or pre-format value rather than breaking sign-in over it.
+        return Array.isArray(parsed) ? parsed.filter((profile) => profile?.id && profile?.identifier) : [];
+    } catch {
+        return [];
+    }
+};
+
+const persist = (profiles: IRememberedProfile[]) => SecureStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+
+/**
+ * Remembered accounts, most recently used first.
+ */
+export const getRememberedProfiles = async (): Promise<IRememberedProfile[]> => {
+    const profiles = parseProfiles(await SecureStorage.getItem(STORAGE_KEY));
+
+    return profiles.sort((a, b) => (b.lastLoginAt || 0) - (a.lastLoginAt || 0));
+};
+
+/**
+ * Inserts or refreshes one account. De-duplicates on `id`, so signing in with a phone number
+ * after previously using an email updates the existing entry instead of adding a second one.
+ */
+export const rememberProfile = async (profile: Omit<IRememberedProfile, 'lastLoginAt' | 'identifierType'> & {
+    lastLoginAt?: number;
+}): Promise<IRememberedProfile[]> => {
+    if (!profile?.id || !profile?.identifier) {
+        return getRememberedProfiles();
+    }
+
+    const existing = await getRememberedProfiles();
+    const entry: IRememberedProfile = {
+        ...profile,
+        identifierType: getIdentifierType(profile.identifier),
+        lastLoginAt: profile.lastLoginAt || Date.now(),
+    };
+    const updated = [entry, ...existing.filter((candidate) => candidate.id !== profile.id)]
+        .slice(0, MAX_REMEMBERED_PROFILES);
+
+    await persist(updated);
+
+    return updated;
+};
+
+export const forgetProfile = async (userId: string): Promise<IRememberedProfile[]> => {
+    const remaining = (await getRememberedProfiles()).filter((profile) => profile.id !== userId);
+
+    await persist(remaining);
+
+    return remaining;
+};
+
+export const forgetAllProfiles = (): Promise<void> => SecureStorage.removeItem(STORAGE_KEY);
+
+/**
+ * Records whoever is signed in right now, reading the session blob the auth actions just
+ * wrote. Call after a successful sign-in of any kind (password, SMS code, SSO).
+ *
+ * Prefers the identifier the user actually typed, so the field pre-fills with what they are
+ * used to seeing rather than whichever column the account happens to have populated.
+ * Fire-and-forget: a failure must never surface on a successful sign-in.
+ */
+export const rememberCurrentUser = async (typedIdentifier?: string): Promise<void> => {
+    try {
+        const storedUser = JSON.parse(await SecureStorage.getItem('therrUser') || 'null');
+
+        if (!storedUser?.id) {
+            return;
+        }
+
+        const identifier = typedIdentifier?.trim()
+            || storedUser.email
+            || storedUser.phoneNumber
+            || storedUser.userName;
+
+        if (!identifier) {
+            return;
+        }
+
+        await rememberProfile({
+            id: storedUser.id,
+            identifier,
+            userName: storedUser.userName,
+            firstName: storedUser.firstName,
+            lastName: storedUser.lastName,
+            media: storedUser.media,
+        });
+    } catch {
+        // Remembering a profile is a convenience; never let it break the sign-in it follows.
+    }
+};
+
+export default {
+    getRememberedProfiles,
+    rememberProfile,
+    rememberCurrentUser,
+    forgetProfile,
+    forgetAllProfiles,
+};

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -15,6 +15,9 @@
 - **Google OAuth** — social sign-in on both platforms
 - **Apple OAuth** — social sign-in (mobile)
 - **Phone verification** — optional during profile creation
+- **Passwordless phone sign-in** (mobile) — entering a phone number in the sign-in field swaps the password step for a texted 6-digit code (`POST /v1/phone/auth/start` → `/auth/verify`). Enumeration-safe: the "code sent" response is identical whether or not an account exists. When a number is attached to several accounts, an account picker completes sign-in via `/auth/select`
+- **Phone-first sign-up** (mobile) — verify a phone number by SMS, then add an e-mail; the account is created already `MOBILE_VERIFIED` and a password is optional. The e-mail still receives its normal verification message
+- **Remembered profiles** (mobile) — the sign-in field pre-fills the account last used on the device, with a chevron that opens a switcher to change accounts, remove a saved one, or start fresh. Stored locally through `SecureStorage`; holds no credentials or tokens
 - **Password reset** — forgot-password email flow
 - **Account types** — personal, business, and creator accounts
 - **Organization management** — business account grouping

--- a/therr-api-gateway/src/index.ts
+++ b/therr-api-gateway/src/index.ts
@@ -113,6 +113,14 @@ app.use(authenticate.unless({
         { url: '/v1/users-service/auth/email-precheck', methods: ['POST'] }, // multi-app email lookup (enumeration-safe)
         { url: '/v1/users-service/auth/handoff/redeem', methods: ['POST'] }, // cross-app handoff: code IS the credential
         { url: '/v1/users-service/users/forgot-password', methods: ['POST'] }, // one time password
+        // Passwordless phone auth. These are pre-session by definition: the SMS code IS the
+        // credential, so requiring a JWT would make them unreachable. Each is rate limited
+        // per IP and per phone number in services/phone/router.ts.
+        { url: '/v1/phone/auth/start', methods: ['POST'] }, // SMS sign-in: request code
+        { url: '/v1/phone/auth/verify', methods: ['POST'] }, // SMS sign-in: submit code
+        { url: '/v1/phone/auth/select', methods: ['POST'] }, // SMS sign-in: pick account when a number has several
+        { url: '/v1/phone/register/start', methods: ['POST'] }, // SMS sign-up: request code
+        { url: '/v1/phone/register/verify', methods: ['POST'] }, // SMS sign-up: submit code
         { url: '/v1/users-service/social-sync/oauth2-tiktok', methods: ['GET'] }, // TikTok OAuth
         { url: '/v1/users-service/social-sync/oauth2-facebook', methods: ['GET'] }, // Facebook OAuth
         { url: '/v1/users-service/social-sync/oauth2-dashboard-facebook', methods: ['GET'] }, // Facebook OAuth

--- a/therr-api-gateway/src/services/phone/limitation/phone.ts
+++ b/therr-api-gateway/src/services/phone/limitation/phone.ts
@@ -23,7 +23,16 @@ const buildRateLimiter = (msg, count = 1, minutes = 1) => RateLimit({
 const verifyPhoneLimiter = buildRateLimiter(limitReachedMessage, 2, 5);
 const verifyPhoneLongLimiter = buildRateLimiter(limitReachedMessage, 5, 24 * 60);
 
+// Passwordless sign-in / sign-up. `start` sends an SMS on every call, so it is capped hard:
+// each request costs real money and is the lever an abuser would pull for SMS pumping.
+// `verify` is cheap but is the code-guessing surface, so it gets a looser per-IP cap and
+// relies on the per-phone attempt counter in the router for the tight bound.
+const phoneAuthStartLimiter = buildRateLimiter(limitReachedMessage, 3, 15);
+const phoneAuthVerifyLimiter = buildRateLimiter(limitReachedMessage, 10, 15);
+
 export {
     verifyPhoneLimiter,
     verifyPhoneLongLimiter,
+    phoneAuthStartLimiter,
+    phoneAuthVerifyLimiter,
 };

--- a/therr-api-gateway/src/services/phone/router.ts
+++ b/therr-api-gateway/src/services/phone/router.ts
@@ -1,13 +1,29 @@
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
+import jwt from 'jsonwebtoken';
 import normalizePhoneNumber from 'therr-js-utilities/normalize-phone-number';
+import {
+    createPhoneVerificationToken,
+    verifyPhoneVerificationToken,
+    PHONE_VERIFICATION_TOKEN_TTL_SECONDS,
+} from 'therr-js-utilities/phone-verification-token';
 import { ErrorCodes } from 'therr-js-utilities/constants';
 import handleHttpError from '../../utilities/handleHttpError';
 import { validate } from '../../validation';
-import redisClient from '../../store/redisClient';
+import redisClient, { storeRefreshToken } from '../../store/redisClient';
 import twilioClient from '../../api/twilio';
 import translate from '../../utilities/translator';
-import { verifyPhoneLimiter, verifyPhoneLongLimiter } from './limitation/phone';
+import {
+    verifyPhoneLimiter,
+    verifyPhoneLongLimiter,
+    phoneAuthStartLimiter,
+    phoneAuthVerifyLimiter,
+} from './limitation/phone';
+import {
+    phoneAuthStartValidation,
+    phoneAuthVerifyValidation,
+    phoneAuthSelectValidation,
+} from './validation/phone';
 import * as globalConfig from '../../../../global-config';
 import restRequest from '../../utilities/restRequest';
 import { hostRegex } from '../../utilities/patterns';
@@ -27,10 +43,134 @@ const generateVerificationCode = () => {
         .random() * (maxm - minm + 1)) + minm;
 };
 
+// Codes for the passwordless flows live 5 minutes and allow 5 wrong guesses. A 6-digit code
+// has 900k possibilities, so 5 guesses inside a 5 minute window is not brute-forceable even
+// before the per-IP rate limiters are considered.
+const AUTH_CODE_EXPIRE_SECONDS = 60 * 5;
+const AUTH_CODE_MAX_ATTEMPTS = 5;
+
+type PhoneAuthPurpose = 'login' | 'register';
+
+const authCodeKey = (purpose: PhoneAuthPurpose, phoneNumber: string) => `phone-${purpose}-codes:${phoneNumber}`;
+const authAttemptsKey = (purpose: PhoneAuthPurpose, phoneNumber: string) => `phone-${purpose}-attempts:${phoneNumber}`;
+
+/**
+ * Internal headers forwarded on every gateway -> users-service hop. The `x-userid` /
+ * `x-username` / access-level headers are tacked on by the JWT decode in `authenticate`;
+ * on the public passwordless routes below they are simply absent.
+ */
+const buildInternalHeaders = (req: any) => ({
+    authorization: req.headers.authorization || '',
+    'x-requestid': uuidv4(),
+    'x-localecode': req.headers['x-localecode'] || '',
+    'x-platform': req.headers['x-platform'] || '',
+    'x-brand-variation': req.headers['x-brand-variation'] || '',
+    'x-user-device-token': req.headers['x-user-device-token'] || '',
+    // (securely) Tacked on from JWT decode
+    'x-userid': req.headers['x-userid'] || req['x-userid'] || '',
+    'x-username': req.headers['x-username'] || req['x-username'] || '',
+    'x-user-access-levels': req.headers['x-user-access-levels'] || req['x-user-access-levels'] || '',
+    'x-organizations': req.headers['x-organizations'] || req['x-organizations'] || '',
+    'x-therr-origin-host': req.headers.origin?.match(hostRegex)?.[1] || '',
+});
+
+const sendVerificationSms = (locale: string, toPhoneNumber: string, verificationCode: number) => twilioClient.messages
+    .create({
+        body: translate(locale, 'sms.yourVerificationCode', {
+            code: verificationCode,
+        }),
+        to: toPhoneNumber, // Text this number
+        from: getTherrFromPhoneNumber(toPhoneNumber), // From a valid Twilio number
+    });
+
+/**
+ * Normalizes and sanity-checks a submitted phone number. `normalizePhoneNumber` returns its
+ * input unchanged when it cannot parse it, so a result that still isn't E.164 means invalid.
+ */
+const toE164 = (rawPhoneNumber: any): string | undefined => {
+    const normalized = normalizePhoneNumber(`${rawPhoneNumber || ''}`.trim().replace(/\s/g, ''));
+
+    return /^\+[1-9]\d{6,15}$/.test(normalized) ? normalized : undefined;
+};
+
+/**
+ * Asks the users-service which accounts are attached to a phone number. Used by both
+ * passwordless flows: sign-in only sends an SMS when an account exists, and sign-up refuses
+ * to start when one already does.
+ */
+const lookupAccountsByPhone = (req: any, phoneNumber: string): Promise<{ accountCount: number, accounts: any[] }> => restRequest({
+    headers: buildInternalHeaders(req),
+    method: 'post',
+    url: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}/auth/phone/lookup`,
+    data: { phoneNumber },
+}).then((response: any) => ({
+    accountCount: response?.data?.accountCount || 0,
+    accounts: response?.data?.accounts || [],
+}));
+
+/**
+ * Best-effort refresh token registration, mirroring what `POST /users-service/auth` does on
+ * a password login. A failure here must never block a successful sign-in.
+ */
+const trackRefreshToken = (responseData: any) => {
+    try {
+        if (responseData?.refreshToken) {
+            const decoded = jwt.decode(responseData.refreshToken) as { jti?: string; id?: string; exp?: number; brand?: string } | null;
+            if (decoded?.jti && decoded?.id && decoded?.exp) {
+                const ttl = decoded.exp - Math.floor(Date.now() / 1000);
+                if (ttl > 0) {
+                    storeRefreshToken(decoded.id, decoded.jti, ttl, decoded.brand);
+                }
+            }
+        }
+    } catch (err) {
+        // Non-critical: don't block login
+    }
+};
+
+/**
+ * Validates a submitted code against the cached one, counting failures so a code cannot be
+ * guessed by repeatedly posting. Resolves `true` only on an exact match; the caller is
+ * responsible for clearing the cache entry once the code has been spent.
+ */
+const isSubmittedCodeValid = async (
+    purpose: PhoneAuthPurpose,
+    phoneNumber: string,
+    submittedCode: string,
+): Promise<boolean> => {
+    const cachedCode = await redisClient.get(authCodeKey(purpose, phoneNumber));
+
+    if (!cachedCode) {
+        return false;
+    }
+
+    if (cachedCode !== submittedCode) {
+        const attempts = await redisClient.incr(authAttemptsKey(purpose, phoneNumber));
+        // Keep the attempt counter alive exactly as long as the code it guards.
+        await redisClient.expire(authAttemptsKey(purpose, phoneNumber), AUTH_CODE_EXPIRE_SECONDS);
+        if (attempts >= AUTH_CODE_MAX_ATTEMPTS) {
+            // Burn the code so an attacker has to trigger a fresh SMS (and a fresh rate limit).
+            await redisClient.del(authCodeKey(purpose, phoneNumber));
+        }
+        return false;
+    }
+
+    return true;
+};
+
+const clearSubmittedCode = (purpose: PhoneAuthPurpose, phoneNumber: string) => Promise.all([
+    redisClient.del(authCodeKey(purpose, phoneNumber)),
+    redisClient.del(authAttemptsKey(purpose, phoneNumber)),
+]);
+
 const phoneRouter = express.Router();
 
 /**
  * Creates a verification code and sends it to the user provided phone number
+ *
+ * NOTE: This is the *authenticated* variant, used when an already signed-in user adds or
+ * changes the phone number on their profile. The passwordless sign-in/sign-up routes further
+ * down are unauthenticated and key their codes on the phone number rather than the user id.
  */
 phoneRouter.post('/verify', verifyPhoneLimiter, validate, async (req, res) => {
     const userId = req.headers['x-userid'] || req['x-userid'];
@@ -42,20 +182,7 @@ phoneRouter.post('/verify', verifyPhoneLimiter, validate, async (req, res) => {
 
         const isNumberValid: boolean = await new Promise((resolve) => {
             const config: any = {
-                headers: {
-                    authorization: req.headers.authorization || '',
-                    'x-requestid': uuidv4(),
-                    'x-localecode': req.headers['x-localecode'] || '',
-                    'x-platform': req.headers['x-platform'] || '',
-                    'x-brand-variation': req.headers['x-brand-variation'] || '',
-                    'x-user-device-token': req.headers['x-user-device-token'] || '',
-                    // (securely) Tacked on from JWT decode
-                    'x-userid': req.headers['x-userid'] || req['x-userid'] || '',
-                    'x-username': req.headers['x-username'] || req['x-username'] || '',
-                    'x-user-access-levels': req.headers['x-user-access-levels'] || req['x-user-access-levels'] || '',
-                    'x-organizations': req.headers['x-organizations'] || req['x-organizations'] || '',
-                    'x-therr-origin-host': req.headers.origin?.match(hostRegex)?.[1] || '',
-                },
+                headers: buildInternalHeaders(req),
                 method: 'get',
                 url: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}/users/by-phone/${normalizedPhoneNumber}`,
             };
@@ -93,14 +220,7 @@ phoneRouter.post('/verify', verifyPhoneLimiter, validate, async (req, res) => {
             redisClient.setex(codeCacheKey, expireSeconds, verificationCode),
             redisClient.setex(phoneCacheKey, expireSeconds, normalizedPhoneNumber),
         ])
-            .then(() => twilioClient.messages
-                .create({
-                    body: translate(userLocale, 'sms.yourVerificationCode', {
-                        code: verificationCode,
-                    }),
-                    to: normalizedPhoneNumber, // Text this number
-                    from: getTherrFromPhoneNumber(normalizedPhoneNumber), // From a valid Twilio number
-                }))
+            .then(() => sendVerificationSms(userLocale, normalizedPhoneNumber, verificationCode))
             // eslint-disable-next-line arrow-body-style
             .then(() => {
                 return res.status(200).send({
@@ -140,20 +260,7 @@ phoneRouter.post('/validate-code', verifyPhoneLongLimiter, validate, async (req,
                 if (cachedCode && cachedCode === verificationCode) {
                     redisClient.del(codeCacheKey);
                     const config: any = {
-                        headers: {
-                            authorization: req.headers.authorization || '',
-                            'x-requestid': uuidv4(),
-                            'x-localecode': req.headers['x-localecode'] || '',
-                            'x-platform': req.headers['x-platform'] || '',
-                            'x-brand-variation': req.headers['x-brand-variation'] || '',
-                            'x-user-device-token': req.headers['x-user-device-token'] || '',
-                            // (securely) Tacked on from JWT decode
-                            'x-userid': req.headers['x-userid'] || req['x-userid'] || '',
-                            'x-username': req.headers['x-username'] || req['x-username'] || '',
-                            'x-user-access-levels': req.headers['x-user-access-levels'] || req['x-user-access-levels'] || '',
-                            'x-organizations': req.headers['x-organizations'] || req['x-organizations'] || '',
-                            'x-therr-origin-host': req.headers.origin?.match(hostRegex)?.[1] || '',
-                        },
+                        headers: buildInternalHeaders(req),
                         method: 'put',
                         url: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}/users/${userId}/verify-phone`,
                         data: {
@@ -180,6 +287,288 @@ phoneRouter.post('/validate-code', verifyPhoneLongLimiter, validate, async (req,
 
                 return handleHttpError({ err, res, message: 'SQL:PHONE_ROUTES:ERROR' });
             });
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'SQL:PHONE_ROUTES:ERROR' });
+    }
+});
+
+/**
+ * PASSWORDLESS SIGN-IN — step 1.
+ *
+ * Texts a one-time code to a phone number that already has an account.
+ *
+ * Enumeration-safe by design: the response is identical whether or not an account exists,
+ * for the same reason `POST /auth/email-precheck` returns a single neutral hint. An SMS is
+ * only dispatched when the number resolves to at least one account, so we neither confirm
+ * existence to the caller nor burn Twilio credit on unknown numbers.
+ */
+phoneRouter.post('/auth/start', phoneAuthStartLimiter, phoneAuthStartValidation, validate, async (req, res) => {
+    const userLocale = (req.headers['x-localecode'] || 'en-us') as string;
+    const normalizedPhoneNumber = toE164(req.body?.phoneNumber);
+
+    if (!normalizedPhoneNumber) {
+        return handleHttpError({
+            res,
+            message: 'Invalid phone number',
+            statusCode: 400,
+        });
+    }
+
+    // Uniform response, declared once so every exit path below is provably identical.
+    const neutralResponse = () => res.status(200).send({
+        status: 'sent',
+        expiresInSeconds: AUTH_CODE_EXPIRE_SECONDS,
+    });
+
+    try {
+        const { accountCount } = await lookupAccountsByPhone(req, normalizedPhoneNumber);
+
+        if (!accountCount) {
+            return neutralResponse();
+        }
+
+        const verificationCode = generateVerificationCode();
+        await redisClient.setex(authCodeKey('login', normalizedPhoneNumber), AUTH_CODE_EXPIRE_SECONDS, verificationCode);
+        await redisClient.del(authAttemptsKey('login', normalizedPhoneNumber));
+        await sendVerificationSms(userLocale, normalizedPhoneNumber, verificationCode);
+
+        return neutralResponse();
+    } catch (err: any) {
+        if (err?.message?.includes('SMS has not been enabled for the region')) {
+            return handleHttpError({
+                err,
+                errorCode: ErrorCodes.INVALID_REGION,
+                res,
+                message: 'Region not enabled for phone number',
+                statusCode: 405,
+            });
+        }
+
+        return handleHttpError({ err, res, message: 'SQL:PHONE_ROUTES:ERROR' });
+    }
+});
+
+/**
+ * Exchanges proof of phone ownership for a session. Shared by `/auth/verify` (proof = a
+ * correct SMS code) and `/auth/select` (proof = the short-lived token minted by
+ * `/auth/verify` when the number matched more than one account).
+ */
+const completePhoneLogin = (req: any, res: any, args: {
+    phoneNumber: string;
+    userId?: string;
+    rememberMe?: boolean;
+}) => restRequest({
+    headers: buildInternalHeaders(req),
+    method: 'post',
+    url: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}/auth/phone`,
+    data: {
+        phoneNumber: args.phoneNumber,
+        userId: args.userId,
+        rememberMe: args.rememberMe,
+    },
+}).then((response: any) => {
+    trackRefreshToken(response?.data);
+
+    return res.status(201).send(response?.data);
+}).catch((err: any) => {
+    const statusCode = err?.response?.data?.statusCode || err?.response?.status;
+    if (statusCode === 403 || statusCode === 404) {
+        return handleHttpError({
+            res,
+            message: 'No account found for this phone number',
+            statusCode: 404,
+        });
+    }
+
+    return handleHttpError({ err, res, message: 'SQL:PHONE_ROUTES:ERROR' });
+});
+
+/**
+ * PASSWORDLESS SIGN-IN — step 2.
+ *
+ * Validates the texted code and signs the user in. When the number is attached to more than
+ * one account (Therr permits a personal + creator + business account per number) we cannot
+ * pick for them, so we return the candidate list plus a short-lived proof token and let the
+ * client render an account picker, which posts back to `/auth/select`.
+ */
+phoneRouter.post('/auth/verify', phoneAuthVerifyLimiter, phoneAuthVerifyValidation, validate, async (req, res) => {
+    const normalizedPhoneNumber = toE164(req.body?.phoneNumber);
+    const submittedCode = `${req.body?.verificationCode || ''}`.trim();
+
+    if (!normalizedPhoneNumber) {
+        return handleHttpError({
+            res,
+            message: 'Invalid phone number',
+            statusCode: 400,
+        });
+    }
+
+    try {
+        const isValid = await isSubmittedCodeValid('login', normalizedPhoneNumber, submittedCode);
+
+        if (!isValid) {
+            return handleHttpError({
+                res,
+                message: 'Invalid verification code',
+                statusCode: 400,
+            });
+        }
+
+        const { accountCount, accounts } = await lookupAccountsByPhone(req, normalizedPhoneNumber);
+
+        // Code is correct — spend it either way. From here ownership is carried by the signed
+        // token, so the account-picker round-trip doesn't need the SMS code again.
+        await clearSubmittedCode('login', normalizedPhoneNumber);
+
+        if (!accountCount) {
+            return handleHttpError({
+                res,
+                message: 'No account found for this phone number',
+                statusCode: 404,
+            });
+        }
+
+        if (accountCount > 1) {
+            return res.status(200).send({
+                requiresAccountSelection: true,
+                accounts,
+                phoneNumber: normalizedPhoneNumber,
+                phoneVerificationToken: createPhoneVerificationToken(normalizedPhoneNumber, 'login'),
+                expiresInSeconds: PHONE_VERIFICATION_TOKEN_TTL_SECONDS,
+            });
+        }
+
+        return completePhoneLogin(req, res, {
+            phoneNumber: normalizedPhoneNumber,
+            userId: accounts[0]?.id,
+            rememberMe: req.body?.rememberMe,
+        });
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'SQL:PHONE_ROUTES:ERROR' });
+    }
+});
+
+/**
+ * PASSWORDLESS SIGN-IN — step 2b (multi-account numbers only).
+ *
+ * Completes sign-in for the account the user picked. Authorization comes entirely from the
+ * `phoneVerificationToken` minted by `/auth/verify`; the requested account must actually be
+ * attached to the phone number in that token, which the users-service re-checks.
+ */
+phoneRouter.post('/auth/select', phoneAuthVerifyLimiter, phoneAuthSelectValidation, validate, async (req, res) => {
+    const claims = verifyPhoneVerificationToken(req.body?.phoneVerificationToken, 'login');
+
+    if (!claims) {
+        return handleHttpError({
+            res,
+            message: 'Invalid or expired verification token',
+            statusCode: 401,
+        });
+    }
+
+    return completePhoneLogin(req, res, {
+        phoneNumber: claims.phoneNumber,
+        userId: req.body?.userId,
+        rememberMe: req.body?.rememberMe,
+    });
+});
+
+/**
+ * PASSWORDLESS SIGN-UP — step 1.
+ *
+ * Texts a one-time code to a phone number that has no account yet. Unlike `/auth/start` this
+ * one deliberately DOES report `USER_EXISTS`: a sign-up form that silently did nothing for an
+ * already-registered number would be a dead end, and the client uses the error to offer
+ * "sign in instead". The number is already known to whoever holds the handset, and the same
+ * disclosure exists today on the authenticated `/phone/verify` route.
+ */
+phoneRouter.post('/register/start', phoneAuthStartLimiter, phoneAuthStartValidation, validate, async (req, res) => {
+    const userLocale = (req.headers['x-localecode'] || 'en-us') as string;
+    const normalizedPhoneNumber = toE164(req.body?.phoneNumber);
+
+    if (!normalizedPhoneNumber) {
+        return handleHttpError({
+            res,
+            message: 'Invalid phone number',
+            statusCode: 400,
+        });
+    }
+
+    try {
+        const { accountCount } = await lookupAccountsByPhone(req, normalizedPhoneNumber);
+
+        if (accountCount) {
+            return handleHttpError({
+                err: new Error('Phone number already exists'),
+                errorCode: ErrorCodes.USER_EXISTS,
+                res,
+                message: 'An account already exists for this phone number',
+                statusCode: 400,
+            });
+        }
+
+        const verificationCode = generateVerificationCode();
+        await redisClient.setex(authCodeKey('register', normalizedPhoneNumber), AUTH_CODE_EXPIRE_SECONDS, verificationCode);
+        await redisClient.del(authAttemptsKey('register', normalizedPhoneNumber));
+        await sendVerificationSms(userLocale, normalizedPhoneNumber, verificationCode);
+
+        return res.status(200).send({
+            status: 'sent',
+            phoneNumber: normalizedPhoneNumber,
+            expiresInSeconds: AUTH_CODE_EXPIRE_SECONDS,
+        });
+    } catch (err: any) {
+        if (err?.message?.includes('SMS has not been enabled for the region')) {
+            return handleHttpError({
+                err,
+                errorCode: ErrorCodes.INVALID_REGION,
+                res,
+                message: 'Region not enabled for phone number',
+                statusCode: 405,
+            });
+        }
+
+        return handleHttpError({ err, res, message: 'SQL:PHONE_ROUTES:ERROR' });
+    }
+});
+
+/**
+ * PASSWORDLESS SIGN-UP — step 2.
+ *
+ * Validates the texted code and hands back a short-lived, signed proof of phone ownership.
+ * The client passes it to `POST /users-service/users` alongside the email it collects next;
+ * the users-service verifies the signature and creates the account already MOBILE_VERIFIED.
+ */
+phoneRouter.post('/register/verify', phoneAuthVerifyLimiter, phoneAuthVerifyValidation, validate, async (req, res) => {
+    const normalizedPhoneNumber = toE164(req.body?.phoneNumber);
+    const submittedCode = `${req.body?.verificationCode || ''}`.trim();
+
+    if (!normalizedPhoneNumber) {
+        return handleHttpError({
+            res,
+            message: 'Invalid phone number',
+            statusCode: 400,
+        });
+    }
+
+    try {
+        const isValid = await isSubmittedCodeValid('register', normalizedPhoneNumber, submittedCode);
+
+        if (!isValid) {
+            return handleHttpError({
+                res,
+                message: 'Invalid verification code',
+                statusCode: 400,
+            });
+        }
+
+        await clearSubmittedCode('register', normalizedPhoneNumber);
+
+        return res.status(200).send({
+            phoneNumber: normalizedPhoneNumber,
+            phoneVerificationToken: createPhoneVerificationToken(normalizedPhoneNumber, 'register'),
+            expiresInSeconds: PHONE_VERIFICATION_TOKEN_TTL_SECONDS,
+        });
     } catch (err: any) {
         return handleHttpError({ err, res, message: 'SQL:PHONE_ROUTES:ERROR' });
     }

--- a/therr-api-gateway/src/services/phone/validation/phone.ts
+++ b/therr-api-gateway/src/services/phone/validation/phone.ts
@@ -1,0 +1,27 @@
+import { body } from 'express-validator';
+
+/**
+ * `isMobilePhone('any')` is intentionally the only shape check here — the router
+ * re-normalizes to E.164 with `normalizePhoneNumber` and rejects anything that
+ * doesn't come back as a valid international number, which is the authoritative
+ * gate. This layer just keeps obvious junk from reaching Redis/Twilio.
+ */
+export const phoneAuthStartValidation = [
+    body('phoneNumber').exists().isString().isMobilePhone('any'),
+];
+
+export const phoneAuthVerifyValidation = [
+    body('phoneNumber').exists().isString().isMobilePhone('any'),
+    body('verificationCode')
+        .exists()
+        .isString()
+        .isLength({ min: 6, max: 6 })
+        .isNumeric(),
+    body('rememberMe').optional().isBoolean(),
+];
+
+export const phoneAuthSelectValidation = [
+    body('phoneVerificationToken').exists().isString(),
+    body('userId').exists().isUUID(4),
+    body('rememberMe').optional().isBoolean(),
+];

--- a/therr-api-gateway/src/services/users/validation/users.ts
+++ b/therr-api-gateway/src/services/users/validation/users.ts
@@ -12,7 +12,22 @@ export const createUserValidation = [
     // same fix on updateUserValidation below.
     body('phoneNumber').optional({ checkFalsy: true }).isMobilePhone('any'),
     body('email').exists().isEmail().normalizeEmail(),
-    body('password').exists().isString().isLength({ min: 8 }), // TODO: RMOBILE-26: Centralize password requirements
+    // TODO: RMOBILE-26: Centralize password requirements
+    // Optional only for the passwordless phone signup, which arrives with a signed
+    // `phoneVerificationToken` and lets the user keep signing in with a texted code. Every
+    // other path still requires a password; the users-service re-checks strength via
+    // `isValidPassword` regardless of what gets through here.
+    body('password')
+        .if(body('phoneVerificationToken').not().exists({ checkFalsy: true }))
+        .exists()
+        .isString()
+        .isLength({ min: 8 }),
+    body('password')
+        .optional({ checkFalsy: true })
+        .isString()
+        .isLength({ min: 8 }),
+    // Short-lived proof of phone ownership minted by POST /v1/phone/register/verify.
+    body('phoneVerificationToken').optional().isString(),
     // Birthdate is optional at the API boundary because SSO providers do not return it
     // (those users are prompted later). When supplied it must meet the minimum signup age.
     body('settingsBirthdate')

--- a/therr-public-library/therr-js-utilities/src/index.js
+++ b/therr-public-library/therr-js-utilities/src/index.js
@@ -46,6 +46,7 @@ const utilities = [
     'scroll-to',
     'normalize-phone-number',
     'normalize-correction-value',
+    'phone-verification-token',
     'print-logs',
     'log-or-update-span',
     'slugify',

--- a/therr-public-library/therr-js-utilities/src/phone-verification-token.ts
+++ b/therr-public-library/therr-js-utilities/src/phone-verification-token.ts
@@ -1,0 +1,95 @@
+import jwt from 'jsonwebtoken';
+
+/**
+ * Short-lived proof that the bearer controls a phone number.
+ *
+ * The API gateway owns the SMS round-trip (Twilio + the Redis code cache), but the
+ * account it unlocks is created by the users-service. Rather than have the gateway
+ * proxy the whole registration, it mints one of these tokens after a correct code
+ * and hands it to the client, which passes it back on `POST /users`. The
+ * users-service verifies the signature and trusts the `phoneNumber` claim.
+ *
+ * Both sides share `JWT_SECRET`, so this is symmetric-signed like the id/refresh
+ * tokens. The claims deliberately mirror those tokens' `iss`/`aud` shape so a
+ * phone-verification token can never be replayed as a session token (and vice
+ * versa) — `type` is checked on verify and the audience differs.
+ */
+
+export const PHONE_VERIFICATION_TOKEN_TYPE = 'phone-verification';
+export const PHONE_VERIFICATION_TOKEN_AUDIENCE = 'therr-phone-verification';
+export const PHONE_VERIFICATION_TOKEN_ISSUER = 'therr-api-gateway';
+
+// 20 minutes: long enough to finish the email/password step at a relaxed pace,
+// short enough that a leaked token (e.g. from a shared device) is dead quickly.
+export const PHONE_VERIFICATION_TOKEN_TTL_SECONDS = 60 * 20;
+
+export type PhoneVerificationPurpose = 'register' | 'login';
+
+export interface IPhoneVerificationClaims {
+    phoneNumber: string;
+    purpose: PhoneVerificationPurpose;
+    type: typeof PHONE_VERIFICATION_TOKEN_TYPE;
+    iat?: number;
+    exp?: number;
+}
+
+/**
+ * Mints a signed proof-of-phone-ownership token. `phoneNumber` MUST already be
+ * normalized (E.164) by the caller so the claim matches what the users-service
+ * writes to `main.users.phoneNumber`.
+ */
+export const createPhoneVerificationToken = (
+    phoneNumber: string,
+    purpose: PhoneVerificationPurpose = 'register',
+    secret: string = process.env.JWT_SECRET || '',
+): string => jwt.sign(
+    {
+        phoneNumber,
+        purpose,
+        type: PHONE_VERIFICATION_TOKEN_TYPE,
+    },
+    secret,
+    {
+        expiresIn: PHONE_VERIFICATION_TOKEN_TTL_SECONDS,
+        issuer: PHONE_VERIFICATION_TOKEN_ISSUER,
+        audience: PHONE_VERIFICATION_TOKEN_AUDIENCE,
+    },
+);
+
+/**
+ * Verifies a phone-verification token and returns its claims, or `undefined`
+ * when the token is missing, expired, forged, or of the wrong type/purpose.
+ * Never throws — callers treat `undefined` as "no proof supplied".
+ */
+export const verifyPhoneVerificationToken = (
+    token: string | undefined | null,
+    purpose: PhoneVerificationPurpose = 'register',
+    secret: string = process.env.JWT_SECRET || '',
+): IPhoneVerificationClaims | undefined => {
+    if (!token) {
+        return undefined;
+    }
+
+    try {
+        const decoded = jwt.verify(token, secret, {
+            issuer: PHONE_VERIFICATION_TOKEN_ISSUER,
+            audience: PHONE_VERIFICATION_TOKEN_AUDIENCE,
+        }) as IPhoneVerificationClaims;
+
+        if (decoded?.type !== PHONE_VERIFICATION_TOKEN_TYPE) {
+            return undefined;
+        }
+        if (decoded?.purpose !== purpose) {
+            return undefined;
+        }
+        if (!decoded?.phoneNumber) {
+            return undefined;
+        }
+
+        return decoded;
+    } catch (err) {
+        return undefined;
+    }
+};
+
+export default createPhoneVerificationToken;

--- a/therr-public-library/therr-js-utilities/tests/phone-verification-token.test.ts
+++ b/therr-public-library/therr-js-utilities/tests/phone-verification-token.test.ts
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import jwt from 'jsonwebtoken';
+import {
+    createPhoneVerificationToken,
+    verifyPhoneVerificationToken,
+    PHONE_VERIFICATION_TOKEN_AUDIENCE,
+    PHONE_VERIFICATION_TOKEN_ISSUER,
+    PHONE_VERIFICATION_TOKEN_TYPE,
+} from '../src/phone-verification-token';
+
+const SECRET = 'test-jwt-secret';
+const PHONE = '+13175551234';
+
+describe('phone-verification-token', () => {
+    it('round-trips a minted token back to its claims', () => {
+        const token = createPhoneVerificationToken(PHONE, 'register', SECRET);
+        const claims = verifyPhoneVerificationToken(token, 'register', SECRET);
+
+        expect(claims?.phoneNumber).to.equal(PHONE);
+        expect(claims?.purpose).to.equal('register');
+        expect(claims?.type).to.equal(PHONE_VERIFICATION_TOKEN_TYPE);
+    });
+
+    it('rejects a token minted for a different purpose', () => {
+        // A sign-in proof must not be redeemable as a sign-up proof, or a user could turn
+        // "log me in" into "create me an account on this number".
+        const token = createPhoneVerificationToken(PHONE, 'login', SECRET);
+
+        expect(verifyPhoneVerificationToken(token, 'register', SECRET)).to.equal(undefined);
+    });
+
+    it('rejects a token signed with a different secret', () => {
+        const token = createPhoneVerificationToken(PHONE, 'register', 'some-other-secret');
+
+        expect(verifyPhoneVerificationToken(token, 'register', SECRET)).to.equal(undefined);
+    });
+
+    it('rejects an expired token', () => {
+        const token = jwt.sign(
+            { phoneNumber: PHONE, purpose: 'register', type: PHONE_VERIFICATION_TOKEN_TYPE },
+            SECRET,
+            {
+                expiresIn: -10,
+                issuer: PHONE_VERIFICATION_TOKEN_ISSUER,
+                audience: PHONE_VERIFICATION_TOKEN_AUDIENCE,
+            },
+        );
+
+        expect(verifyPhoneVerificationToken(token, 'register', SECRET)).to.equal(undefined);
+    });
+
+    it('rejects a session-shaped token that is not a phone-verification token', () => {
+        // Guards the boundary the audience/type claims exist to enforce: an id token must
+        // never be usable as proof of phone ownership.
+        const sessionToken = jwt.sign(
+            { id: 'some-user-id', phoneNumber: PHONE, purpose: 'register' },
+            SECRET,
+            { issuer: PHONE_VERIFICATION_TOKEN_ISSUER, audience: 'therr-app' },
+        );
+
+        expect(verifyPhoneVerificationToken(sessionToken, 'register', SECRET)).to.equal(undefined);
+    });
+
+    it('treats a missing token as no proof supplied rather than throwing', () => {
+        expect(verifyPhoneVerificationToken(undefined, 'register', SECRET)).to.equal(undefined);
+        expect(verifyPhoneVerificationToken('', 'register', SECRET)).to.equal(undefined);
+        expect(verifyPhoneVerificationToken('not-a-jwt', 'register', SECRET)).to.equal(undefined);
+    });
+});

--- a/therr-public-library/therr-react/src/redux/actions/Users.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Users.ts
@@ -2,12 +2,28 @@
 import { SocketClientActionTypes } from 'therr-js-utilities/constants';
 import { IUser, IUserSettings, UserActionTypes } from '../../types/redux/user';
 import UsersService, { ISearchUsersArgs, ISocialSyncs } from '../../services/UsersService';
+import ApiService, {
+    IPhoneAuthAccount,
+    IPhoneAuthSelectArgs,
+    IPhoneAuthVerifyArgs,
+} from '../../services/ApiService';
 import { ContentActionTypes } from '../../types/redux/content';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ISearchThoughtsArgs {}
 interface ILoginSSOTokens {
     google?: string;
+}
+
+/**
+ * Outcome of submitting a texted sign-in code. When `requiresAccountSelection` is true no
+ * session has been established yet — the number matched several accounts and the caller must
+ * present `accounts` and follow up with `selectPhoneLoginAccount`.
+ */
+export interface IPhoneLoginResult {
+    requiresAccountSelection: boolean;
+    accounts: IPhoneAuthAccount[];
+    phoneVerificationToken?: string;
 }
 
 interface IUpdateTourArgs {
@@ -233,89 +249,141 @@ class UsersActions {
         });
     };
 
-    login = (data: any, idTokens?: ILoginSSOTokens) => async (dispatch: any) => {
-        await UsersService.authenticate(data).then(async (response) => {
-            const storedUserDetails = JSON.parse(
-                await (this.NativeStorage || sessionStorage).getItem('therrUser')
-                || await (this.NativeStorage || localStorage).getItem('therrUser')
-                || null,
-            );
-            const storedUserSettings = JSON.parse(
-                await (this.NativeStorage || sessionStorage).getItem('therrUserSettings')
-                || await (this.NativeStorage || localStorage).getItem('therrUserSettings')
-                || null,
-            );
-            const {
-                id,
-                idToken,
-                refreshToken,
-            } = response.data;
-            const responseData = {
-                ...response.data,
-            };
+    /**
+     * Turns a successful auth response into a live session: persists tokens to storage,
+     * opens the websocket, and dispatches the LOGIN actions.
+     *
+     * Shared by every way in — password, SSO, and the passwordless phone flows below — so a
+     * user who signs in with a texted code ends up in exactly the same state as one who typed
+     * a password. Callers must not duplicate any of this.
+     */
+    private establishSession = async (
+        authResponseData: any,
+        options: { rememberMe?: boolean },
+        idTokens: ILoginSSOTokens | undefined,
+        dispatch: any,
+    ) => {
+        const storedUserDetails = JSON.parse(
+            await (this.NativeStorage || sessionStorage).getItem('therrUser')
+            || await (this.NativeStorage || localStorage).getItem('therrUser')
+            || null,
+        );
+        const storedUserSettings = JSON.parse(
+            await (this.NativeStorage || sessionStorage).getItem('therrUserSettings')
+            || await (this.NativeStorage || localStorage).getItem('therrUserSettings')
+            || null,
+        );
+        const {
+            id,
+            idToken,
+            refreshToken,
+        } = authResponseData;
+        const responseData = {
+            ...authResponseData,
+        };
 
-            // Same user logging in again; maintain client stored settings that are not stored in the database
-            if (storedUserDetails?.id === id) {
-                responseData.navigationTourCount = storedUserSettings?.navigationTourCount || 0;
+        // Same user logging in again; maintain client stored settings that are not stored in the database
+        if (storedUserDetails?.id === id) {
+            responseData.navigationTourCount = storedUserSettings?.navigationTourCount || 0;
+        }
+
+        const { userData, userSettingsData } = this.extractUserData(responseData);
+        this.socketIO.io.opts.query = {
+            token: idToken,
+        };
+        const afterIOConnectAttempt = () => {
+            // These two dispatches were moved here to fix a bug when one dispatch happened before the callback
+            // For some reason it caused the websocket server to NOT receive the message in the callback.
+            // We should also call these regardless when failing to connect to the socket server
+            dispatch({
+                type: SocketClientActionTypes.LOGIN,
+                data: userData,
+            });
+            dispatch({
+                type: UserActionTypes.LOGIN,
+                data: userData,
+            });
+            dispatch({
+                type: SocketClientActionTypes.RESET_USER_SETTINGS,
+                data: {
+                    settings: userSettingsData,
+                },
+            });
+        };
+        // Connect and get socketIO.id
+        const onIOConnectListener = async () => {
+            const sessionData = { id: this.socketIO.id, idTokens: idTokens || {} };
+            // NOTE: Native Storage methods return a promise, but in this case we don't need to await
+            await (this.NativeStorage || sessionStorage)
+                .setItem('therrSession', JSON.stringify(sessionData));
+            if (options.rememberMe && !this.NativeStorage) {
+                localStorage.setItem('therrSession', JSON.stringify(sessionData));
             }
 
-            const { userData, userSettingsData } = this.extractUserData(responseData);
-            this.socketIO.io.opts.query = {
-                token: idToken,
-            };
-            const afterIOConnectAttempt = () => {
-                // These two dispatches were moved here to fix a bug when one dispatch happened before the callback
-                // For some reason it caused the websocket server to NOT receive the message in the callback.
-                // We should also call these regardless when failing to connect to the socket server
-                dispatch({
-                    type: SocketClientActionTypes.LOGIN,
-                    data: userData,
-                });
-                dispatch({
-                    type: UserActionTypes.LOGIN,
-                    data: userData,
-                });
-                dispatch({
-                    type: SocketClientActionTypes.RESET_USER_SETTINGS,
-                    data: {
-                        settings: userSettingsData,
-                    },
-                });
-            };
-            // Connect and get socketIO.id
-            const onIOConnectListener = async () => {
-                const sessionData = { id: this.socketIO.id, idTokens: idTokens || {} };
-                // NOTE: Native Storage methods return a promise, but in this case we don't need to await
-                await (this.NativeStorage || sessionStorage)
-                    .setItem('therrSession', JSON.stringify(sessionData));
-                if (data.rememberMe && !this.NativeStorage) {
-                    localStorage.setItem('therrSession', JSON.stringify(sessionData));
-                }
-
-                afterIOConnectAttempt();
-            };
-            // TODO: Send event to Google Analytics and/or Datadog
-            const onIOConnectErrorListener = (error: any) => {
-                // We still need to let the user login when websocket service is down or not available
-                console.warn(error);
-                afterIOConnectAttempt();
-            };
-            this.socketIO.on('connect', onIOConnectListener);
-            this.socketIO.on('connect_error', onIOConnectErrorListener);
-            this.socketIO.connect();
-            (this.NativeStorage || sessionStorage).setItem('therrUser', JSON.stringify(userData));
-            (this.NativeStorage || sessionStorage).setItem('therrUserSettings', JSON.stringify(userSettingsData));
+            afterIOConnectAttempt();
+        };
+        // TODO: Send event to Google Analytics and/or Datadog
+        const onIOConnectErrorListener = (error: any) => {
+            // We still need to let the user login when websocket service is down or not available
+            console.warn(error);
+            afterIOConnectAttempt();
+        };
+        this.socketIO.on('connect', onIOConnectListener);
+        this.socketIO.on('connect_error', onIOConnectErrorListener);
+        this.socketIO.connect();
+        (this.NativeStorage || sessionStorage).setItem('therrUser', JSON.stringify(userData));
+        (this.NativeStorage || sessionStorage).setItem('therrUserSettings', JSON.stringify(userSettingsData));
+        if (refreshToken) {
+            (this.NativeStorage || sessionStorage).setItem('therrRefreshToken', refreshToken);
+        }
+        if (options.rememberMe && !this.NativeStorage) {
+            localStorage.setItem('therrUser', JSON.stringify(userData));
+            localStorage.setItem('therrUserSettings', JSON.stringify(userSettingsData));
             if (refreshToken) {
-                (this.NativeStorage || sessionStorage).setItem('therrRefreshToken', refreshToken);
+                localStorage.setItem('therrRefreshToken', refreshToken);
             }
-            if (data.rememberMe && !this.NativeStorage) {
-                localStorage.setItem('therrUser', JSON.stringify(userData));
-                localStorage.setItem('therrUserSettings', JSON.stringify(userSettingsData));
-                if (refreshToken) {
-                    localStorage.setItem('therrRefreshToken', refreshToken);
-                }
-            }
-        });
+        }
+
+        return userData;
+    };
+
+    login = (data: any, idTokens?: ILoginSSOTokens) => async (dispatch: any) => {
+        await UsersService.authenticate(data)
+            .then((response) => this.establishSession(response.data, data, idTokens, dispatch));
+    };
+
+    /**
+     * Passwordless sign-in, step 2: submit the code that was texted by `ApiService.startPhoneLogin`.
+     *
+     * Resolves with `{ requiresAccountSelection: true, accounts, phoneVerificationToken }` when
+     * the number is attached to more than one account — no session is established in that case;
+     * present the accounts and call `selectPhoneLoginAccount` with the user's choice. Otherwise
+     * the user is signed in and `requiresAccountSelection` is false.
+     */
+    loginWithPhone = (data: IPhoneAuthVerifyArgs) => async (dispatch: any): Promise<IPhoneLoginResult> => {
+        const response: any = await ApiService.verifyPhoneLogin(data);
+
+        if (response?.data?.requiresAccountSelection) {
+            return {
+                requiresAccountSelection: true,
+                accounts: response.data.accounts || [],
+                phoneVerificationToken: response.data.phoneVerificationToken,
+            };
+        }
+
+        await this.establishSession(response.data, data, undefined, dispatch);
+
+        return { requiresAccountSelection: false, accounts: [] };
+    };
+
+    /**
+     * Passwordless sign-in, step 2b: complete sign-in for the account the user picked out of
+     * `loginWithPhone`'s `accounts` list.
+     */
+    selectPhoneLoginAccount = (data: IPhoneAuthSelectArgs) => async (dispatch: any) => {
+        const response: any = await ApiService.selectPhoneLoginAccount(data);
+
+        await this.establishSession(response.data, data, undefined, dispatch);
     };
 
     getMe = () => async (dispatch: any) => {

--- a/therr-public-library/therr-react/src/services/ApiService.ts
+++ b/therr-public-library/therr-react/src/services/ApiService.ts
@@ -1,7 +1,39 @@
 /* eslint-disable class-methods-use-this */
 import axios from 'axios';
 
+/**
+ * One account the caller may sign into, as returned when a phone number is attached to more
+ * than one (Therr permits a personal + creator + business account per number). Deliberately
+ * narrow — it is rendered by a pre-auth account picker, so it carries nothing sensitive.
+ */
+export interface IPhoneAuthAccount {
+    id: string;
+    userName?: string;
+    firstName?: string;
+    lastName?: string;
+    media?: any;
+    isBusinessAccount?: boolean;
+    isCreatorAccount?: boolean;
+}
+
+export interface IPhoneAuthVerifyArgs {
+    phoneNumber: string;
+    verificationCode: string;
+    rememberMe?: boolean;
+}
+
+export interface IPhoneAuthSelectArgs {
+    phoneVerificationToken: string;
+    userId: string;
+    rememberMe?: boolean;
+}
+
 class ApiService {
+    /**
+     * Sends a verification code to the phone number of an ALREADY SIGNED IN user, so they can
+     * attach or change the number on their profile. For signed-out sign-in/sign-up use the
+     * passwordless methods further down.
+     */
     verifyPhone = (phoneNumber) => axios({
         method: 'post',
         url: '/phone/verify',
@@ -16,6 +48,59 @@ class ApiService {
         data: {
             verificationCode,
         },
+    });
+
+    // PASSWORDLESS SIGN-IN
+    //
+    // The response to `startPhoneLogin` is intentionally identical whether or not an account
+    // exists for the number — do not branch UI on it. Render the code-entry step either way
+    // and let `verifyPhoneLogin` be the call that succeeds or fails.
+
+    startPhoneLogin = (phoneNumber: string) => axios({
+        method: 'post',
+        url: '/phone/auth/start',
+        data: {
+            phoneNumber,
+        },
+    });
+
+    /**
+     * Submits the texted code. Resolves either with a full session payload (same shape as
+     * `POST /users-service/auth`) or, when the number has several accounts, with
+     * `{ requiresAccountSelection: true, accounts, phoneVerificationToken }` — pass that token
+     * and the chosen account id to `selectPhoneLoginAccount`.
+     */
+    verifyPhoneLogin = (data: IPhoneAuthVerifyArgs) => axios({
+        method: 'post',
+        url: '/phone/auth/verify',
+        data,
+    });
+
+    selectPhoneLoginAccount = (data: IPhoneAuthSelectArgs) => axios({
+        method: 'post',
+        url: '/phone/auth/select',
+        data,
+    });
+
+    // PASSWORDLESS SIGN-UP
+
+    startPhoneRegistration = (phoneNumber: string) => axios({
+        method: 'post',
+        url: '/phone/register/start',
+        data: {
+            phoneNumber,
+        },
+    });
+
+    /**
+     * Submits the texted code and resolves with a short-lived `phoneVerificationToken`. Pass
+     * that token to `UsersService.create` alongside the email collected in the next step; the
+     * account is then created already phone-verified.
+     */
+    verifyPhoneRegistration = (data: Omit<IPhoneAuthVerifyArgs, 'rememberMe'>) => axios({
+        method: 'post',
+        url: '/phone/register/verify',
+        data,
     });
 }
 

--- a/therr-public-library/therr-react/src/services/UsersService.ts
+++ b/therr-public-library/therr-react/src/services/UsersService.ts
@@ -18,16 +18,24 @@ interface ILogoutCredentials {
 }
 
 interface IRegisterCredentials {
-    firstName: string;
-    lastName: string;
+    // Email is the only universally required field. Names and username are collected during
+    // profile creation, and password is optional on the phone-first path below — the shape
+    // used to over-declare these as required, which no caller actually satisfied.
     email: string;
-    phoneNumber: string;
-    userName: string;
-    password: string;
+    firstName?: string;
+    lastName?: string;
+    phoneNumber?: string;
+    userName?: string;
+    password?: string;
+    settingsBirthdate?: string;
+    settingsLocale?: string;
     inviteCode?: string;
     // Magic invite-link token: trusts the invited contact channel and
     // auto-connects the user to the inviter on signup.
     inviteToken?: string;
+    // Short-lived proof of phone ownership from POST /v1/phone/register/verify. When present,
+    // the account is created already phone-verified and `password` may be omitted.
+    phoneVerificationToken?: string;
 }
 
 export interface ISearchUsersArgs {

--- a/therr-public-library/therr-react/src/services/index.ts
+++ b/therr-public-library/therr-react/src/services/index.ts
@@ -1,4 +1,8 @@
-import ApiService from './ApiService';
+import ApiService, {
+    IPhoneAuthAccount,
+    IPhoneAuthSelectArgs,
+    IPhoneAuthVerifyArgs,
+} from './ApiService';
 import CampaignsService from './CampaignsService';
 import ForumsService from './ForumsService';
 import MapsService,
@@ -24,6 +28,9 @@ import StreaksService from './StreaksService';
 
 export {
     ApiService,
+    IPhoneAuthAccount,
+    IPhoneAuthSelectArgs,
+    IPhoneAuthVerifyArgs,
     CampaignsService,
     ForumsService,
     MapsService,

--- a/therr-services/users-service/src/handlers/auth.ts
+++ b/therr-services/users-service/src/handlers/auth.ts
@@ -54,6 +54,172 @@ const basicHash = (input: string) => {
     return hash;
 };
 
+/**
+ * Everything that happens *after* a caller has proven who they are: mint the id/refresh
+ * tokens, run the first-login side effects, bump the audit columns, and shape the response.
+ *
+ * Factored out of `login` so the passwordless phone flow (`loginWithVerifiedPhone` below)
+ * produces a byte-identical session payload instead of a near-copy that drifts. Credential
+ * checking stays with the callers — this function assumes it has already happened.
+ *
+ * `userSearchResults` is the pre-auth DB lookup and may be empty (first-time SSO, where the
+ * user row was created during validation); it is used only to reproduce the original
+ * first-login heuristics and logging.
+ */
+const issueUserSession = async (req: any, res: any, {
+    userDetails,
+    userSearchResults,
+    oauthResponseData,
+    brandVariation,
+    platform,
+}: {
+    userDetails: any;
+    userSearchResults: any[];
+    oauthResponseData?: any;
+    brandVariation: string;
+    platform: string;
+}) => {
+    const user = {
+        ...userDetails,
+        isSSO: !!req.body.isSSO,
+        integrations: {
+            ...decryptIntegrationsAccess(userDetails?.integrationsAccess),
+        },
+    };
+    if (oauthResponseData?.access_token) {
+        // TODO: Store access_tokens encrypted in DB (integrationsAccess) for fetching
+        // TODO: Fetch stored access_tokens and return in integrations object
+        const DEFAULT_60_DAYS_AS_SECONDS = 60 * 60 * 24 * 60; // 60 days
+        user.integrations[OAuthIntegrationProviders.FACEBOOK] = {
+            user_access_token: oauthResponseData.access_token,
+            user_access_token_expires_at: Date.now() + ((oauthResponseData?.expires_in || DEFAULT_60_DAYS_AS_SECONDS) * 1000),
+        };
+    }
+    const userNameEmailPhone = userNameOrEmailOrPhone(userDetails);
+
+    const userEmail = userDetails.email?.trim() || ''; // DB response values should already be normalized
+    const userPhone = userDetails.phoneNumber?.trim()?.replace(/\s/g, ''); // DB response values should already be normalized
+    const userOrgs = await Store.userOrganizations.get({
+        userId: user.id,
+    }).catch((err) => {
+        logSpan({
+            level: 'error',
+            messageOrigin: 'API_SERVER',
+            messages: [err?.message, 'Failed to fetch user organizations for idToken'],
+            traceArgs: {
+                issue: '',
+                port: process.env.USERS_SERVICE_API_PORT,
+                'process.id': process.pid,
+            },
+        });
+        return [];
+    });
+
+    const idToken = createUserToken(user, userOrgs, req.body.rememberMe, brandVariation);
+    const refreshTokenData = createRefreshToken(user.id, req.body.rememberMe, brandVariation);
+    const userHash = basicHash(userNameEmailPhone);
+
+    logSpan({
+        level: 'info',
+        messageOrigin: 'API_SERVER',
+        messages: ['user login success'],
+        traceArgs: {
+            'user.isSSO': req.body.isSSO,
+            'user.loginCount': !userSearchResults?.length ? 1 : userSearchResults[0].loginCount,
+            'user.hash': userHash,
+            'user.id': userDetails.id,
+        },
+    });
+
+    // Fire and forget — first-login invite redemption. Marks every
+    // matching pending invite accepted, rewards each inviter, and
+    // guarantees a COMPLETE userConnection between inviter and this
+    // new user (the viral-loop contract: the friend you invited is
+    // in your connections the moment they first sign in).
+    if (!userSearchResults?.length || userSearchResults[0].loginCount < 2) {
+        recordFunnelMetric(MetricNames.FUNNEL_USER_FIRST_LOGIN, userDetails.id, {
+            brandVariation: brandVariation || '',
+            platform: platform || '',
+        });
+
+        acceptInvitesOnFirstLogin(req.headers, {
+            id: userDetails.id,
+            email: userEmail ? normalizeEmail(userEmail.trim()) : undefined,
+            phoneNumber: userPhone || undefined,
+            firstName: userDetails.firstName,
+            lastName: userDetails.lastName,
+        }).catch((err) => {
+            logSpan({
+                level: 'error',
+                messageOrigin: 'API_SERVER',
+                messages: [err?.message, 'Failed to process first-login invite acceptance'],
+                traceArgs: {
+                    'user.id': userDetails.id,
+                    port: process.env.USERS_SERVICE_API_PORT,
+                    'process.id': process.pid,
+                },
+            });
+        });
+    }
+
+    const updateArgs: any = {
+        accessLevels: JSON.stringify([...new Set(user.accessLevels)]),
+        loginCount: user.loginCount + 1,
+        lastLoginAt: new Date(),
+        integrationsAccess: user.integrations,
+    };
+
+    if (req.body.billingEmail) {
+        if (req.body.billingEmail !== user.email) {
+            // TODO: Improve security so users cannot claim the same billing email as another user
+            // Send verification e-mail before updating param
+        }
+        updateArgs.billingEmail = req.body.billingEmail;
+    }
+
+    return Store.users.updateUser(updateArgs, {
+        id: user.id,
+    }).then((userResponse) => {
+        const finalUser = userResponse[0];
+        // Remove credentials from object
+        redactUserCreds(finalUser);
+        // Track which apps a user actually uses. Fire-and-forget: a failure here
+        // must not block the login response, but we want to log it for observability.
+        // Skip DASHBOARD_THERR for non-business accounts so dashboard sign-ins don't
+        // pollute consumer brand membership records.
+        // Only track brands we recognize. Without this guard a malicious client could
+        // submit `x-brand-variation: <anything>` to pollute the user's brandVariations
+        // array (no SQL injection — it's parameterized — but it would let an attacker
+        // grow the JSONB array unboundedly via repeated logins under different bogus
+        // values, an integrity / DoS angle).
+        const shouldTrackBrand = isKnownBrand(brandVariation)
+            && !(brandVariation === BrandVariations.DASHBOARD_THERR && !finalUser?.isBusinessAccount);
+        if (shouldTrackBrand) {
+            Store.users.upsertBrandVariation(user.id, brandVariation).catch((err) => {
+                logSpan({
+                    level: 'error',
+                    messageOrigin: 'API_SERVER',
+                    messages: [err?.message, 'Failed to upsert brandVariations on login'],
+                    traceArgs: {
+                        'user.id': user.id,
+                        'brand.variation': brandVariation,
+                    },
+                });
+            });
+        }
+        // TODO: Save, Encrypt, and return stored user integrations
+        // const storedIntegrations = encryptIntegrationsAccess(access);
+        return res.status(201).send({
+            ...finalUser,
+            idToken,
+            refreshToken: refreshTokenData.token,
+            integrations: user.integrations || {},
+            rememberMe: req.body.rememberMe,
+            userOrganizations: userOrgs,
+        });
+    });
+};
+
 // Authenticate user
 const login: RequestHandler = (req: any, res: any) => {
     const {
@@ -68,18 +234,12 @@ const login: RequestHandler = (req: any, res: any) => {
     // const { paymentSessionId } = req.body;
     // TODO: Use paymentSessionId to fetch subscription details and add accessLevels to user
 
-    // TODO: Mitigate user with multiple accounts attached to the same phone number.
-    // Logging in by phone number should attach to all accounts with that phone number and allow them to pick one
-    let userNameEmailPhone = userNameOrEmailOrPhone(req.body);
-    let userEmail = normalizeEmail(req.body.userName?.trim() || req.body.userEmail?.trim() || req.body.email?.trim()?.replace(/\s/g, '') || '');
-    let userPhone = normalizePhoneNumber(
-        req.body.userName?.trim()?.replace(/\s/g, '')
-            || req.body.userEmail?.trim()?.replace(/\s/g, '')
-            || req.body.email?.trim()?.replace(/\s/g, '')
-            || req.body.phoneNumber?.trim()?.replace(/\s/g, '') || '',
-    );
+    // NOTE: When a phone number is attached to more than one account, password login still
+    // resolves to whichever row the OR-lookup returns first. The passwordless flow below
+    // (`phoneAccountLookup` + `loginWithVerifiedPhone`) is the path that lets the user pick.
+    const userNameEmailPhone = userNameOrEmailOrPhone(req.body);
 
-    let userHash = userNameEmailPhone ? basicHash(userNameEmailPhone) : undefined;
+    const userHash = userNameEmailPhone ? basicHash(userNameEmailPhone) : undefined;
     let getUsersPromise;
 
     /**
@@ -172,144 +332,12 @@ const login: RequestHandler = (req: any, res: any) => {
                 },
             }, res).then(async ([isValid, userDetails, oauthResponseData]) => {
                 if (isValid) {
-                    const user = {
-                        ...userDetails,
-                        isSSO: !!req.body.isSSO,
-                        integrations: {
-                            ...decryptIntegrationsAccess(userDetails?.integrationsAccess),
-                        },
-                    };
-                    if (oauthResponseData?.access_token) {
-                        // TODO: Store access_tokens encrypted in DB (integrationsAccess) for fetching
-                        // TODO: Fetch stored access_tokens and return in integrations object
-                        const DEFAULT_60_DAYS_AS_SECONDS = 60 * 60 * 24 * 60; // 60 days
-                        user.integrations[OAuthIntegrationProviders.FACEBOOK] = {
-                            user_access_token: oauthResponseData.access_token,
-                            user_access_token_expires_at: Date.now() + ((oauthResponseData?.expires_in || DEFAULT_60_DAYS_AS_SECONDS) * 1000),
-                        };
-                    }
-                    userNameEmailPhone = userNameOrEmailOrPhone(userDetails);
-
-                    userEmail = userDetails.email?.trim() || ''; // DB response values should already be normalized
-                    userPhone = userDetails.phoneNumber?.trim()?.replace(/\s/g, ''); // DB response values should already be normalized
-                    const userOrgs = await Store.userOrganizations.get({
-                        userId: user.id,
-                    }).catch((err) => {
-                        logSpan({
-                            level: 'error',
-                            messageOrigin: 'API_SERVER',
-                            messages: [err?.message, 'Failed to fetch user organizations for idToken'],
-                            traceArgs: {
-                                issue: '',
-                                port: process.env.USERS_SERVICE_API_PORT,
-                                'process.id': process.pid,
-                            },
-                        });
-                        return [];
-                    });
-
-                    const idToken = createUserToken(user, userOrgs, req.body.rememberMe, brandVariation);
-                    const refreshTokenData = createRefreshToken(user.id, req.body.rememberMe, brandVariation);
-                    userHash = basicHash(userNameEmailPhone);
-
-                    logSpan({
-                        level: 'info',
-                        messageOrigin: 'API_SERVER',
-                        messages: ['user login success'],
-                        traceArgs: {
-                            'user.isSSO': req.body.isSSO,
-                            'user.loginCount': !userSearchResults?.length ? 1 : userSearchResults[0].loginCount,
-                            'user.hash': userHash,
-                            'user.id': userDetails.id,
-                        },
-                    });
-
-                    // Fire and forget — first-login invite redemption. Marks every
-                    // matching pending invite accepted, rewards each inviter, and
-                    // guarantees a COMPLETE userConnection between inviter and this
-                    // new user (the viral-loop contract: the friend you invited is
-                    // in your connections the moment they first sign in).
-                    if (!userSearchResults?.length || userSearchResults[0].loginCount < 2) {
-                        recordFunnelMetric(MetricNames.FUNNEL_USER_FIRST_LOGIN, userDetails.id, {
-                            brandVariation: brandVariation || '',
-                            platform: platform || '',
-                        });
-
-                        acceptInvitesOnFirstLogin(req.headers, {
-                            id: userDetails.id,
-                            email: userEmail ? normalizeEmail(userEmail.trim()) : undefined,
-                            phoneNumber: userPhone || undefined,
-                            firstName: userDetails.firstName,
-                            lastName: userDetails.lastName,
-                        }).catch((err) => {
-                            logSpan({
-                                level: 'error',
-                                messageOrigin: 'API_SERVER',
-                                messages: [err?.message, 'Failed to process first-login invite acceptance'],
-                                traceArgs: {
-                                    'user.id': userDetails.id,
-                                    port: process.env.USERS_SERVICE_API_PORT,
-                                    'process.id': process.pid,
-                                },
-                            });
-                        });
-                    }
-
-                    const updateArgs: any = {
-                        accessLevels: JSON.stringify([...new Set(user.accessLevels)]),
-                        loginCount: user.loginCount + 1,
-                        lastLoginAt: new Date(),
-                        integrationsAccess: user.integrations,
-                    };
-
-                    if (req.body.billingEmail) {
-                        if (req.body.billingEmail !== user.email) {
-                            // TODO: Improve security so users cannot claim the same billing email as another user
-                            // Send verification e-mail before updating param
-                        }
-                        updateArgs.billingEmail = req.body.billingEmail;
-                    }
-
-                    return Store.users.updateUser(updateArgs, {
-                        id: user.id,
-                    }).then((userResponse) => {
-                        const finalUser = userResponse[0];
-                        // Remove credentials from object
-                        redactUserCreds(finalUser);
-                        // Track which apps a user actually uses. Fire-and-forget: a failure here
-                        // must not block the login response, but we want to log it for observability.
-                        // Skip DASHBOARD_THERR for non-business accounts so dashboard sign-ins don't
-                        // pollute consumer brand membership records.
-                        // Only track brands we recognize. Without this guard a malicious client could
-                        // submit `x-brand-variation: <anything>` to pollute the user's brandVariations
-                        // array (no SQL injection — it's parameterized — but it would let an attacker
-                        // grow the JSONB array unboundedly via repeated logins under different bogus
-                        // values, an integrity / DoS angle).
-                        const shouldTrackBrand = isKnownBrand(brandVariation)
-                            && !(brandVariation === BrandVariations.DASHBOARD_THERR && !finalUser?.isBusinessAccount);
-                        if (shouldTrackBrand) {
-                            Store.users.upsertBrandVariation(user.id, brandVariation).catch((err) => {
-                                logSpan({
-                                    level: 'error',
-                                    messageOrigin: 'API_SERVER',
-                                    messages: [err?.message, 'Failed to upsert brandVariations on login'],
-                                    traceArgs: {
-                                        'user.id': user.id,
-                                        'brand.variation': brandVariation,
-                                    },
-                                });
-                            });
-                        }
-                        // TODO: Save, Encrypt, and return stored user integrations
-                        // const storedIntegrations = encryptIntegrationsAccess(access);
-                        return res.status(201).send({
-                            ...finalUser,
-                            idToken,
-                            refreshToken: refreshTokenData.token,
-                            integrations: user.integrations || {},
-                            rememberMe: req.body.rememberMe,
-                            userOrganizations: userOrgs,
-                        });
+                    return issueUserSession(req, res, {
+                        userDetails,
+                        userSearchResults,
+                        oauthResponseData,
+                        brandVariation,
+                        platform,
                     });
                 }
 
@@ -327,6 +355,163 @@ const login: RequestHandler = (req: any, res: any) => {
                     message: translate(locale, 'errorMessages.auth.incorrectUserPass'),
                     statusCode: 401,
                 });
+            });
+        })
+        .catch((err) => handleHttpError({ err, res, message: 'SQL:AUTH_ROUTES:ERROR' }));
+};
+
+// PASSWORDLESS PHONE AUTH
+//
+// The SMS round-trip itself lives in the API gateway (it owns Twilio and the Redis code
+// cache). By the time either handler below runs, the gateway has already proven the caller
+// controls the phone number — these two are the account-side half of that flow.
+
+/**
+ * Minimal, non-sensitive account list for a phone number.
+ *
+ * The gateway calls this twice: before texting a code (to decide whether a code is worth
+ * sending at all) and after validating one (to build the account picker when a number has
+ * several accounts). It returns only what a picker needs to render — never credentials,
+ * email, or access levels. Blocked and soft-deleted accounts are omitted so they neither
+ * appear in the picker nor make a number look "registered" to the sign-up flow.
+ */
+const phoneAccountLookup: RequestHandler = (req: any, res: any) => {
+    const rawPhoneNumber = `${req.body?.phoneNumber || ''}`.trim().replace(/\s/g, '');
+    const phoneNumber = rawPhoneNumber ? normalizePhoneNumber(rawPhoneNumber) : '';
+
+    if (!phoneNumber) {
+        return res.status(200).send({ accountCount: 0, accounts: [] });
+    }
+
+    return Store.users.getAllByPhoneNumber(phoneNumber, [
+        'id',
+        'userName',
+        'firstName',
+        'lastName',
+        'media',
+        'isBusinessAccount',
+        'isCreatorAccount',
+        'isBlocked',
+    ])
+        .then((results) => {
+            const accounts = (results || [])
+                .filter((account) => !account.isBlocked)
+                .map(({ isBlocked, ...account }) => account); // eslint-disable-line @typescript-eslint/no-unused-vars
+
+            return res.status(200).send({
+                accountCount: accounts.length,
+                accounts,
+            });
+        })
+        .catch((err) => handleHttpError({ err, res, message: 'SQL:AUTH_ROUTES:ERROR' }));
+};
+
+/**
+ * Signs a user in on the strength of a verified phone number — no password involved.
+ *
+ * Trust boundary: this endpoint is internal (users-service is not publicly routable) and is
+ * reachable only via the gateway's `/phone/auth/*` routes, which will not call it until a
+ * texted one-time code has been matched. It therefore performs NO credential check of its
+ * own; it re-validates only that the requested account really is attached to the phone
+ * number, so a compromised or buggy caller still cannot pivot to an arbitrary account.
+ *
+ * `userId` is required whenever the number resolves to more than one account: we refuse to
+ * guess which of a user's personal / creator / business accounts they meant.
+ */
+const loginWithVerifiedPhone: RequestHandler = (req: any, res: any) => {
+    const {
+        locale,
+        brandVariation,
+        platform,
+    } = parseHeaders(req.headers);
+    const rawPhoneNumber = `${req.body?.phoneNumber || ''}`.trim().replace(/\s/g, '');
+    const phoneNumber = rawPhoneNumber ? normalizePhoneNumber(rawPhoneNumber) : '';
+    const requestedUserId = req.body?.userId;
+
+    if (!phoneNumber) {
+        return handleHttpError({
+            res,
+            message: 'A phone number is required',
+            statusCode: 400,
+        });
+    }
+
+    return Store.users.getAllByPhoneNumber(phoneNumber)
+        .then((userSearchResults) => {
+            if (!userSearchResults.length) {
+                logSpan({
+                    level: 'warn',
+                    messageOrigin: 'API_SERVER',
+                    messages: ['phone auth failed: user not found'],
+                    traceArgs: {
+                        'user.hash': basicHash(phoneNumber),
+                    },
+                });
+                return handleHttpError({
+                    res,
+                    message: translate(locale, 'errorMessages.auth.noUserFound'),
+                    statusCode: 404,
+                });
+            }
+
+            // Re-bind the requested account to the proven phone number rather than trusting
+            // the caller's id outright. `find` over the phone-scoped result set means an id
+            // for some other account simply isn't there.
+            const userDetails = requestedUserId
+                ? userSearchResults.find((user) => user.id === requestedUserId)
+                : userSearchResults[0];
+
+            if (!userDetails) {
+                return handleHttpError({
+                    res,
+                    message: 'Requested account is not associated with this phone number',
+                    statusCode: 403,
+                });
+            }
+
+            if (!requestedUserId && userSearchResults.length > 1) {
+                return handleHttpError({
+                    res,
+                    message: 'Multiple accounts are associated with this phone number; a userId is required',
+                    statusCode: 400,
+                });
+            }
+
+            if (userDetails.isBlocked) {
+                return handleHttpError({
+                    res,
+                    message: translate(locale, 'errorMessages.auth.accountNotVerified'),
+                    statusCode: 403,
+                });
+            }
+
+            // Same verification gate password login enforces. An account that has never
+            // confirmed its email cannot slip in through the SMS door — phone-first signups
+            // are granted the missing-properties level at creation precisely so they can.
+            if (!(userDetails.accessLevels?.includes(AccessLevels.EMAIL_VERIFIED)
+                || userDetails.accessLevels?.includes(AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES))) {
+                return handleHttpError({
+                    res,
+                    message: translate(locale, 'errorMessages.auth.accountNotVerified'),
+                    statusCode: 401,
+                });
+            }
+
+            // The SMS round-trip just proved this number, so persist that fact. `issueUserSession`
+            // writes the merged set back to the row as part of its normal audit update.
+            const accessLevels = new Set([
+                ...(userDetails.accessLevels || []),
+                AccessLevels.MOBILE_VERIFIED,
+            ]);
+
+            return issueUserSession(req, res, {
+                userDetails: {
+                    ...userDetails,
+                    accessLevels: [...accessLevels],
+                },
+                userSearchResults,
+                brandVariation,
+                platform,
             });
         })
         .catch((err) => handleHttpError({ err, res, message: 'SQL:AUTH_ROUTES:ERROR' }));
@@ -686,6 +871,8 @@ export {
     refreshToken,
     verifyToken,
     emailPrecheck,
+    phoneAccountLookup,
+    loginWithVerifiedPhone,
     mintHandoff,
     redeemHandoff,
     cancelHandoff,

--- a/therr-services/users-service/src/handlers/helpers/user.ts
+++ b/therr-services/users-service/src/handlers/helpers/user.ts
@@ -57,6 +57,36 @@ export interface IUserByInviteDetails {
     toEmail: string;
 }
 
+/**
+ * Everything about *how* a registration arrived, as opposed to *what* the user submitted.
+ * Collected into one bag because the flags are mutually informative (each one relaxes some
+ * part of the verification ceremony) and because a seven-argument positional signature had
+ * become impossible to read at the call sites.
+ */
+export interface ICreateUserOptions {
+    /** Registration came from an OAuth provider that already vouched for the email. */
+    isSSO?: boolean;
+    /** Account is being stubbed out on someone else's behalf (email invite). */
+    userByInviteDetails?: IUserByInviteDetails;
+    /** Registrant typed a friend's referral code. */
+    hasInviteCode?: boolean;
+    /** Magic invite-link token; proves control of whichever channel it was delivered on. */
+    inviteToken?: string;
+    /**
+     * Registration arrived with proof of contact-channel ownership (e.g. a pact claim
+     * token/code delivered to this exact email/phone). Treated like SSO for verification
+     * purposes: access levels are granted up-front and no verification email is sent.
+     */
+    isPreVerified?: boolean;
+    /**
+     * The API gateway validated a texted one-time code for `userDetails.phoneNumber` before
+     * this call (passwordless sign-up). Grants MOBILE_VERIFIED and admits the user to the
+     * app immediately — but, unlike `isPreVerified`, the email is still unproven, so the
+     * verification email is sent as usual.
+     */
+    isPhoneVerified?: boolean;
+}
+
 interface IGetUserHelperArgs {
     isAuthorized: boolean;
     requestingUserId?: string;
@@ -275,27 +305,27 @@ const isUserProfileIncomplete = (updateArgs, existingUser?) => {
     return !(updateArgs.userName || existingUser.userName);
 };
 
-// eslint-disable-next-line default-param-last
 const createUserHelper = (
     headers: InternalConfigHeaders,
     userDetails: IRequiredUserDetails,
-    // eslint-disable-next-line default-param-last
-    isSSO = false,
-    userByInviteDetails?: IUserByInviteDetails,
-    // eslint-disable-next-line default-param-last
-    hasInviteCode = false,
-    inviteToken?: string,
-    // Registration arrived with proof of contact-channel ownership (e.g. a
-    // pact claim token/code that was delivered to this exact email/phone).
-    // Treated like SSO for verification purposes: access levels are granted
-    // up-front and no verification email is sent.
-    isPreVerified = false,
+    options: ICreateUserOptions = {},
 ) => {
+    const {
+        isSSO = false,
+        userByInviteDetails,
+        hasInviteCode = false,
+        inviteToken,
+        isPreVerified = false,
+        isPhoneVerified = false,
+    } = options;
     // TODO: Supply user agent to determine if web or mobile
     const codeDetails = generateCode({ email: userDetails.email, type: 'email' });
     const verificationCode = { type: codeDetails.type, code: codeDetails.code };
-    // Create a different/random permanent password as a placeholder
-    const shouldGeneratePassword = (isSSO || !!userByInviteDetails);
+    // Create a different/random permanent password as a placeholder.
+    // Phone-first signups are passwordless by design — the user proved the handset and will
+    // keep signing in with a texted code — so they get a placeholder too unless they chose
+    // to set one during the email step.
+    const shouldGeneratePassword = (isSSO || !!userByInviteDetails || (isPhoneVerified && !userDetails.password));
     const password = shouldGeneratePassword ? generateOneTimePassword(8) : (userDetails.password || '');
     const hasAgreedToTerms = !userByInviteDetails;
     let user;
@@ -349,7 +379,13 @@ const createUserHelper = (
             if (userDetails.isDashboardRegistration) {
                 userAccessLevels.add(AccessLevels.DASHBOARD_SIGNUP);
             }
-            if (isSSO || isPreVerified) {
+            // Phone-first signup: the texted code proved the handset, which is what admits
+            // the user to the app. EMAIL_VERIFIED* is the gate `login` checks, so it is
+            // granted here on the strength of the phone rather than the email — the email
+            // itself is still unproven and still gets its verification message below.
+            // Squatting a *registered* address remains impossible: the unique constraint on
+            // main.users.email rejects the insert, exactly as on the password signup path.
+            if (isSSO || isPreVerified || isPhoneVerified) {
                 if (isMissingUserProps) {
                     userAccessLevels.add(AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES);
                 } else {
@@ -364,7 +400,7 @@ const createUserHelper = (
                     ? AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES
                     : AccessLevels.EMAIL_VERIFIED);
             }
-            if (phoneChannelVerified) {
+            if (phoneChannelVerified || isPhoneVerified) {
                 userAccessLevels.add(AccessLevels.MOBILE_VERIFIED);
             }
             const nowIso = new Date().toISOString();
@@ -636,6 +672,10 @@ const createUserHelper = (
             //    email/phone — the same ownership proof a verification link
             //    provides. Skipping removes the leave-the-app-verify-return wall
             //    between an invitee and their friend's pact.
+            //
+            // Deliberately NOT including isPhoneVerified: a phone-first signup proved the
+            // handset, not the address it typed afterwards. That user is let into the app
+            // right away, but the email still has to earn its own confirmation.
             if (emailChannelVerified || isPreVerified) {
                 return user;
             }
@@ -752,7 +792,7 @@ const validateCredentials = (headers: InternalConfigHeaders, userSearchResults, 
                         firstName: reqBody.userFirstName || fbUserFirstName,
                         lastName: reqBody.userLastName || fbUserLastName,
                         phoneNumber: reqBody.userPhoneNumber || (reqBody.ssoProvider === 'apple' ? 'apple-sso' : undefined),
-                    }, true, undefined, false).then((user) => [true, user, response]);
+                    }, { isSSO: true }).then((user) => [true, user, response]);
                 }
             }
 

--- a/therr-services/users-service/src/handlers/userConnections.ts
+++ b/therr-services/users-service/src/handlers/userConnections.ts
@@ -118,11 +118,13 @@ const createUserConnection: RequestHandler = async (req: any, res: any) => {
                     // This is disabled until we can find a better way to handle this.
                     unverifiedUser = await createUserHelper(req.headers, {
                         email: acceptingUserEmail,
-                    }, false, {
-                        fromName: fromUserFullName,
-                        fromEmail: requestingUserEmail,
-                        toEmail: acceptingUserEmail,
-                    }, false);
+                    }, {
+                        userByInviteDetails: {
+                            fromName: fromUserFullName,
+                            fromEmail: requestingUserEmail,
+                            toEmail: acceptingUserEmail,
+                        },
+                    });
                 } else {
                     return handleHttpError({
                         res,

--- a/therr-services/users-service/src/handlers/users.ts
+++ b/therr-services/users-service/src/handlers/users.ts
@@ -3,6 +3,7 @@ import {
     AccessLevels, COIN_PACKAGE_IDS, ErrorCodes, MetricNames, PushNotifications, ReferralRewards, UserConnectionTypes,
 } from 'therr-js-utilities/constants';
 import logSpan from 'therr-js-utilities/log-or-update-span';
+import { verifyPhoneVerificationToken } from 'therr-js-utilities/phone-verification-token';
 import { getBrandContext, parseHeaders } from 'therr-js-utilities/http';
 import handleHttpError from '../utilities/handleHttpError';
 import Store from '../store';
@@ -59,7 +60,16 @@ const createUser: RequestHandler = (req: any, res: any) => {
         inviteCode,
     } = req.body;
 
-    return Store.users.findUser(req.body)
+    // Passwordless sign-up: the API gateway texted a one-time code to this number and, on a
+    // correct answer, minted a short-lived signed token naming it. An absent/expired/forged
+    // token simply yields `undefined` here and registration proceeds as an ordinary
+    // email+password signup — there is no path where a bad token grants anything.
+    const verifiedPhoneNumber = verifyPhoneVerificationToken(req.body.phoneVerificationToken, 'register')?.phoneNumber;
+
+    return Store.users.findUser({
+        ...req.body,
+        phoneNumber: verifiedPhoneNumber || req.body.phoneNumber,
+    })
         .then((findResults) => {
             if (findResults.length) {
                 return handleHttpError({
@@ -236,15 +246,18 @@ const createUser: RequestHandler = (req: any, res: any) => {
                         settingsEmailBusMarketing: req.body.settingsEmailBusMarketing,
                         settingsLocale: req.body.settingsLocale || locale,
                         lastName: req.body.lastName,
-                        phoneNumber: req.body.phoneNumber,
+                        // Prefer the number inside the signed token over anything the client
+                        // typed: the token is the only version we have actually texted.
+                        phoneNumber: verifiedPhoneNumber || req.body.phoneNumber,
                         userName: req.body.userName,
                         accessLevels: levels,
                     },
-                    false,
-                    undefined,
-                    !!inviteCode,
-                    req.body.inviteToken,
-                    isPreVerifiedByPactClaim,
+                    {
+                        hasInviteCode: !!inviteCode,
+                        inviteToken: req.body.inviteToken,
+                        isPreVerified: isPreVerifiedByPactClaim,
+                        isPhoneVerified: !!verifiedPhoneNumber,
+                    },
                 );
             }).then(async (user) => {
                 let registrationSource = 'organic';

--- a/therr-services/users-service/src/routes/authRouter.ts
+++ b/therr-services/users-service/src/routes/authRouter.ts
@@ -3,8 +3,10 @@ import {
     cancelHandoff,
     emailPrecheck,
     login,
+    loginWithVerifiedPhone,
     logout,
     mintHandoff,
+    phoneAccountLookup,
     redeemHandoff,
     refreshToken,
     verifyToken,
@@ -27,6 +29,12 @@ router.post('/user-token/validate', verifyToken);
 // Pre-check an email (does NOT confirm account existence). Returns a hint the client uses to render
 // the next step (password field, SSO button, magic link, sign up).
 router.post('/email-precheck', emailPrecheck);
+
+// Passwordless phone auth (internal — the API gateway calls these after it has validated a
+// texted one-time code). `/phone/lookup` answers "which accounts use this number"; `/phone`
+// mints the session for the chosen one.
+router.post('/phone/lookup', phoneAccountLookup);
+router.post('/phone', loginWithVerifiedPhone);
 
 // Cross-app handoff (first-party single-sign-on between sister apps).
 router.post('/handoff/mint', mintHandoff);

--- a/therr-services/users-service/src/store/UsersStore.ts
+++ b/therr-services/users-service/src/store/UsersStore.ts
@@ -165,6 +165,28 @@ export default class UsersStore {
         return this.db.read.query(queryString).then((response) => response.rows);
     };
 
+    /**
+     * Full rows for every non-deleted account attached to a phone number, newest last.
+     *
+     * Distinct from `getByPhoneNumber` above, which returns a deliberately narrow projection
+     * for the "is this number already taken?" check and omits `id`. Passwordless sign-in
+     * needs the whole row (it mints a session from it) and needs to see *all* matches, since
+     * Therr permits a personal + creator + business account per number.
+     */
+    getAllByPhoneNumber = (phoneNumber: string, returning: any = '*') => {
+        const normalizedPhone = normalizePhoneNumber(phoneNumber as string);
+        const queryString = knexBuilder.select(returning)
+            .from(USERS_TABLE_NAME)
+            .where({
+                phoneNumber: normalizedPhone,
+                settingsIsAccountSoftDeleted: false,
+            })
+            .orderBy('createdAt', 'asc')
+            .toString();
+
+        return this.db.read.query(queryString).then((response) => response.rows);
+    };
+
     findUser = ({
         id,
         email,

--- a/therr-services/users-service/tests/unit/handlers-helpers-user.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-helpers-user.test.ts
@@ -131,7 +131,7 @@ describe('handlers/helpers/user', () => {
                 .value(new UserAchievementsStore(mockUserAchievementsStoreConnection as any));
             const awsStub = sinon.stub(awsSES, 'sendEmail').resolves({});
 
-            createUserHelper(mockHeaders, mockUserDetails, false, undefined, true).then((result) => {
+            createUserHelper(mockHeaders, mockUserDetails, { hasInviteCode: true }).then((result) => {
                 expect(mockVerificationCodesStoreConnection.write.query.args[0][0].includes(`insert into "main"."verificationCodes" ("code", "type") values (`))
                     .to.be.equal(true);
                 expect(mockVerificationCodesStoreConnection.write.query.args[0][0].includes(`', 'email')`))
@@ -204,7 +204,7 @@ describe('handlers/helpers/user', () => {
                 .value(new UserAchievementsStore(mockUserAchievementsStoreConnection as any));
             const awsStub = sinon.stub(awsSES, 'sendEmail').resolves({});
 
-            createUserHelper(mockHeaders, mockUserDetails, true).then((result) => {
+            createUserHelper(mockHeaders, mockUserDetails, { isSSO: true }).then((result) => {
                 expect(mockVerificationCodesStoreConnection.write.query.args[0][0].includes(`insert into "main"."verificationCodes" ("code", "type") values (`))
                     .to.be.equal(true);
                 expect(mockVerificationCodesStoreConnection.write.query.args[0][0].includes(`', 'email')`))
@@ -290,7 +290,7 @@ describe('handlers/helpers/user', () => {
                 .value(new UserAchievementsStore(mockUserAchievementsStoreConnection as any));
             const awsStub = sinon.stub(awsSES, 'sendEmail').resolves({});
 
-            createUserHelper(mockHeaders, mockUserDetails, false, mockUserByInviteDetails).then((result) => {
+            createUserHelper(mockHeaders, mockUserDetails, { userByInviteDetails: mockUserByInviteDetails }).then((result) => {
                 expect(mockVerificationCodesStoreConnection.write.query.args[0][0].includes(`insert into "main"."verificationCodes" ("code", "type") values (`))
                     .to.be.equal(true);
                 expect(mockVerificationCodesStoreConnection.write.query.args[0][0].includes(`', 'email')`))


### PR DESCRIPTION
The API gateway owns the SMS round-trip (Twilio + Redis code cache) but the
account it unlocks is created by the users-service. Rather than proxy the whole
registration through the gateway, it now mints a short-lived signed token naming
the verified phone number and hands it to the client, which passes it back on
registration.

Claims mirror the id/refresh token shape (iss/aud) with a distinct audience and
an explicit `type`, so a phone-verification token can never be replayed as a
session token or vice versa. Verification never throws — an absent, expired, or
forged token is indistinguishable from 'no proof supplied' to callers.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017gmoFWo77L377Wu6af7Ky2