### PR TITLE
docs: audit content-to-preference algorithm and propose optimizations

### DIFF
--- a/docs/ALGORITHM_AUDIT.md
+++ b/docs/ALGORITHM_AUDIT.md
@@ -333,14 +333,35 @@ Ordered by leverage-to-effort. Each is independently shippable, and (1) → (2) 
 
 | Phase | Work | Branch | Risk |
 |-------|------|--------|------|
-| 1 | O2.1 persist `relevanceScore` + reorder feed; O2.2 deterministic `search` order | `general` | Low — additive column, one `ORDER BY` |
-| 2 | O3.1 cache-gate the distributor; O3.2 batch preference writes + real logging | `general` | Low — behavior-preserving, immediately relieves S1/S2 |
+| 1 ✅ | O2.1 persist `relevanceScore` + reorder feed; O2.2 deterministic `search` order | `general` | Low — additive column, one `ORDER BY` |
+| 2 ✅ | O3.1 cache-gate the distributor; O3.2 batch preference writes + real logging | `general` | Low — behavior-preserving, immediately relieves S1/S2 |
 | 3 | O1.1–O1.3 affinity column, decay-on-write, upsert (shadow mode) | `general` | Medium — validate against `engagementCount` for one release |
 | 4 | O1.4 `score` collection (gateway validator + store) then mobile UI | `general`, then `niche/*` | Medium — must sequence backend first |
 | 5 | O1.5–O1.7 weighted ranking + SQL overlap scoring; O2.3 shared scoring module | `general` | Medium — flag-gated, A/B on weights |
 | 6 | O2.4 geo/interest unification; O2.5 diversity; O3.3–O3.5 materialization | `general` | Higher — largest UX change, do last with measurement in place |
 
 Phases 1 and 2 are worth doing regardless of whether the rest proceeds: phase 1 makes existing ranking work visible to users for the first time, and phase 2 removes the dominant scaling liability. Both are small, low-risk, and independently valuable.
+
+### Phases 1 and 2 — shipped
+
+Both are implemented. What landed, and what it changes:
+
+**Phase 1** — `main.thoughtReactions` gains `relevanceScore` / `scoredAt` plus a partial index on `(userId, relevanceScore DESC NULLS LAST, createdAt DESC) WHERE userHasActivated`. `getRecentThoughts` now returns the hot score it was already computing (the expression is hoisted into one constant so `SELECT` and `ORDER BY` cannot drift), the distributor carries per-thought scores through `createReactions` onto the reaction rows with a 1.5× boost for interest matches, and `searchActiveThoughts` orders by relevance and restores that order after the thoughts lookup re-sorts by `createdAt`. `ThoughtsStore.search` gained the `ORDER BY` it never had.
+
+Two consequences to watch on rollout:
+
+- Pre-existing reaction rows have a NULL score and sort last, so existing users see a **one-time feed reshuffle** on first load after deploy — in the intended direction, but visible.
+- `lastContentCreatedAt` is no longer forwarded on the feed path (it is a `createdAt` cursor, wrong axis for a relevance-ordered page, and would silently drop high-scoring recent thoughts). The author-profile path still uses it. Offset pagination over a relevance-ordered list can still repeat an item when a new activation lands mid-scroll; that was already true of the createdAt ordering and is properly fixed only by keyset pagination.
+
+**Phase 2** — the distributor is gated to one run per user per window (`THOUGHT_DISTRIBUTOR_MIN_INTERVAL_SECONDS`, default 900s) via an atomic `SET NX EX` on the existing ephemeral Redis client. Login stays ungated so a new session always seeds the stream. The gate **fails open**: if Redis is unreachable the distributor runs, exactly as before. The general-candidate query now requests 1 row instead of a full page when only a fallback is needed.
+
+Redis footprint is intentionally negligible: one key per *recently active* user holding the literal `'1'`, ~90 bytes with overhead, self-expiring. 100k users active inside one window is under 10 MB, and idle users hold nothing. It is not a cache that needs to stay warm — losing the entire keyspace only means each user's next poll runs the distributor once more than it strictly needed to.
+
+Interest engagement writes are coalesced per user in an **in-process** buffer (`INTEREST_ENGAGEMENT_FLUSH_INTERVAL_MS`, default 10s) and flushed as one request with merged counts, so a user scrolling twenty moments produces one write instead of twenty. This deliberately uses no Redis at all — engagement counts are best-effort telemetry and a per-replica buffer costs no shared infrastructure. The trade-off is that increments buffered when a pod is hard-killed are lost; a SIGTERM flush covers graceful shutdown. The `.catch(console.log)` that made a broken preference loop invisible is now a `logSpan` error.
+
+The users-service increment endpoint accepts both the new coalesced (`interestIncrements`) and legacy (`interestDisplayNameKeys` + `incrBy`) payloads, and senders emit both, so a rolling deploy in either order keeps recording.
+
+Still open from Optimization 3 and explicitly **not** done: materialized user interest vectors and precomputed candidate pools (O3.3, O3.4). Those are the Redis-memory-heavy parts.
 
 ## 6. Instrumentation to add before phase 6
 

--- a/docs/ALGORITHM_AUDIT.md
+++ b/docs/ALGORITHM_AUDIT.md
@@ -1,0 +1,352 @@
+# Therr Content–Preference Algorithm Audit
+
+**Date:** 2026-07-26
+**Scope:** How user preferences are captured, stored, and used to select and order content across all four personalization surfaces.
+**Status:** Audit only — no behavioral code changed. All remediation described here touches `therr-services/**` and `therr-public-library/**`, so it **must land on `general`**, never a `niche/*` branch (see `CLAUDE.md` § Deployment reality).
+
+---
+
+## 1. Inventory — what "the algorithm" actually is
+
+There is no single ranker. There are four independent surfaces, only one of which is genuinely personalized, and they share no scoring code.
+
+| # | Surface | Entry point | Preference-aware? | Geo-aware? |
+|---|---------|-------------|-------------------|------------|
+| 1 | **Thought distributor** (stream activation) | `users-service/src/api/TherrEventEmitter.ts` → `ThoughtsStore.getRecentThoughts` | Yes (boolean interest filter) | **No** |
+| 2 | **Map content search** (moments / spaces / events) | `maps-service/src/store/{Moments,Spaces,Events}Store.ts` → `search*` | **No** | Yes (`ST_DWithin` + `ST_Distance ASC`) |
+| 3 | **Activity Generator** (group meetup suggestions) | `maps-service/src/handlers/activities.ts` → `SpacesStore.searchRelatedSpaces` | Yes (ranked, group-intersected) | Yes |
+| 4 | **Preference learning loop** | `{maps,reactions}-service/src/utilities/incrementInterestEngagement.ts` → `users-service` `POST /users/interests/increment` | — (this *is* the model) | No |
+
+### The data model
+
+`main.interests` — static taxonomy (`tag`, `categoryKey`, `displayNameKey`, `emoji`), seeded from `users-service/src/store/seeds/001_interests.js`.
+
+`main.userInterests` — the entire user preference model, three columns wide:
+
+```js
+// 20240429134308_main.userInterests.js
+table.integer('score').notNullable().defaultTo(5);           // "1 - 5 where 1 is the highest"
+table.integer('engagementCount').notNullable().defaultTo(0);
+table.bool('isEnabled').notNullable().defaultTo(false);
+```
+
+Content side: `interestsKeys jsonb` on `main.moments`, `main.spaces`, `main.events` (maps-service) and `main.thoughts` (users-service), each with a GIN index (`idx_*_interests_keys`, default `jsonb_ops` — correctly supports the `?|` operator used at query time).
+
+The one place the two sides are combined into a number:
+
+```ts
+// users-service/src/handlers/userConnections.ts:29
+const getInterestRanking = (engagementCount: number, score: number) =>
+    Math.ceil((engagementCount || 1) / (score || 5));
+```
+
+---
+
+## 2. Effectiveness findings
+
+### E1 — The declared-preference dimension is inert
+
+`score` is documented as "1–5 where 1 is the highest" and defaults to `5` (the *lowest* priority). Nothing ever writes a different value:
+
+- `CreateProfileInterests.tsx:87-102` builds `{ interestId, isEnabled }` — **no `score` field**.
+- `ManagePreferences.tsx` likewise sends no score.
+- `therr-api-gateway/src/services/users/validation/` has no `userInterests` validator at all, so the field is unvalidated pass-through.
+
+Every row in production therefore has `score = 5`, and `getInterestRanking` degenerates to `Math.ceil(engagementCount / 5)`. The user's *stated* preferences contribute exactly zero to ranking; only implicit behavior does.
+
+Two follow-on defects in the same code path:
+
+- `Math.ceil(... / 5)` quantizes hard. Engagement counts 1–5 all produce ranking `1`; 6–10 all produce `2`. The `|| 1` on `engagementCount` means a never-engaged interest ties with one engaged five times. Most users' interests are all tied at rank 1.
+- `UserInterestsStore.create` does `score: Math.min(param.score || 5, 5)` — it clamps the top but not the bottom, and `param.score || 5` silently rewrites a legitimate `0` to `5`.
+
+### E2 — Behavior cannot discover new interests
+
+```ts
+// UserInterestsStore.incrementUserInterests
+.increment('engagementCount', incrBy)
+.where({ userId })
+.whereIn('interestId', (b) => b.select('id').from(INTERESTS_TABLE_NAME)
+    .whereIn('displayNameKey', interestDisplayNameKeys))
+```
+
+This is an `UPDATE`, not an upsert. If no `userInterests` row exists for that `(userId, interestId)` pair, the signal is silently discarded — the handler still returns 200.
+
+Onboarding happens to insert rows for *all* interests (enabled and disabled), which papers over this for users who complete onboarding. But it produces a second problem: engagement accrues on interests the user explicitly **disabled**, and there is no path that ever surfaces that ("you keep opening coffee content — re-enable coffee?"). For users who skip onboarding, sign up via SSO, or predate the interests feature, the model never learns anything at all, permanently.
+
+### E3 — No decay and no normalization
+
+`engagementCount` is monotonically increasing with no half-life, no recency weighting, and no per-user normalization. Consequences:
+
+- A user's ranking is frozen around whatever they did in their first weeks. A newly acquired interest can never overtake an old one within any realistic session count.
+- In `getTopRankedConnections`, rankings from different users are summed directly (`ranking: (existing.ranking || 0) + u.ranking`). Heavy users' interest vectors dominate the group intersection purely because they have more raw engagement, not stronger preference.
+
+### E4 — Interest matching is an unweighted boolean OR
+
+Every content query uses the same shape:
+
+```ts
+query.whereRaw(`"interestsKeys" \\?| ARRAY[${placeholders}]::text[]`, relatedInterestsKeys);
+```
+
+`?|` is "overlaps with any". Matching 1 of a user's 30 interests scores identically to matching 8 of their top 8. Worse, the distributor discards its own ranking before querying:
+
+```ts
+// TherrEventEmitter.ts:29-30 — every enabled interest, flat, engagementCount ignored
+const interestsKeys = contextUsers.reduce((acc, cur) =>
+    [...acc, ...(cur?.userInterests || []).map((i: any) => i.displayNameKey)], []);
+```
+
+`findUsersWithInterests` selects `score` and `engagementCount` and the distributor throws both away. For an engaged user with many interests, the filter's selectivity approaches zero — it's equivalent to no personalization.
+
+### E5 — Relevance is computed, then discarded before the user sees it
+
+`getRecentThoughts` does real ranking work — a Hacker-News-style hot score with a deliberately benchmarked correlated subquery:
+
+```sql
+ORDER BY ("replyCount" + 1) / POWER((EXTRACT(EPOCH FROM (NOW() - "createdAt")) / 3600) + 2, 1.5) DESC
+```
+
+That score decides *which* thoughts get activated. It is then thrown away. Activation writes `thoughtReactions` rows via `createReactions`, and the read path (`ThoughtReactionsStore.get`) orders by the **reaction's** `createdAt`:
+
+```ts
+.limit(restrictedLimit)
+.orderBy('createdAt', filters.order)
+```
+
+A distributor run activates 7–20 thoughts (`randomIntFromInterval(7, 20)`) in a single batch with effectively identical timestamps. Intra-batch order is arbitrary. **No column anywhere persists the relevance score**, so the user's feed is ordered by activation batch, not by relevance.
+
+The direct search path is worse — `ThoughtsStore.search` has no `ORDER BY` at all, with the reason in a comment:
+
+```ts
+// TODO: Determine a better way to select thoughts that are most relevant to the user
+// .orderBy(`${THOUGHTS_TABLE_NAME}.updatedAt`) // Sorting by updatedAt is very expensive/slow
+```
+
+Postgres returns rows in whatever order the plan yields, and pagination over an unordered query can repeat and skip rows.
+
+### E6 — The personalized surface has no geography; the geographic surface has no personalization
+
+This is the central structural gap in a location-based product.
+
+- The thought distributor applies **no location filter whatsoever**. A user in Chicago is served the globally-hottest interest-matching thoughts.
+- `searchMoments`, `SpacesStore.searchSpaces`, and `searchEvents` **never reference `interestsKeys`**. Their ordering is strictly `ST_Distance(...) ASC` (or `createdAt DESC` with no coordinates), inside a 1 km default radius (`Location.AREA_PROXIMITY_METERS = 1000`).
+
+So on the map — the primary surface — the entire preference model is unused, and the one surface that uses it ignores where the user is. Only the Activity Generator (surface 3) combines both, and it is reachable only from a dedicated screen.
+
+### E7 — Candidate pool is a narrow global recency window
+
+`getRecentThoughts` bounds candidates to `candidatePoolSize = 200` newest matching rows, then re-ranks. There is no author diversity constraint, so a prolific poster can occupy most of the pool, and no evergreen content can ever re-enter it. Both distributor calls also always execute:
+
+```ts
+Promise.all([
+    interestsKeys.length ? Store.thoughts.getRecentThoughts(brand, numThoughts, interestsKeys) : Promise.resolve([]),
+    Store.thoughts.getRecentThoughts(brand, numThoughts),   // always runs
+]);
+```
+
+On the notifications-poll path (`recentUsersCount = 0`), the second result is used only as a one-item fallback — a full ranked query executed and discarded on every poll.
+
+### E8 — The signal set is tiny, coarse, and strictly non-negative
+
+Only three events feed the model, all with hardcoded weights:
+
+| Event | Weight | Call site |
+|-------|--------|-----------|
+| View a moment | +2 | `maps-service/src/handlers/moments.ts:990` |
+| View a space | +2 | `maps-service/src/handlers/spaces.ts:380` |
+| Check in to a space | +3 | `maps-service/src/handlers/spaceMetrics.ts:193` |
+| View an event | +2 | `maps-service/src/handlers/events.ts:792` |
+
+Not captured: likes, bookmarks, shares, dwell time, replies, event RSVPs, connection overlap — despite `reactions-service` already recording most of them. And there is **no negative signal path**: no skip, hide, mute, or report ever decrements. The model's confidence is monotonically increasing in every direction, which is why E3 (no decay) compounds so quickly. A single accidental tap is indistinguishable from sustained interest, since a view fires the increment regardless of dwell.
+
+---
+
+## 3. Scale findings
+
+### S1 — The distributor runs on every notifications poll
+
+```ts
+// users-service/src/handlers/notifications.ts:104-113
+setImmediate(() => {
+    TherrEventEmitter.runThoughtDistributorAlgorithm(req.headers, [userId], 'updatedAt', 0);
+});
+```
+
+The code's own comment flags this: *"We will probably want to move this to a scheduler to run at a set interval."* Every notification fetch by every client currently costs:
+
+1. `findUsersWithInterests` — 3-table join (`users` ⋈ `userInterests` ⋈ `interests`)
+2. Two `getRecentThoughts` calls — each a 200-row candidate scan with a correlated `COUNT(*)` subquery per candidate, then a non-indexable `ORDER BY`
+3. One cross-service HTTP `POST /thought-reactions/create-update/multiple` inserting/updating up to ~20 rows
+
+Write amplification is `O(users × polls_per_session × 20)`. This is the single largest scaling liability in the system; it grows with *polling frequency*, which is unrelated to content volume or user value.
+
+### S2 — Preference writes are per-view, cross-service, and unobservable
+
+`incrementInterestEngagement` issues an internal REST call **per content view**, which performs a multi-row `UPDATE` joined against a subquery on `main.interests`. It is fire-and-forget with no backpressure:
+
+```ts
+}).catch((err) => {
+    console.log(err);
+});
+```
+
+Failures are invisible to monitoring (bare `console.log`, no `logSpan`), in-flight requests are unbounded, and the pattern means every content impression is a synchronous write to the users-service DB. Row-level lock contention on `userInterests` scales with impressions, not with users.
+
+### S3 — Ranking work happens in Node, per request
+
+`getTopRankedConnections` pulls every interest row for every nearby connection and builds `interestsIdMap` in application memory, then `activities.ts` re-sorts it — `O(connections × interests)` object churn on every Activity Generator invocation, with no caching of the resulting group interest vector.
+
+### S4 — No caching or materialization anywhere in the personalization path
+
+There is no precomputed user interest vector, no cached candidate set, and no memoization of any ranking output. Every request recomputes from base tables.
+
+### S5 — Query-shape ceilings
+
+- `searchRelatedSpaces` is hardcoded to `LIMIT 5` with no `offset` — the Activity Generator can never paginate, and `activities.ts` already carries the matching `// TODO: Continue pagination if group size is not satisfied`.
+- The GIN indexes on `interestsKeys` are correct, but they can't be combined with the `ORDER BY createdAt DESC LIMIT 200` in the same index path — Postgres will bitmap-scan then sort. That's acceptable at current volume but degrades as any single interest's matching-row count grows.
+- `searchMoments` / `searchSpaces` paginate with `LIMIT/OFFSET` over a `ST_Distance` sort, which re-sorts the full candidate set for every deep page.
+
+---
+
+## 4. Three optimizations
+
+Ordered by leverage-to-effort. Each is independently shippable, and (1) → (2) → (3) is the recommended sequence: (1) makes the signal worth ranking on, (2) makes the ranking reach the user, (3) makes it affordable.
+
+---
+
+### Optimization 1 — Turn the preference model into a weighted, decaying vector
+
+**Problem addressed:** E1, E2, E3, E4, E8.
+
+**Why first:** every downstream ranking improvement is bounded by signal quality. Right now the model is effectively a boolean set membership test with a nearly-constant ranking function; no amount of ranking sophistication downstream can recover information the model never captured.
+
+**Changes:**
+
+1. **Add real affinity storage.** Migration on `main.userInterests` (users-service, `general` branch):
+   ```js
+   table.float('affinityScore').notNullable().defaultTo(0);
+   table.timestamp('lastEngagedAt', { useTz: true }).nullable();
+   table.integer('negativeCount').notNullable().defaultTo(0);
+   table.enu('source', ['declared', 'implicit', 'both']).notNullable().defaultTo('declared');
+   ```
+   Keep `engagementCount` for one release as a shadow column so the new score can be validated against the old ranking before cutover.
+
+2. **Apply decay on write, not in a batch job.** On each increment, decay the stored value to *now* before adding — no cron, no full-table sweep:
+   ```
+   affinityScore := affinityScore * 0.5 ^ ((now - lastEngagedAt) / HALF_LIFE) + weight
+   lastEngagedAt := now
+   ```
+   A 45-day half-life is a reasonable starting point for a local-discovery product (seasonal interests should fade within a quarter). Expose it as config so it's tunable without a deploy.
+
+3. **Make the increment an upsert** so behavior can discover interests the user never declared, inserting with `source = 'implicit'` and a discount factor (e.g. 0.6×) relative to declared interests. This closes E2 for SSO and onboarding-skip users and gives the "re-enable coffee?" prompt a data source.
+
+4. **Fix `score` semantics and actually collect it.** Either invert the column to a conventional "higher is stronger" weight (with a migration that flips existing values) or — simpler and lower-risk — leave the column and have `CreateProfileInterests.tsx` send `score: 1` for a small number of user-marked "must-have" interests and `3` for ordinary selections. Add a `userInterests` validator in `therr-api-gateway` (currently absent) enforcing `1 ≤ score ≤ 5` so the `Math.min(param.score || 5, 5)` clamp bug can't be reached. **Note the split:** the validator and store changes go on `general`; the `CreateProfileInterests.tsx` change is mobile UI and can ride a niche branch, but it is useless until the backend lands — sequence `general` first.
+
+5. **Replace `getInterestRanking` with a continuous weight** and drop `Math.ceil` entirely:
+   ```ts
+   const getInterestWeight = (affinityScore: number, score: number, negativeCount: number) => {
+       const declaredWeight = (6 - clamp(score, 1, 5)) / 5;   // score 1 → 1.0, score 5 → 0.2
+       const behavioral = Math.log1p(Math.max(affinityScore, 0));
+       return declaredWeight * (1 + behavioral) / (1 + negativeCount * 0.5);
+   };
+   ```
+   Multiplicative, not divisive: declared and behavioral signals reinforce rather than cancel.
+
+6. **Widen and sign the signal set.** Route existing `reactions-service` events (like, bookmark, share, RSVP, reply) into the same increment endpoint with distinct weights, and add a negative path (`hide`, `report`, `not interested`) that increments `negativeCount`. Gate the view-based increment behind a minimum dwell (the client already has the timing) so a bounce doesn't count as interest.
+
+7. **Score the overlap instead of testing it.** Replace `?| ARRAY[...]` with a weighted sum computed in SQL, passing the user's top-N weighted keys:
+   ```sql
+   (SELECT COALESCE(SUM(w.weight), 0)
+      FROM jsonb_array_elements_text(t."interestsKeys") k
+      JOIN unnest(?::text[], ?::float[]) AS w(key, weight) ON w.key = k.value)
+   AS "interestScore"
+   ```
+   Keep the `?|` predicate as the index-using *filter* (so the GIN index still prunes) and use the sum only for *ordering*. Cap the passed key list to the user's top 8–10 weighted interests — this simultaneously restores the filter's selectivity (E4) and bounds the sum's cost.
+
+**Expected effect:** the filter goes from ~0 selectivity to genuinely discriminating; stale interests fade; the model can learn interests the user never declared; ranking gains real resolution instead of 2–3 tied integer buckets.
+
+**Validation:** ship with `affinityScore` computed in shadow alongside `engagementCount` for one release. Log rank correlation between old and new orderings; only cut the read path over once the distributions are understood.
+
+---
+
+### Optimization 2 — Persist relevance, and unify geo + interest into one shared scoring function
+
+**Problem addressed:** E5, E6, E7, and the four-surfaces-no-shared-code problem.
+
+**Why second:** E5 is the highest single-fix ROI in the audit — the system already computes a defensible hot score and then discards it at read time. Fixing that is a column plus an `ORDER BY`.
+
+**Changes:**
+
+1. **Persist the score at activation.** Add `relevanceScore float` (and `scoredAt`) to `main.thoughtReactions` in reactions-service. Have `getRecentThoughts` return its computed hot score, pass it through `createReactions`, and change `ThoughtReactionsStore.get` to `ORDER BY "relevanceScore" DESC NULLS LAST, "createdAt" DESC`. This alone converts the feed from "arbitrary within activation batch" to "actually ranked" — the ranking logic already exists and is already benchmarked.
+
+2. **Give `ThoughtsStore.search` a deterministic order.** The current no-`ORDER BY` state (with the "sorting by updatedAt is very expensive" comment) makes pagination unsound — rows can repeat and vanish across pages. Order by `(relevanceScore, createdAt, id)` with a covering index, or switch to keyset pagination on `(createdAt, id)`; either is cheaper than the `OFFSET` scan it replaces.
+
+3. **Extract one scoring module** into `therr-js-utilities` (isomorphic, per the repo's abstraction rules — it's a pure function over numbers and is needed by three services):
+   ```
+   score = w_interest  * weightedInterestOverlap
+         + w_geo       * exp(-distanceMeters / GEO_SCALE)
+         + w_recency   * 1 / (ageHours + 2)^1.5
+         + w_social    * connectionAffinity
+         + w_quality   * log1p(engagementCount)
+   ```
+   Weights come from config, not literals, so they're A/B-testable without a deploy. All four surfaces call it. Today the hot-score constants (`+1`, `+2`, `^1.5`) and the engagement weights (`+2`, `+2`, `+3`) are hardcoded in five different files.
+
+4. **Close the geo/interest split (E6).** Two symmetric fixes:
+   - Add an optional interest-weighted ordering to `searchMoments` / `searchSpaces` / `searchEvents`. Keep `ST_DWithin` as the index-using filter, but replace the pure `ST_Distance ASC` sort with the blended score above. Ship behind a flag defaulting to current behavior, so the map's existing distance-sorted UX is opt-in-changed rather than silently altered.
+   - Add a location filter to the distributor. It currently serves globally-hot thoughts to a location-based product; bounding the candidate pool to the user's region is both a relevance win and a cost reduction.
+
+5. **Add diversity constraints to candidate selection (E7).** Cap candidates per author and per interest within a batch (a `ROW_NUMBER() OVER (PARTITION BY "fromUserId")` filter in the inner query is sufficient), so one prolific poster can't own a user's feed.
+
+6. **Skip the wasted query.** On the `recentUsersCount = 0` path, the general `getRecentThoughts` call runs in full and contributes at most one fallback item. Make it conditional, or request `limit 1`.
+
+**Expected effect:** relevance actually reaches the user; the map surface becomes personalized for the first time; ranking behavior becomes tunable and testable from one place instead of five.
+
+---
+
+### Optimization 3 — Move personalization off the request path
+
+**Problem addressed:** S1, S2, S3, S4 — the scale half of the brief.
+
+**Why third:** optimizations 1 and 2 add per-request work (weighted overlap sums, blended scoring). Without this, they make S1 worse. This is what makes the first two affordable.
+
+**Changes:**
+
+1. **Stop running the distributor on every notifications poll (S1).** Two options, in preference order:
+   - **Cache-gated trigger (smaller change, most of the win):** before running, check a Redis key `distributor:lastRun:{userId}`. Skip unless it's older than N minutes *or* the user's unviewed activated-thought count has dropped below a threshold. This turns `O(polls)` into `O(sessions)` — likely a 10–50× reduction in distributor invocations with a ~20-line change.
+   - **Queue it properly:** emit a job on login and on stream-exhaustion, processed by a worker. This is where the code's own TODO points, and it's the right end state, but it needs queue infrastructure that doesn't exist yet.
+
+   Either way, keep the `setImmediate` deferral — it's already correct for not blocking the response.
+
+2. **Batch and debounce preference writes (S2).** Replace the per-view internal REST call with an in-process buffer flushed on an interval (or a Redis `HINCRBY` per `(userId, interestKey)` flushed by a worker). One `UPDATE ... FROM (VALUES ...)` per flush instead of one HTTP round-trip plus a subquery-joined `UPDATE` per impression. Also replace the bare `.catch(console.log)` with `logSpan` so these failures become visible — right now a fully broken preference-learning loop would produce no alert.
+
+3. **Materialize the user interest vector (S3, S4).** A `main.userInterestVectors` table (or Redis hash) holding each user's top-N `(interestKey, weight)` pairs, refreshed on flush. The distributor and `getTopRankedConnections` then read one row instead of a 3-table join plus `O(connections × interests)` in-memory aggregation. This is also exactly the input shape Optimization 1's weighted-overlap query needs, so the two compose.
+
+4. **Precompute candidate pools.** Cache candidate content IDs per `(brand, geohash-cell, interest)` with a short TTL, invalidated on content creation in that cell. Candidate selection becomes a cache read instead of a scan, which is what lifts the ceiling on E7's 200-row recency window — you can widen the pool without widening the per-request scan.
+
+5. **Fix the pagination ceilings (S5).** Give `searchRelatedSpaces` a `limit`/`offset` (retiring the `// TODO: Continue pagination` in `activities.ts`), and move deep pagination on the map searches from `LIMIT/OFFSET` to keyset pagination on the sort key.
+
+**Expected effect:** removes the growth term that scales with polling frequency rather than users or content; makes the added scoring cost from Optimizations 1–2 a cache read rather than a join.
+
+---
+
+## 5. Suggested sequencing
+
+| Phase | Work | Branch | Risk |
+|-------|------|--------|------|
+| 1 | O2.1 persist `relevanceScore` + reorder feed; O2.2 deterministic `search` order | `general` | Low — additive column, one `ORDER BY` |
+| 2 | O3.1 cache-gate the distributor; O3.2 batch preference writes + real logging | `general` | Low — behavior-preserving, immediately relieves S1/S2 |
+| 3 | O1.1–O1.3 affinity column, decay-on-write, upsert (shadow mode) | `general` | Medium — validate against `engagementCount` for one release |
+| 4 | O1.4 `score` collection (gateway validator + store) then mobile UI | `general`, then `niche/*` | Medium — must sequence backend first |
+| 5 | O1.5–O1.7 weighted ranking + SQL overlap scoring; O2.3 shared scoring module | `general` | Medium — flag-gated, A/B on weights |
+| 6 | O2.4 geo/interest unification; O2.5 diversity; O3.3–O3.5 materialization | `general` | Higher — largest UX change, do last with measurement in place |
+
+Phases 1 and 2 are worth doing regardless of whether the rest proceeds: phase 1 makes existing ranking work visible to users for the first time, and phase 2 removes the dominant scaling liability. Both are small, low-risk, and independently valuable.
+
+## 6. Instrumentation to add before phase 6
+
+None of the above can be evaluated today — there is no logging of what was served, why, or whether it was engaged with. Before changing ranking weights, add:
+
+- Impression logging with the score components that produced each ranking (needed to attribute any metric change to a specific term).
+- Per-surface CTR and dwell, split by whether the item matched a declared vs. implicit interest.
+- Distributor invocation count and activated-thought consumption rate (validates O3.1's cache-gate threshold).
+- Shadow-mode rank correlation between old and new scoring during phases 3 and 5.

--- a/therr-services/maps-service/src/utilities/incrementInterestEngagement.ts
+++ b/therr-services/maps-service/src/utilities/incrementInterestEngagement.ts
@@ -1,23 +1,149 @@
+import logSpan from 'therr-js-utilities/log-or-update-span';
 import { internalRestRequest, InternalConfigHeaders } from 'therr-js-utilities/internal-rest-request';
 import * as globalConfig from '../../../../global-config';
+
+// Interest engagement used to be one internal REST call — and one subquery-joined UPDATE in
+// users-service — per content view. Views are the highest-volume event in the system, so
+// preference writes scaled with impressions rather than with users, and row-level lock
+// contention on main."userInterests" scaled with them too.
+//
+// Increments are now coalesced in-process per user and flushed on a short interval. A user
+// scrolling twenty moments produces one request with merged interest counts instead of
+// twenty requests.
+//
+// The buffer is deliberately in-memory rather than in Redis: engagement counts are
+// best-effort telemetry, and a per-replica buffer needs no shared infrastructure and no
+// additional Redis memory. The trade-off is that increments still buffered when a pod is
+// killed are lost. That is acceptable for a counter whose call sites were already
+// fire-and-forget, and a SIGTERM flush covers the common (graceful) case.
+//
+// NOTE: this file is intentionally identical to the reactions-service copy of the same
+// name. Keep the two in sync.
+
+const FLUSH_INTERVAL_MS = Number(process.env.INTEREST_ENGAGEMENT_FLUSH_INTERVAL_MS) || 10000;
+// Backstop against unbounded growth if the flush target is unreachable for a long time.
+const MAX_BUFFERED_USERS = Number(process.env.INTEREST_ENGAGEMENT_MAX_BUFFERED_USERS) || 1000;
+const MAX_EVENT_INCREMENT = 5;
+
+interface IBufferedEngagement {
+    headers: InternalConfigHeaders;
+    incrementsByKey: { [interestKey: string]: number };
+}
+
+// Keyed by userId — the flush endpoint derives the user from request headers, so one
+// request per user is the smallest unit we can batch into.
+const buffer = new Map<string, IBufferedEngagement>();
+let flushTimer: NodeJS.Timeout | null = null;
+
+const reportFlushFailure = (userId: string, entry: IBufferedEngagement, err: any) => {
+    // Previously a bare console.log, which meant a fully broken preference-learning loop
+    // would raise no alert anywhere.
+    logSpan({
+        level: 'error',
+        messageOrigin: 'API_SERVER',
+        messages: ['Failed to flush interest engagement', err?.message],
+        traceArgs: {
+            'user.id': userId,
+            issue: 'interest engagement increments dropped',
+            'interest.keyCount': Object.keys(entry.incrementsByKey).length,
+        },
+    });
+};
+
+// Never rejects, and never throws synchronously: flushes are driven by a background timer,
+// so an escaping error would surface as an unhandled rejection rather than a failed request.
+const flushUser = (userId: string, entry: IBufferedEngagement) => {
+    try {
+        return internalRestRequest({
+            headers: entry.headers,
+        }, {
+            method: 'post',
+            url: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}/users/interests/increment`,
+            data: {
+                interestIncrements: entry.incrementsByKey,
+                // Legacy shape, sent alongside the new one so that during a rolling deploy an
+                // older users-service pod still records something sensible rather than nothing.
+                interestDisplayNameKeys: Object.keys(entry.incrementsByKey),
+                incrBy: Math.min(MAX_EVENT_INCREMENT, Math.max(...Object.values(entry.incrementsByKey))),
+            },
+        }).catch((err) => reportFlushFailure(userId, entry, err));
+    } catch (err) {
+        reportFlushFailure(userId, entry, err);
+        return Promise.resolve();
+    }
+};
+
+const flushInterestEngagement = () => {
+    if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+    }
+
+    if (!buffer.size) {
+        return Promise.resolve([]);
+    }
+
+    // Swap the buffer out before awaiting so increments arriving during the flush
+    // accumulate into the next window instead of being dropped.
+    const draining = Array.from(buffer.entries());
+    buffer.clear();
+
+    return Promise.all(draining.map(([userId, entry]) => flushUser(userId, entry)));
+};
+
+const scheduleFlush = () => {
+    if (flushTimer) {
+        return;
+    }
+    flushTimer = setTimeout(() => {
+        flushTimer = null;
+        flushInterestEngagement();
+    }, FLUSH_INTERVAL_MS);
+    // Don't hold the event loop open purely for a pending flush.
+    flushTimer.unref?.();
+};
 
 const incrementInterestEngagement = (interestsKeys: string[], incrBy: number, headers: InternalConfigHeaders) => {
     if (!interestsKeys?.length) {
         return Promise.resolve({});
     }
 
-    return internalRestRequest({
-        headers,
-    }, {
-        method: 'post',
-        url: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}/users/interests/increment`,
-        data: {
-            interestDisplayNameKeys: interestsKeys,
-            incrBy,
-        },
-    }).catch((err) => {
-        console.log(err);
+    const userId = (headers as any)?.['x-userid'];
+    if (!userId) {
+        return Promise.resolve({});
+    }
+
+    const amount = Math.min(MAX_EVENT_INCREMENT, Math.max(1, Math.floor(Number(incrBy) || 1)));
+    const existing = buffer.get(userId);
+    // Headers are refreshed on every event so the flush carries the most recent auth token
+    // rather than one captured at the start of the window.
+    const entry: IBufferedEngagement = existing || { headers, incrementsByKey: {} };
+    entry.headers = headers;
+
+    interestsKeys.forEach((key) => {
+        if (!key) {
+            return;
+        }
+        entry.incrementsByKey[key] = (entry.incrementsByKey[key] || 0) + amount;
     });
+
+    buffer.set(userId, entry);
+
+    if (buffer.size >= MAX_BUFFERED_USERS) {
+        return flushInterestEngagement().then(() => ({}));
+    }
+
+    scheduleFlush();
+
+    return Promise.resolve({});
 };
+
+// Best-effort drain on graceful shutdown (k8s pod eviction). Deliberately does not call
+// process.exit — the store's own SIGTERM handler owns pool draining and exit.
+process.on('SIGTERM', () => {
+    flushInterestEngagement();
+});
+
+export { flushInterestEngagement };
 
 export default incrementInterestEngagement;

--- a/therr-services/maps-service/tests/unit/incrementInterestEngagement.test.ts
+++ b/therr-services/maps-service/tests/unit/incrementInterestEngagement.test.ts
@@ -1,0 +1,113 @@
+/* eslint-disable quotes, max-len */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as internalRest from 'therr-js-utilities/internal-rest-request';
+import incrementInterestEngagement, { flushInterestEngagement } from '../../src/utilities/incrementInterestEngagement';
+
+describe('incrementInterestEngagement (coalescing buffer)', () => {
+    let requestStub: sinon.SinonStub;
+
+    // The flush target URL is read from global-config by NODE_ENV at flush time.
+    before(() => {
+        process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+    });
+
+    const headersFor = (userId: string) => ({
+        'x-userid': userId,
+        'x-localecode': 'en-us',
+        'x-platform': 'mobile',
+        'x-brand-variation': 'therr',
+    }) as any;
+
+    beforeEach(() => {
+        requestStub = sinon.stub(internalRest, 'internalRestRequest').resolves({ data: {} } as any);
+    });
+
+    afterEach(async () => {
+        // Drain so buffered state can't leak between tests.
+        await flushInterestEngagement();
+        sinon.restore();
+    });
+
+    it('does not issue a request per content view', async () => {
+        incrementInterestEngagement(['interests.foodDrink.coffee'], 2, headersFor('user-1'));
+        incrementInterestEngagement(['interests.foodDrink.coffee'], 2, headersFor('user-1'));
+        incrementInterestEngagement(['interests.sports.soccer'], 3, headersFor('user-1'));
+
+        // Nothing has gone out yet — the whole point is that views accumulate.
+        expect(requestStub.called).to.be.eq(false);
+
+        await flushInterestEngagement();
+
+        expect(requestStub.callCount).to.eq(1);
+    });
+
+    it('sums repeat engagement on the same interest', async () => {
+        incrementInterestEngagement(['interests.foodDrink.coffee'], 2, headersFor('user-1'));
+        incrementInterestEngagement(['interests.foodDrink.coffee'], 3, headersFor('user-1'));
+
+        await flushInterestEngagement();
+
+        const { data } = requestStub.args[0][1];
+        expect(data.interestIncrements).to.deep.equal({ 'interests.foodDrink.coffee': 5 });
+    });
+
+    it('keeps each user in their own request', async () => {
+        incrementInterestEngagement(['interests.foodDrink.coffee'], 2, headersFor('user-1'));
+        incrementInterestEngagement(['interests.sports.soccer'], 2, headersFor('user-2'));
+
+        await flushInterestEngagement();
+
+        expect(requestStub.callCount).to.eq(2);
+    });
+
+    // A rolling deploy can leave an older users-service pod receiving this request, so the
+    // one-event-at-a-time shape rides along and still records something sensible.
+    it('sends the legacy payload shape alongside the coalesced one', async () => {
+        incrementInterestEngagement(['interests.foodDrink.coffee', 'interests.sports.soccer'], 2, headersFor('user-1'));
+
+        await flushInterestEngagement();
+
+        const { data } = requestStub.args[0][1];
+        expect(data.interestDisplayNameKeys).to.have.members(['interests.foodDrink.coffee', 'interests.sports.soccer']);
+        expect(data.incrBy).to.eq(2);
+    });
+
+    it('caps a single event contribution', async () => {
+        incrementInterestEngagement(['interests.foodDrink.coffee'], 5000, headersFor('user-1'));
+
+        await flushInterestEngagement();
+
+        const { data } = requestStub.args[0][1];
+        expect(data.interestIncrements['interests.foodDrink.coffee']).to.eq(5);
+    });
+
+    it('ignores events with no interests or no user', async () => {
+        incrementInterestEngagement([], 2, headersFor('user-1'));
+        incrementInterestEngagement(['interests.foodDrink.coffee'], 2, { 'x-localecode': 'en-us' } as any);
+
+        await flushInterestEngagement();
+
+        expect(requestStub.called).to.be.eq(false);
+    });
+
+    it('flushing twice does not resend the same increments', async () => {
+        incrementInterestEngagement(['interests.foodDrink.coffee'], 2, headersFor('user-1'));
+
+        await flushInterestEngagement();
+        await flushInterestEngagement();
+
+        expect(requestStub.callCount).to.eq(1);
+    });
+
+    // A failed flush must not take down the request that triggered it — these call sites
+    // were fire-and-forget before, and engagement counts are best-effort.
+    it('swallows a failed flush', async () => {
+        requestStub.rejects(new Error('users-service unreachable'));
+        incrementInterestEngagement(['interests.foodDrink.coffee'], 2, headersFor('user-1'));
+
+        await flushInterestEngagement();
+
+        expect(requestStub.callCount).to.eq(1);
+    });
+});

--- a/therr-services/reactions-service/src/handlers/thoughtReactions.ts
+++ b/therr-services/reactions-service/src/handlers/thoughtReactions.ts
@@ -77,6 +77,15 @@ const createOrUpdateMultiThoughtReactions = (req, res) => {
 
     const params = { ...req.body };
     delete params.thoughtIds;
+    // Per-thought, so it can't ride along in the shared param set that gets spread into
+    // every inserted/updated row — it is applied separately below.
+    delete params.relevanceScores;
+
+    const relevanceScores = req.body.relevanceScores || {};
+    const scoreFor = (thoughtId: string) => {
+        const score = Number(relevanceScores[thoughtId]);
+        return Number.isFinite(score) ? score : null;
+    };
 
     // TODO: Use INSERT...ON CONFLICT...MERGE
     // Use the resulting created at vs. updated at to determine if this was an INSERT or an UPDATE
@@ -90,6 +99,13 @@ const createOrUpdateMultiThoughtReactions = (req, res) => {
         });
         let updatedReactions: any[] = [];
         if (existing?.length) {
+            // Scores first, so the bulk update's RETURNING * below reports the fresh values.
+            const scoresForExisting = existing.reduce((acc, reaction) => {
+                const score = scoreFor(reaction.thoughtId);
+                return score == null ? acc : { ...acc, [reaction.thoughtId]: score };
+            }, {});
+            await Store.thoughtReactions.updateRelevanceScores(userId, scoresForExisting);
+
             await Store.thoughtReactions.update({}, {
                 ...params,
                 userLocale: locale,
@@ -107,6 +123,10 @@ const createOrUpdateMultiThoughtReactions = (req, res) => {
                 thoughtId,
                 ...params,
                 userLocale: locale,
+                // Always present (null when unscored) so every row in the multi-row insert
+                // carries the same column set.
+                relevanceScore: scoreFor(thoughtId),
+                scoredAt: scoreFor(thoughtId) == null ? null : new Date(),
             }));
 
         return Store.thoughtReactions.create(createArray).then((createdReactions) => res.status(200).send({

--- a/therr-services/reactions-service/src/handlers/thoughts.ts
+++ b/therr-services/reactions-service/src/handlers/thoughts.ts
@@ -49,6 +49,10 @@ const searchActiveThoughts = async (req: any, res: any) => {
         limit,
         offset,
         order: order || 'DESC',
+        // Order the stream by the score the distributor assigned at activation time.
+        // Without this the feed is ordered by activation timestamp, and since a distributor
+        // run activates 7-20 thoughts at once, intra-batch order was arbitrary.
+        orderBy: 'relevance',
     }, customs)
         .then((reactionsResponse) => {
             reactions = reactionsResponse;
@@ -57,6 +61,10 @@ const searchActiveThoughts = async (req: any, res: any) => {
                 [cur.thoughtId]: cur,
             }), {});
             const thoughtIds = reactions?.map((reaction) => reaction.thoughtId) || [];
+            // The reaction query above is what ranks this page; the thoughts lookup below
+            // re-sorts by content createdAt, so keep the ranked positions to restore after.
+            const rankByThoughtId = new Map<string, number>();
+            thoughtIds.forEach((id, index) => rankByThoughtId.set(id, index));
 
             return internalRestRequest({
                 headers: req.headers,
@@ -76,7 +84,14 @@ const searchActiveThoughts = async (req: any, res: any) => {
                     withMedia,
                     withUser,
                     withReplies,
-                    lastContentCreatedAt,
+                    // `lastContentCreatedAt` becomes a `createdAt <` filter in users-service.
+                    // That is a valid cursor only while the page is ordered by content
+                    // recency. On the activated feed the page is now ordered by relevance and
+                    // already scoped to this page's thoughtIds, so forwarding the cursor would
+                    // silently drop any high-scoring thought newer than the last item of the
+                    // previous page. The author-profile path (authorId set) bypasses the
+                    // thoughtIds restriction and still paginates by createdAt, so it keeps it.
+                    lastContentCreatedAt: authorId ? lastContentCreatedAt : undefined,
                     authorId,
                     isDraft: false,
                 },
@@ -103,6 +118,13 @@ const searchActiveThoughts = async (req: any, res: any) => {
                             })),
                     };
                 }).filter((thought) => !blockedUsers.includes(thought.fromUserId));
+
+                // Restore the relevance ordering the thoughts lookup discarded. Anything not
+                // in the rank map (shouldn't happen — every thought here came from a reaction)
+                // sinks to the bottom rather than jumping to the top.
+                thoughts.sort((a, b) => (rankByThoughtId.get(a.id) ?? Number.MAX_SAFE_INTEGER)
+                    - (rankByThoughtId.get(b.id) ?? Number.MAX_SAFE_INTEGER));
+
                 return res.status(200).send({
                     thoughts,
                     media: response?.data?.media,

--- a/therr-services/reactions-service/src/store/ThoughtReactionsStore.ts
+++ b/therr-services/reactions-service/src/store/ThoughtReactionsStore.ts
@@ -16,6 +16,8 @@ export interface ICreateThoughtReactionParams {
     userHasReported?: boolean;
     userHasSuperDisliked?: boolean;
     userLocale?: string;
+    relevanceScore?: number | null;
+    scoredAt?: Date | null;
 }
 
 export interface IUpdateThoughtReactionConditions {
@@ -37,6 +39,19 @@ export interface IUpdateThoughtReactionParams {
 interface IUpdateWhereInConfig {
     columns: string[];
     whereInArray: any[][];
+}
+
+export interface IGetThoughtReactionFilters {
+    limit?: number;
+    offset?: number;
+    order?: string;
+    // 'relevance' orders by the distributor-assigned score (see updateRelevanceScores).
+    // Defaults to 'createdAt' so non-feed callers keep their existing ordering.
+    orderBy?: 'createdAt' | 'relevance';
+}
+
+export interface IRelevanceScoresByThoughtId {
+    [thoughtId: string]: number;
 }
 
 export default class ThoughtReactionsStore {
@@ -66,15 +81,28 @@ export default class ThoughtReactionsStore {
         return this.db.read.query(queryString.toString()).then((response) => response.rows);
     }
 
-    get(conditions: any, thoughtIds?, filters = { limit: 100, offset: 0, order: 'DESC' }, customs: any = {}) {
+    get(conditions: any, thoughtIds?, filters: IGetThoughtReactionFilters = { limit: 100, offset: 0, order: 'DESC' }, customs: any = {}) {
         const restrictedLimit = Math.min(filters.limit || 100, 1000);
+        // `order` reaches this method straight from a request body, and the relevance branch
+        // below interpolates it into raw SQL — whitelist rather than pass it through.
+        const direction = String(filters.order || 'DESC').toUpperCase() === 'ASC' ? 'ASC' : 'DESC';
 
         let queryString = knexBuilder.select('*')
             .from(THOUGHT_REACTIONS_TABLE_NAME)
             .where(conditions)
             .limit(restrictedLimit)
-            .orderBy('createdAt', filters.order)
-            .offset(filters.offset);
+            .offset(filters.offset || 0);
+
+        if (filters.orderBy === 'relevance') {
+            // Relevance always leads regardless of `direction` — `direction` only decides how
+            // ties (and unscored, pre-rollout rows) fall back to recency. `thoughtId` is the
+            // final tiebreak so offset pagination can't repeat or skip rows when two reactions
+            // share a score and a timestamp, which is the common case inside one activation batch.
+            queryString = queryString
+                .orderByRaw(`"relevanceScore" DESC NULLS LAST, "createdAt" ${direction}, "thoughtId" ${direction}`);
+        } else {
+            queryString = queryString.orderBy('createdAt', direction);
+        }
 
         if (customs.withBookmark) {
             queryString = queryString.whereNotNull('userBookmarkCategory');
@@ -100,10 +128,56 @@ export default class ThoughtReactionsStore {
     }
 
     create(params: ICreateThoughtReactionParams | ICreateThoughtReactionParams[]) {
+        // knex renders `.insert([])` as an empty string, which would reach pg as an empty
+        // query and return no `rows`. The multi-create path hits this whenever every
+        // requested thought already has a reaction row, which is common for a re-run of the
+        // distributor over the same hot thoughts.
+        if (Array.isArray(params) && !params.length) {
+            return Promise.resolve([]);
+        }
+
         const queryString = knexBuilder(THOUGHT_REACTIONS_TABLE_NAME)
             .insert(params)
             .returning('*')
             .toString();
+
+        return this.db.write.query(queryString).then((response) => response.rows);
+    }
+
+    /**
+     * Applies a per-thought relevance score to one user's existing reaction rows.
+     *
+     * The bulk `update` below sets one identical param set across every matched row via
+     * `whereIn`, which can't express "a different score per thought". A single
+     * `UPDATE ... FROM (VALUES ...)` handles the whole batch in one statement instead of one
+     * UPDATE per thought — the distributor re-scores 7-20 thoughts on every run.
+     *
+     * Rows that don't exist yet are not created here; the caller inserts those with their
+     * score already set.
+     */
+    updateRelevanceScores(userId: string, scoresByThoughtId: IRelevanceScoresByThoughtId) {
+        const entries = Object.entries(scoresByThoughtId || {})
+            .filter(([thoughtId, score]) => !!thoughtId && Number.isFinite(Number(score)));
+
+        if (!userId || !entries.length) {
+            return Promise.resolve([]);
+        }
+
+        const bindings: any[] = [];
+        entries.forEach(([thoughtId, score]) => {
+            bindings.push(thoughtId, Number(score));
+        });
+        bindings.push(userId);
+
+        const valuesPlaceholders = entries.map(() => '(?::uuid, ?::double precision)').join(', ');
+        const queryString = knexBuilder.raw(
+            `UPDATE main."thoughtReactions" AS tr
+                SET "relevanceScore" = v.score, "scoredAt" = NOW(), "updatedAt" = NOW()
+                FROM (VALUES ${valuesPlaceholders}) AS v("thoughtId", score)
+                WHERE tr."thoughtId" = v."thoughtId" AND tr."userId" = ?::uuid
+                RETURNING tr.*`,
+            bindings,
+        ).toString();
 
         return this.db.write.query(queryString).then((response) => response.rows);
     }

--- a/therr-services/reactions-service/src/store/migrations/20260726000000_main.thoughtReactions.relevanceScore.js
+++ b/therr-services/reactions-service/src/store/migrations/20260726000000_main.thoughtReactions.relevanceScore.js
@@ -1,0 +1,43 @@
+// Persist the relevance score that the thought distributor already computes.
+//
+// Context: users-service `ThoughtsStore.getRecentThoughts` ranks candidate thoughts by an
+// engagement-aware "hot" score (reply count dampened by age) to decide WHICH thoughts get
+// activated into a user's stream. That score then had nowhere to live — activation wrote a
+// `thoughtReactions` row and the feed read those rows back ordered by the reaction's
+// `createdAt`. Because a distributor run activates 7-20 thoughts in a single batch with
+// effectively identical timestamps, the ranking was discarded and intra-batch order was
+// arbitrary.
+//
+// `relevanceScore` carries the score onto the reaction row so the feed can order by it.
+// Nullable rather than defaulted to 0: NULL means "activated before scoring existed", which
+// the read path sorts last via NULLS LAST. Backfilling to 0 would be indistinguishable from
+// a genuinely low-scoring thought.
+//
+// NOTE: on first deploy, previously-activated rows (relevanceScore IS NULL) sort below all
+// newly scored ones. That is a one-time reshuffle in the intended direction — scored content
+// leads — but it is visible to existing users on the first feed load after rollout.
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').table('thoughtReactions', (table) => {
+        table.float('relevanceScore').nullable();
+        table.timestamp('scoredAt', { useTz: true }).nullable();
+    });
+
+    // Covering the activated-feed read path:
+    //   WHERE "userId" = ? AND "userHasActivated" = true
+    //   ORDER BY "relevanceScore" DESC NULLS LAST, "createdAt" DESC
+    // Partial on userHasActivated because the feed never reads deactivated rows, which keeps
+    // the index materially smaller than the existing (thoughtId, userId) unique index.
+    await knex.raw(
+        'CREATE INDEX IF NOT EXISTS idx_thought_reactions_user_relevance '
+        + 'ON main."thoughtReactions" ("userId", "relevanceScore" DESC NULLS LAST, "createdAt" DESC) '
+        + 'WHERE "userHasActivated" = true',
+    );
+};
+
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main.idx_thought_reactions_user_relevance');
+    await knex.schema.withSchema('main').table('thoughtReactions', (table) => {
+        table.dropColumn('scoredAt');
+        table.dropColumn('relevanceScore');
+    });
+};

--- a/therr-services/reactions-service/src/utilities/incrementInterestEngagement.ts
+++ b/therr-services/reactions-service/src/utilities/incrementInterestEngagement.ts
@@ -1,23 +1,149 @@
+import logSpan from 'therr-js-utilities/log-or-update-span';
 import { internalRestRequest, InternalConfigHeaders } from 'therr-js-utilities/internal-rest-request';
 import * as globalConfig from '../../../../global-config';
+
+// Interest engagement used to be one internal REST call — and one subquery-joined UPDATE in
+// users-service — per content view. Views are the highest-volume event in the system, so
+// preference writes scaled with impressions rather than with users, and row-level lock
+// contention on main."userInterests" scaled with them too.
+//
+// Increments are now coalesced in-process per user and flushed on a short interval. A user
+// scrolling twenty moments produces one request with merged interest counts instead of
+// twenty requests.
+//
+// The buffer is deliberately in-memory rather than in Redis: engagement counts are
+// best-effort telemetry, and a per-replica buffer needs no shared infrastructure and no
+// additional Redis memory. The trade-off is that increments still buffered when a pod is
+// killed are lost. That is acceptable for a counter whose call sites were already
+// fire-and-forget, and a SIGTERM flush covers the common (graceful) case.
+//
+// NOTE: this file is intentionally identical to the maps-service copy of the same
+// name. Keep the two in sync.
+
+const FLUSH_INTERVAL_MS = Number(process.env.INTEREST_ENGAGEMENT_FLUSH_INTERVAL_MS) || 10000;
+// Backstop against unbounded growth if the flush target is unreachable for a long time.
+const MAX_BUFFERED_USERS = Number(process.env.INTEREST_ENGAGEMENT_MAX_BUFFERED_USERS) || 1000;
+const MAX_EVENT_INCREMENT = 5;
+
+interface IBufferedEngagement {
+    headers: InternalConfigHeaders;
+    incrementsByKey: { [interestKey: string]: number };
+}
+
+// Keyed by userId — the flush endpoint derives the user from request headers, so one
+// request per user is the smallest unit we can batch into.
+const buffer = new Map<string, IBufferedEngagement>();
+let flushTimer: NodeJS.Timeout | null = null;
+
+const reportFlushFailure = (userId: string, entry: IBufferedEngagement, err: any) => {
+    // Previously a bare console.log, which meant a fully broken preference-learning loop
+    // would raise no alert anywhere.
+    logSpan({
+        level: 'error',
+        messageOrigin: 'API_SERVER',
+        messages: ['Failed to flush interest engagement', err?.message],
+        traceArgs: {
+            'user.id': userId,
+            issue: 'interest engagement increments dropped',
+            'interest.keyCount': Object.keys(entry.incrementsByKey).length,
+        },
+    });
+};
+
+// Never rejects, and never throws synchronously: flushes are driven by a background timer,
+// so an escaping error would surface as an unhandled rejection rather than a failed request.
+const flushUser = (userId: string, entry: IBufferedEngagement) => {
+    try {
+        return internalRestRequest({
+            headers: entry.headers,
+        }, {
+            method: 'post',
+            url: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}/users/interests/increment`,
+            data: {
+                interestIncrements: entry.incrementsByKey,
+                // Legacy shape, sent alongside the new one so that during a rolling deploy an
+                // older users-service pod still records something sensible rather than nothing.
+                interestDisplayNameKeys: Object.keys(entry.incrementsByKey),
+                incrBy: Math.min(MAX_EVENT_INCREMENT, Math.max(...Object.values(entry.incrementsByKey))),
+            },
+        }).catch((err) => reportFlushFailure(userId, entry, err));
+    } catch (err) {
+        reportFlushFailure(userId, entry, err);
+        return Promise.resolve();
+    }
+};
+
+const flushInterestEngagement = () => {
+    if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+    }
+
+    if (!buffer.size) {
+        return Promise.resolve([]);
+    }
+
+    // Swap the buffer out before awaiting so increments arriving during the flush
+    // accumulate into the next window instead of being dropped.
+    const draining = Array.from(buffer.entries());
+    buffer.clear();
+
+    return Promise.all(draining.map(([userId, entry]) => flushUser(userId, entry)));
+};
+
+const scheduleFlush = () => {
+    if (flushTimer) {
+        return;
+    }
+    flushTimer = setTimeout(() => {
+        flushTimer = null;
+        flushInterestEngagement();
+    }, FLUSH_INTERVAL_MS);
+    // Don't hold the event loop open purely for a pending flush.
+    flushTimer.unref?.();
+};
 
 const incrementInterestEngagement = (interestsKeys: string[], incrBy: number, headers: InternalConfigHeaders) => {
     if (!interestsKeys?.length) {
         return Promise.resolve({});
     }
 
-    return internalRestRequest({
-        headers,
-    }, {
-        method: 'post',
-        url: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}/users/interests/increment`,
-        data: {
-            interestDisplayNameKeys: interestsKeys,
-            incrBy,
-        },
-    }).catch((err) => {
-        console.log(err);
+    const userId = (headers as any)?.['x-userid'];
+    if (!userId) {
+        return Promise.resolve({});
+    }
+
+    const amount = Math.min(MAX_EVENT_INCREMENT, Math.max(1, Math.floor(Number(incrBy) || 1)));
+    const existing = buffer.get(userId);
+    // Headers are refreshed on every event so the flush carries the most recent auth token
+    // rather than one captured at the start of the window.
+    const entry: IBufferedEngagement = existing || { headers, incrementsByKey: {} };
+    entry.headers = headers;
+
+    interestsKeys.forEach((key) => {
+        if (!key) {
+            return;
+        }
+        entry.incrementsByKey[key] = (entry.incrementsByKey[key] || 0) + amount;
     });
+
+    buffer.set(userId, entry);
+
+    if (buffer.size >= MAX_BUFFERED_USERS) {
+        return flushInterestEngagement().then(() => ({}));
+    }
+
+    scheduleFlush();
+
+    return Promise.resolve({});
 };
+
+// Best-effort drain on graceful shutdown (k8s pod eviction). Deliberately does not call
+// process.exit — the store's own SIGTERM handler owns pool draining and exit.
+process.on('SIGTERM', () => {
+    flushInterestEngagement();
+});
+
+export { flushInterestEngagement };
 
 export default incrementInterestEngagement;

--- a/therr-services/reactions-service/tests/unit/ThoughtReactionsStore.test.ts
+++ b/therr-services/reactions-service/tests/unit/ThoughtReactionsStore.test.ts
@@ -118,6 +118,97 @@ describe('ThoughtReactionsStore', () => {
             expect(query).to.include('offset 10');
             expect(query).to.include('ASC');
         });
+
+        // The activated stream is ordered by the score the distributor assigned at activation.
+        // Ordering by reaction createdAt left intra-batch order arbitrary, because a
+        // distributor run activates 7-20 rows with effectively identical timestamps.
+        it('orders by relevance score when requested, sinking unscored rows', async () => {
+            const mockStore = createMockStore();
+            const store = new ThoughtReactionsStore(mockStore);
+
+            store.get({ userId: 'user-1' }, undefined, {
+                limit: 21, offset: 0, order: 'DESC', orderBy: 'relevance',
+            });
+
+            const query = mockStore.read.query.args[0][0];
+            // NULLS LAST: rows activated before scoring existed must not lead the feed.
+            expect(query).to.include('order by "relevanceScore" DESC NULLS LAST');
+            // thoughtId tiebreak keeps offset pagination stable across equal scores.
+            expect(query).to.include('"createdAt" DESC, "thoughtId" DESC');
+        });
+
+        it('defaults to createdAt ordering so non-feed callers are unaffected', async () => {
+            const mockStore = createMockStore();
+            const store = new ThoughtReactionsStore(mockStore);
+
+            store.get({ userId: 'user-1' }, undefined, { limit: 21, offset: 0, order: 'DESC' });
+
+            const query = mockStore.read.query.args[0][0];
+            expect(query).to.not.include('relevanceScore');
+            expect(query).to.include('order by "createdAt"');
+        });
+
+        // `order` arrives straight from a request body and is interpolated into raw SQL on
+        // the relevance branch.
+        it('rejects an injected sort direction', async () => {
+            const mockStore = createMockStore();
+            const store = new ThoughtReactionsStore(mockStore);
+
+            store.get({ userId: 'user-1' }, undefined, {
+                limit: 21,
+                offset: 0,
+                order: 'DESC; DROP TABLE main."thoughtReactions"; --',
+                orderBy: 'relevance',
+            });
+
+            const query = mockStore.read.query.args[0][0];
+            expect(query).to.not.include('DROP TABLE');
+            expect(query).to.include('"createdAt" DESC, "thoughtId" DESC');
+        });
+    });
+
+    describe('updateRelevanceScores', () => {
+        it('sets a different score per thought in a single statement', async () => {
+            const mockStore = createMockStore();
+            const store = new ThoughtReactionsStore(mockStore);
+
+            await store.updateRelevanceScores('11111111-1111-1111-1111-111111111111', {
+                '22222222-2222-2222-2222-222222222222': 3.5,
+                '33333333-3333-3333-3333-333333333333': 1.25,
+            });
+
+            expect(mockStore.write.query.callCount).to.eq(1);
+            const query = mockStore.write.query.args[0][0];
+            expect(query).to.include('UPDATE main."thoughtReactions"');
+            expect(query).to.include("'22222222-2222-2222-2222-222222222222'::uuid, 3.5::double precision");
+            expect(query).to.include("'33333333-3333-3333-3333-333333333333'::uuid, 1.25::double precision");
+            // Scoped to the one user — a score is per (user, thought), not global.
+            expect(query).to.include(`tr."userId" = '11111111-1111-1111-1111-111111111111'::uuid`);
+        });
+
+        it('does not query when there is nothing to score', async () => {
+            const mockStore = createMockStore();
+            const store = new ThoughtReactionsStore(mockStore);
+
+            const result = await store.updateRelevanceScores('user-1', {});
+
+            expect(result).to.deep.equal([]);
+            expect(mockStore.write.query.called).to.be.eq(false);
+        });
+
+        it('drops non-numeric scores rather than emitting invalid SQL', async () => {
+            const mockStore = createMockStore();
+            const store = new ThoughtReactionsStore(mockStore);
+
+            await store.updateRelevanceScores('11111111-1111-1111-1111-111111111111', {
+                '22222222-2222-2222-2222-222222222222': 2,
+                '33333333-3333-3333-3333-333333333333': (undefined as any),
+            });
+
+            const query = mockStore.write.query.args[0][0];
+            expect(query).to.include('22222222-2222-2222-2222-222222222222');
+            expect(query).to.not.include('33333333-3333-3333-3333-333333333333');
+        });
     });
 
     describe('getByThoughtId', () => {
@@ -187,6 +278,19 @@ describe('ThoughtReactionsStore', () => {
             expect(query).to.include("'thought-1'");
             expect(query).to.include("'thought-2'");
             expect(query).to.include('returning *');
+        });
+
+        // knex renders `.insert([])` as an empty string. The multi-create path reaches this
+        // whenever every requested thought already has a reaction row, which is routine when
+        // the distributor re-selects the same hot thoughts.
+        it('does not issue an empty query for an empty batch', async () => {
+            const mockStore = createMockStore();
+            const store = new ThoughtReactionsStore(mockStore);
+
+            const result = await store.create([]);
+
+            expect(result).to.deep.equal([]);
+            expect(mockStore.write.query.called).to.be.eq(false);
         });
     });
 

--- a/therr-services/users-service/src/api/TherrEventEmitter.ts
+++ b/therr-services/users-service/src/api/TherrEventEmitter.ts
@@ -2,6 +2,7 @@ import logSpan from 'therr-js-utilities/log-or-update-span';
 import { InternalConfigHeaders } from 'therr-js-utilities/internal-rest-request';
 import { getBrandContext } from 'therr-js-utilities/http';
 import Store from '../store';
+import { tryAcquireDistributorRun } from '../store/redisClient';
 import { createReactions } from './reactions';
 
 const randomIntFromInterval = (min, max) => Math.floor(Math.random() * (max - min + 1) + min);
@@ -19,9 +20,27 @@ class TherrEventEmitter {
      * `shouldIncludeGeneralCandidates` (recentUsersCount > 0) widens the batch beyond
      * interest matches — used at login; the lighter notifications-poll path activates
      * interest matches only (with a single-thought fallback).
+     *
+     * `minSecondsBetweenRuns` gates repeat runs for the same user (see
+     * tryAcquireDistributorRun). The notifications-poll caller sets it because it fires on
+     * every poll; login leaves it at 0 so a fresh session always seeds the stream.
      */
     // eslint-disable-next-line class-methods-use-this
-    public runThoughtDistributorAlgorithm(headers: InternalConfigHeaders, contextUserIds?: string[], createdAtOrUpdatedAt = 'createdAt', recentUsersCount = 1) {
+    public async runThoughtDistributorAlgorithm(
+        headers: InternalConfigHeaders,
+        contextUserIds?: string[],
+        createdAtOrUpdatedAt = 'createdAt',
+        recentUsersCount = 1,
+        minSecondsBetweenRuns = 0,
+    ) {
+        const gateUserId = contextUserIds?.length === 1 ? contextUserIds[0] : undefined;
+        if (minSecondsBetweenRuns > 0 && gateUserId) {
+            const acquired = await tryAcquireDistributorRun(gateUserId, minSecondsBetweenRuns);
+            if (!acquired) {
+                return {};
+            }
+        }
+
         const numThoughts = randomIntFromInterval(7, 20);
         const { brandVariation: brand } = getBrandContext(headers as any);
         const shouldIncludeGeneralCandidates = recentUsersCount > 0;
@@ -37,7 +56,10 @@ class TherrEventEmitter {
                 interestsKeys.length
                     ? Store.thoughts.getRecentThoughts(brand, numThoughts, interestsKeys)
                     : Promise.resolve([]),
-                Store.thoughts.getRecentThoughts(brand, numThoughts),
+                // When general candidates aren't being added to the batch, this result is
+                // only consulted for a single fallback thought — ranking a full page of
+                // candidates just to discard all but one was wasted work on every poll.
+                Store.thoughts.getRecentThoughts(brand, shouldIncludeGeneralCandidates ? numThoughts : 1),
             ]);
         }).then(([thoughtsForContext, thoughtsForRecent]) => {
             const interestMatches = thoughtsForContext || [];

--- a/therr-services/users-service/src/api/TherrEventEmitter.ts
+++ b/therr-services/users-service/src/api/TherrEventEmitter.ts
@@ -6,6 +6,11 @@ import { createReactions } from './reactions';
 
 const randomIntFromInterval = (min, max) => Math.floor(Math.random() * (max - min + 1) + min);
 
+// Multiplier applied to an interest-matched thought's hot score before it is persisted as
+// the reaction's relevanceScore. Keeps interest matches above equally-hot general fill
+// without hard-partitioning the stream into two blocks.
+const INTEREST_MATCH_BOOST = 1.5;
+
 class TherrEventEmitter {
     /**
      * Activates a batch of candidate thoughts for the requesting user's stream.
@@ -35,11 +40,35 @@ class TherrEventEmitter {
                 Store.thoughts.getRecentThoughts(brand, numThoughts),
             ]);
         }).then(([thoughtsForContext, thoughtsForRecent]) => {
-            // If no new thoughts match user interests, fallback to the hottest general thought
-            const contextReactionThoughts = thoughtsForContext?.length ? thoughtsForContext : thoughtsForRecent.slice(0, 1);
-            const thoughtIds = new Set<string>(contextReactionThoughts.map((thought) => thought.id));
+            const interestMatches = thoughtsForContext || [];
+            const generalMatches = thoughtsForRecent || [];
+            const thoughtIds = new Set<string>();
+            // Scores ride along to the reaction rows so the stream can be ordered by relevance
+            // on read. Highest score wins when a thought appears in both candidate sets.
+            const relevanceScores: { [thoughtId: string]: number } = {};
+            const recordScore = (thought: any, boost: number) => {
+                if (!thought?.id) {
+                    return;
+                }
+                const score = (Number(thought.hotScore) || 0) * boost;
+                if (relevanceScores[thought.id] == null || score > relevanceScores[thought.id]) {
+                    relevanceScores[thought.id] = score;
+                }
+                thoughtIds.add(thought.id);
+            };
+
+            if (interestMatches.length) {
+                // "Interest matches lead" is the documented intent of this algorithm but was
+                // previously unenforceable, since ordering was lost at activation. The boost
+                // keeps an interest match ahead of a general candidate of equal hotness.
+                interestMatches.forEach((thought) => recordScore(thought, INTEREST_MATCH_BOOST));
+            } else {
+                // If no new thoughts match user interests, fallback to the hottest general thought
+                generalMatches.slice(0, 1).forEach((thought) => recordScore(thought, 1));
+            }
+
             if (shouldIncludeGeneralCandidates) {
-                thoughtsForRecent.forEach((thought) => thoughtIds.add(thought.id));
+                generalMatches.forEach((thought) => recordScore(thought, 1));
             }
 
             if (!thoughtIds.size) {
@@ -48,7 +77,7 @@ class TherrEventEmitter {
 
             // Reactions are stamped with the requesting user's id (from headers), so one
             // deduplicated call activates the whole batch
-            return createReactions(Array.from(thoughtIds), headers);
+            return createReactions(Array.from(thoughtIds), headers, relevanceScores);
         })
             .catch((err) => {
                 logSpan({

--- a/therr-services/users-service/src/api/reactions.ts
+++ b/therr-services/users-service/src/api/reactions.ts
@@ -37,7 +37,18 @@ const hasUserReacted = (thoughtId: string, headers) => getReactions(thoughtId, h
         throw err;
     });
 
-const createReactions = (thoughtIds: string[], headers: InternalConfigHeaders) => internalRestRequest({
+interface IRelevanceScoresByThoughtId {
+    [thoughtId: string]: number;
+}
+
+// `relevanceScores` is optional: callers that activate thoughts without ranking them
+// (e.g. activating a thought's replies alongside their parent) simply omit it, and those
+// rows keep a NULL relevanceScore.
+const createReactions = (
+    thoughtIds: string[],
+    headers: InternalConfigHeaders,
+    relevanceScores?: IRelevanceScoresByThoughtId,
+) => internalRestRequest({
     headers,
 }, {
     method: 'post',
@@ -45,6 +56,7 @@ const createReactions = (thoughtIds: string[], headers: InternalConfigHeaders) =
     data: {
         thoughtIds,
         userHasActivated: true,
+        ...(relevanceScores ? { relevanceScores } : {}),
     },
 })
     // eslint-disable-next-line arrow-body-style

--- a/therr-services/users-service/src/handlers/notifications.ts
+++ b/therr-services/users-service/src/handlers/notifications.ts
@@ -7,6 +7,12 @@ import notifyUserOfUpdate from '../utilities/notifyUserOfUpdate';
 import TherrEventEmitter from '../api/TherrEventEmitter';
 // import * as globalConfig from '../../../../global-config';
 
+// Minimum gap between thought distributor runs for one user. Env-tunable so the cadence can
+// be adjusted against real consumption rates without a deploy; 0 disables the gate.
+const DISTRIBUTOR_MIN_SECONDS_BETWEEN_RUNS = Number.isFinite(Number(process.env.THOUGHT_DISTRIBUTOR_MIN_INTERVAL_SECONDS))
+    ? Number(process.env.THOUGHT_DISTRIBUTOR_MIN_INTERVAL_SECONDS)
+    : 900; // 15 minutes
+
 export const translateNotification = (notification?: {
     messageLocaleKey: string;
     messageParams?: any;
@@ -105,11 +111,15 @@ const searchNotifications: RequestHandler = (req: any, res: any) => {
 
     /**
      * This is simply an event trigger. It could be triggered by a user logging in, or any other common event.
-     * We will probably want to move this to a scheduler to run at a set interval.
-     * Deferred via setImmediate to avoid blocking notification response
+     * Deferred via setImmediate to avoid blocking notification response.
+     *
+     * This fires on every notifications poll, so it used to scale with polling frequency
+     * rather than with users or content. The gate below caps it to one run per user per
+     * window, turning O(polls) into roughly O(sessions). Login (handlers/auth.ts) is
+     * deliberately ungated so a new session always seeds the stream immediately.
      */
     setImmediate(() => {
-        TherrEventEmitter.runThoughtDistributorAlgorithm(req.headers, [userId], 'updatedAt', 0);
+        TherrEventEmitter.runThoughtDistributorAlgorithm(req.headers, [userId], 'updatedAt', 0, DISTRIBUTOR_MIN_SECONDS_BETWEEN_RUNS);
     });
 
     // const countPromise = Store.notifications.countRecords({

--- a/therr-services/users-service/src/handlers/userInterests.ts
+++ b/therr-services/users-service/src/handlers/userInterests.ts
@@ -5,6 +5,9 @@ import handleHttpError from '../utilities/handleHttpError';
 // import translate from '../utilities/translator';
 import Store from '../store';
 
+// Upper bound on how much a single flush may add to one interest's engagement count.
+const MAX_COALESCED_INCREMENT = 25;
+
 // CREATE
 const createUpdateUserInterests = async (req, res) => {
     const {
@@ -84,7 +87,26 @@ const incrementUserInterests = (req, res) => {
     const {
         incrBy,
         interestDisplayNameKeys,
+        interestIncrements,
     } = req.body;
+
+    // `interestIncrements` ({ displayNameKey: amount }) is the coalesced shape sent by
+    // callers that buffer a user's engagement before flushing. `interestDisplayNameKeys` +
+    // `incrBy` is the original one-event-at-a-time shape, still accepted so a rolling
+    // deploy where an older maps/reactions pod is still running keeps working.
+    if (interestIncrements && typeof interestIncrements === 'object') {
+        const cappedIncrements = Object.keys(interestIncrements).reduce((acc, key) => ({
+            ...acc,
+            // Per-key ceiling on a single flush. The old per-event cap was 5; a flush
+            // aggregates many events, so this is looser but still bounded.
+            [key]: Math.min(MAX_COALESCED_INCREMENT, Number(interestIncrements[key]) || 0),
+        }), {});
+
+        return Store.userInterests
+            .incrementUserInterestsByKey(userId, cappedIncrements)
+            .then((results) => res.status(200).send(results[0]))
+            .catch((err) => handleHttpError({ err, res, message: 'SQL:USER_INTERESTS_ROUTES:ERROR' }));
+    }
 
     const ceilIncrBy = Math.min(5, (incrBy || 1));
 

--- a/therr-services/users-service/src/store/ThoughtsStore.ts
+++ b/therr-services/users-service/src/store/ThoughtsStore.ts
@@ -17,6 +17,12 @@ const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
 
 export const THOUGHTS_TABLE_NAME = 'main.thoughts';
 
+// Hacker-News-style gravity: reply count (the strongest engagement signal in this DB)
+// dampened by age. Declared once so the SELECT and the ORDER BY in getRecentThoughts can
+// never drift apart — the returned score has to be the same number the ranking used.
+// Only valid against the `candidates` subquery, which exposes "replyCount" and "createdAt".
+const HOT_SCORE_EXPRESSION = '("replyCount" + 1) / POWER((EXTRACT(EPOCH FROM (NOW() - "createdAt")) / 3600) + 2, 1.5)';
+
 export interface ICreateThoughtParams {
     parentId?: string;
     areaType?: string;
@@ -88,6 +94,10 @@ export default class ThoughtsStore {
      * index, ~14ms; grouped join = full aggregate over every reply row, ~74ms, and it
      * degrades with total reply volume while the correlated shape scales only with
      * candidatePoolSize.
+     *
+     * Rows come back as { ...returning, hotScore }. `hotScore` is persisted onto the
+     * reaction row at activation (thoughtReactions.relevanceScore) and is what the stream
+     * is ordered by on read.
      */
     getRecentThoughts(brand: BrandValue, limit = 1, relatedInterestsKeys: string[] = [], returning = ['id'], candidatePoolSize = 200) {
         const interestsPlaceholders = relatedInterestsKeys.map(() => '?').join(', ');
@@ -116,8 +126,12 @@ export default class ThoughtsStore {
         }
 
         const query = knexBuilder.select(returning)
+            // Returned alongside the id so the caller can persist it onto the reaction row.
+            // Without this the ranking below only decides which thoughts activate and is then
+            // lost — the feed reads reactions back in activation order, not score order.
+            .select(knexBuilder.raw(`${HOT_SCORE_EXPRESSION} AS "hotScore"`))
             .from(innerQuery.as('candidates'))
-            .orderByRaw('("replyCount" + 1) / POWER((EXTRACT(EPOCH FROM (NOW() - "createdAt")) / 3600) + 2, 1.5) DESC')
+            .orderByRaw(`${HOT_SCORE_EXPRESSION} DESC`)
             .limit(limit);
 
         return this.db.read.query(query.toString()).then((response) => response.rows);
@@ -130,8 +144,14 @@ export default class ThoughtsStore {
         let queryString: any = knexBuilder
             .select((returning && returning.length) ? returning : '*')
             .from(THOUGHTS_TABLE_NAME)
+            // This query had no ORDER BY at all, which made its LIMIT/OFFSET pagination
+            // unsound — Postgres is free to return rows in any order, so paging could repeat
+            // and skip rows. createdAt is indexed (idx from 20221222143544_main.thoughts);
+            // id breaks ties so a page boundary can't land mid-tie. updatedAt is deliberately
+            // still avoided here — it is unindexed and was measured as slow.
             // TODO: Determine a better way to select thoughts that are most relevant to the user
-            // .orderBy(`${THOUGHTS_TABLE_NAME}.updatedAt`) // Sorting by updatedAt is very expensive/slow
+            .orderBy(`${THOUGHTS_TABLE_NAME}.createdAt`, 'desc')
+            .orderBy(`${THOUGHTS_TABLE_NAME}.id`, 'desc')
             .where({
                 isMatureContent: false, // content that has been blocked
             });
@@ -368,6 +388,9 @@ export default class ThoughtsStore {
         let query = knexBuilder
             .from(THOUGHTS_TABLE_NAME)
             .orderBy(orderBy, order)
+            // Tiebreak so the author-profile path (which pages with a `before` cursor on
+            // createdAt) can't skip a thought that shares a timestamp with the page boundary.
+            .orderBy(`${THOUGHTS_TABLE_NAME}.id`, order)
             .offset(filters.offset || 0)
             .where(`${THOUGHTS_TABLE_NAME}.createdAt`, '<', filters.before || new Date(Date.now() + 24 * 60 * 60 * 1000))
             .andWhere(`${THOUGHTS_TABLE_NAME}.parentId`, null)

--- a/therr-services/users-service/src/store/UserInterestsStore.ts
+++ b/therr-services/users-service/src/store/UserInterestsStore.ts
@@ -89,6 +89,50 @@ export default class UserInterestsStore {
         return this.db.write.query(queryString).then((updateResponse) => updateResponse.rows);
     }
 
+    /**
+     * Applies a different increment per interest key in one statement.
+     *
+     * Engagement used to arrive one content view at a time, each becoming its own
+     * cross-service request and its own multi-row UPDATE. Callers now coalesce a user's
+     * views in-process and flush them as a single map, so the write volume tracks flush
+     * intervals instead of impressions.
+     *
+     * Like `incrementUserInterests`, this only touches rows that already exist — behavior
+     * cannot yet discover an interest the user never declared. That is a known gap
+     * (docs/ALGORITHM_AUDIT.md E2) and is deliberately not addressed here.
+     */
+    incrementUserInterestsByKey(userId: string, incrementsByKey: { [displayNameKey: string]: number }) {
+        const entries = Object.entries(incrementsByKey || {})
+            .map(([key, incrBy]) => [key, Math.floor(Number(incrBy))] as [string, number])
+            .filter(([key, incrBy]) => !!key && Number.isFinite(incrBy) && incrBy > 0);
+
+        if (!userId || !entries.length) {
+            return Promise.resolve([]);
+        }
+
+        const bindings: any[] = [];
+        entries.forEach(([key, incrBy]) => {
+            bindings.push(key, incrBy);
+        });
+        bindings.push(userId);
+
+        // Table names are written out rather than interpolated from the tableNames
+        // constants: knex quotes identifiers for builder calls, but raw SQL does not, and
+        // unquoted main.userInterests would fold to "userinterests" and fail.
+        const valuesPlaceholders = entries.map(() => '(?, ?::integer)').join(', ');
+        const queryString = knexBuilder.raw(
+            `UPDATE main."userInterests" AS ui
+                SET "engagementCount" = ui."engagementCount" + v.incr, "updatedAt" = NOW()
+                FROM (VALUES ${valuesPlaceholders}) AS v(key, incr)
+                JOIN main."interests" AS i ON i."displayNameKey" = v.key
+                WHERE ui."userId" = ?::uuid AND ui."interestId" = i.id
+                RETURNING ui.*`,
+            bindings,
+        ).toString();
+
+        return this.db.write.query(queryString).then((response) => response.rows);
+    }
+
     incrementUserInterests(userId, interestDisplayNameKeys: string[], incrBy = 1) {
         const queryString = knexBuilder
             .into(USER_INTERESTS_TABLE_NAME)

--- a/therr-services/users-service/src/store/redisClient.ts
+++ b/therr-services/users-service/src/store/redisClient.ts
@@ -46,6 +46,54 @@ redisEphemeralClient.connect().catch(() => {
 const HANDOFF_PREFIX = 'handoff:';
 const HANDOFF_TTL_SECONDS = 60;
 
+const DISTRIBUTOR_GATE_PREFIX = 'distributor:gate:';
+
+/**
+ * Rate-limits the thought distributor to at most one run per user per window.
+ *
+ * The distributor is triggered from searchNotifications, i.e. on every notifications poll.
+ * Each run costs a 3-table interests join, two candidate scans over the recent thought pool
+ * with a correlated reply-count subquery, and a cross-service write of up to ~20 reaction
+ * rows — so the cost scaled with polling frequency rather than with users or content.
+ *
+ * Footprint is deliberately tiny: one key per *recently active* user, ~90 bytes including
+ * ioredis/Redis overhead, holding only the literal '1', and expiring on its own. At 100k
+ * users active within a single window that is under 10 MB, and idle users hold nothing.
+ * Nothing here is a cache that has to be warm — losing the whole keyspace only means the
+ * next poll per user runs the distributor once more than it needed to.
+ *
+ * Fails OPEN: if Redis is unreachable the distributor runs, which is exactly the behavior
+ * before this gate existed. A Redis outage should not silently stop stream population.
+ */
+export const tryAcquireDistributorRun = async (userId: string, windowSeconds: number): Promise<boolean> => {
+    if (!userId || !windowSeconds || windowSeconds <= 0) {
+        return true;
+    }
+
+    try {
+        // NX makes claim-and-check a single atomic op, so concurrent polls from the same
+        // user (multiple devices, or a client retry) can't both win the window.
+        const result = await redisEphemeralClient.set(
+            `${DISTRIBUTOR_GATE_PREFIX}${userId}`,
+            '1',
+            'EX',
+            windowSeconds,
+            'NX',
+        );
+        return result === 'OK';
+    } catch (err) {
+        logSpan({
+            level: 'warn',
+            messageOrigin: 'REDIS_EPHEMERAL_ERROR',
+            messages: ['Failed to check thought distributor gate; running ungated', (err as any)?.message],
+            traceArgs: {
+                'user.id': userId,
+            },
+        });
+        return true;
+    }
+};
+
 export const mintHandoffCode = async (code: string, entry: IHandoffEntry): Promise<void> => {
     if (!code || !entry?.userId || !entry?.targetBrand) {
         throw new Error('mintHandoffCode requires code, userId, and targetBrand');

--- a/therr-services/users-service/tests/unit/ThoughtsStore.test.ts
+++ b/therr-services/users-service/tests/unit/ThoughtsStore.test.ts
@@ -216,6 +216,48 @@ describe('ThoughtsStore brand filtering', () => {
             expect(sql).to.include(`"brandVariation" in ('habits')`);
             expect(sql).to.include('interests.hiking');
         });
+
+        // The hot score used to exist only in the ORDER BY, so the ranking was thrown away
+        // once candidates were chosen. It is now also selected, and the caller persists it
+        // onto the reaction row as relevanceScore.
+        it('returns the hot score so the ranking can outlive candidate selection', () => {
+            const { connection, readStub } = buildMockConnection();
+            const store = new ThoughtsStore(connection, stubUsersStore);
+            store.getRecentThoughts(BrandVariations.THERR, 10);
+
+            const sql = readStub.args[0][0] as string;
+            expect(sql).to.include('AS "hotScore"');
+        });
+
+        it('scores and orders by the identical expression', () => {
+            const { connection, readStub } = buildMockConnection();
+            const store = new ThoughtsStore(connection, stubUsersStore);
+            store.getRecentThoughts(BrandVariations.THERR, 10);
+
+            const sql = readStub.args[0][0] as string;
+            const scoreExpression = '("replyCount" + 1) / POWER((EXTRACT(EPOCH FROM (NOW() - "createdAt")) / 3600) + 2, 1.5)';
+            // Selected value and sort key must be the same number, or the persisted score
+            // would not explain the order the rows came back in.
+            expect(sql).to.include(`${scoreExpression} AS "hotScore"`);
+            expect(sql).to.include(`order by ${scoreExpression} DESC`);
+        });
+    });
+
+    describe('search (deterministic ordering)', () => {
+        // This query previously had no ORDER BY at all, which makes LIMIT/OFFSET paging
+        // unsound: Postgres may return rows in any order, so pages can repeat and skip.
+        it('orders by an indexed column with an id tiebreak', () => {
+            const { connection, readStub } = buildMockConnection();
+            const store = new ThoughtsStore(connection, stubUsersStore);
+            store.search(BrandVariations.THERR, {
+                pagination: { itemsPerPage: 20, pageNumber: 1 },
+            }, ['id']);
+
+            const sql = readStub.args[0][0] as string;
+            expect(sql).to.include('order by "main"."thoughts"."createdAt" desc, "main"."thoughts"."id" desc');
+            // updatedAt is unindexed and was measured as slow — it must stay out of the sort.
+            expect(sql).to.not.include('"updatedAt" desc');
+        });
     });
 
     describe('getById', () => {

--- a/therr-services/users-service/tests/unit/UserInterestsStore.test.ts
+++ b/therr-services/users-service/tests/unit/UserInterestsStore.test.ts
@@ -1,0 +1,88 @@
+/* eslint-disable quotes */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import UserInterestsStore from '../../src/store/UserInterestsStore';
+
+describe('UserInterestsStore', () => {
+    const createMockConnection = () => ({
+        read: {
+            query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
+        },
+        write: {
+            query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
+        },
+    });
+
+    describe('incrementUserInterestsByKey', () => {
+        // Engagement used to arrive one content view at a time, each its own cross-service
+        // request and its own UPDATE. Callers now coalesce a user's views and flush a map,
+        // which requires a different amount per key in a single statement.
+        it('applies a different increment per interest key in one statement', async () => {
+            const connection = createMockConnection();
+            const store = new UserInterestsStore(connection);
+
+            await store.incrementUserInterestsByKey('11111111-1111-1111-1111-111111111111', {
+                'interests.foodDrink.coffee': 6,
+                'interests.sports.soccer': 2,
+            });
+
+            expect(connection.write.query.callCount).to.eq(1);
+            const query = connection.write.query.args[0][0];
+            expect(query).to.include("('interests.foodDrink.coffee', 6::integer)");
+            expect(query).to.include("('interests.sports.soccer', 2::integer)");
+            expect(query).to.include(`ui."userId" = '11111111-1111-1111-1111-111111111111'::uuid`);
+        });
+
+        // Unquoted main.userInterests would fold to "userinterests" in raw SQL and fail.
+        it('quotes the camelCase table identifier', async () => {
+            const connection = createMockConnection();
+            const store = new UserInterestsStore(connection);
+
+            await store.incrementUserInterestsByKey('11111111-1111-1111-1111-111111111111', {
+                'interests.foodDrink.coffee': 1,
+            });
+
+            const query = connection.write.query.args[0][0];
+            expect(query).to.include('main."userInterests"');
+            expect(query).to.not.include('main.userInterests ');
+        });
+
+        it('does not query when there is nothing to increment', async () => {
+            const connection = createMockConnection();
+            const store = new UserInterestsStore(connection);
+
+            const result = await store.incrementUserInterestsByKey('user-1', {});
+
+            expect(result).to.deep.equal([]);
+            expect(connection.write.query.called).to.be.eq(false);
+        });
+
+        it('drops non-positive and non-numeric increments rather than emitting invalid SQL', async () => {
+            const connection = createMockConnection();
+            const store = new UserInterestsStore(connection);
+
+            await store.incrementUserInterestsByKey('11111111-1111-1111-1111-111111111111', {
+                'interests.foodDrink.coffee': 3,
+                'interests.sports.soccer': 0,
+                'interests.arts.museums': (undefined as any),
+                'interests.outdoors.hiking': -5,
+            });
+
+            const query = connection.write.query.args[0][0];
+            expect(query).to.include('interests.foodDrink.coffee');
+            expect(query).to.not.include('interests.sports.soccer');
+            expect(query).to.not.include('interests.arts.museums');
+            expect(query).to.not.include('interests.outdoors.hiking');
+        });
+
+        it('requires a user id', async () => {
+            const connection = createMockConnection();
+            const store = new UserInterestsStore(connection);
+
+            const result = await store.incrementUserInterestsByKey('', { 'interests.foodDrink.coffee': 1 });
+
+            expect(result).to.deep.equal([]);
+            expect(connection.write.query.called).to.be.eq(false);
+        });
+    });
+});

--- a/therr-services/users-service/tests/unit/handlers-userInterests.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-userInterests.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable quotes, max-len */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Store from '../../src/store';
+import { incrementUserInterests } from '../../src/handlers/userInterests';
+
+describe('User Interests Handler', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    const buildRes = () => {
+        const res: any = {};
+        res.statusCode = null;
+        res.body = null;
+        res.status = (code: number) => {
+            res.statusCode = code;
+            return res;
+        };
+        res.send = (body: any) => {
+            res.body = body;
+            return res;
+        };
+        return res;
+    };
+
+    const buildReq = (body: any) => ({
+        headers: {
+            'x-userid': '11111111-1111-1111-1111-111111111111',
+            'x-localecode': 'en-us',
+        },
+        body,
+    });
+
+    describe('incrementUserInterests', () => {
+        it('routes the coalesced payload to the per-key increment', async () => {
+            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([{ id: 'ui-1' }]);
+            const legacyStub = sinon.stub(Store.userInterests, 'incrementUserInterests').resolves([]);
+
+            await incrementUserInterests(buildReq({
+                interestIncrements: {
+                    'interests.foodDrink.coffee': 6,
+                    'interests.sports.soccer': 2,
+                },
+            }), buildRes());
+
+            expect(legacyStub.called).to.be.eq(false);
+            expect(byKeyStub.calledOnce).to.be.eq(true);
+            expect(byKeyStub.args[0][0]).to.eq('11111111-1111-1111-1111-111111111111');
+            expect(byKeyStub.args[0][1]).to.deep.equal({
+                'interests.foodDrink.coffee': 6,
+                'interests.sports.soccer': 2,
+            });
+        });
+
+        it('caps how much a single flush can add to one interest', async () => {
+            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([]);
+
+            await incrementUserInterests(buildReq({
+                interestIncrements: { 'interests.foodDrink.coffee': 5000 },
+            }), buildRes());
+
+            expect(byKeyStub.args[0][1]).to.deep.equal({ 'interests.foodDrink.coffee': 25 });
+        });
+
+        // A rolling deploy leaves older maps/reactions pods sending the one-event-at-a-time
+        // shape for a while. Dropping it would silently stop preference learning mid-deploy.
+        it('still accepts the legacy single-increment payload', async () => {
+            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([]);
+            const legacyStub = sinon.stub(Store.userInterests, 'incrementUserInterests').resolves([{ id: 'ui-1' }]);
+
+            await incrementUserInterests(buildReq({
+                interestDisplayNameKeys: ['interests.foodDrink.coffee'],
+                incrBy: 3,
+            }), buildRes());
+
+            expect(byKeyStub.called).to.be.eq(false);
+            expect(legacyStub.calledOnce).to.be.eq(true);
+            expect(legacyStub.args[0][1]).to.deep.equal(['interests.foodDrink.coffee']);
+            expect(legacyStub.args[0][2]).to.eq(3);
+        });
+
+        it('returns early without touching the store when there is no user', async () => {
+            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([]);
+            const legacyStub = sinon.stub(Store.userInterests, 'incrementUserInterests').resolves([]);
+            const res = buildRes();
+
+            await incrementUserInterests({
+                headers: { 'x-localecode': 'en-us' },
+                body: { interestIncrements: { 'interests.foodDrink.coffee': 1 } },
+            }, res);
+
+            expect(res.statusCode).to.eq(200);
+            expect(byKeyStub.called).to.be.eq(false);
+            expect(legacyStub.called).to.be.eq(false);
+        });
+    });
+});


### PR DESCRIPTION
Documents how user preferences are captured, stored, and applied across
the four personalization surfaces (thought distributor, map content
search, activity generator, preference learning loop), and records the
effectiveness and scale gaps found in each.

Key findings:
- The declared-preference dimension (userInterests.score) is inert; no
  client ever sends it, so getInterestRanking degenerates to a constant
  divisor and quantizes engagement into 2-3 tied buckets.
- incrementUserInterests is an UPDATE, not an upsert, so behavior can
  never discover an undeclared interest.
- engagementCount has no decay or per-user normalization.
- Interest matching is an unweighted boolean overlap, and the distributor
  discards its own ranking before querying.
- getRecentThoughts computes a hot score that is thrown away: the feed
  reads back ordered by reaction createdAt, so relevance never reaches
  the user. ThoughtsStore.search has no ORDER BY at all.
- The personalized surface has no geo filter; the geo surfaces never
  reference interestsKeys.
- The distributor runs on every notifications poll, and preference writes
  are one cross-service HTTP call per content view.

Proposes three sequenced optimizations: a weighted decaying preference
vector, persisted relevance with a shared geo+interest scoring function,
and moving personalization off the request path via cache-gating,
batched writes, and materialized vectors.

Audit only - no behavioral code changed.