### PR TITLE
test: stop unit tests sending real SMS and email

### DIFF
--- a/therr-api-gateway/.mocharc.js
+++ b/therr-api-gateway/.mocharc.js
@@ -1,3 +1,4 @@
 module.exports = {
   extension: ['ts', 'js'],
+  require: ['./tests/setup.ts'],
 };

--- a/therr-api-gateway/tests/helpers/outboundStubs.ts
+++ b/therr-api-gateway/tests/helpers/outboundStubs.ts
@@ -1,0 +1,69 @@
+/**
+ * Test double for Twilio, the only third-party transport this gateway sends
+ * on. The passwordless phone routes (`/v1/phone/auth/start`,
+ * `/v1/phone/register/start`, `/v1/phone/verify`) all dispatch an SMS, so a
+ * test that exercises `services/phone/router` without this would bill real
+ * messages to whatever number the fixture happens to name.
+ *
+ * Patched at `Twilio.prototype.request` — the single choke point every Twilio
+ * resource call funnels through — so a future call site cannot slip past by
+ * constructing its own client.
+ *
+ * Captured sends land in `smsOutbox` so tests can assert what would have gone
+ * out. Call `resetSmsOutbox()` in a `beforeEach` when asserting.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// The SDK request/response shapes are internal to Twilio's client; typing them
+// here would couple this double to SDK internals for no test benefit.
+
+import twilio from 'twilio';
+
+export interface ISentSms {
+    to?: string;
+    from?: string;
+    body?: string;
+}
+
+export const smsOutbox: ISentSms[] = [];
+
+export const resetSmsOutbox = () => {
+    smsOutbox.length = 0;
+};
+
+let isInstalled = false;
+
+/**
+ * Idempotent — `tests/setup.ts` is the only intended caller, but mocha can
+ * load a required file more than once across watch runs.
+ */
+export const installOutboundTransportStubs = () => {
+    if (isInstalled) {
+        return;
+    }
+    isInstalled = true;
+
+    twilio.Twilio.prototype.request = function stubbedRequest(opts: any) {
+        const data = opts?.data || {};
+        smsOutbox.push({
+            to: data.To,
+            from: data.From,
+            body: data.Body,
+        });
+
+        // Mirrors the shape Twilio's resource layer expects back from an HTTP
+        // POST so `messages.create()` resolves to a MessageInstance as usual.
+        return Promise.resolve({
+            statusCode: 201,
+            body: {
+                sid: `SM${'0'.repeat(30)}${smsOutbox.length}`,
+                status: 'queued',
+                to: data.To,
+                from: data.From,
+                body: data.Body,
+            },
+        });
+    } as any;
+};
+
+export default installOutboundTransportStubs;

--- a/therr-api-gateway/tests/setup.ts
+++ b/therr-api-gateway/tests/setup.ts
@@ -1,0 +1,25 @@
+// Mocha global setup: seed test-safe defaults for env vars that production
+// modules read at module load, and neuter the outbound SMS transport for the
+// whole run. Required by mocharc via `require`.
+//
+// Real values from .env are used when present (set by the run script or the
+// developer's shell). These defaults only fill in when unset.
+
+// Safe to hoist above the env seeding below: installing the stubs only
+// patches the Twilio prototype and reads no configuration.
+import { installOutboundTransportStubs } from './helpers/outboundStubs';
+
+if (!process.env.TWILIO_ACCOUNT_SID) {
+    // Twilio's constructor rejects empty strings and anything not starting
+    // with 'AC'. Provide a syntactically valid placeholder; tests that
+    // actually need to inspect a send should assert on the outbox below.
+    process.env.TWILIO_ACCOUNT_SID = `AC${'0'.repeat(32)}`;
+}
+if (!process.env.TWILIO_AUTH_TOKEN) {
+    process.env.TWILIO_AUTH_TOKEN = 'test-auth-token';
+}
+
+// Nothing under tests/ may reach Twilio: the phone routes send an SMS on every
+// start/verify call, and a developer shell carrying real credentials would
+// bill (and deliver) them for real. See tests/helpers/outboundStubs.ts.
+installOutboundTransportStubs();

--- a/therr-api-gateway/tests/unit/outboundStubs.test.ts
+++ b/therr-api-gateway/tests/unit/outboundStubs.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Guards the test-suite safety net itself.
+ *
+ * `tests/setup.ts` neuters Twilio by patching `Twilio.prototype.request`, the
+ * one method every resource call funnels through. That choke point is an
+ * implementation detail of the SDK: a major `twilio` upgrade could move it,
+ * and nothing else in the suite would notice — tests would keep passing while
+ * quietly billing and delivering real SMS from developer machines and CI.
+ *
+ * This asserts the patch is still in the path.
+ */
+import { expect } from 'chai';
+import twilio from 'twilio';
+import { resetSmsOutbox, smsOutbox } from '../helpers/outboundStubs';
+
+describe('outbound transport stubs (test safety net)', () => {
+    beforeEach(() => {
+        resetSmsOutbox();
+    });
+
+    it('captures a Twilio send instead of putting it on the wire', async () => {
+        const client = new twilio.Twilio(`AC${'0'.repeat(32)}`, 'test-auth-token');
+
+        const message = await client.messages.create({
+            body: 'verification code 123456',
+            to: '+13175551234',
+            from: '+15551234567',
+        });
+
+        expect(smsOutbox).to.have.lengthOf(1);
+        expect(smsOutbox[0].to).to.equal('+13175551234');
+        expect(smsOutbox[0].from).to.equal('+15551234567');
+        expect(smsOutbox[0].body).to.equal('verification code 123456');
+        // The stub must still resolve to something message-shaped, or callers
+        // that read the returned sid would break only under test.
+        expect(message.sid).to.be.a('string');
+    });
+});

--- a/therr-services/users-service/tests/helpers/outboundStubs.ts
+++ b/therr-services/users-service/tests/helpers/outboundStubs.ts
@@ -1,0 +1,102 @@
+/**
+ * Test doubles for the two transports in this service that reach a third party:
+ * AWS SES (email) and Twilio (SMS).
+ *
+ * Installed once from `tests/setup.ts`, so no test — present or future — can
+ * send a real email or SMS. This matters because `tests/setup.ts` loads the
+ * root `.env`, which on a developer machine holds live SES and Twilio
+ * credentials: without these stubs, any test that reaches a dispatch path
+ * bills a real SMS and mails a real (usually bouncing) address.
+ *
+ * Both are patched at the SDK's own choke point rather than at our
+ * `api/aws` / `api/twilio` wrappers:
+ *   - every SESv2 command funnels through `SESv2.prototype.send`
+ *   - every Twilio resource call funnels through `Twilio.prototype.request`
+ * so a future call site cannot slip past by constructing its own client.
+ *
+ * Captured sends land in `emailOutbox` / `smsOutbox` so tests can assert on
+ * what *would* have gone out. Call `resetOutboxes()` in a `beforeEach` when
+ * asserting, otherwise sends from earlier tests are still in the array.
+ *
+ * Individual tests may still `sinon.stub(awsSES, 'sendEmail')` — an instance
+ * stub shadows the prototype patch, and `sinon.restore()` uncovers the patch
+ * again rather than the real transport.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// The SDK command/response shapes are internal to each vendor's client; typing
+// them here would couple these doubles to SDK internals for no test benefit.
+
+import { SESv2 } from '@aws-sdk/client-sesv2';
+import twilio from 'twilio';
+
+export interface ISentEmail {
+    toAddresses: string[];
+    fromEmailAddress?: string;
+    subject?: string;
+    html?: string;
+}
+
+export interface ISentSms {
+    to?: string;
+    from?: string;
+    body?: string;
+}
+
+export const emailOutbox: ISentEmail[] = [];
+export const smsOutbox: ISentSms[] = [];
+
+export const resetOutboxes = () => {
+    emailOutbox.length = 0;
+    smsOutbox.length = 0;
+};
+
+let isInstalled = false;
+
+/**
+ * Idempotent — `tests/setup.ts` is the only intended caller, but mocha can
+ * load a required file more than once across watch runs.
+ */
+export const installOutboundTransportStubs = () => {
+    if (isInstalled) {
+        return;
+    }
+    isInstalled = true;
+
+    SESv2.prototype.send = function stubbedSend(command: any) {
+        const input = command?.input || {};
+        const simple = input.Content?.Simple;
+        emailOutbox.push({
+            toAddresses: input.Destination?.ToAddresses || [],
+            fromEmailAddress: input.FromEmailAddress,
+            subject: simple?.Subject?.Data,
+            html: simple?.Body?.Html?.Data,
+        });
+
+        return Promise.resolve({ MessageId: `test-ses-message-${emailOutbox.length}` });
+    } as any;
+
+    twilio.Twilio.prototype.request = function stubbedRequest(opts: any) {
+        const data = opts?.data || {};
+        smsOutbox.push({
+            to: data.To,
+            from: data.From,
+            body: data.Body,
+        });
+
+        // Mirrors the shape Twilio's resource layer expects back from an HTTP
+        // POST so `messages.create()` resolves to a MessageInstance as usual.
+        return Promise.resolve({
+            statusCode: 201,
+            body: {
+                sid: `SM${'0'.repeat(30)}${smsOutbox.length}`,
+                status: 'queued',
+                to: data.To,
+                from: data.From,
+                body: data.Body,
+            },
+        });
+    } as any;
+};
+
+export default installOutboundTransportStubs;

--- a/therr-services/users-service/tests/setup.ts
+++ b/therr-services/users-service/tests/setup.ts
@@ -6,6 +6,10 @@
 // Real values from .env are used when present (set by the run script or the
 // developer's shell). These defaults only fill in when unset.
 
+// Safe to hoist above the env seeding below: installing the stubs only
+// patches SDK prototypes and reads no configuration.
+import { installOutboundTransportStubs } from './helpers/outboundStubs';
+
 // Load the root .env first so config.ts (read at import time) picks up the real
 // DB host/port. The unit `test:` scripts don't load dotenv themselves, so without
 // this any test that exercises an unstubbed store falls back to localhost:5432 and
@@ -33,3 +37,9 @@ if (!process.env.JWT_SECRET) {
 if (!process.env.JWT_EMAIL_SECRET) {
     process.env.JWT_EMAIL_SECRET = 'test-email-secret-key';
 }
+
+// Neuter the outbound transports (AWS SES, Twilio) for the whole run. The
+// dotenv load above pulls in real credentials on a developer machine, so
+// without this any test that reaches a dispatch path sends a real SMS and a
+// real email — see tests/helpers/outboundStubs.ts.
+installOutboundTransportStubs();

--- a/therr-services/users-service/tests/unit/handlers-pacts-claim.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-pacts-claim.test.ts
@@ -10,6 +10,7 @@ import {
     isOnHabits,
 } from '../../src/utilities/dispatchPactInvitation';
 import { isMatchingInvitee } from '../../src/handlers/helpers/pactRedemption';
+import { emailOutbox, resetOutboxes, smsOutbox } from '../helpers/outboundStubs';
 
 describe('Pacts handler — claim flow', () => {
     afterEach(() => {
@@ -106,6 +107,36 @@ describe('Pacts handler — claim flow', () => {
             whiteLabelOrigin: 'habits.therr.com',
             locale: 'en-us',
         };
+        const originalSender = process.env.TWILIO_SENDER_PHONE_NUMBER;
+
+        // The two dispatch branches below hit real transports: email goes out
+        // over AWS SES and the SMS fallback bills a Twilio message. Both are
+        // stubbed at the SDK boundary by tests/setup.ts, so sends land in the
+        // outboxes instead of leaving the machine — assert on them rather than
+        // letting them fire unobserved.
+        beforeEach(() => {
+            resetOutboxes();
+            // Pin the sender so the SMS branch is exercised identically whether
+            // or not the developer's .env defines one. Without this the branch
+            // silently no-ops in CI and sends for real locally.
+            process.env.TWILIO_SENDER_PHONE_NUMBER = '+15551234567';
+            // sendEmail() consults the blacklist before dispatching; stub both
+            // lookups so the email branch doesn't depend on a live database.
+            sinon.stub(Store.blacklistedEmails, 'get').resolves([]);
+            sinon.stub(Store.users, 'getUserByEmail').resolves([]);
+        });
+
+        after(() => {
+            if (originalSender === undefined) {
+                delete process.env.TWILIO_SENDER_PHONE_NUMBER;
+            } else {
+                process.env.TWILIO_SENDER_PHONE_NUMBER = originalSender;
+            }
+        });
+
+        // Dispatch is deliberately fire-and-forget behind a store lookup, so the
+        // send lands a few microtasks after dispatchPactInvitation resolves.
+        const flushDispatch = () => new Promise((resolve) => { setImmediate(resolve); });
 
         it('short-circuits with isOnBrand=true when the partner is active on Habits', async () => {
             sinon.stub(Store.users, 'findUser').resolves([{
@@ -117,10 +148,14 @@ describe('Pacts handler — claim flow', () => {
             const updateSpy = sinon.spy(Store.pactMembers, 'update');
 
             const result = await dispatchPactInvitation(baseArgs);
+            await flushDispatch();
 
             expect(result.isOnBrand).to.be.eq(true);
             expect(result.claimToken).to.be.eq(undefined);
             expect(updateSpy.called).to.be.eq(false);
+            // On-brand partners get a push from the caller, never an email/SMS.
+            expect(emailOutbox).to.have.lengthOf(0);
+            expect(smsOutbox).to.have.lengthOf(0);
         });
 
         it('mints a token + code and writes them to pact_members for an off-brand partner', async () => {
@@ -134,6 +169,7 @@ describe('Pacts handler — claim flow', () => {
             const updateStub = sinon.stub(Store.pactMembers, 'update').resolves({} as any);
 
             const result = await dispatchPactInvitation(baseArgs);
+            await flushDispatch();
 
             expect(result.isOnBrand).to.be.eq(false);
             expect(result.claimToken).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
@@ -144,22 +180,37 @@ describe('Pacts handler — claim flow', () => {
             expect(writePayload.claimToken).to.equal(result.claimToken);
             expect(writePayload.claimCode).to.equal(result.claimCode);
             expect(writePayload.invitedVia).to.equal('email');
+            // Exactly one email, no SMS — delivery is single-channel.
+            expect(smsOutbox).to.have.lengthOf(0);
+            expect(emailOutbox).to.have.lengthOf(1);
+            expect(emailOutbox[0].toAddresses).to.deep.equal(['p@example.com']);
+            expect(emailOutbox[0].html).to.contain(result.claimCode);
         });
 
         it('falls back to invitedVia=sms when the partner has only a phone on file', async () => {
             sinon.stub(Store.users, 'findUser').resolves([{
                 id: 'partner-1',
                 email: null,
-                phoneNumber: '+13175551234',
+                // NANP reserved fictitious range (555-0100..555-0199): this is
+                // the one fixture in the file that reaches a dispatch path, so
+                // if the Twilio stub ever regresses it dials nobody.
+                phoneNumber: '+13175550123',
                 isUnclaimed: false,
                 brandVariations: [],
             }]);
             sinon.stub(Store.pactMembers, 'update').resolves({} as any);
 
             const result = await dispatchPactInvitation(baseArgs);
+            await flushDispatch();
 
             expect(result.isOnBrand).to.be.eq(false);
             expect(result.invitedVia).to.equal('sms');
+            // Exactly one SMS, no email — delivery is single-channel.
+            expect(emailOutbox).to.have.lengthOf(0);
+            expect(smsOutbox).to.have.lengthOf(1);
+            expect(smsOutbox[0].to).to.equal('+13175550123');
+            expect(smsOutbox[0].from).to.equal('+15551234567');
+            expect(smsOutbox[0].body).to.contain(result.claimCode);
         });
 
         it('skips dispatch entirely when the partner has neither email nor phone', async () => {
@@ -173,10 +224,13 @@ describe('Pacts handler — claim flow', () => {
             const updateSpy = sinon.spy(Store.pactMembers, 'update');
 
             const result = await dispatchPactInvitation(baseArgs);
+            await flushDispatch();
 
             expect(result.isOnBrand).to.be.eq(false);
             expect(result.claimToken).to.be.eq(undefined);
             expect(updateSpy.called).to.be.eq(false);
+            expect(emailOutbox).to.have.lengthOf(0);
+            expect(smsOutbox).to.have.lengthOf(0);
         });
 
         it('treats an isUnclaimed user as having no email (placeholder accounts get skipped)', async () => {
@@ -190,9 +244,14 @@ describe('Pacts handler — claim flow', () => {
             const updateSpy = sinon.spy(Store.pactMembers, 'update');
 
             const result = await dispatchPactInvitation(baseArgs);
+            await flushDispatch();
 
             expect(result.isOnBrand).to.be.eq(false);
             expect(updateSpy.called).to.be.eq(false);
+            // Placeholder accounts must never be mailed — the address is not
+            // one the user gave us, so a send here is a hard bounce.
+            expect(emailOutbox).to.have.lengthOf(0);
+            expect(smsOutbox).to.have.lengthOf(0);
         });
 
         it('returns isOnBrand=false (silent) when the partner cannot be found', async () => {
@@ -274,6 +333,11 @@ describe('Pacts handler — claim flow', () => {
 
             expect(caught).to.equal(fatalErr);
             expect(updateStub.callCount).to.equal(1);
+            // Nothing is dispatched when the row never persisted — otherwise the
+            // invitee gets a claim code the database has no record of.
+            await flushDispatch();
+            expect(emailOutbox).to.have.lengthOf(0);
+            expect(smsOutbox).to.have.lengthOf(0);
         });
     });
 });

--- a/therr-services/users-service/tests/unit/outboundStubs.test.ts
+++ b/therr-services/users-service/tests/unit/outboundStubs.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Guards the test-suite safety net itself.
+ *
+ * `tests/setup.ts` neuters the two outbound transports by patching
+ * `SESv2.prototype.send` and `Twilio.prototype.request` — the single methods
+ * every SES command and every Twilio resource call funnel through. Those choke
+ * points are implementation details of each SDK: a major version bump could
+ * move them, and nothing else in the suite would notice. Tests would keep
+ * passing while quietly mailing real addresses and billing real SMS from
+ * developer machines (where `tests/setup.ts` loads live credentials out of the
+ * root `.env`) and from CI.
+ *
+ * This asserts both patches are still in the path.
+ */
+import { expect } from 'chai';
+import twilio from 'twilio';
+import { awsSES } from '../../src/api/aws';
+import { emailOutbox, resetOutboxes, smsOutbox } from '../helpers/outboundStubs';
+
+describe('outbound transport stubs (test safety net)', () => {
+    beforeEach(() => {
+        resetOutboxes();
+    });
+
+    it('captures an SES send instead of putting it on the wire', async () => {
+        const result: any = await awsSES.sendEmail({
+            Destination: { ToAddresses: ['recipient@example.com'] },
+            FromEmailAddress: '"Therr" <noreply@therr.com>',
+            Content: {
+                Simple: {
+                    Subject: { Data: 'Test subject' },
+                    Body: { Html: { Data: '<p>Test body</p>' } },
+                },
+            },
+        });
+
+        expect(emailOutbox).to.have.lengthOf(1);
+        expect(emailOutbox[0].toAddresses).to.deep.equal(['recipient@example.com']);
+        expect(emailOutbox[0].subject).to.equal('Test subject');
+        expect(emailOutbox[0].html).to.equal('<p>Test body</p>');
+        expect(result.MessageId).to.be.a('string');
+    });
+
+    it('captures a Twilio send instead of putting it on the wire', async () => {
+        const client = new twilio.Twilio(`AC${'0'.repeat(32)}`, 'test-auth-token');
+
+        const message = await client.messages.create({
+            body: 'PACT-ABCD',
+            to: '+13175551234',
+            from: '+15551234567',
+        });
+
+        expect(smsOutbox).to.have.lengthOf(1);
+        expect(smsOutbox[0].to).to.equal('+13175551234');
+        expect(smsOutbox[0].from).to.equal('+15551234567');
+        expect(smsOutbox[0].body).to.equal('PACT-ABCD');
+        // The stub must still resolve to something message-shaped, or callers
+        // that read the returned sid would break only under test.
+        expect(message.sid).to.be.a('string');
+    });
+});


### PR DESCRIPTION
Running the users-service unit suite on a machine with a populated root .env sent one real Twilio SMS and three real AWS SES emails per run. All four came from the dispatchPactInvitation tests in handlers-pacts-claim.test.ts: the helper dispatches fire-and-forget, so tests written to assert on the pact_members write also completed the outbound send. The SMS went to a live NANP number and the emails went to @example.com, which is IANA-reserved and always hard-bounces — those bounces count against the SES account's reputation, on top of the Twilio spend and the bounce alerts.

tests/setup.ts loads the root .env (for DB config), so the transports had live credentials in every local run. CI, with no .env, silently skipped the sends — which is why this never surfaced as a test failure.

Adds tests/helpers/outboundStubs.ts to both packages, installed from tests/setup.ts, patching each SDK at its single choke point (SESv2.prototype.send, Twilio.prototype.request) rather than at our own api/ wrappers, so a new call site cannot slip past. Sends are captured in emailOutbox / smsOutbox instead of leaving the machine.

The pact dispatch tests now assert on those outboxes, turning four unobserved side effects into coverage of which channel each branch picks. The SMS branch previously depended on TWILIO_SENDER_PHONE_NUMBER being set, so it no-opped in CI and sent for real locally; it is now pinned.

therr-api-gateway had no test setup file at all, and its phone routes are the codebase's main SMS senders — the same guard is added there before a router test exists to trip it.

Both packages get an outboundStubs.test.ts asserting the patches are still in the SDK path, since a major twilio/@aws-sdk bump could move those choke points and silently restore live sends.

Verified by intercepting http(s).request across every package's unit suite: 4 outbound attempts before, 0 after, 402 + 262 tests passing.


Claude-Session: https://claude.ai/code/session_01494hi88HYT7DgjPMg4Jg8J