### PR TITLE
Allow multiple accounts per phone number, capped per brand

### DIFF
--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -910,12 +910,15 @@
         "enterPhone": "What's your number?",
         "enterCode": "Enter your code",
         "enterEmail": "Add your e-mail",
-        "optionalPassword": "Password (optional)"
+        "optionalPassword": "Password (optional)",
+        "accountType": "Which kind of account?"
       },
       "subtitles": {
         "enterPhone": "We'll text you a code to verify it's you.",
         "enterEmail": "We use it for receipts, password resets, and account recovery.",
-        "optionalPassword": "Skip it — you can always sign in with a texted code."
+        "optionalPassword": "Skip it — you can always sign in with a texted code.",
+        "accountType": "This number already has an account, so pick a different type for this one.",
+        "accountTypeHint": "Each phone number can have one personal, one creator, and one business account."
       },
       "buttons": {
         "sendCode": "Send Code",
@@ -925,7 +928,9 @@
         "usePhoneInstead": "Sign up with your phone instead"
       },
       "errorMessages": {
-        "accountExists": "An account already uses this number. Try signing in."
+        "accountExists": "An account already uses this number. Try signing in.",
+        "accountTypeTaken": "This number already has an account of that type. Pick another type or sign in instead.",
+        "accountLimitReached": "This number already has the maximum number of accounts. Try signing in."
       }
     }
   },

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -910,12 +910,15 @@
         "enterPhone": "¿Cuál es tu número?",
         "enterCode": "Ingresa tu código",
         "enterEmail": "Agrega tu correo",
-        "optionalPassword": "Contraseña (opcional)"
+        "optionalPassword": "Contraseña (opcional)",
+        "accountType": "¿Qué tipo de cuenta?"
       },
       "subtitles": {
         "enterPhone": "Te enviaremos un código para verificar que eres tú.",
         "enterEmail": "Lo usamos para recibos, restablecer contraseñas y recuperar tu cuenta.",
-        "optionalPassword": "Puedes omitirla: siempre puedes iniciar sesión con un código."
+        "optionalPassword": "Puedes omitirla: siempre puedes iniciar sesión con un código.",
+        "accountType": "Este número ya tiene una cuenta, así que elige un tipo diferente para esta.",
+        "accountTypeHint": "Cada número de teléfono puede tener una cuenta personal, una de creador y una de negocio."
       },
       "buttons": {
         "sendCode": "Enviar código",
@@ -925,7 +928,9 @@
         "usePhoneInstead": "Registrarse con tu teléfono"
       },
       "errorMessages": {
-        "accountExists": "Ya existe una cuenta con este número. Intenta iniciar sesión."
+        "accountExists": "Ya existe una cuenta con este número. Intenta iniciar sesión.",
+        "accountTypeTaken": "Este número ya tiene una cuenta de ese tipo. Elige otro tipo o inicia sesión.",
+        "accountLimitReached": "Este número ya tiene el número máximo de cuentas. Intenta iniciar sesión."
       }
     }
   },

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -910,12 +910,15 @@
         "enterPhone": "Quel est votre numéro?",
         "enterCode": "Entrez votre code",
         "enterEmail": "Ajoutez votre courriel",
-        "optionalPassword": "Mot de passe (facultatif)"
+        "optionalPassword": "Mot de passe (facultatif)",
+        "accountType": "Quel type de compte?"
       },
       "subtitles": {
         "enterPhone": "Nous vous enverrons un code pour vérifier que c’est bien vous.",
         "enterEmail": "Il sert aux reçus, à la réinitialisation du mot de passe et à la récupération du compte.",
-        "optionalPassword": "Vous pouvez l’ignorer : un code texte suffit pour vous connecter."
+        "optionalPassword": "Vous pouvez l’ignorer : un code texte suffit pour vous connecter.",
+        "accountType": "Ce numéro a déjà un compte, alors choisissez un type différent pour celui-ci.",
+        "accountTypeHint": "Chaque numéro de téléphone peut avoir un compte personnel, un compte créateur et un compte entreprise."
       },
       "buttons": {
         "sendCode": "Envoyer le code",
@@ -925,7 +928,9 @@
         "usePhoneInstead": "S’inscrire avec votre téléphone"
       },
       "errorMessages": {
-        "accountExists": "Un compte utilise déjà ce numéro. Essayez de vous connecter."
+        "accountExists": "Un compte utilise déjà ce numéro. Essayez de vous connecter.",
+        "accountTypeTaken": "Ce numéro a déjà un compte de ce type. Choisissez un autre type ou connectez-vous.",
+        "accountLimitReached": "Ce numéro a déjà le nombre maximal de comptes. Essayez de vous connecter."
       }
     }
   },

--- a/TherrMobile/main/routes/CreateProfile/index.tsx
+++ b/TherrMobile/main/routes/CreateProfile/index.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { Content } from 'therr-js-utilities/constants';
+import { Content, getPhoneAccountType } from 'therr-js-utilities/constants';
 import { sanitizeUserName } from 'therr-js-utilities/sanitizers';
 import { IUserState } from 'therr-react/types';
 import { UsersService } from 'therr-react/services';
@@ -85,6 +85,11 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
             croppedImageDetails: {},
             errorMsg: '',
             inputs: {
+                // Seeded from the account rather than defaulted, because sign-up now sets the
+                // type up-front when the phone number already has an account. Leaving this
+                // blank would submit `personal` on the next Save and quietly demote a creator
+                // or business account into a duplicate type on that number.
+                accountType: getPhoneAccountType(props.user.details),
                 email: props.user.details.email,
                 firstName: Platform.OS === 'ios' ? (props.user.details.firstName || DEFAULT_FIRSTNAME) : props.user.details.firstName,
                 lastName: Platform.OS === 'ios' ? (props.user.details.lastName || DEFAULT_LASTNAME) : props.user.details.lastName,

--- a/TherrMobile/main/routes/CreateProfile/index.tsx
+++ b/TherrMobile/main/routes/CreateProfile/index.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { Content, getPhoneAccountType } from 'therr-js-utilities/constants';
+import { Content, ErrorCodes, getPhoneAccountType } from 'therr-js-utilities/constants';
 import { sanitizeUserName } from 'therr-js-utilities/sanitizers';
 import { IUserState } from 'therr-react/types';
 import { UsersService } from 'therr-react/services';
@@ -295,7 +295,13 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
                     }
                 })
                 .catch((error: any) => {
-                    if (
+                    // The account type or phone number collides with another account on the
+                    // same number. The service's message is English-only, so translate here.
+                    if (error?.errorCode === ErrorCodes.TOO_MANY_ACCOUNTS) {
+                        this.setState({
+                            errorMsg: this.translate('alertMessages.phoneNumberAlreadyInUse'),
+                        });
+                    } else if (
                         error.statusCode === 400 ||
                         error.statusCode === 401 ||
                         error.statusCode === 404

--- a/TherrMobile/main/routes/Register/PhoneSignupForm.tsx
+++ b/TherrMobile/main/routes/Register/PhoneSignupForm.tsx
@@ -7,9 +7,17 @@ import {
     View,
 } from 'react-native';
 import DatePicker from 'react-native-date-picker';
+import { SegmentedButtons } from 'react-native-paper';
 import { ApiService } from 'therr-react/services';
-import { ErrorCodes, PasswordRegex } from 'therr-js-utilities/constants';
+import {
+    ErrorCodes,
+    PasswordRegex,
+    PHONE_ACCOUNT_TYPES,
+    PhoneAccountType,
+    getMaxAccountsPerPhone,
+} from 'therr-js-utilities/constants';
 import isValidSignupAge, { MINIMUM_SIGNUP_AGE } from 'therr-js-utilities/is-valid-signup-age';
+import { CURRENT_BRAND_VARIATION } from '../../config/brandConfig';
 import { Button } from '../../components/BaseButton';
 import { showToast } from '../../utilities/toasts';
 import translator from '../../utilities/translator';
@@ -29,6 +37,13 @@ import { ITherrThemeColors, ITherrThemeColorVariations, isDarkTheme } from '../.
  * abandoned sign-up leaves nothing behind — only a spent SMS code and an expired token.
  */
 type PhoneSignupStep = 'phone' | 'code' | 'details';
+
+/** Reuses the labels the CreateProfile account-type picker already ships in every locale. */
+const ACCOUNT_TYPE_LABEL_KEYS: { [key in PhoneAccountType]: string } = {
+    personal: 'forms.settings.labels.personalAccount',
+    creator: 'forms.settings.labels.creatorAccount',
+    business: 'forms.settings.labels.businessAccount',
+};
 
 interface IPhoneSignupFormProps {
     register: Function;
@@ -63,7 +78,16 @@ interface IPhoneSignupFormState {
     hasCodeError: boolean;
     /** Signed proof of phone ownership; expires ~20 minutes after the code is accepted. */
     phoneVerificationToken: string;
+    /**
+     * How many accounts the verified number already holds, and which types are still free.
+     * Both arrive with the verified code. A number with no accounts skips the type picker
+     * entirely — that user still chooses their type on the CreateProfile screen, as before.
+     */
+    existingAccountCount: number;
+    availableAccountTypes: PhoneAccountType[];
+    accountType: PhoneAccountType | '';
     email: string;
+    inviteCode: string;
     password: string;
     settingsBirthdate: string;
     isBirthdatePickerOpen: boolean;
@@ -97,7 +121,11 @@ export class PhoneSignupFormComponent extends React.Component<
             verificationCode: '',
             hasCodeError: false,
             phoneVerificationToken: '',
+            existingAccountCount: 0,
+            availableAccountTypes: [],
+            accountType: '',
             email: '',
+            inviteCode: '',
             password: '',
             settingsBirthdate: '',
             isBirthdatePickerOpen: false,
@@ -146,8 +174,12 @@ export class PhoneSignupFormComponent extends React.Component<
                 // Unlike sign-in, this endpoint does tell us the number is taken — surface it
                 // and point at sign-in rather than leaving the user stuck on a dead form.
                 if (error?.errorCode === ErrorCodes.USER_EXISTS) {
+                    // On a brand that allows several accounts per number, "an account already
+                    // uses this number" is not why we refused — the number is full.
                     this.setState({
-                        errorMessage: this.translate('forms.phoneSignupForm.errorMessages.accountExists'),
+                        errorMessage: getMaxAccountsPerPhone(CURRENT_BRAND_VARIATION) > 1
+                            ? this.translate('forms.phoneSignupForm.errorMessages.accountLimitReached')
+                            : this.translate('forms.phoneSignupForm.errorMessages.accountExists'),
                     });
                     showToast.error({
                         text1: this.translate('alertTitles.phoneNumberAlreadyInUse'),
@@ -184,9 +216,17 @@ export class PhoneSignupFormComponent extends React.Component<
 
         ApiService.verifyPhoneRegistration({ phoneNumber, verificationCode })
             .then((response: any) => {
+                const availableAccountTypes: PhoneAccountType[] = response?.data?.availableAccountTypes
+                    || [...PHONE_ACCOUNT_TYPES];
+
                 this.setState({
                     step: 'details',
                     phoneVerificationToken: response?.data?.phoneVerificationToken || '',
+                    existingAccountCount: response?.data?.existingAccountCount || 0,
+                    availableAccountTypes,
+                    // Pre-select when only one type is left, so the picker is a confirmation
+                    // rather than a decision the user has no room to get wrong.
+                    accountType: availableAccountTypes.length === 1 ? availableAccountTypes[0] : '',
                 });
             })
             .catch((error: any) => {
@@ -220,15 +260,25 @@ export class PhoneSignupFormComponent extends React.Component<
         this.setState({ settingsBirthdate: date.toISOString() });
     };
 
-    isDetailsStepDisabled = () => {
-        const { email, isSubmitting, settingsBirthdate } = this.state;
+    /** The type picker only appears for a number that already has an account. */
+    shouldSelectAccountType = () => this.state.existingAccountCount > 0
+        && this.state.availableAccountTypes.length > 0;
 
-        return !email || !settingsBirthdate || !isValidSignupAge(settingsBirthdate) || isSubmitting;
+    isDetailsStepDisabled = () => {
+        const { accountType, email, isSubmitting, settingsBirthdate } = this.state;
+
+        return !email
+            || !settingsBirthdate
+            || !isValidSignupAge(settingsBirthdate)
+            || (this.shouldSelectAccountType() && !accountType)
+            || isSubmitting;
     };
 
     onSubmitDetails = () => {
         const {
+            accountType,
             email,
+            inviteCode,
             password,
             phoneNumber,
             phoneVerificationToken,
@@ -262,14 +312,33 @@ export class PhoneSignupFormComponent extends React.Component<
         this.props
             .register({
                 email: email.trim(),
+                // Referral code from the inviter's share link. Sending it is what auto-connects
+                // the two accounts once the new one exists, so it has to survive this path too.
+                inviteCode: inviteCode.trim() || undefined,
                 password: password || undefined,
                 phoneNumber,
                 phoneVerificationToken,
                 settingsBirthdate,
                 settingsLocale: this.props.userSettings?.locale || 'en-us',
+                // Omitted unless the picker was shown; a first account on a number keeps
+                // choosing its type on the CreateProfile screen.
+                ...(this.shouldSelectAccountType()
+                    ? {
+                        isBusinessAccount: accountType === 'business',
+                        isCreatorAccount: accountType === 'creator',
+                    }
+                    : {}),
             })
             .then(() => this.props.onSuccess({ email: email.trim(), phoneNumber }))
             .catch((error: any) => {
+                if (error?.errorCode === ErrorCodes.TOO_MANY_ACCOUNTS) {
+                    // The number filled its last slot between verification and submit.
+                    this.setState({
+                        isSubmitting: false,
+                        errorMessage: this.translate('forms.phoneSignupForm.errorMessages.accountTypeTaken'),
+                    });
+                    return;
+                }
                 this.setState({
                     isSubmitting: false,
                     errorMessage: error?.statusCode === 400
@@ -380,10 +449,41 @@ export class PhoneSignupFormComponent extends React.Component<
         );
     }
 
+    renderAccountTypeSelector() {
+        const { theme, themeForms } = this.props;
+        const { accountType, availableAccountTypes } = this.state;
+
+        return (
+            <View style={localStyles.accountTypeContainer}>
+                <Text style={[localStyles.sectionHeading, { color: themeForms.colors.onSurface }]}>
+                    {this.translate('forms.phoneSignupForm.labels.accountType')}
+                </Text>
+                <Text style={[localStyles.sectionSubheading, { color: themeForms.colors.onSurfaceMuted }]}>
+                    {this.translate('forms.phoneSignupForm.subtitles.accountType')}
+                </Text>
+                <SegmentedButtons
+                    value={accountType}
+                    onValueChange={(value) => this.setState({
+                        accountType: value as PhoneAccountType,
+                        errorMessage: '',
+                    })}
+                    buttons={availableAccountTypes.map((type) => ({
+                        value: type,
+                        label: this.translate(ACCOUNT_TYPE_LABEL_KEYS[type]),
+                    }))}
+                />
+                <Text style={[theme.styles.sectionDescription, localStyles.hint]}>
+                    {this.translate('forms.phoneSignupForm.subtitles.accountTypeHint')}
+                </Text>
+            </View>
+        );
+    }
+
     renderDetailsStep() {
         const { theme, themeAlerts, themeAuthForm, themeForms, toggleEULA } = this.props;
         const {
             email,
+            inviteCode,
             isBirthdatePickerOpen,
             isPasswordEntryDirty,
             isSubmitting,
@@ -418,6 +518,27 @@ export class PhoneSignupFormComponent extends React.Component<
                     containerStyle={{ marginBottom: 14 }}
                     testID="phone-signup-email"
                 />
+                <RoundInput
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    placeholder={this.translate('forms.registerForm.labels.inviteCode')}
+                    value={inviteCode}
+                    onChangeText={(text) => this.setState({ inviteCode: text, errorMessage: '' })}
+                    rightIcon={
+                        <TherrIcon
+                            name="gift"
+                            size={26}
+                            color={themeAlerts.colors.placeholderTextColorAlt}
+                        />
+                    }
+                    themeForms={themeForms}
+                    containerStyle={{ marginBottom: 6 }}
+                    testID="phone-signup-invite-code"
+                />
+                <Text style={[theme.styles.sectionDescription, localStyles.hint]}>
+                    {this.translate('forms.registerForm.subtitles.inviteCodeHint')}
+                </Text>
+                {this.shouldSelectAccountType() ? this.renderAccountTypeSelector() : null}
                 <Pressable onPress={() => this.setState({ isBirthdatePickerOpen: true })}>
                     <View pointerEvents="none">
                         <RoundInput
@@ -573,6 +694,20 @@ const localStyles = StyleSheet.create({
         textAlign: 'center',
         marginTop: space.xs,
         marginBottom: space.lg,
+    },
+    accountTypeContainer: {
+        marginBottom: space.sm,
+    },
+    sectionHeading: {
+        fontSize: fontSizes.md,
+        fontWeight: '600',
+        textAlign: 'center',
+        marginBottom: space.xs,
+    },
+    sectionSubheading: {
+        fontSize: fontSizes.xs,
+        textAlign: 'center',
+        marginBottom: space.sm,
     },
     disclaimer: {
         marginBottom: space.xl,

--- a/TherrMobile/main/routes/Register/index.tsx
+++ b/TherrMobile/main/routes/Register/index.tsx
@@ -20,6 +20,7 @@ import { bindActionCreators } from 'redux';
 import UsersActions from '../../redux/actions/UsersActions';
 import setPreLoginLocale from '../../redux/actions/setPreLoginLocale';
 import translator from '../../utilities/translator';
+import spacingStyles from '../../styles/layouts/spacing';
 import BaseStatusBar from '../../components/BaseStatusBar';
 import LanguageSelector from '../../components/LanguageSelector';
 import ConfirmModal from '../../components/Modals/ConfirmModal';
@@ -213,7 +214,10 @@ class RegisterComponent extends React.Component<IRegisterProps, IRegisterState> 
                                 onChangeLocale={this.onChangeLocale}
                                 translate={this.translate}
                                 theme={this.theme}
-                                containerStyle={this.theme.styles.sectionContainerWide}
+                                // Unlike Login, the selector sits *above* the form here, so it
+                                // needs real separation from the first step's heading —
+                                // otherwise "What's your number?" reads as its caption.
+                                containerStyle={[this.theme.styles.sectionContainerWide, spacingStyles.marginBotXl]}
                             />
                             {
                                 signupMethod === 'phone'

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -16,7 +16,8 @@
 - **Apple OAuth** — social sign-in (mobile)
 - **Phone verification** — optional during profile creation
 - **Passwordless phone sign-in** (mobile) — entering a phone number in the sign-in field swaps the password step for a texted 6-digit code (`POST /v1/phone/auth/start` → `/auth/verify`). Enumeration-safe: the "code sent" response is identical whether or not an account exists. When a number is attached to several accounts, an account picker completes sign-in via `/auth/select`
-- **Phone-first sign-up** (mobile) — verify a phone number by SMS, then add an e-mail; the account is created already `MOBILE_VERIFIED` and a password is optional. The e-mail still receives its normal verification message
+- **Phone-first sign-up** (mobile) — verify a phone number by SMS, then add an e-mail and (optionally) an invite code; the account is created already `MOBILE_VERIFIED` and a password is optional. The e-mail still receives its normal verification message
+- **Accounts per phone number** — brand-configurable cap (`getMaxAccountsPerPhone`): Therr allows one personal + one creator + one business account per number, Friends with Habits allows exactly one. When a number already holds an account, sign-up asks which type the new one is and offers only the free types; a first account still picks its type on the profile-creation screen
 - **Remembered profiles** (mobile) — the sign-in field pre-fills the account last used on the device, with a chevron that opens a switcher to change accounts, remove a saved one, or start fresh. Stored locally through `SecureStorage`; holds no credentials or tokens
 - **Password reset** — forgot-password email flow
 - **Account types** — personal, business, and creator accounts

--- a/therr-api-gateway/src/services/phone/router.ts
+++ b/therr-api-gateway/src/services/phone/router.ts
@@ -8,7 +8,11 @@ import {
     verifyPhoneVerificationToken,
     PHONE_VERIFICATION_TOKEN_TTL_SECONDS,
 } from 'therr-js-utilities/phone-verification-token';
-import { ErrorCodes } from 'therr-js-utilities/constants';
+import {
+    ErrorCodes,
+    getAvailablePhoneAccountTypes,
+    getMaxAccountsPerPhone,
+} from 'therr-js-utilities/constants';
 import handleHttpError from '../../utilities/handleHttpError';
 import { validate } from '../../validation';
 import redisClient, { storeRefreshToken } from '../../store/redisClient';
@@ -495,11 +499,15 @@ phoneRouter.post('/auth/select', phoneAuthVerifyLimiter, phoneAuthSelectValidati
 /**
  * PASSWORDLESS SIGN-UP — step 1.
  *
- * Texts a one-time code to a phone number that has no account yet. Unlike `/auth/start` this
- * one deliberately DOES report `USER_EXISTS`: a sign-up form that silently did nothing for an
- * already-registered number would be a dead end, and the client uses the error to offer
- * "sign in instead". The number is already known to whoever holds the handset, and the same
- * disclosure exists today on the authenticated `/phone/verify` route.
+ * Texts a one-time code to a phone number that has room for another account. Unlike
+ * `/auth/start` this one deliberately DOES report `USER_EXISTS`: a sign-up form that silently
+ * did nothing for a number at its cap would be a dead end, and the client uses the error to
+ * offer "sign in instead". The number is already known to whoever holds the handset, and the
+ * same disclosure exists today on the authenticated `/phone/verify` route.
+ *
+ * "Has room" is per-brand: Therr allows a personal + creator + business account per number
+ * (the same allowance `/auth/verify` and `getUserByPhoneNumber` already grant), Habits allows
+ * exactly one. See `getMaxAccountsPerPhone`.
  */
 phoneRouter.post('/register/start', phoneAuthStartLimiter, phoneAuthStartValidation, validate, async (req, res) => {
     const userLocale = (req.headers['x-localecode'] || 'en-us') as string;
@@ -514,14 +522,17 @@ phoneRouter.post('/register/start', phoneAuthStartLimiter, phoneAuthStartValidat
     }
 
     try {
-        const { accountCount } = await lookupAccountsByPhone(buildInternalHeaders(req), phone.canonical);
+        const { accounts } = await lookupAccountsByPhone(buildInternalHeaders(req), phone.canonical);
+        const brandVariation = `${req.headers['x-brand-variation'] || ''}`;
 
-        if (accountCount) {
+        if (!getAvailablePhoneAccountTypes(accounts, brandVariation).length) {
             return handleHttpError({
-                err: new Error('Phone number already exists'),
+                err: new Error('Phone number has reached its account limit'),
                 errorCode: ErrorCodes.USER_EXISTS,
                 res,
-                message: 'An account already exists for this phone number',
+                message: getMaxAccountsPerPhone(brandVariation) > 1
+                    ? 'This phone number already has the maximum number of accounts'
+                    : 'An account already exists for this phone number',
                 statusCode: 400,
             });
         }
@@ -567,6 +578,10 @@ phoneRouter.post('/register/start', phoneAuthStartLimiter, phoneAuthStartValidat
  * Validates the texted code and hands back a short-lived, signed proof of phone ownership.
  * The client passes it to `POST /users-service/users` alongside the email it collects next;
  * the users-service verifies the signature and creates the account already MOBILE_VERIFIED.
+ *
+ * Also reports which account types the number may still register. That is only meaningful once
+ * the number already holds an account, and it is only disclosed *after* the code is verified —
+ * before that point the caller has proven nothing about the handset.
  */
 phoneRouter.post('/register/verify', phoneAuthVerifyLimiter, phoneAuthVerifyValidation, validate, async (req, res) => {
     const phone = canonicalizePhoneNumber(req.body?.phoneNumber);
@@ -593,6 +608,9 @@ phoneRouter.post('/register/verify', phoneAuthVerifyLimiter, phoneAuthVerifyVali
 
         await clearSubmittedCode('register', phone.e164);
 
+        const { accountCount, accounts } = await lookupAccountsByPhone(buildInternalHeaders(req), phone.canonical);
+        const brandVariation = `${req.headers['x-brand-variation'] || ''}`;
+
         return res.status(200).send({
             phoneNumber: phone.canonical,
             // The token carries the canonical form because `createUserHelper` writes it
@@ -600,6 +618,8 @@ phoneRouter.post('/register/verify', phoneAuthVerifyLimiter, phoneAuthVerifyVali
             // dialect every phone lookup re-derives.
             phoneVerificationToken: createPhoneVerificationToken(phone.canonical, 'register'),
             expiresInSeconds: PHONE_VERIFICATION_TOKEN_TTL_SECONDS,
+            existingAccountCount: accountCount,
+            availableAccountTypes: getAvailablePhoneAccountTypes(accounts, brandVariation),
         });
     } catch (err: any) {
         return handleHttpError({ err, res, message: 'SQL:PHONE_ROUTES:ERROR' });

--- a/therr-client-web/src/routes/CreateProfile.tsx
+++ b/therr-client-web/src/routes/CreateProfile.tsx
@@ -120,7 +120,11 @@ export class CreateProfileComponent extends React.Component<ICreateProfileProps,
                 }
             });
         }).catch((error: any) => {
-            if (error.statusCode === 400) {
+            // Switching account type onto a number that already has one of that type. The
+            // service's message is English-only, so translate rather than passing it through.
+            if (error?.errorCode === ErrorCodes.TOO_MANY_ACCOUNTS) {
+                this.setError(this.props.translate('pages.createProfile.phoneNumberAlreadyInUseError'));
+            } else if (error.statusCode === 400) {
                 this.setError(error.message);
             } else if (error.statusCode === 403) {
                 this.setError(this.props.translate('pages.createProfile.authError'));

--- a/therr-public-library/therr-js-utilities/src/constants/index.ts
+++ b/therr-public-library/therr-js-utilities/src/constants/index.ts
@@ -39,6 +39,15 @@ import {
     getReadableBrands,
 } from './brandThoughtsVisibility';
 import {
+    PhoneAccountType,
+    PHONE_ACCOUNT_TYPES,
+    MAX_ACCOUNTS_PER_PHONE_BY_BRAND,
+    DEFAULT_MAX_ACCOUNTS_PER_PHONE,
+    getMaxAccountsPerPhone,
+    getPhoneAccountType,
+    getAvailablePhoneAccountTypes,
+} from './phoneAccounts';
+import {
     FeatureFlags,
     HABITS_FREE_PACT_LIMIT,
     DEFAULT_HABITS_FREE_PACT_LIMIT,
@@ -105,6 +114,13 @@ export {
     OAuthIntegrationProviders,
     PushNotifications,
     PasswordRegex,
+    PhoneAccountType,
+    PHONE_ACCOUNT_TYPES,
+    MAX_ACCOUNTS_PER_PHONE_BY_BRAND,
+    DEFAULT_MAX_ACCOUNTS_PER_PHONE,
+    getMaxAccountsPerPhone,
+    getPhoneAccountType,
+    getAvailablePhoneAccountTypes,
     CurrentSocialValuations,
     CurrentMomentValuations,
     CurrentCheckInValuations,

--- a/therr-public-library/therr-js-utilities/src/constants/phoneAccounts.ts
+++ b/therr-public-library/therr-js-utilities/src/constants/phoneAccounts.ts
@@ -1,0 +1,71 @@
+import { BrandVariations } from './enums/Branding';
+
+/**
+ * The three mutually-exclusive shapes a user row can take, derived from the
+ * `isBusinessAccount` / `isCreatorAccount` booleans on `main.users`.
+ */
+export type PhoneAccountType = 'personal' | 'creator' | 'business';
+
+export const PHONE_ACCOUNT_TYPES: PhoneAccountType[] = ['personal', 'creator', 'business'];
+
+/**
+ * How many accounts one phone number may hold, keyed by brand.
+ *
+ * Therr (and any variant without an entry here) allows one account per type — a person, the
+ * creator persona they publish under, and the business they run are three different identities
+ * that legitimately share a handset. Habits is deliberately capped at one: its whole premise is
+ * accountability between real people, and a second account on the same number is a way to fake
+ * a pact partner, not a real use case.
+ */
+export const MAX_ACCOUNTS_PER_PHONE_BY_BRAND: { [brand: string]: number } = {
+    [BrandVariations.HABITS]: 1,
+};
+
+export const DEFAULT_MAX_ACCOUNTS_PER_PHONE = PHONE_ACCOUNT_TYPES.length;
+
+export const getMaxAccountsPerPhone = (brandVariation?: string): number => {
+    const configured = brandVariation && MAX_ACCOUNTS_PER_PHONE_BY_BRAND[brandVariation];
+
+    return configured || DEFAULT_MAX_ACCOUNTS_PER_PHONE;
+};
+
+/**
+ * Business wins over creator when both flags are set — matching how the rest of the codebase
+ * branches on `isBusinessAccount` first (see `HeaderMenuRight`, `EditSpace`).
+ */
+export const getPhoneAccountType = (account: {
+    isBusinessAccount?: boolean;
+    isCreatorAccount?: boolean;
+}): PhoneAccountType => {
+    if (account?.isBusinessAccount) {
+        return 'business';
+    }
+    if (account?.isCreatorAccount) {
+        return 'creator';
+    }
+
+    return 'personal';
+};
+
+/**
+ * Which account types a phone number may still register, given the accounts it already holds.
+ *
+ * Returns an empty list once the brand's cap is reached, so callers can treat "no types left"
+ * and "at the cap" as the same rejection. Below the cap, every type the number does not
+ * already have is fair game — the first account on a number can be any of the three, which is
+ * why a brand capped at 1 still offers all three to a brand-new number.
+ */
+export const getAvailablePhoneAccountTypes = (
+    existingAccounts: { isBusinessAccount?: boolean; isCreatorAccount?: boolean }[],
+    brandVariation?: string,
+): PhoneAccountType[] => {
+    const accounts = existingAccounts || [];
+
+    if (accounts.length >= getMaxAccountsPerPhone(brandVariation)) {
+        return [];
+    }
+
+    const takenTypes = accounts.map(getPhoneAccountType);
+
+    return PHONE_ACCOUNT_TYPES.filter((type) => !takenTypes.includes(type));
+};

--- a/therr-public-library/therr-js-utilities/tests/phone-accounts.test.ts
+++ b/therr-public-library/therr-js-utilities/tests/phone-accounts.test.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import { BrandVariations } from '../src/constants/enums/Branding';
+import {
+    DEFAULT_MAX_ACCOUNTS_PER_PHONE,
+    getAvailablePhoneAccountTypes,
+    getMaxAccountsPerPhone,
+    getPhoneAccountType,
+} from '../src/constants/phoneAccounts';
+
+const personal = {};
+const creator = { isCreatorAccount: true };
+const business = { isBusinessAccount: true };
+
+describe('getMaxAccountsPerPhone', () => {
+    it('allows one account per type on Therr', () => {
+        expect(getMaxAccountsPerPhone(BrandVariations.THERR)).to.equal(3);
+    });
+
+    it('allows exactly one account on Habits', () => {
+        expect(getMaxAccountsPerPhone(BrandVariations.HABITS)).to.equal(1);
+    });
+
+    it('falls back to the default for an unconfigured or missing brand', () => {
+        expect(getMaxAccountsPerPhone('some-future-brand')).to.equal(DEFAULT_MAX_ACCOUNTS_PER_PHONE);
+        expect(getMaxAccountsPerPhone()).to.equal(DEFAULT_MAX_ACCOUNTS_PER_PHONE);
+        expect(getMaxAccountsPerPhone('')).to.equal(DEFAULT_MAX_ACCOUNTS_PER_PHONE);
+    });
+});
+
+describe('getPhoneAccountType', () => {
+    it('reads the type off the account flags', () => {
+        expect(getPhoneAccountType(personal)).to.equal('personal');
+        expect(getPhoneAccountType(creator)).to.equal('creator');
+        expect(getPhoneAccountType(business)).to.equal('business');
+    });
+
+    it('resolves a row carrying both flags as business', () => {
+        expect(getPhoneAccountType({ isBusinessAccount: true, isCreatorAccount: true })).to.equal('business');
+    });
+});
+
+describe('getAvailablePhoneAccountTypes', () => {
+    it('offers every type to a number with no accounts', () => {
+        expect(getAvailablePhoneAccountTypes([], BrandVariations.THERR))
+            .to.deep.equal(['personal', 'creator', 'business']);
+    });
+
+    it('offers every type to a brand-new number even on a brand capped at one', () => {
+        expect(getAvailablePhoneAccountTypes([], BrandVariations.HABITS))
+            .to.deep.equal(['personal', 'creator', 'business']);
+    });
+
+    it('excludes types the number already holds', () => {
+        expect(getAvailablePhoneAccountTypes([personal], BrandVariations.THERR))
+            .to.deep.equal(['creator', 'business']);
+        expect(getAvailablePhoneAccountTypes([personal, business], BrandVariations.THERR))
+            .to.deep.equal(['creator']);
+    });
+
+    it('returns nothing once the number holds one of each type', () => {
+        expect(getAvailablePhoneAccountTypes([personal, creator, business], BrandVariations.THERR))
+            .to.deep.equal([]);
+    });
+
+    it('returns nothing for a Habits number that already has one account', () => {
+        expect(getAvailablePhoneAccountTypes([personal], BrandVariations.HABITS)).to.deep.equal([]);
+        expect(getAvailablePhoneAccountTypes([business], BrandVariations.HABITS)).to.deep.equal([]);
+    });
+
+    it('treats a null account list as empty', () => {
+        expect(getAvailablePhoneAccountTypes(null as any, BrandVariations.THERR))
+            .to.deep.equal(['personal', 'creator', 'business']);
+    });
+});

--- a/therr-public-library/therr-react/src/services/UsersService.ts
+++ b/therr-public-library/therr-react/src/services/UsersService.ts
@@ -33,6 +33,12 @@ interface IRegisterCredentials {
     // Magic invite-link token: trusts the invited contact channel and
     // auto-connects the user to the inviter on signup.
     inviteToken?: string;
+    // Account type, when the sign-up flow collects it up-front. Only the phone-first path does
+    // today, and only for a number that already holds an account — the cap is one account per
+    // type, so the type can no longer be deferred to profile creation. Everyone else omits
+    // these and picks their type on the CreateProfile screen as before.
+    isBusinessAccount?: boolean;
+    isCreatorAccount?: boolean;
     // Short-lived proof of phone ownership from POST /v1/phone/register/verify. When present,
     // the account is created already phone-verified and `password` may be omitted.
     phoneVerificationToken?: string;

--- a/therr-services/users-service/src/handlers/users.ts
+++ b/therr-services/users-service/src/handlers/users.ts
@@ -41,6 +41,18 @@ import {
     resendVerification,
 } from './userVerification';
 
+/**
+ * Whether a `phoneNumber` value is an actual handset.
+ *
+ * Apple SSO signups deliberately write the sentinel `'apple-sso'` into that column
+ * (`createUserHelper`), and every one of those rows carries the same value — so counting "the
+ * accounts on this number" for it would return the entire Apple SSO cohort and refuse them all.
+ */
+const isPhoneNumberLike = (value?: string) => /^\+?[\d\s\-().]{7,}$/.test(`${value || ''}`);
+
+/** Digits only, for comparing two spellings of the same number. See `phoneNumberMatchCandidates`. */
+const toPhoneNumberDigits = (value?: string) => `${value || ''}`.replace(/[^\d]/g, '');
+
 // CREATE
 const createUser: RequestHandler = (req: any, res: any) => {
     const {
@@ -76,10 +88,6 @@ const createUser: RequestHandler = (req: any, res: any) => {
     const verifiedPhoneNumber = verifyPhoneVerificationToken(req.body.phoneVerificationToken, 'register')?.phoneNumber;
 
     const registrationPhoneNumber = verifiedPhoneNumber || req.body.phoneNumber;
-    // Guard against non-phone values reaching the by-number lookup. The `'apple-sso'` sentinel
-    // is shared by every Apple SSO row, so counting "accounts on this number" for it would
-    // return the entire cohort and lock those signups out.
-    const isPhoneLike = /^\+?[\d\s\-().]{7,}$/.test(`${registrationPhoneNumber || ''}`);
 
     return Promise.all([
         // E-mail and username uniqueness is absolute. Phone number is not: one number may hold
@@ -89,7 +97,7 @@ const createUser: RequestHandler = (req: any, res: any) => {
             ...req.body,
             phoneNumber: undefined,
         }),
-        isPhoneLike
+        isPhoneNumberLike(registrationPhoneNumber)
             ? Store.users.getAllByPhoneNumber(registrationPhoneNumber, ['id', 'isBusinessAccount', 'isCreatorAccount'])
             : Promise.resolve([]),
     ])
@@ -898,6 +906,31 @@ const updateUser = (req, res) => {
                 autoRechargePackageId: rawAutoRechargePackageId,
             };
 
+            // A phone number holds at most one account of each type. `createUser` enforces that
+            // at sign-up, but both halves of the pair stay editable afterwards — without this,
+            // two accounts sharing a number could each edit their way to `business`, or an
+            // account could move onto a number whose slot for its type is already filled.
+            //
+            // Deliberately only checked when the type or the number actually changes. Rows that
+            // predate the cap (or were seeded around it) would otherwise fail every unrelated
+            // profile save, locking their owners out of editing a bio.
+            const currentUser = userSearchResults[0];
+            // `undefined` means "leave as-is" here for the same reason it does in
+            // `UsersStore.updateUser`, which only writes these when explicitly true or false.
+            const nextAccountType = getPhoneAccountType({
+                isBusinessAccount: req.body.isBusinessAccount ?? currentUser.isBusinessAccount,
+                isCreatorAccount: req.body.isCreatorAccount ?? currentUser.isCreatorAccount,
+            });
+            const nextPhoneNumber = req.body.phoneNumber || currentUser.phoneNumber;
+            const isChangingAccountType = nextAccountType !== getPhoneAccountType(currentUser);
+            const isChangingPhoneNumber = toPhoneNumberDigits(nextPhoneNumber)
+                !== toPhoneNumberDigits(currentUser.phoneNumber);
+
+            const phoneAccountsPromise: Promise<any[]> = (isChangingAccountType || isChangingPhoneNumber)
+                && isPhoneNumberLike(nextPhoneNumber)
+                ? Store.users.getAllByPhoneNumber(nextPhoneNumber, ['id', 'isBusinessAccount', 'isCreatorAccount'])
+                : Promise.resolve([]);
+
             const isMissingUserProps = isUserProfileIncomplete(updateArgs, userSearchResults[0]);
             const nextAccessLevels = computeAccessLevelsAfterProfileUpdate(
                 userSearchResults[0].accessLevels,
@@ -907,8 +940,8 @@ const updateUser = (req, res) => {
                 updateArgs.accessLevels = nextAccessLevels;
             }
 
-            return Promise.all([passwordPromise, orgsPromise, mediaPromise])
-                .then(([passwordResult, orgsResult, isMediaSafeForWork]) => {
+            return Promise.all([passwordPromise, orgsPromise, mediaPromise, phoneAccountsPromise])
+                .then(([passwordResult, orgsResult, isMediaSafeForWork, phoneAccounts]) => {
                     if (!isMediaSafeForWork) {
                         return handleHttpError({
                             res,
@@ -916,6 +949,22 @@ const updateUser = (req, res) => {
                             statusCode: 400,
                         });
                     }
+
+                    // Empty unless the check above was warranted. Your own row never counts
+                    // against you — it is the one being updated.
+                    const otherPhoneAccounts = phoneAccounts.filter((account) => account.id !== userId);
+                    if (otherPhoneAccounts.length
+                        && !getAvailablePhoneAccountTypes(otherPhoneAccounts, brandVariation).includes(nextAccountType)) {
+                        return handleHttpError({
+                            res,
+                            message: getMaxAccountsPerPhone(brandVariation) > 1
+                                ? `This phone number already has a ${nextAccountType} account.`
+                                : 'Another account already uses this phone number.',
+                            statusCode: 400,
+                            errorCode: ErrorCodes.TOO_MANY_ACCOUNTS,
+                        });
+                    }
+
                     return Store.users
                         .updateUser(updateArgs, {
                             id: userId,

--- a/therr-services/users-service/src/handlers/users.ts
+++ b/therr-services/users-service/src/handlers/users.ts
@@ -1,6 +1,15 @@
 import { RequestHandler } from 'express';
 import {
-    AccessLevels, COIN_PACKAGE_IDS, ErrorCodes, MetricNames, PushNotifications, ReferralRewards, UserConnectionTypes,
+    AccessLevels,
+    COIN_PACKAGE_IDS,
+    ErrorCodes,
+    MetricNames,
+    PushNotifications,
+    ReferralRewards,
+    UserConnectionTypes,
+    getAvailablePhoneAccountTypes,
+    getMaxAccountsPerPhone,
+    getPhoneAccountType,
 } from 'therr-js-utilities/constants';
 import logSpan from 'therr-js-utilities/log-or-update-span';
 import { verifyPhoneVerificationToken } from 'therr-js-utilities/phone-verification-token';
@@ -66,18 +75,48 @@ const createUser: RequestHandler = (req: any, res: any) => {
     // email+password signup — there is no path where a bad token grants anything.
     const verifiedPhoneNumber = verifyPhoneVerificationToken(req.body.phoneVerificationToken, 'register')?.phoneNumber;
 
-    return Store.users.findUser({
-        ...req.body,
-        phoneNumber: verifiedPhoneNumber || req.body.phoneNumber,
-    })
-        .then((findResults) => {
+    const registrationPhoneNumber = verifiedPhoneNumber || req.body.phoneNumber;
+    // Guard against non-phone values reaching the by-number lookup. The `'apple-sso'` sentinel
+    // is shared by every Apple SSO row, so counting "accounts on this number" for it would
+    // return the entire cohort and lock those signups out.
+    const isPhoneLike = /^\+?[\d\s\-().]{7,}$/.test(`${registrationPhoneNumber || ''}`);
+
+    return Promise.all([
+        // E-mail and username uniqueness is absolute. Phone number is not: one number may hold
+        // up to one account per type (personal/creator/business), capped per brand, so it gets
+        // the dedicated check below instead of being OR'd into this lookup.
+        Store.users.findUser({
+            ...req.body,
+            phoneNumber: undefined,
+        }),
+        isPhoneLike
+            ? Store.users.getAllByPhoneNumber(registrationPhoneNumber, ['id', 'isBusinessAccount', 'isCreatorAccount'])
+            : Promise.resolve([]),
+    ])
+        .then(([findResults, existingPhoneAccounts]) => {
             if (findResults.length) {
                 return handleHttpError({
                     res,
-                    message: 'Username, e-mail, and phone number must be unique. A user already exists.',
+                    message: 'Username and e-mail must be unique. A user already exists.',
                     statusCode: 400,
                     errorCode: ErrorCodes.USER_EXISTS,
                 });
+            }
+
+            if (existingPhoneAccounts.length) {
+                const availableAccountTypes = getAvailablePhoneAccountTypes(existingPhoneAccounts, brandVariation);
+                const requestedAccountType = getPhoneAccountType(req.body);
+
+                if (!availableAccountTypes.includes(requestedAccountType)) {
+                    return handleHttpError({
+                        res,
+                        message: getMaxAccountsPerPhone(brandVariation) > 1
+                            ? `This phone number already has a ${requestedAccountType} account.`
+                            : 'An account already exists for this phone number.',
+                        statusCode: 400,
+                        errorCode: ErrorCodes.TOO_MANY_ACCOUNTS,
+                    });
+                }
             }
 
             let getSubsAccessLvlsPromise: Promise<AccessLevels[]> = Promise.resolve([]);
@@ -509,6 +548,7 @@ const getUser = (req, res) => {
 const getUserByPhoneNumber = (req, res) => {
     const userId = req.headers['x-userid'];
     const { phoneNumber } = req.params;
+    const { brandVariation } = parseHeaders(req.headers);
 
     return Store.users.getUserById(userId, ['email', 'phoneNumber', 'isBusinessAccount', 'isCreatorAccount']).then((userSearchResults) => {
         if (!userSearchResults.length) {
@@ -519,46 +559,25 @@ const getUserByPhoneNumber = (req, res) => {
             });
         }
 
-        return Store.users.getByPhoneNumber(phoneNumber).then((results) => {
+        return Store.users.getAllByPhoneNumber(phoneNumber, ['id', 'isBusinessAccount', 'isCreatorAccount']).then((results) => {
             const requestingUser = userSearchResults[0];
-            if (!results.length) {
-                // 1st account with this phone number
-                return res.status(200).send({
-                    isSecondAccount: false,
-                    isThirdAccount: false,
-                    existingUsers: results,
+            // Re-verifying the number already on your own profile is not competing with
+            // yourself for a slot, so your own row never counts against the cap.
+            const otherAccounts = results.filter((result) => result.id !== userId);
+            const availableAccountTypes = getAvailablePhoneAccountTypes(otherAccounts, brandVariation);
+
+            if (!availableAccountTypes.includes(getPhoneAccountType(requestingUser))) {
+                return res.status(400).send({
+                    existingUsers: otherAccounts,
+                    errorCode: ErrorCodes.TOO_MANY_ACCOUNTS,
+                    statusCode: 400,
                 });
-            }
-            if (results.length === 1 && (
-                results[0].isBusinessAccount !== requestingUser.isBusinessAccount
-                || results[0].isCreatorAccount !== requestingUser.isCreatorAccount)
-            ) {
-                // 2nd account with this phone number
-                return res.status(200).send({
-                    isSecondAccount: true,
-                    isThirdAccount: false,
-                    existingUsers: results,
-                });
-            }
-            // TODO: Unit test
-            if (results.length > 1) {
-                const hasExistingBusAccount = results.find((result) => result.isBusinessAccount);
-                const hasExistingCreatorAccount = results.find((result) => result.isCreatorAccount);
-                if ((requestingUser.isBusinessAccount && !hasExistingBusAccount)
-                    || (requestingUser.isCreatorAccount && !hasExistingCreatorAccount)) {
-                    // 3rd account with this phone number
-                    return res.status(200).send({
-                        isSecondAccount: false,
-                        isThirdAccount: true,
-                        existingUsers: results,
-                    });
-                }
             }
 
-            return res.status(400).send({
-                existingUsers: results,
-                errorCode: ErrorCodes.TOO_MANY_ACCOUNTS,
-                statusCode: 400,
+            return res.status(200).send({
+                isSecondAccount: otherAccounts.length === 1,
+                isThirdAccount: otherAccounts.length === 2,
+                existingUsers: otherAccounts,
             });
         });
     });

--- a/therr-services/users-service/src/store/UsersStore.ts
+++ b/therr-services/users-service/src/store/UsersStore.ts
@@ -250,11 +250,11 @@ export default class UsersStore {
         if (phoneNumber) {
             // Candidate-matched for the same reason as the lookups above, and additionally
             // because writes are now normalized: an exact match would miss a row this store
-            // itself reformatted on the way in. This is the registration duplicate check, so
-            // missing a row means letting a second account onto a number that already has one.
-            // Widening does not loosen the accounts-per-number policy — registration has always
-            // rejected *any* phone match here; the personal/creator/business allowance is
-            // granted by `getByPhoneNumber` via the authenticated /phone/verify flow.
+            // itself reformatted on the way in.
+            // NOTE: this OR is a *find*, not a uniqueness check — it backs contact matching
+            // (see `userConnections`). Registration deliberately does not pass `phoneNumber`
+            // here, because a number may legitimately hold one account per type; that cap is
+            // enforced against `getAllByPhoneNumber` in the `createUser` handler.
             queryString = queryString.orWhereIn('phoneNumber', phoneNumberMatchCandidates(phoneNumber));
         }
 

--- a/therr-services/users-service/tests/unit/handlers-users.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-users.test.ts
@@ -9,7 +9,7 @@ import {
     isUserProfileIncomplete,
     redactUserCreds,
 } from '../../src/handlers/helpers/user';
-import { getMe } from '../../src/handlers/users';
+import { getMe, updateUser } from '../../src/handlers/users';
 
 // Minimal Express res double that captures the status + payload getMe sends.
 const makeRes = () => {
@@ -555,6 +555,134 @@ describe('Users Handler', () => {
             expect(res.sendCount).to.equal(1);
             // Short-circuit should happen before any device-token lookup.
             expect(getTokensStub.called).to.equal(false);
+        });
+    });
+
+    describe('updateUser accounts-per-phone cap', () => {
+        // A phone number holds at most one account of each type. createUser enforces that at
+        // sign-up, but both accounts on a shared number stay editable afterwards — without a
+        // guard here, two of them could each edit their way to `business`, or an account could
+        // move onto a number whose slot for its type is already filled.
+        const PHONE = '+1 317-555-1234';
+
+        const stubUpdateChain = () => {
+            const updateStub = sinon.stub(Store.users, 'updateUser').resolves([{ id: 'user-1' }] as any);
+            sinon.stub(Store.userOrganizations, 'get').resolves([] as any);
+            return updateStub;
+        };
+
+        const makeReq = (body: any, brandVariation = 'therr') => ({
+            headers: { 'x-userid': 'user-1', 'x-brand-variation': brandVariation },
+            body,
+        });
+
+        it('rejects switching to an account type another account on the number already holds', async () => {
+            sinon.stub(Store.users, 'getUserById').resolves([{
+                id: 'user-1', phoneNumber: PHONE, isBusinessAccount: false, isCreatorAccount: true, accessLevels: [],
+            }] as any);
+            sinon.stub(Store.users, 'getAllByPhoneNumber').resolves([
+                { id: 'user-1', isBusinessAccount: false, isCreatorAccount: true },
+                { id: 'user-2', isBusinessAccount: true, isCreatorAccount: false },
+            ] as any);
+            const updateStub = stubUpdateChain();
+
+            const res = makeRes();
+            await updateUser(makeReq({ isBusinessAccount: true, isCreatorAccount: false }), res);
+
+            expect(res.statusCode).to.equal(400);
+            expect(res.body.errorCode).to.equal('OnlyThreeAccountsPerPhoneNumber');
+            expect(updateStub.called).to.equal(false);
+        });
+
+        it('allows switching to an account type that is still free on the number', async () => {
+            sinon.stub(Store.users, 'getUserById').resolves([{
+                id: 'user-1', phoneNumber: PHONE, isBusinessAccount: false, isCreatorAccount: false, accessLevels: [],
+            }] as any);
+            sinon.stub(Store.users, 'getAllByPhoneNumber').resolves([
+                { id: 'user-1', isBusinessAccount: false, isCreatorAccount: false },
+                { id: 'user-2', isBusinessAccount: true, isCreatorAccount: false },
+            ] as any);
+            const updateStub = stubUpdateChain();
+
+            const res = makeRes();
+            await updateUser(makeReq({ isCreatorAccount: true }), res);
+
+            expect(res.statusCode).to.equal(202);
+            expect(updateStub.calledOnce).to.equal(true);
+        });
+
+        it('skips the check when neither the account type nor the number changes', async () => {
+            sinon.stub(Store.users, 'getUserById').resolves([{
+                id: 'user-1', phoneNumber: PHONE, isBusinessAccount: false, isCreatorAccount: false, accessLevels: [],
+            }] as any);
+            // Two personal accounts already share this number (seeded before the cap existed).
+            // An unrelated save must not fail — otherwise these users can never edit a bio.
+            const lookupStub = sinon.stub(Store.users, 'getAllByPhoneNumber').resolves([
+                { id: 'user-1', isBusinessAccount: false, isCreatorAccount: false },
+                { id: 'user-2', isBusinessAccount: false, isCreatorAccount: false },
+            ] as any);
+            const updateStub = stubUpdateChain();
+
+            const res = makeRes();
+            await updateUser(makeReq({ settingsBio: 'a new bio' }), res);
+
+            expect(res.statusCode).to.equal(202);
+            expect(updateStub.calledOnce).to.equal(true);
+            expect(lookupStub.called).to.equal(false);
+        });
+
+        it('rejects moving onto a number whose slot for this account type is taken', async () => {
+            sinon.stub(Store.users, 'getUserById').resolves([{
+                id: 'user-1', phoneNumber: '', isBusinessAccount: false, isCreatorAccount: false, accessLevels: [],
+            }] as any);
+            sinon.stub(Store.users, 'getAllByPhoneNumber').resolves([
+                { id: 'user-2', isBusinessAccount: false, isCreatorAccount: false },
+            ] as any);
+            const updateStub = stubUpdateChain();
+
+            const res = makeRes();
+            await updateUser(makeReq({ phoneNumber: PHONE }), res);
+
+            expect(res.statusCode).to.equal(400);
+            expect(res.body.errorCode).to.equal('OnlyThreeAccountsPerPhoneNumber');
+            expect(updateStub.called).to.equal(false);
+        });
+
+        it('rejects a second account on the same number for Habits, whatever the type', async () => {
+            sinon.stub(Store.users, 'getUserById').resolves([{
+                id: 'user-1', phoneNumber: '', isBusinessAccount: false, isCreatorAccount: false, accessLevels: [],
+            }] as any);
+            sinon.stub(Store.users, 'getAllByPhoneNumber').resolves([
+                { id: 'user-2', isBusinessAccount: true, isCreatorAccount: false },
+            ] as any);
+            const updateStub = stubUpdateChain();
+
+            const res = makeRes();
+            await updateUser(makeReq({ phoneNumber: PHONE }, 'habits'), res);
+
+            expect(res.statusCode).to.equal(400);
+            expect(res.body.errorCode).to.equal('OnlyThreeAccountsPerPhoneNumber');
+            expect(updateStub.called).to.equal(false);
+        });
+
+        it('does not treat the apple-sso sentinel as a phone number', async () => {
+            sinon.stub(Store.users, 'getUserById').resolves([{
+                id: 'user-1', phoneNumber: 'apple-sso', isBusinessAccount: false, isCreatorAccount: false, accessLevels: [],
+            }] as any);
+            // Every Apple SSO row carries this same value; counting "accounts on this number"
+            // would return the whole cohort and refuse them all.
+            const lookupStub = sinon.stub(Store.users, 'getAllByPhoneNumber').resolves([
+                { id: 'user-2', isBusinessAccount: false, isCreatorAccount: false },
+                { id: 'user-3', isBusinessAccount: false, isCreatorAccount: false },
+            ] as any);
+            const updateStub = stubUpdateChain();
+
+            const res = makeRes();
+            await updateUser(makeReq({ isCreatorAccount: true }), res);
+
+            expect(res.statusCode).to.equal(202);
+            expect(updateStub.calledOnce).to.equal(true);
+            expect(lookupStub.called).to.equal(false);
         });
     });
 


### PR DESCRIPTION
Phone-first sign-up refused any number that already had an account, which
contradicted the rest of the codebase: passwordless sign-in ships an account
picker for exactly this case, and the authenticated /phone/verify route has
always allowed one personal + one creator + one business account per number.
Sign-up was the only path enforcing a cap of one.

Adds `getMaxAccountsPerPhone` / `getAvailablePhoneAccountTypes` to
therr-js-utilities as the single definition of the policy: three accounts
(one per type) by default, one for Friends with Habits, whose premise is
accountability between real people — a second account on the same handset is
a way to fake a pact partner.

- `POST /v1/phone/register/start` now refuses only when the number is out of
  free types, and `/register/verify` reports which types remain so the client
  can ask. The types are disclosed only after the code is verified.
- `createUser` no longer OR's `phoneNumber` into the email/username uniqueness
  lookup. It checks the number separately against `getAllByPhoneNumber` and
  rejects with TOO_MANY_ACCOUNTS only when the requested type is taken.
  Non-phone values (the 'apple-sso' sentinel) skip that lookup entirely.
- `getUserByPhoneNumber` now derives the same answer from the shared helper
  instead of its own hardcoded 3-account ladder, so the profile-edit path and
  sign-up agree on the cap, and the caller's own row no longer counts against
  them when re-verifying their existing number.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ju36atZQbavn8kdhLf1Cmf