### PR TITLE
fix(mobile): stay on the current screen when the locale changes

### DIFF
--- a/TherrMobile/__tests__/navigation/LocaleRemountState.test.tsx
+++ b/TherrMobile/__tests__/navigation/LocaleRemountState.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ */
+import 'react-native';
+import React from 'react';
+import { Text, View } from 'react-native';
+import {
+    NavigationContainer,
+    StackRouter,
+    createNavigationContainerRef,
+    createNavigatorFactory,
+    useNavigationBuilder,
+} from '@react-navigation/native';
+import renderer, { act } from 'react-test-renderer';
+
+// Note: import explicitly to use the types shipped with jest.
+import { it, describe, expect, beforeEach, afterEach } from '@jest/globals';
+
+/**
+ * Locale Remount Navigation State Regression Tests
+ *
+ * `Layout.tsx` keys its `NavigationContainer` on the active locale so that every route
+ * remounts and re-runs its translator when the language changes. Left alone, that remount
+ * drops the navigation state and the user is dumped back on the navigator's first screen —
+ * which is how changing the language from the sign-up screen used to bounce people out to
+ * the landing/sign-in screen.
+ *
+ * The fix mirrors the latest root state and feeds it back as `initialState` on remount.
+ * These tests pin both halves of that contract: the remount happens, and the stack survives it.
+ */
+
+/**
+ * A bare-bones stack navigator built on the same `StackRouter` the app's native stack uses.
+ * Going through `@react-navigation/native-stack` would drag in the native screen/header views,
+ * which don't render under Jest — and the behavior under test lives entirely in the router and
+ * the container, not in the presentation layer.
+ */
+const MinimalStackNavigator = ({ initialRouteName, children, screenOptions }: any) => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(StackRouter, {
+        initialRouteName,
+        children,
+        screenOptions,
+    });
+
+    return (
+        <NavigationContent>
+            <View>{descriptors[state.routes[state.index].key].render()}</View>
+        </NavigationContent>
+    );
+};
+
+const Stack = createNavigatorFactory(MinimalStackNavigator)();
+
+const LandingScreen = () => <Text>Landing</Text>;
+const LoginScreen = () => <Text>Login</Text>;
+const RegisterScreen = () => <Text>Register</Text>;
+
+interface ITestNavProps {
+    locale: string;
+    navigationRef: any;
+    // Mirrors Layout's `lastNavigationState` instance field.
+    stateRef: { current: any };
+    preserveState: boolean;
+}
+
+const TestNav = ({
+    locale, navigationRef, stateRef, preserveState,
+}: ITestNavProps) => (
+    <NavigationContainer
+        key={locale}
+        initialState={preserveState ? stateRef.current : undefined}
+        ref={navigationRef}
+        onReady={() => {
+            stateRef.current = navigationRef?.getRootState();
+        }}
+        onStateChange={() => {
+            stateRef.current = navigationRef?.getRootState();
+        }}
+    >
+        <Stack.Navigator>
+            <Stack.Screen name="Landing" component={LandingScreen} />
+            <Stack.Screen name="Login" component={LoginScreen} />
+            <Stack.Screen name="Register" component={RegisterScreen} />
+        </Stack.Navigator>
+    </NavigationContainer>
+);
+
+describe('locale-keyed NavigationContainer remount', () => {
+    let navigationRef: any;
+    let stateRef: { current: any };
+
+    beforeEach(() => {
+        navigationRef = createNavigationContainerRef();
+        stateRef = { current: undefined };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    const renderNav = async (locale: string, preserveState: boolean) => {
+        let component: renderer.ReactTestRenderer;
+        await act(async () => {
+            component = renderer.create(
+                <TestNav
+                    locale={locale}
+                    navigationRef={navigationRef}
+                    stateRef={stateRef}
+                    preserveState={preserveState}
+                />
+            );
+        });
+
+        return component!;
+    };
+
+    const navigateTo = async (routeName: string) => {
+        await act(async () => {
+            navigationRef.navigate(routeName);
+        });
+    };
+
+    const changeLocale = async (component: renderer.ReactTestRenderer, locale: string, preserveState: boolean) => {
+        await act(async () => {
+            component.update(
+                <TestNav
+                    locale={locale}
+                    navigationRef={navigationRef}
+                    stateRef={stateRef}
+                    preserveState={preserveState}
+                />
+            );
+        });
+    };
+
+    it('keeps the user on the sign-up screen when the locale changes', async () => {
+        const component = await renderNav('en-us', true);
+        await navigateTo('Register');
+        expect(navigationRef.getCurrentRoute()?.name).toBe('Register');
+
+        await changeLocale(component, 'es', true);
+
+        expect(navigationRef.getCurrentRoute()?.name).toBe('Register');
+    });
+
+    it('preserves the back stack so the user can still return to earlier screens', async () => {
+        const component = await renderNav('en-us', true);
+        await navigateTo('Login');
+        await navigateTo('Register');
+
+        await changeLocale(component, 'fr-ca', true);
+
+        expect(navigationRef.getRootState()?.routes.map((route: any) => route.name))
+            .toEqual(['Landing', 'Login', 'Register']);
+    });
+
+    it('remounts every route on locale change so stale translations cannot survive', async () => {
+        const component = await renderNav('en-us', true);
+        await navigateTo('Register');
+        const keyBeforeChange = navigationRef.getRootState()?.key;
+
+        await changeLocale(component, 'es', true);
+
+        expect(navigationRef.getRootState()?.key).not.toBe(keyBeforeChange);
+    });
+
+    it('falls back to the first screen without state preservation (the bug being fixed)', async () => {
+        const component = await renderNav('en-us', false);
+        await navigateTo('Register');
+
+        await changeLocale(component, 'es', false);
+
+        expect(navigationRef.getCurrentRoute()?.name).toBe('Landing');
+    });
+});

--- a/TherrMobile/main/components/Layout.tsx
+++ b/TherrMobile/main/components/Layout.tsx
@@ -207,6 +207,9 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
     private unsubscribePushNotifications;
     private urlEventListener;
     private routeNameRef: any = {};
+    // Latest navigation state, mirrored on every state change so it survives the
+    // locale-keyed remount of the NavigationContainer (see `render`).
+    private lastNavigationState: any = undefined;
     private theme = buildStyles();
     private themeBottomSheet = buildBottomSheetStyles();
     private themeButtons = buildButtonStyles();
@@ -1942,10 +1945,18 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
                 // Keyed on locale only so theme toggles do not remount the entire nav tree.
                 // Locale change still requires a remount because route translators close over locale at construction.
                     key={this.props.user?.settings?.locale || 'en-us'}
+                    // Restore the stack the user was already on across that remount. Without this the
+                    // navigator falls back to its first screen, so switching languages from, say, the
+                    // sign-up screen would bounce the user out to the landing/sign-in screen. Route
+                    // names are locale-independent (`translate` returns the key when it is not a
+                    // dictionary path), so a state captured under one locale is valid under any other.
+                    // Undefined on first mount, which is the normal "start at the initial route" case.
+                    initialState={this.lastNavigationState}
                     theme={buildNavTheme(this.theme, this.props.user?.settings?.mobileThemeName)}
                     ref={navigationRef}
                     onReady={() => {
                         this.routeNameRef.current = navigationRef?.getCurrentRoute()?.name;
+                        this.lastNavigationState = navigationRef?.getRootState();
                         Promise.allSettled(preLoadImageList.map((image) => {
                             const img = Image.resolveAssetSource(image).uri;
                             return Image.prefetch(img);
@@ -1958,6 +1969,9 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
                         });
                     }}
                     onStateChange={async () => {
+                        // Capture synchronously, before any await, so a locale change dispatched
+                        // during this tick still remounts with the up-to-date stack.
+                        this.lastNavigationState = navigationRef?.getRootState();
                         const previousRouteName = this.routeNameRef.current;
                         const currentRouteName = navigationRef?.getCurrentRoute()?.name;
                         if (currentRouteName !== 'Map') {


### PR DESCRIPTION
The NavigationContainer is keyed on the active locale so every route
remounts and re-runs its translator when the language changes. That
remount also discarded the navigation state, so the navigator fell back
to its first screen — changing the language from the sign-up screen
bounced the user out to the landing/sign-in screen instead of leaving
them where they were.

Mirror the root navigation state on every state change and feed it back
as `initialState` across the remount. Route names are locale-independent
(the translator returns the key when it is not a dictionary path), so a
state captured under one locale is valid under any other, and the
StackRouter drops any route that is no longer registered. Same fix
applies to the post-login locale picker in Settings.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AcHfRYKrJGxC2gENmEy6fV