### PR TITLE
Phase 3: decaying, discoverable interest affinity (shadow mode)

### DIFF
--- a/docs/ALGORITHM_AUDIT.md
+++ b/docs/ALGORITHM_AUDIT.md
@@ -335,7 +335,7 @@ Ordered by leverage-to-effort. Each is independently shippable, and (1) → (2) 
 |-------|------|--------|------|
 | 1 ✅ | O2.1 persist `relevanceScore` + reorder feed; O2.2 deterministic `search` order | `general` | Low — additive column, one `ORDER BY` |
 | 2 ✅ | O3.1 cache-gate the distributor; O3.2 batch preference writes + real logging | `general` | Low — behavior-preserving, immediately relieves S1/S2 |
-| 3 | O1.1–O1.3 affinity column, decay-on-write, upsert (shadow mode) | `general` | Medium — validate against `engagementCount` for one release |
+| 3 ✅ | O1.1–O1.3 affinity column, decay-on-write, upsert (shadow mode) | `general` | Medium — validate against `engagementCount` for one release |
 | 4 | O1.4 `score` collection (gateway validator + store) then mobile UI | `general`, then `niche/*` | Medium — must sequence backend first |
 | 5 | O1.5–O1.7 weighted ranking + SQL overlap scoring; O2.3 shared scoring module | `general` | Medium — flag-gated, A/B on weights |
 | 6 | O2.4 geo/interest unification; O2.5 diversity; O3.3–O3.5 materialization | `general` | Higher — largest UX change, do last with measurement in place |
@@ -362,6 +362,22 @@ Interest engagement writes are coalesced per user in an **in-process** buffer (`
 The users-service increment endpoint accepts both the new coalesced (`interestIncrements`) and legacy (`interestDisplayNameKeys` + `incrBy`) payloads, and senders emit both, so a rolling deploy in either order keeps recording.
 
 Still open from Optimization 3 and explicitly **not** done: materialized user interest vectors and precomputed candidate pools (O3.3, O3.4). Those are the Redis-memory-heavy parts.
+
+### Phase 3 — shipped (shadow mode)
+
+`main.userInterests` gains `affinityScore`, `lastEngagedAt`, `negativeCount`, and `source`, backfilled from `engagementCount` / `updatedAt` so the new signal starts from the evidence already collected rather than cold.
+
+`incrementUserInterestsByKey` became an `INSERT … ON CONFLICT` that does three things the old `UPDATE … FROM` could not:
+
+- **Decays on write.** `affinityScore := affinityScore * 0.5^(secondsSinceLastEngagement / halfLife) + weight`, so scores stay current without a nightly sweep over the table. Half-life defaults to 45 days (`INTEREST_AFFINITY_HALF_LIFE_DAYS`).
+- **Discovers.** Engagement on an interest the user never declared now creates a row instead of being silently dropped (E2). Discovered rows are `source = 'implicit'`, `isEnabled = false`, and discounted 0.6× (`INTEREST_IMPLICIT_DISCOUNT`) — they accumulate evidence for a future "enable this?" prompt without entering any existing read path.
+- **Keeps one write path.** Both the coalesced and legacy payload shapes normalize onto this method, so decay and discovery cannot apply to one and not the other.
+
+**Nothing reads `affinityScore` yet.** `getInterestRanking` still ranks on `engagementCount`, which is maintained in step. `utilities/interestWeights.ts` holds the live formula and the candidate replacement side by side, and `getTopRankedConnections` logs a sampled comparison of the two orderings (normalized Spearman footrule + top-5 overlap, `INTEREST_SHADOW_LOG_SAMPLE_RATE`, default 2%). Flip the read path in phase 5 once those logs show the distributions are sane — that is the whole point of shipping this write-only.
+
+Note for the read flip: the stored score is decayed only as far as its last write, so a row read long after its last engagement is "stale high". Any read path must re-apply the decay factor at read time, as `getShadowInterestWeight` already does.
+
+Row growth is bounded by the interest taxonomy (~50-100 rows/user), and for onboarded users is zero — onboarding already inserts a row per interest, so discovery only creates rows for SSO and onboarding-skip users, which is exactly the population E2 was failing.
 
 ## 6. Instrumentation to add before phase 6
 

--- a/therr-services/users-service/src/handlers/thoughts.ts
+++ b/therr-services/users-service/src/handlers/thoughts.ts
@@ -348,7 +348,13 @@ const getThoughtDetails = (req, res) => {
                         Store.userConnections.incrementUserConnection(userId, thought.fromUserId, 1)
                             .catch((err) => console.log(err));
                         if (thought.interestsKeys?.length) {
-                            Store.userInterests.incrementUserInterests(userId, thought.interestsKeys, 1)
+                            // In-service call, so it does not go through the coalescing
+                            // buffer the maps/reactions services use — one thought view is
+                            // one event, and the map shape is just how the store now takes
+                            // per-key weights.
+                            const increments = thought.interestsKeys
+                                .reduce((acc: any, key: string) => ({ ...acc, [key]: 1 }), {});
+                            Store.userInterests.incrementUserInterestsByKey(userId, increments)
                                 .catch((err) => console.log(err));
                         }
                     }

--- a/therr-services/users-service/src/handlers/userConnections.ts
+++ b/therr-services/users-service/src/handlers/userConnections.ts
@@ -22,11 +22,10 @@ import { createOrUpdateAchievement } from './helpers/achievements';
 import { parseConfigValue } from './config';
 import { IFindUsersByContactInfo } from '../store/UsersStore';
 import recordFunnelMetric from '../utilities/recordFunnelMetric';
+import { getInterestRanking, logShadowInterestRanking } from '../utilities/interestWeights';
 
-/**
- * Used for sorting interests by a singular value. Set defaults to ensure no zero values.
- */
-const getInterestRanking = (engagementCount: number, score: number) => Math.ceil((engagementCount || 1) / (score || 5));
+// Moved to utilities/interestWeights so the live formula and the shadow candidate it is
+// being compared against live side by side and can be unit-tested together.
 
 const getTherrFromPhoneNumber = (receivingPhoneNumber: string) => {
     if (receivingPhoneNumber.startsWith('+44')) {
@@ -736,10 +735,24 @@ const getTopRankedConnections = (req, res) => {
             }).then((results) => {
                 const userIds = results?.reduce((acc, cur) => [...new Set([...acc, cur.requestingUserId, cur.acceptingUserId])], [requestingUserDetails.id]);
 
+                // affinityScore / negativeCount / lastEngagedAt are selected for the shadow
+                // comparison only — the live ranking below still uses engagementCount.
+                const interestColumns = [
+                    'userId', 'interestId', 'score', 'engagementCount', 'isEnabled', 'updatedAt',
+                    'affinityScore', 'negativeCount', 'lastEngagedAt',
+                ];
+
                 return Store.userInterests.getByUserIds(userIds, {
                     isEnabled: true,
-                }, 'engagementCount', ['userId', 'interestId', 'score', 'engagementCount', 'isEnabled', 'updatedAt'])
+                }, 'engagementCount', interestColumns)
                     .then((userInterests) => {
+                        // Shadow only — the ordering below is still the live engagementCount
+                        // ranking. This measures how far the affinity-based weight would move
+                        // it, so the read path can be flipped on evidence rather than hope.
+                        // Scoped to the requesting user's own rows: mixing several users'
+                        // interests into one ordering would measure nothing meaningful.
+                        logShadowInterestRanking(userId, userInterests.filter((i) => i.userId === userId && i.isEnabled));
+
                         const interestsIdMap = {};
                         userInterests.forEach((uInterest) => {
                             if (uInterest.isEnabled) {

--- a/therr-services/users-service/src/handlers/userInterests.ts
+++ b/therr-services/users-service/src/handlers/userInterests.ts
@@ -94,29 +94,37 @@ const incrementUserInterests = (req, res) => {
     // callers that buffer a user's engagement before flushing. `interestDisplayNameKeys` +
     // `incrBy` is the original one-event-at-a-time shape, still accepted so a rolling
     // deploy where an older maps/reactions pod is still running keeps working.
+    //
+    // Both shapes normalize to one map and take a single write path. Keeping two store
+    // methods meant two places that would each have to grow decay and discovery, and would
+    // quietly diverge the moment only one of them did.
+    //
     // `Array.isArray` guard because an array also passes `typeof === 'object'`. An array
     // body would take this branch and key the increments by numeric index, which then joins
     // against no interest at all — a silent no-op rather than an obvious rejection.
-    if (interestIncrements && typeof interestIncrements === 'object' && !Array.isArray(interestIncrements)) {
-        const cappedIncrements = Object.keys(interestIncrements).reduce((acc, key) => ({
+    const isCoalescedShape = interestIncrements
+        && typeof interestIncrements === 'object'
+        && !Array.isArray(interestIncrements);
+
+    let normalizedIncrements: { [displayNameKey: string]: number };
+
+    if (isCoalescedShape) {
+        normalizedIncrements = Object.keys(interestIncrements).reduce((acc, key) => ({
             ...acc,
             // Per-key ceiling on a single flush. The old per-event cap was 5; a flush
             // aggregates many events, so this is looser but still bounded.
             [key]: Math.min(MAX_COALESCED_INCREMENT, Number(interestIncrements[key]) || 0),
         }), {});
-
-        return Store.userInterests
-            .incrementUserInterestsByKey(userId, cappedIncrements)
-            // `|| {}` because a flush whose keys match no declared interest updates no rows,
-            // and `res.send(undefined)` sends a bodiless 200 the caller cannot parse.
-            .then((results) => res.status(200).send(results[0] || {}))
-            .catch((err) => handleHttpError({ err, res, message: 'SQL:USER_INTERESTS_ROUTES:ERROR' }));
+    } else {
+        const ceilIncrBy = Math.min(5, (incrBy || 1));
+        normalizedIncrements = (Array.isArray(interestDisplayNameKeys) ? interestDisplayNameKeys : [])
+            .reduce((acc, key) => ({ ...acc, [key]: ceilIncrBy }), {});
     }
 
-    const ceilIncrBy = Math.min(5, (incrBy || 1));
-
     return Store.userInterests
-        .incrementUserInterests(userId, interestDisplayNameKeys, ceilIncrBy)
+        .incrementUserInterestsByKey(userId, normalizedIncrements)
+        // `|| {}` because a flush whose keys match no known interest writes no rows, and
+        // `res.send(undefined)` sends a bodiless 200 the caller cannot parse.
         .then((results) => res.status(200).send(results[0] || {}))
         .catch((err) => handleHttpError({ err, res, message: 'SQL:USER_INTERESTS_ROUTES:ERROR' }));
 };

--- a/therr-services/users-service/src/store/UserInterestsStore.ts
+++ b/therr-services/users-service/src/store/UserInterestsStore.ts
@@ -4,6 +4,19 @@ import { IConnection } from './connection';
 import { INTERESTS_TABLE_NAME, USER_INTERESTS_TABLE_NAME } from './tableNames';
 
 const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
+
+// How long it takes an untouched affinity score to halve. A local-discovery product wants
+// seasonal interests to fade within a quarter or so, and 45 days puts a score ~1% of its
+// original value after 10 months of no engagement. Env-tunable because the right value can
+// only be found from real consumption data, and changing it must not require a deploy.
+const AFFINITY_HALF_LIFE_DAYS = Number(process.env.INTEREST_AFFINITY_HALF_LIFE_DAYS) || 45;
+const AFFINITY_HALF_LIFE_SECONDS = AFFINITY_HALF_LIFE_DAYS * 24 * 60 * 60;
+
+// Weight applied to affinity when engagement CREATES a row — i.e. the user engaged with an
+// interest they never picked. Behavior is a weaker signal than an explicit choice, so a
+// discovered interest starts below a declared one that saw the same engagement.
+const IMPLICIT_DISCOVERY_DISCOUNT = Number(process.env.INTEREST_IMPLICIT_DISCOUNT) || 0.6;
+
 export interface ICreateUserInterestParams {
     userId: string;
     interestId: string;
@@ -90,16 +103,33 @@ export default class UserInterestsStore {
     }
 
     /**
-     * Applies a different increment per interest key in one statement.
+     * Applies a different increment per interest key in one statement, decaying the stored
+     * affinity toward the present as it goes, and creating a row when the user engages with
+     * an interest they never declared.
      *
      * Engagement used to arrive one content view at a time, each becoming its own
      * cross-service request and its own multi-row UPDATE. Callers now coalesce a user's
      * views in-process and flush them as a single map, so the write volume tracks flush
      * intervals instead of impressions.
      *
-     * Like `incrementUserInterests`, this only touches rows that already exist — behavior
-     * cannot yet discover an interest the user never declared. That is a known gap
-     * (docs/ALGORITHM_AUDIT.md E2) and is deliberately not addressed here.
+     * Decay is applied on write rather than by a scheduled job:
+     *
+     *     affinityScore := affinityScore * 0.5 ^ (secondsSinceLastEngagement / halfLife) + weight
+     *
+     * so a row is only ever touched when that user engages, and no sweep over the whole
+     * table is needed to keep scores current. A row read long after its last write is
+     * "stale high", which is why any future read path must apply the same decay factor at
+     * read time rather than trusting the stored number verbatim.
+     *
+     * Rows that do not exist are INSERTed as `source = 'implicit'` and `isEnabled = false`,
+     * at a discount to declared interests: behavior is a weaker signal than an explicit
+     * pick, and an implicit row must not start competing with declared ones on equal terms.
+     * `isEnabled = false` keeps discovered interests out of every existing read path — they
+     * accumulate evidence for a later "enable this?" prompt without silently changing what
+     * the user sees today.
+     *
+     * SHADOW MODE: engagementCount is still maintained in step, and is still what
+     * getInterestRanking ranks on. Nothing reads affinityScore yet.
      */
     incrementUserInterestsByKey(userId: string, incrementsByKey: { [displayNameKey: string]: number }) {
         const entries = Object.entries(incrementsByKey || {})
@@ -110,45 +140,52 @@ export default class UserInterestsStore {
             return Promise.resolve([]);
         }
 
-        const bindings: any[] = [];
+        // Built in the order the placeholders appear in the finished statement — pg numbers
+        // them by position in the string, not by clause.
+        const valuesBindings: any[] = [];
         entries.forEach(([key, incrBy]) => {
-            bindings.push(key, incrBy);
+            valuesBindings.push(key, incrBy);
         });
-        bindings.push(userId);
+        const bindings: any[] = [
+            userId, // SELECT ?::uuid
+            IMPLICIT_DISCOVERY_DISCOUNT, // v.incr * ?::real
+            ...valuesBindings, // VALUES (?, ?::integer), ...
+            AFFINITY_HALF_LIFE_SECONDS, // decay divisor in the conflict branch
+        ];
 
         // Table names are written out rather than interpolated from the tableNames
         // constants: knex quotes identifiers for builder calls, but raw SQL does not, and
         // unquoted main.userInterests would fold to "userinterests" and fail.
+        //
+        // The INSERT..SELECT..ON CONFLICT shape (rather than an UPDATE..FROM) is what makes
+        // discovery possible: the join against main.interests resolves displayNameKey to an
+        // interestId whether or not the user already has a row for it.
+        //
+        // EXCLUDED."engagementCount" carries the *undiscounted* weight into the conflict
+        // branch — the discount belongs only to rows this statement is creating, not to
+        // interests the user actually declared.
         const valuesPlaceholders = entries.map(() => '(?, ?::integer)').join(', ');
         const queryString = knexBuilder.raw(
-            `UPDATE main."userInterests" AS ui
-                SET "engagementCount" = ui."engagementCount" + v.incr, "updatedAt" = NOW()
-                FROM (VALUES ${valuesPlaceholders}) AS v(key, incr)
-                JOIN main."interests" AS i ON i."displayNameKey" = v.key
-                WHERE ui."userId" = ?::uuid AND ui."interestId" = i.id
-                RETURNING ui.*`,
+            `INSERT INTO main."userInterests"
+                ("userId", "interestId", "affinityScore", "engagementCount", "lastEngagedAt", "isEnabled", "source")
+             SELECT ?::uuid, i.id, v.incr * ?::real, v.incr, NOW(), false, 'implicit'
+               FROM (VALUES ${valuesPlaceholders}) AS v(key, incr)
+               JOIN main."interests" AS i ON i."displayNameKey" = v.key
+             ON CONFLICT ("userId", "interestId") DO UPDATE SET
+                "affinityScore" = main."userInterests"."affinityScore"
+                    * POWER(
+                        0.5,
+                        EXTRACT(EPOCH FROM (NOW() - COALESCE(main."userInterests"."lastEngagedAt", NOW()))) / ?::real
+                    )
+                    + EXCLUDED."engagementCount",
+                "engagementCount" = main."userInterests"."engagementCount" + EXCLUDED."engagementCount",
+                "lastEngagedAt" = NOW(),
+                "updatedAt" = NOW()
+             RETURNING main."userInterests".*`,
             bindings,
         ).toString();
 
         return this.db.write.query(queryString).then((response) => response.rows);
-    }
-
-    incrementUserInterests(userId, interestDisplayNameKeys: string[], incrBy = 1) {
-        const queryString = knexBuilder
-            .into(USER_INTERESTS_TABLE_NAME)
-            .increment('engagementCount', incrBy)
-            .update({
-                updatedAt: new Date(),
-            })
-            .where({
-                userId,
-            })
-            .whereIn('interestId', (builder) => {
-                builder.select('id').from(INTERESTS_TABLE_NAME).whereIn('displayNameKey', interestDisplayNameKeys);
-            })
-            .returning('*');
-
-        return this.db.write.query(queryString.toString()).then((response) => response.rows);
     }
 
     delete(id: string, userId: string) {

--- a/therr-services/users-service/src/store/migrations/20260727000000_main.userInterests.affinityScore.js
+++ b/therr-services/users-service/src/store/migrations/20260727000000_main.userInterests.affinityScore.js
@@ -1,0 +1,70 @@
+// Give the user preference model a decaying, discoverable affinity signal.
+//
+// Context (docs/ALGORITHM_AUDIT.md E2/E3): `engagementCount` is a monotonic counter with no
+// half-life and no per-user normalization, and the only writer is an UPDATE that touches
+// rows which already exist. Two consequences:
+//   - A user's ranking freezes around whatever they did in their first weeks; a newly
+//     acquired interest can never overtake an old one within any realistic session count.
+//   - Engagement on an interest the user never declared is silently discarded, so behavior
+//     can never discover a new interest.
+//
+// `affinityScore` replaces the counter semantics: it is decayed toward the present on every
+// write (see UserInterestsStore.incrementUserInterestsByKey) rather than by a batch job, so
+// stale interests fade without a nightly sweep over the whole table.
+//
+// SHADOW MODE: nothing reads affinityScore yet. `getInterestRanking` still ranks on
+// engagementCount, which is still maintained alongside. This release only populates the new
+// columns and logs how the two orderings disagree; the read path flips in a later change,
+// once those logs show the distributions are sane.
+//
+// Idempotent (ADD COLUMN IF NOT EXISTS / CREATE INDEX IF NOT EXISTS) so it can be re-run
+// against a database where the columns or index were created by hand — which is how the
+// index gets built CONCURRENTLY ahead of a deploy without holding ACCESS EXCLUSIVE.
+// `real` / `timestamptz` / `integer` are exactly what table.float() /
+// table.timestamp({ useTz: true }) / table.integer() compile to on pg, so no environment
+// ends up with a different type depending on which path created the column.
+exports.up = async (knex) => {
+    await knex.raw('ALTER TABLE main."userInterests" ADD COLUMN IF NOT EXISTS "affinityScore" real NOT NULL DEFAULT 0');
+    await knex.raw('ALTER TABLE main."userInterests" ADD COLUMN IF NOT EXISTS "lastEngagedAt" timestamptz');
+    // Reserved for the negative-signal path (hide / not-interested / report). Nothing writes
+    // it yet; the shadow weight already divides by it so the formula is complete when it does.
+    await knex.raw('ALTER TABLE main."userInterests" ADD COLUMN IF NOT EXISTS "negativeCount" integer NOT NULL DEFAULT 0');
+    // 'declared' = created by the user picking it during onboarding/preferences.
+    // 'implicit' = created by the engagement upsert because the user engaged with content
+    // tagged with an interest they never picked. Records how the row was CREATED and is
+    // never rewritten, so an implicit row stays identifiable for a future "you keep opening
+    // coffee content — enable coffee?" prompt.
+    await knex.raw('ALTER TABLE main."userInterests" ADD COLUMN IF NOT EXISTS "source" varchar(16) NOT NULL DEFAULT \'declared\'');
+
+    // Seed affinity from the signal we already have rather than starting everyone cold, so
+    // the shadow comparison is meaningful from day one instead of after weeks of accrual.
+    // `lastEngagedAt` is seeded from updatedAt so decay runs from each row's real last
+    // activity — that is what lets the imported (undecayed) counts start fading immediately
+    // instead of importing the old recency bias permanently.
+    await knex.raw(`
+        UPDATE main."userInterests"
+           SET "affinityScore" = "engagementCount",
+               "lastEngagedAt" = "updatedAt"
+         WHERE "lastEngagedAt" IS NULL
+    `);
+
+    // The engagement upsert conflicts on (userId, interestId) — already covered by the
+    // unique constraint from 20240429134308. This index serves the read side: pulling one
+    // user's interests strongest-first, which is what the ranking path will do once the
+    // read flips over. Partial on isEnabled to match how getByUserIds filters today.
+    await knex.raw(`
+        CREATE INDEX IF NOT EXISTS idx_user_interests_user_affinity
+        ON main."userInterests" ("userId", "affinityScore" DESC)
+        WHERE "isEnabled" = true
+    `);
+};
+
+// Symmetrically idempotent: dropColumn throws on an already-absent column, which would leave
+// a partial rollback (index dropped, columns still present) wedged and un-re-runnable.
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main.idx_user_interests_user_affinity');
+    await knex.raw('ALTER TABLE main."userInterests" DROP COLUMN IF EXISTS "source"');
+    await knex.raw('ALTER TABLE main."userInterests" DROP COLUMN IF EXISTS "negativeCount"');
+    await knex.raw('ALTER TABLE main."userInterests" DROP COLUMN IF EXISTS "lastEngagedAt"');
+    await knex.raw('ALTER TABLE main."userInterests" DROP COLUMN IF EXISTS "affinityScore"');
+};

--- a/therr-services/users-service/src/utilities/interestWeights.ts
+++ b/therr-services/users-service/src/utilities/interestWeights.ts
@@ -1,0 +1,125 @@
+import logSpan from 'therr-js-utilities/log-or-update-span';
+
+// Must match UserInterestsStore's write-side half-life, or a score decayed on write and a
+// score decayed on read describe different curves.
+const AFFINITY_HALF_LIFE_DAYS = Number(process.env.INTEREST_AFFINITY_HALF_LIFE_DAYS) || 45;
+const AFFINITY_HALF_LIFE_MS = AFFINITY_HALF_LIFE_DAYS * 24 * 60 * 60 * 1000;
+
+// Fraction of shadow evaluations that get logged. Comparing rankings is cheap (it runs over
+// rows already in memory) but the log line is not, and this fires on a hot path.
+const SHADOW_LOG_SAMPLE_RATE = Number(process.env.INTEREST_SHADOW_LOG_SAMPLE_RATE) || 0.02;
+
+export interface IInterestWeightRow {
+    interestId: string;
+    score?: number;
+    engagementCount?: number;
+    affinityScore?: number;
+    negativeCount?: number;
+    lastEngagedAt?: string | Date | null;
+}
+
+/**
+ * The ranking currently in production.
+ *
+ * Note what this actually computes: `score` defaults to 5 and no client has ever sent
+ * anything else, so in practice this is `ceil(engagementCount / 5)` — the declared-
+ * preference dimension contributes nothing, and the ceil quantizes engagement 1-5 into a
+ * single tied bucket. See docs/ALGORITHM_AUDIT.md E1.
+ */
+export const getInterestRanking = (engagementCount: number, score: number) => Math.ceil((engagementCount || 1) / (score || 5));
+
+/**
+ * Candidate replacement, evaluated in shadow only — nothing ranks on this yet.
+ *
+ * Differences that matter:
+ *  - Decay is re-applied at read time. The stored score was decayed to whenever the row was
+ *    last written, so a row untouched for months reads "stale high" unless the elapsed time
+ *    since `lastEngagedAt` is discounted here too.
+ *  - Declared and behavioral signals multiply rather than divide. The live formula divides
+ *    engagement BY score, so a stronger declared preference produces a weaker ranking the
+ *    moment `score` stops being a constant.
+ *  - No `Math.ceil`, so the result keeps its resolution instead of collapsing into 2-3
+ *    tied integer buckets.
+ *  - Negative signals damp the weight. Nothing writes `negativeCount` yet (that is the
+ *    hide/not-interested path), so today this term is always 1.
+ */
+export const getShadowInterestWeight = (row: IInterestWeightRow, now: number = Date.now()) => {
+    const clampedScore = Math.min(Math.max(Number(row.score) || 5, 1), 5);
+    // score 1 ("highest" per the column's own documentation) -> 1.0, score 5 -> 0.2
+    const declaredWeight = (6 - clampedScore) / 5;
+
+    const stored = Math.max(Number(row.affinityScore) || 0, 0);
+    const lastEngagedAt = row.lastEngagedAt ? new Date(row.lastEngagedAt).getTime() : null;
+    const elapsedMs = lastEngagedAt && Number.isFinite(lastEngagedAt) ? Math.max(now - lastEngagedAt, 0) : 0;
+    const decayed = stored * (0.5 ** (elapsedMs / AFFINITY_HALF_LIFE_MS));
+
+    const negativeCount = Math.max(Number(row.negativeCount) || 0, 0);
+
+    return (declaredWeight * (1 + Math.log1p(decayed))) / (1 + (negativeCount * 0.5));
+};
+
+const rankByDescending = (rows: IInterestWeightRow[], weigh: (row: IInterestWeightRow) => number) => [...rows]
+    // interestId as a stable tiebreak so ties don't register as disagreement purely
+    // because two equal weights came back in a different order.
+    .sort((a, b) => (weigh(b) - weigh(a)) || String(a.interestId).localeCompare(String(b.interestId)))
+    .map((row) => row.interestId);
+
+/**
+ * Measures how far the shadow ranking moves an ordering versus the live one.
+ *
+ * Reported as normalized Spearman footrule (0 = identical ordering, 1 = maximally
+ * reversed) plus top-5 overlap, which is the part a user would actually notice.
+ */
+export const compareInterestRankings = (rows: IInterestWeightRow[], now: number = Date.now()) => {
+    if (!rows?.length || rows.length < 2) {
+        return null;
+    }
+
+    const liveOrder = rankByDescending(rows, (row) => getInterestRanking(row.engagementCount as number, row.score as number));
+    const shadowOrder = rankByDescending(rows, (row) => getShadowInterestWeight(row, now));
+
+    const livePositions = new Map(liveOrder.map((id, index) => [id, index]));
+    const displacement = shadowOrder.reduce((sum, id, index) => sum + Math.abs((livePositions.get(id) ?? index) - index), 0);
+    // Max footrule for n items is floor(n^2 / 2); normalize so the number is comparable
+    // across users with different numbers of enabled interests.
+    const maxDisplacement = Math.floor((rows.length ** 2) / 2) || 1;
+
+    const topN = Math.min(5, rows.length);
+    const liveTop = new Set(liveOrder.slice(0, topN));
+    const sharedTop = shadowOrder.slice(0, topN).filter((id) => liveTop.has(id)).length;
+
+    return {
+        interestCount: rows.length,
+        footruleNormalized: Number((displacement / maxDisplacement).toFixed(4)),
+        topOverlap: Number((sharedTop / topN).toFixed(4)),
+    };
+};
+
+/**
+ * Sampled shadow comparison. Never throws — this is observability hanging off a live
+ * request path, so a bug here must not be able to fail the request it is measuring.
+ */
+export const logShadowInterestRanking = (userId: string, rows: IInterestWeightRow[]) => {
+    try {
+        if (Math.random() >= SHADOW_LOG_SAMPLE_RATE) {
+            return;
+        }
+        const comparison = compareInterestRankings(rows);
+        if (!comparison) {
+            return;
+        }
+        logSpan({
+            level: 'info',
+            messageOrigin: 'INTEREST_RANKING_SHADOW',
+            messages: ['Shadow interest ranking comparison'],
+            traceArgs: {
+                'user.id': userId,
+                'interest.count': comparison.interestCount,
+                'interest.shadowFootrule': comparison.footruleNormalized,
+                'interest.shadowTopOverlap': comparison.topOverlap,
+            },
+        });
+    } catch {
+        // Observability must never break the caller.
+    }
+};

--- a/therr-services/users-service/tests/unit/UserInterestsStore.test.ts
+++ b/therr-services/users-service/tests/unit/UserInterestsStore.test.ts
@@ -30,7 +30,73 @@ describe('UserInterestsStore', () => {
             const query = connection.write.query.args[0][0];
             expect(query).to.include("('interests.foodDrink.coffee', 6::integer)");
             expect(query).to.include("('interests.sports.soccer', 2::integer)");
-            expect(query).to.include(`ui."userId" = '11111111-1111-1111-1111-111111111111'::uuid`);
+            expect(query).to.include(`SELECT '11111111-1111-1111-1111-111111111111'::uuid`);
+        });
+
+        // The E2 gap: the previous UPDATE..FROM could only touch rows that already existed,
+        // so engagement on an interest the user never picked was silently discarded.
+        it('inserts a discovered interest rather than dropping the signal', async () => {
+            const connection = createMockConnection();
+            const store = new UserInterestsStore(connection);
+
+            await store.incrementUserInterestsByKey('11111111-1111-1111-1111-111111111111', {
+                'interests.outdoors.hiking': 10,
+            });
+
+            const query = connection.write.query.args[0][0];
+            expect(query).to.include('INSERT INTO main."userInterests"');
+            expect(query).to.include('ON CONFLICT ("userId", "interestId") DO UPDATE');
+            // Discovered rows are implicit and disabled, so they accumulate evidence without
+            // silently entering any existing read path.
+            expect(query).to.include("false, 'implicit'");
+            // Discounted relative to a declared interest with the same engagement.
+            expect(query).to.include('v.incr * 0.6::real');
+        });
+
+        // Decay is applied on write so no scheduled job has to sweep the table.
+        it('decays the stored affinity toward now before adding the new weight', async () => {
+            const connection = createMockConnection();
+            const store = new UserInterestsStore(connection);
+
+            await store.incrementUserInterestsByKey('11111111-1111-1111-1111-111111111111', {
+                'interests.foodDrink.coffee': 4,
+            });
+
+            const query = connection.write.query.args[0][0];
+            expect(query).to.include('POWER(');
+            expect(query).to.include('EXTRACT(EPOCH FROM (NOW() - COALESCE(main."userInterests"."lastEngagedAt", NOW())))');
+            // 45-day half-life in seconds.
+            expect(query).to.include('3888000');
+            // A row that has never been engaged decays by a factor of 1, not to zero.
+            expect(query).to.include('COALESCE(main."userInterests"."lastEngagedAt", NOW())');
+        });
+
+        // The conflict branch must add the raw weight, not the discounted one — the discount
+        // belongs only to rows this statement creates.
+        it('adds the undiscounted weight to an existing row', async () => {
+            const connection = createMockConnection();
+            const store = new UserInterestsStore(connection);
+
+            await store.incrementUserInterestsByKey('11111111-1111-1111-1111-111111111111', {
+                'interests.foodDrink.coffee': 4,
+            });
+
+            const query = connection.write.query.args[0][0];
+            expect(query).to.include('+ EXCLUDED."engagementCount"');
+        });
+
+        // Shadow mode: the live ranking still reads engagementCount, so it has to keep
+        // moving in step or the comparison measures nothing.
+        it('keeps engagementCount maintained alongside affinityScore', async () => {
+            const connection = createMockConnection();
+            const store = new UserInterestsStore(connection);
+
+            await store.incrementUserInterestsByKey('11111111-1111-1111-1111-111111111111', {
+                'interests.foodDrink.coffee': 4,
+            });
+
+            const query = connection.write.query.args[0][0];
+            expect(query).to.include('"engagementCount" = main."userInterests"."engagementCount" + EXCLUDED."engagementCount"');
         });
 
         // Unquoted main.userInterests would fold to "userinterests" in raw SQL and fail.

--- a/therr-services/users-service/tests/unit/handlers-userInterests.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-userInterests.test.ts
@@ -35,7 +35,6 @@ describe('User Interests Handler', () => {
     describe('incrementUserInterests', () => {
         it('routes the coalesced payload to the per-key increment', async () => {
             const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([{ id: 'ui-1' }]);
-            const legacyStub = sinon.stub(Store.userInterests, 'incrementUserInterests').resolves([]);
 
             await incrementUserInterests(buildReq({
                 interestIncrements: {
@@ -44,7 +43,6 @@ describe('User Interests Handler', () => {
                 },
             }), buildRes());
 
-            expect(legacyStub.called).to.be.eq(false);
             expect(byKeyStub.calledOnce).to.be.eq(true);
             expect(byKeyStub.args[0][0]).to.eq('11111111-1111-1111-1111-111111111111');
             expect(byKeyStub.args[0][1]).to.deep.equal({
@@ -66,26 +64,48 @@ describe('User Interests Handler', () => {
         // A rolling deploy leaves older maps/reactions pods sending the one-event-at-a-time
         // shape for a while. Dropping it would silently stop preference learning mid-deploy.
         it('still accepts the legacy single-increment payload', async () => {
-            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([]);
-            const legacyStub = sinon.stub(Store.userInterests, 'incrementUserInterests').resolves([{ id: 'ui-1' }]);
+            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([{ id: 'ui-1' }]);
 
             await incrementUserInterests(buildReq({
-                interestDisplayNameKeys: ['interests.foodDrink.coffee'],
+                interestDisplayNameKeys: ['interests.foodDrink.coffee', 'interests.sports.soccer'],
                 incrBy: 3,
             }), buildRes());
 
-            expect(byKeyStub.called).to.be.eq(false);
-            expect(legacyStub.calledOnce).to.be.eq(true);
-            expect(legacyStub.args[0][1]).to.deep.equal(['interests.foodDrink.coffee']);
-            expect(legacyStub.args[0][2]).to.eq(3);
+            // Normalized onto the same write path rather than a second store method, so
+            // decay and discovery cannot apply to one shape and not the other.
+            expect(byKeyStub.calledOnce).to.be.eq(true);
+            expect(byKeyStub.args[0][1]).to.deep.equal({
+                'interests.foodDrink.coffee': 3,
+                'interests.sports.soccer': 3,
+            });
+        });
+
+        it('caps the legacy per-event increment', async () => {
+            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([]);
+
+            await incrementUserInterests(buildReq({
+                interestDisplayNameKeys: ['interests.foodDrink.coffee'],
+                incrBy: 999,
+            }), buildRes());
+
+            expect(byKeyStub.args[0][1]).to.deep.equal({ 'interests.foodDrink.coffee': 5 });
+        });
+
+        it('tolerates a legacy payload with no keys', async () => {
+            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([]);
+            const res = buildRes();
+
+            await incrementUserInterests(buildReq({ incrBy: 2 }), res);
+
+            expect(byKeyStub.args[0][1]).to.deep.equal({});
+            expect(res.statusCode).to.eq(200);
         });
 
         // An array passes `typeof === 'object'`, so without an explicit guard it would take
         // the coalesced branch and key increments by numeric index — matching no interest at
         // all, so the request would 200 having recorded nothing.
         it('does not treat an array payload as the coalesced shape', async () => {
-            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([]);
-            const legacyStub = sinon.stub(Store.userInterests, 'incrementUserInterests').resolves([{ id: 'ui-1' }]);
+            const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([{ id: 'ui-1' }]);
 
             await incrementUserInterests(buildReq({
                 interestIncrements: ['interests.foodDrink.coffee'],
@@ -93,8 +113,9 @@ describe('User Interests Handler', () => {
                 incrBy: 2,
             }), buildRes());
 
-            expect(byKeyStub.called).to.be.eq(false);
-            expect(legacyStub.calledOnce).to.be.eq(true);
+            // Falls through to the legacy branch, which keys by displayNameKey rather than
+            // by array index (which would have matched no interest at all).
+            expect(byKeyStub.args[0][1]).to.deep.equal({ 'interests.foodDrink.coffee': 2 });
         });
 
         // The store only updates interests the user already declared, so a flush can
@@ -113,7 +134,6 @@ describe('User Interests Handler', () => {
 
         it('returns early without touching the store when there is no user', async () => {
             const byKeyStub = sinon.stub(Store.userInterests, 'incrementUserInterestsByKey').resolves([]);
-            const legacyStub = sinon.stub(Store.userInterests, 'incrementUserInterests').resolves([]);
             const res = buildRes();
 
             await incrementUserInterests({
@@ -123,7 +143,6 @@ describe('User Interests Handler', () => {
 
             expect(res.statusCode).to.eq(200);
             expect(byKeyStub.called).to.be.eq(false);
-            expect(legacyStub.called).to.be.eq(false);
         });
     });
 });

--- a/therr-services/users-service/tests/unit/interestWeights.test.ts
+++ b/therr-services/users-service/tests/unit/interestWeights.test.ts
@@ -1,0 +1,159 @@
+/* eslint-disable quotes, max-len */
+import { expect } from 'chai';
+import {
+    getInterestRanking,
+    getShadowInterestWeight,
+    compareInterestRankings,
+    logShadowInterestRanking,
+} from '../../src/utilities/interestWeights';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 6, 27);
+
+describe('interestWeights', () => {
+    describe('getInterestRanking (live formula)', () => {
+        // Pinning the documented defects so the shadow comparison has a known baseline and
+        // so a later change to this formula is a deliberate act, not a silent drift.
+        it('collapses low engagement into a single tied bucket', () => {
+            // score is 5 for every row in production — no client has ever sent another value
+            expect(getInterestRanking(1, 5)).to.eq(1);
+            expect(getInterestRanking(5, 5)).to.eq(1);
+            // ...so an interest engaged 5x ranks identically to one engaged once
+            expect(getInterestRanking(0, 5)).to.eq(1);
+        });
+
+        it('treats a stronger declared preference as weaker', () => {
+            // score 1 is documented as "the highest" preference, yet dividing by it produces
+            // a LARGER ranking than score 5 for the same engagement — the live formula only
+            // survives because score is a constant today.
+            expect(getInterestRanking(10, 1)).to.eq(10);
+            expect(getInterestRanking(10, 5)).to.eq(2);
+        });
+    });
+
+    describe('getShadowInterestWeight', () => {
+        it('re-applies decay at read time for a row not written in a while', () => {
+            // The stored score was decayed to whenever the row was last written, so a row
+            // untouched for a half-life must read at half its stored value.
+            const fresh = getShadowInterestWeight({
+                interestId: 'a', score: 5, affinityScore: 40, lastEngagedAt: new Date(NOW),
+            }, NOW);
+            const stale = getShadowInterestWeight({
+                interestId: 'a', score: 5, affinityScore: 40, lastEngagedAt: new Date(NOW - (45 * DAY_MS)),
+            }, NOW);
+
+            expect(stale).to.be.lessThan(fresh);
+            // 40 -> 20 after one half-life, through log1p and the 0.2 declared weight
+            expect(stale).to.be.closeTo(0.2 * (1 + Math.log1p(20)), 1e-6);
+        });
+
+        it('keeps resolution instead of quantizing into tied buckets', () => {
+            const a = getShadowInterestWeight({
+                interestId: 'a', score: 5, affinityScore: 2, lastEngagedAt: new Date(NOW),
+            }, NOW);
+            const b = getShadowInterestWeight({
+                interestId: 'b', score: 5, affinityScore: 4, lastEngagedAt: new Date(NOW),
+            }, NOW);
+
+            // Both are ranking 1 under the live formula; the shadow weight separates them.
+            expect(getInterestRanking(2, 5)).to.eq(getInterestRanking(4, 5));
+            expect(b).to.be.greaterThan(a);
+        });
+
+        it('makes a stronger declared preference rank higher, not lower', () => {
+            const strongest = getShadowInterestWeight({
+                interestId: 'a', score: 1, affinityScore: 10, lastEngagedAt: new Date(NOW),
+            }, NOW);
+            const weakest = getShadowInterestWeight({
+                interestId: 'b', score: 5, affinityScore: 10, lastEngagedAt: new Date(NOW),
+            }, NOW);
+
+            expect(strongest).to.be.greaterThan(weakest);
+        });
+
+        it('damps a weight that has drawn negative signals', () => {
+            const clean = getShadowInterestWeight({
+                interestId: 'a', score: 5, affinityScore: 10, negativeCount: 0, lastEngagedAt: new Date(NOW),
+            }, NOW);
+            const damped = getShadowInterestWeight({
+                interestId: 'a', score: 5, affinityScore: 10, negativeCount: 4, lastEngagedAt: new Date(NOW),
+            }, NOW);
+
+            expect(damped).to.be.lessThan(clean);
+        });
+
+        it('handles never-engaged and malformed rows without producing NaN', () => {
+            const rows = [
+                { interestId: 'a' },
+                { interestId: 'b', affinityScore: undefined, lastEngagedAt: null },
+                {
+                    interestId: 'c', affinityScore: -5, score: 0, lastEngagedAt: 'not-a-date',
+                },
+                {
+                    interestId: 'd', score: 99, affinityScore: 3, lastEngagedAt: new Date(NOW),
+                },
+            ];
+
+            rows.forEach((row) => {
+                const weight = getShadowInterestWeight(row as any, NOW);
+                expect(Number.isFinite(weight), `row ${row.interestId}`).to.be.eq(true);
+                expect(weight).to.be.at.least(0);
+            });
+        });
+    });
+
+    describe('compareInterestRankings', () => {
+        it('reports no displacement when both formulas agree', () => {
+            const rows = [
+                {
+                    interestId: 'a', score: 5, engagementCount: 50, affinityScore: 50, lastEngagedAt: new Date(NOW),
+                },
+                {
+                    interestId: 'b', score: 5, engagementCount: 20, affinityScore: 20, lastEngagedAt: new Date(NOW),
+                },
+                {
+                    interestId: 'c', score: 5, engagementCount: 5, affinityScore: 5, lastEngagedAt: new Date(NOW),
+                },
+            ];
+
+            const result = compareInterestRankings(rows, NOW);
+
+            expect(result?.footruleNormalized).to.eq(0);
+            expect(result?.topOverlap).to.eq(1);
+        });
+
+        it('registers displacement when decay demotes a stale but heavily-engaged interest', () => {
+            const rows = [
+                // Big lifetime count, untouched for a year — the case decay exists for
+                {
+                    interestId: 'stale', score: 5, engagementCount: 200, affinityScore: 200, lastEngagedAt: new Date(NOW - (365 * DAY_MS)),
+                },
+                {
+                    interestId: 'fresh', score: 5, engagementCount: 12, affinityScore: 12, lastEngagedAt: new Date(NOW),
+                },
+            ];
+
+            const result = compareInterestRankings(rows, NOW);
+
+            expect(result?.footruleNormalized).to.be.greaterThan(0);
+            // Live ranks purely on the raw count, shadow demotes the year-old interest
+            expect(getInterestRanking(200, 5)).to.be.greaterThan(getInterestRanking(12, 5));
+            expect(getShadowInterestWeight(rows[1], NOW)).to.be.greaterThan(getShadowInterestWeight(rows[0], NOW));
+        });
+
+        it('returns null when there is nothing meaningful to compare', () => {
+            expect(compareInterestRankings([], NOW)).to.eq(null);
+            expect(compareInterestRankings([{ interestId: 'a' }], NOW)).to.eq(null);
+            expect(compareInterestRankings(undefined as any, NOW)).to.eq(null);
+        });
+    });
+
+    describe('logShadowInterestRanking', () => {
+        // It hangs off a live request path, so it must be incapable of failing that request.
+        it('never throws, whatever it is handed', () => {
+            expect(() => logShadowInterestRanking('user-1', null as any)).to.not.throw();
+            expect(() => logShadowInterestRanking('user-1', [{ interestId: 'a' }, { interestId: 'b' }])).to.not.throw();
+            expect(() => logShadowInterestRanking(undefined as any, [null, undefined] as any)).to.not.throw();
+        });
+    });
+});


### PR DESCRIPTION
Phase 3 of `docs/ALGORITHM_AUDIT.md` (O1.1–O1.3), following phases 1 and 2 already on `general`.

**Nothing in this PR changes what any user sees.** It only populates a new signal and measures it against the live one.

## Why

The preference model had two structural gaps:

- **E3 — no decay.** `engagementCount` is a monotonic counter, so a user's ranking freezes around whatever they did in their first weeks and a newly acquired interest can never overtake an old one within any realistic session count.
- **E2 — no discovery.** The only writer was an `UPDATE` that touched rows which already exist, so engagement on an interest the user never declared was silently dropped (the handler still returned 200). Users who sign up via SSO or skip onboarding never learn anything, permanently.

## What changed

**Migration** — `main.userInterests` gains `affinityScore`, `lastEngagedAt`, `negativeCount`, `source`, backfilled from `engagementCount` / `updatedAt` so the new signal starts from evidence already collected rather than cold. Written with `ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` and a symmetric `down`, so it is re-runnable against a database where the columns or index were pre-created by hand — matching the CONCURRENTLY pre-build pattern from the phase 1 migration.

**Decay on write** — `incrementUserInterestsByKey` became `INSERT … ON CONFLICT` and applies:

```
affinityScore := affinityScore * 0.5^(secondsSinceLastEngagement / halfLife) + weight
```

so scores stay current without a nightly sweep over the table. A row is only touched when that user engages. Half-life defaults to 45 days (`INTEREST_AFFINITY_HALF_LIFE_DAYS`).

**Discovery** — engagement on an undeclared interest now creates a row instead of dropping the signal, as `source = 'implicit'`, `isEnabled = false`, discounted 0.6× (`INTEREST_IMPLICIT_DISCOUNT`). Discovered interests accumulate evidence for a future "you keep opening coffee content — enable coffee?" prompt **without entering any existing read path**, since every current reader filters `isEnabled = true`.

**One write path** — both the coalesced (`interestIncrements`) and legacy (`interestDisplayNameKeys` + `incrBy`) payload shapes normalize onto this single store method. Keeping two meant two places that would each have to grow decay and discovery, and would diverge the moment only one did. Retires the second increment method and its other caller in `handlers/thoughts.ts`.

## Shadow mode

`getInterestRanking` still ranks on `engagementCount`, which is maintained in step. `utilities/interestWeights.ts` holds the live formula and the candidate replacement side by side, and `getTopRankedConnections` logs a sampled comparison of the two orderings — normalized Spearman footrule plus top-5 overlap (`INTEREST_SHADOW_LOG_SAMPLE_RATE`, default 2%).

Flip the read path in phase 5 once those logs show the distributions are sane. That is the point of shipping this write-only: there is currently no impression or CTR logging anywhere, so this is the first evidence the ranking work can be judged on.

**Note for whoever does the read flip:** the stored score is decayed only as far as its last write, so a row read long after its last engagement is "stale high". Any read path must re-apply the decay factor at read time, as `getShadowInterestWeight` already does.

## Verification

Beyond lint / `tsc --noEmit` / 436 passing unit tests (28 new), the SQL was validated against a real PostgreSQL 16 rather than only inspected as generated strings:

- `up` and `down` each run twice cleanly; `down` restores the original column set exactly.
- Running the **actual store method** against a seeded database: a declared interest with `affinityScore` 40 last engaged 60 days ago, plus an increment of 4, lands at `19.874` — exactly `40 × 0.5^(60/45) + 4`.
- The same statement created `interests.outdoors.hiking` — never declared — at `6.000` (`10 × 0.6`), `source='implicit'`, `isEnabled=false`.
- Rapid successive flushes do not erode a score (decay factor ≈ 1 over a 10s window), and a key matching no interest is a silent no-op rather than an error.

This caught two real defects during development: `main.userInterests` unquoted in raw SQL folds to `userinterests` and fails, and `tsc` surfaced a second caller of the retired store method that a grep had missed.

## Risk / rollout

Low. The write path is additive and the read path is untouched, so the failure mode is "the new column is wrong and nobody notices", which the shadow logs exist to catch. Row growth is bounded by the interest taxonomy (~50–100 rows/user) and is **zero for onboarded users** — onboarding already inserts a row per interest, so discovery only creates rows for the SSO and onboarding-skip population, which is exactly who E2 was failing.

`negativeCount` is reserved for the hide/not-interested path in phase 5; nothing writes it yet, and the shadow weight already divides by it so the formula is complete when something does.

Backend-only, so it targets `general` — it can never ship from a niche branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_013xnjzWJPbXLdYqKwfMzyhy)_