### PR TITLE
fix(migrations): unbreak CI migration runs — async knex table-builder callbacks

### DIFF
--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -773,6 +773,16 @@ English-formatted timestamps.
   join (avoids stale "discovery radius" once cities densify)
 - `therr-api-gateway/src/services/users/router.ts:569` — Validate AWS SNS
   signatures on bounce webhook
+- `main.moments` has **no foreign key on `spaceId`**, in every environment.
+  `20230316132958_main.moments.js` intended to drop and re-add it with
+  `onDelete('SET NULL')`, but it was written as an `async` alterTable callback,
+  so knex emitted only the `dropForeign` and silently discarded the re-add (see
+  the comment in that migration). Verified against a from-scratch replay: zero
+  FK constraints on the table. If the constraint is wanted, it needs a **new
+  forward migration** — do not edit the historical one, which would diverge
+  fresh databases from production. That migration must first find and clear
+  orphaned `moments.spaceId` values accumulated since 2023, or the
+  `ADD CONSTRAINT` will fail.
 
 ### 4.5 Observability gaps
 

--- a/eslint-config/migration-rules.js
+++ b/eslint-config/migration-rules.js
@@ -1,0 +1,57 @@
+// Lint rules specific to Knex migration files (src/store/migrations/**).
+//
+// Guards against the defect class that broke CI in 20230815184654_main.users.js: passing an
+// `async` callback to a Knex table builder.
+//
+// Knex invokes the createTable/alterTable callback *synchronously* while it collects the
+// statement list, and discards whatever the callback returns. An `async` callback therefore
+// splits the migration in two: everything before the first `await` is collected into the
+// ALTER/CREATE TABLE, and everything after it resumes as a floating promise that nothing
+// awaits — the migration's own promise resolves as soon as the table statement does.
+//
+// The consequences are both silent and loud:
+//   - Silent: `table.*` calls placed after an `await` are registered after Knex already
+//     called toSQL(), so they are dropped from the emitted DDL with no error. This is how
+//     main.moments lost its spaceId foreign key in 20230316132958.
+//   - Loud: queries issued after the `await` land on a transaction that has already
+//     committed, which throws "Transaction query already complete". This stayed dormant for
+//     years because Knex wrapped the whole batch in a single transaction; it detonates the
+//     moment any one migration in the service sets `config.transaction = false` (Knex then
+//     switches to a transaction per migration — see Migrator.latest()).
+//
+// A callback with no `await` in it is harmless today, but it is one edit away from the above,
+// so the rule bans the `async` keyword outright rather than trying to detect suspension points.
+// Sequence the work explicitly instead:
+//
+//   exports.up = async (knex) => {
+//       await knex.schema.withSchema('main').alterTable('users', (table) => { ... });
+//       await knex.schema.raw('...');
+//   };
+
+const TABLE_BUILDER_METHODS = [
+    'createTable',
+    'createTableIfNotExists',
+    'createTableLike',
+    'alterTable',
+    'table',
+];
+
+const MESSAGE = 'Do not pass an `async` callback to a Knex table builder. Knex calls it synchronously '
+    + 'and ignores the returned promise, so `table.*` calls after an `await` are silently dropped from the '
+    + 'DDL and queries after an `await` can outlive the migration\'s transaction. Await each step in the '
+    + 'migration body instead. See eslint-config/migration-rules.js.';
+
+const methodPattern = `/^(${TABLE_BUILDER_METHODS.join('|')})$/`;
+
+const NO_ASYNC_TABLE_BUILDER_CALLBACK = [
+    'ArrowFunctionExpression',
+    'FunctionExpression',
+].map((fnType) => ({
+    selector: `CallExpression[callee.property.name=${methodPattern}] > ${fnType}[async=true]`,
+    message: MESSAGE,
+}));
+
+module.exports = {
+    TABLE_BUILDER_METHODS,
+    NO_ASYNC_TABLE_BUILDER_CALLBACK,
+};

--- a/eslint-config/service.js
+++ b/eslint-config/service.js
@@ -6,6 +6,7 @@
 const path = require('path');
 const baseConfig = require('./base');
 const { BRAND_SCOPED_TABLES } = require('./brand-scoped-tables');
+const { NO_ASYNC_TABLE_BUILDER_CALLBACK } = require('./migration-rules');
 
 // Build a no-restricted-syntax selector that flags string literals matching brand-scoped table names.
 // Catches `.from('main.notifications')`, `into('main.notifications')`, raw SQL `FROM main.notifications`,
@@ -67,11 +68,14 @@ module.exports = function createServiceConfig(serviceDir, overrides = {}) {
             },
             // Migration files legitimately reference brand-scoped tables when creating, altering,
             // or dropping them. The brand-scoping enforcement is at runtime via BrandScopedStore;
-            // schema-level operations are safe by definition.
+            // schema-level operations are safe by definition. So the brand-scoped-table selectors
+            // are dropped here — but no-restricted-syntax is re-pointed rather than turned off,
+            // because migrations have their own footgun to guard against (async table-builder
+            // callbacks). See eslint-config/migration-rules.js.
             {
                 files: ['src/store/migrations/**/*.js', 'src/store/seeds/**/*.js'],
                 rules: {
-                    'no-restricted-syntax': 'off',
+                    'no-restricted-syntax': ['error', ...NO_ASYNC_TABLE_BUILDER_CALLBACK],
                 },
             },
             ...(overrides.overrides || []),

--- a/therr-services/maps-service/src/store/migrations/20201114133957_main.moments.js
+++ b/therr-services/maps-service/src/store/migrations/20201114133957_main.moments.js
@@ -22,9 +22,14 @@ const installExtensions = async (knex) => {
     await knex.schema.raw('CREATE EXTENSION IF NOT EXISTS "postgis_tiger_geocoder";');
 };
 
-exports.up = (knex) => installExtensions(knex)
-    .then(() => knex.schema.raw('CREATE SCHEMA IF NOT EXISTS "main";'))
-    .then(() => knex.schema.withSchema('main').createTable('moments', async (table) => {
+// Sequenced explicitly rather than nested inside an async createTable callback: knex invokes that
+// callback synchronously and discards its promise, so the Postgis raws below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+exports.up = async (knex) => {
+    await installExtensions(knex);
+    await knex.schema.raw('CREATE SCHEMA IF NOT EXISTS "main";');
+
+    await knex.schema.withSchema('main').createTable('moments', (table) => {
         table.uuid('id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
         table.uuid('fromUserId').notNullable();
         table.string('locale', 8);
@@ -59,11 +64,12 @@ exports.up = (knex) => installExtensions(knex)
 
         // Indexes
         table.index('fromUserId');
+    });
 
-        // Postgis
-        await knex.schema.raw(`SELECT AddGeometryColumn('main', 'moments', 'geom', 4326, 'POINT', 2);`); // eslint-disable-line quotes
-        await knex.schema.raw(`UPDATE main.moments SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326);`); // eslint-disable-line quotes
-        await knex.schema.raw(`CREATE INDEX idx_moments_geom ON main.moments USING gist(geom);`); // eslint-disable-line quotes
-    }));
+    // Postgis
+    await knex.schema.raw(`SELECT AddGeometryColumn('main', 'moments', 'geom', 4326, 'POINT', 2);`); // eslint-disable-line quotes
+    await knex.schema.raw(`UPDATE main.moments SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326);`); // eslint-disable-line quotes
+    await knex.schema.raw(`CREATE INDEX idx_moments_geom ON main.moments USING gist(geom);`); // eslint-disable-line quotes
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').dropTable('moments');

--- a/therr-services/maps-service/src/store/migrations/20210505070730_main.media.js
+++ b/therr-services/maps-service/src/store/migrations/20210505070730_main.media.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').createTable('media', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').createTable('media', (table) => {
     table.uuid('id').notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
     table.uuid('fromUserId').notNullable();
     table.string('altText').notNullable().defaultsTo('');

--- a/therr-services/maps-service/src/store/migrations/20211204165013_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20211204165013_main.spaces.js
@@ -17,48 +17,57 @@ const dropFunctions = async (knex) => {
     await knex.schema.raw('DROP FUNCTION IF EXISTS main.no_area_overlaps(id uuid, g geometry)');
 };
 
-exports.up = (knex) => knex.schema.withSchema('main').createTable('spaces', async (table) => {
-    table.uuid('id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
-    table.uuid('fromUserId').notNullable();
-    table.string('locale', 8);
-    table.bool('isPublic').notNullable().defaultTo(false);
-    table.text('message').notNullable().defaultsTo('');
-    table.string('notificationMsg').notNullable(); // If empty, should default to first x characters of message
-    table.text('mediaIds').notNullable().defaultsTo('');
-    table.text('mentionsIds').notNullable().defaultsTo(''); // Other connection/user mentions for linking
-    table.text('hashTags').notNullable().defaultsTo('');
-    table.integer('maxViews').notNullable().defaultsTo(0);
-    table.double('latitude', 15).notNullable();
-    table.double('longitude', 15).notNullable();
-    table.float('radius');
-    table.jsonb('polygonCoords').notNullable().defaultsTo(JSON.stringify([]));
-    table.float('maxProximity').defaultTo(0.0);
-    table.bool('doesRequireProximityToView').notNullable().defaultTo(false);
-    table.boolean('isMatureContent').notNullable().defaultTo(false);
-    table.bool('isModeratorApproved').notNullable().defaultTo(false);
-    table.bool('isForSale').notNullable().defaultTo(false);
-    table.bool('isHirable').notNullable().defaultTo(false);
-    table.bool('isPromotional').notNullable().defaultTo(false);
-    table.bool('isExclusiveToGroups').notNullable().defaultTo(false);
-    table.string('category', 50).notNullable().defaultTo('uncategorized');
-    table.timestamp('isScheduledAt', { useTz: true });
+// Sequenced explicitly rather than nested inside an async createTable callback: knex invokes that
+// callback synchronously and discards its promise, so the Postgis raws below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+//
+// Ordering matters here beyond the transaction concern: the no_overlaps CHECK references the geom
+// column, so the column has to exist and be backfilled before createFunctions/ALTER TABLE run.
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').createTable('spaces', (table) => {
+        table.uuid('id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
+        table.uuid('fromUserId').notNullable();
+        table.string('locale', 8);
+        table.bool('isPublic').notNullable().defaultTo(false);
+        table.text('message').notNullable().defaultsTo('');
+        table.string('notificationMsg').notNullable(); // If empty, should default to first x characters of message
+        table.text('mediaIds').notNullable().defaultsTo('');
+        table.text('mentionsIds').notNullable().defaultsTo(''); // Other connection/user mentions for linking
+        table.text('hashTags').notNullable().defaultsTo('');
+        table.integer('maxViews').notNullable().defaultsTo(0);
+        table.double('latitude', 15).notNullable();
+        table.double('longitude', 15).notNullable();
+        table.float('radius');
+        table.jsonb('polygonCoords').notNullable().defaultsTo(JSON.stringify([]));
+        table.float('maxProximity').defaultTo(0.0);
+        table.bool('doesRequireProximityToView').notNullable().defaultTo(false);
+        table.boolean('isMatureContent').notNullable().defaultTo(false);
+        table.bool('isModeratorApproved').notNullable().defaultTo(false);
+        table.bool('isForSale').notNullable().defaultTo(false);
+        table.bool('isHirable').notNullable().defaultTo(false);
+        table.bool('isPromotional').notNullable().defaultTo(false);
+        table.bool('isExclusiveToGroups').notNullable().defaultTo(false);
+        table.string('category', 50).notNullable().defaultTo('uncategorized');
+        table.timestamp('isScheduledAt', { useTz: true });
 
-    // Audit
-    table.integer('valuation').notNullable().defaultTo(0);
-    table.string('region').notNullable(); // Also used for sharding, db location
-    table.timestamp('expiresAt', { useTz: true });
-    table.timestamp('createdAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
-    table.timestamp('updatedAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+        // Audit
+        table.integer('valuation').notNullable().defaultTo(0);
+        table.string('region').notNullable(); // Also used for sharding, db location
+        table.timestamp('expiresAt', { useTz: true });
+        table.timestamp('createdAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+        table.timestamp('updatedAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
 
-    // Indexes
-    table.index('fromUserId');
+        // Indexes
+        table.index('fromUserId');
+    });
 
     // Postgis
     await knex.schema.raw(`SELECT AddGeometryColumn('main', 'spaces', 'geom', 4326, 'POLYGON', 2);`); // eslint-disable-line quotes
     await knex.schema.raw(`UPDATE main.spaces SET geom = ST_SetSRID(ST_Buffer(ST_MakePoint(longitude, latitude), radius), 4326);`); // eslint-disable-line quotes, max-len
     await knex.schema.raw(`CREATE INDEX idx_spaces_geom ON main.spaces USING gist(geom);`); // eslint-disable-line quotes
-}).then(() => createFunctions(knex)).then(async () => {
+
+    await createFunctions(knex);
     await knex.schema.raw('ALTER TABLE main.spaces ADD CONSTRAINT no_overlaps CHECK (main.no_area_overlaps(id, geom));');
-});
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').dropTable('spaces').then(() => dropFunctions(knex));

--- a/therr-services/maps-service/src/store/migrations/20211224164034_main.moments.js
+++ b/therr-services/maps-service/src/store/migrations/20211224164034_main.moments.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', (table) => {
     table.string('areaType', 25).notNullable().defaultsTo('moments');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20211224164243_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20211224164243_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.string('areaType', 25).notNullable().defaultsTo('spaces');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20220425130128_main.moments.js
+++ b/therr-services/maps-service/src/store/migrations/20220425130128_main.moments.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', (table) => {
     table.bool('isDraft').notNullable().defaultTo(false);
 });
 

--- a/therr-services/maps-service/src/store/migrations/20220604131806_main.externalMediaIntegrations.js
+++ b/therr-services/maps-service/src/store/migrations/20220604131806_main.externalMediaIntegrations.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').createTable('externalMediaIntegrations', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').createTable('externalMediaIntegrations', (table) => {
     table.uuid('id').notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
     table.uuid('fromUserId').notNullable();
     table.uuid('momentId')

--- a/therr-services/maps-service/src/store/migrations/20221229201430_main.moments.js
+++ b/therr-services/maps-service/src/store/migrations/20221229201430_main.moments.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', (table) => {
     table.index('createdAt');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20221229201532_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20221229201532_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.index('createdAt');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20230131013155_main.moments.js
+++ b/therr-services/maps-service/src/store/migrations/20230131013155_main.moments.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', (table) => {
     table.uuid('spaceId')
         .references('id')
         .inTable('main.spaces')

--- a/therr-services/maps-service/src/store/migrations/20230201210346_main.moments.js
+++ b/therr-services/maps-service/src/store/migrations/20230201210346_main.moments.js
@@ -1,6 +1,6 @@
 // nearbySpacesSnapshot is used for drafted moments so we can get nearby spaces without requiring location
 // to edit a drafted moment
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', (table) => {
     table.jsonb('nearbySpacesSnapshot').defaultsTo(JSON.stringify([]));
 });
 

--- a/therr-services/maps-service/src/store/migrations/20230201222947_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20230201222947_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.string('featuredIncentiveKey'); // These are duplicated properties from the spaceIncentiveDetails table
     table.double('featuredIncentiveValue'); // These are duplicated properties from the spaceIncentiveDetails table
     table.string('featuredIncentiveRewardKey'); // These are duplicated properties from the spaceIncentiveDetails table

--- a/therr-services/maps-service/src/store/migrations/20230206135133_main.spaceIncentives.js
+++ b/therr-services/maps-service/src/store/migrations/20230206135133_main.spaceIncentives.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').createTable('spaceIncentives', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').createTable('spaceIncentives', (table) => {
     table.uuid('id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
     table.uuid('spaceId')
         .references('id')

--- a/therr-services/maps-service/src/store/migrations/20230206135652_main.spaceIncentiveCoupons.js
+++ b/therr-services/maps-service/src/store/migrations/20230206135652_main.spaceIncentiveCoupons.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').createTable('spaceIncentiveCoupons', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').createTable('spaceIncentiveCoupons', (table) => {
     table.uuid('spaceIncentiveId')
         .references('id')
         .inTable('main.spaceIncentives')

--- a/therr-services/maps-service/src/store/migrations/20230316132958_main.moments.js
+++ b/therr-services/maps-service/src/store/migrations/20230316132958_main.moments.js
@@ -1,13 +1,26 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', async (table) => {
-    await table.dropForeign('spaceid');
-    table.uuid('spaceId')
-        .alter()
-        .references('id')
-        .inTable('main.spaces')
-        .onDelete('SET NULL');
+// DELIBERATELY PRESERVED AS-IS — this migration has never done what it appears to do, and making
+// it do so here would be wrong. Do not "repair" it inline.
+//
+// It was originally written as an `async` alterTable callback whose first statement was
+// `await table.dropForeign('spaceid')`. Knex invokes that callback synchronously while collecting
+// the DDL, so only the statements before the first `await` were ever emitted: the dropForeign
+// landed, and the spaceId foreign-key re-add that followed it resumed a microtask later — after
+// toSQL() had already run — and was silently discarded.
+//
+// So the real, shipped effect of this migration is "drop the spaceId foreign key", full stop.
+// Verified against a database replayed from scratch: main.moments has zero foreign-key
+// constraints. Production ran this same code, so production has no such constraint either.
+//
+// Re-adding the FK here would give freshly-built databases (CI, local dev) a constraint that
+// production lacks, which is exactly the divergence this file must not introduce. If the
+// constraint is actually wanted, it needs a NEW forward migration, and that migration has to
+// reckon with orphaned moments.spaceId values that have accumulated in the years since — adding
+// the constraint will fail outright if any exist. Tracked in docs/WORK_IN_PROGRESS.md.
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', (table) => {
+    table.dropForeign('spaceid');
 });
 
-exports.down = (knex) => knex.schema.withSchema('main').alterTable('moments', async (table) => {
+exports.down = (knex) => knex.schema.withSchema('main').alterTable('moments', (table) => {
     // await table.dropForeign('spaceid');
     table.uuid('spaceId')
         .alter()

--- a/therr-services/maps-service/src/store/migrations/20230407195827_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20230407195827_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.string('addressReadable');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20230505183519_main.spaceMetrics.js
+++ b/therr-services/maps-service/src/store/migrations/20230505183519_main.spaceMetrics.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceMetrics', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceMetrics', (table) => {
     table.dropIndex('name');
     table.index(['spaceId', 'createdAt']);
     table.index(['spaceId', 'name']);

--- a/therr-services/maps-service/src/store/migrations/20230530134352_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20230530134352_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.bool('isClaimPending').notNullable().defaultsTo(false); // Used to allow businesses to claim a space without providing location
 
     table.index('isClaimPending');

--- a/therr-services/maps-service/src/store/migrations/20230801002048_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20230801002048_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.string('phoneNumber', 24).nullable();
     table.string('websiteUrl').nullable();
     table.string('menuUrl').nullable();

--- a/therr-services/maps-service/src/store/migrations/20230815183844_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20230815183844_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.bool('isPointOfInterest').notNullable().defaultTo(true);
     table.string('businessTransactionId').nullable();
     table.string('businessTransactionName').nullable();

--- a/therr-services/maps-service/src/store/migrations/20230918000539_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20230918000539_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.string('addressLocality'); // The locality of the address within the region (city)
     table.string('addressRegion'); // The region of the address within the country (state, province)
     table.string('addressStreetAddress');

--- a/therr-services/maps-service/src/store/migrations/20230918162859_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20230918162859_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.uuid('organizationId');
     table.index('organizationId');
 });

--- a/therr-services/maps-service/src/store/migrations/20231003154643_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20231003154643_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.integer('priceRange').defaultTo(2); // 1-5, 5 is the highest
     table.string('foodStyle'); // italian, mexican, etc.
     table.jsonb('openingHours').defaultTo(JSON.stringify({

--- a/therr-services/maps-service/src/store/migrations/20231003195556_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20231003195556_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.jsonb('thirdPartyRatings').defaultTo(JSON.stringify({}));
 });
 

--- a/therr-services/maps-service/src/store/migrations/20231009184616_main.spaceMetrics.js
+++ b/therr-services/maps-service/src/store/migrations/20231009184616_main.spaceMetrics.js
@@ -1,12 +1,18 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceMetrics', async (table) => {
-    table.double('userLatitude', 15).nullable();
-    table.double('userLongitude', 15).nullable();
+// Sequenced explicitly rather than nested inside an async alterTable callback: knex invokes that
+// callback synchronously and discards its promise, so the Postgis raws below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').alterTable('spaceMetrics', (table) => {
+        table.double('userLatitude', 15).nullable();
+        table.double('userLongitude', 15).nullable();
+    });
+
     // Postgis
     await knex.schema.raw(`SELECT AddGeometryColumn('main', 'spaceMetrics', 'userLocation', 4326, 'POINT', 2);`); // eslint-disable-line quotes
     // eslint-disable-next-line max-len
     await knex.schema.raw(`UPDATE main."spaceMetrics" SET "userLocation" = ST_SetSRID(ST_MakePoint("userLongitude", "userLatitude"), 4326);`); // eslint-disable-line quotes
     await knex.schema.raw(`CREATE INDEX idx_user_location ON main."spaceMetrics" USING gist("userLocation");`); // eslint-disable-line quotes
-});
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').alterTable('spaceMetrics', (table) => {
     table.dropColumn('userLatitude');

--- a/therr-services/maps-service/src/store/migrations/20231106135656_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20231106135656_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.uuid('requestedByUserId').nullable();
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240123210937_main.events.js
+++ b/therr-services/maps-service/src/store/migrations/20240123210937_main.events.js
@@ -22,9 +22,14 @@ const installExtensions = async (knex) => {
     await knex.schema.raw('CREATE EXTENSION IF NOT EXISTS "postgis_tiger_geocoder";');
 };
 
-exports.up = (knex) => installExtensions(knex)
-    .then(() => knex.schema.raw('CREATE SCHEMA IF NOT EXISTS "main";'))
-    .then(() => knex.schema.withSchema('main').createTable('events', async (table) => {
+// Sequenced explicitly rather than nested inside an async createTable callback: knex invokes that
+// callback synchronously and discards its promise, so the Postgis raws below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+exports.up = async (knex) => {
+    await installExtensions(knex);
+    await knex.schema.raw('CREATE SCHEMA IF NOT EXISTS "main";');
+
+    await knex.schema.withSchema('main').createTable('events', (table) => {
         table.uuid('id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
         table.uuid('fromUserId').notNullable();
         table.uuid('groupId').notNullable();
@@ -70,11 +75,12 @@ exports.up = (knex) => installExtensions(knex)
         table.index('spaceId');
         table.index('scheduleStartAt');
         table.index('scheduleStopAt');
+    });
 
-        // Postgis
-        await knex.schema.raw(`SELECT AddGeometryColumn('main', 'events', 'geom', 4326, 'POINT', 2);`); // eslint-disable-line quotes
-        await knex.schema.raw(`UPDATE main.events SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326);`); // eslint-disable-line quotes
-        await knex.schema.raw(`CREATE INDEX idx_events_geom ON main.events USING gist(geom);`); // eslint-disable-line quotes
-    }));
+    // Postgis
+    await knex.schema.raw(`SELECT AddGeometryColumn('main', 'events', 'geom', 4326, 'POINT', 2);`); // eslint-disable-line quotes
+    await knex.schema.raw(`UPDATE main.events SET geom = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326);`); // eslint-disable-line quotes
+    await knex.schema.raw(`CREATE INDEX idx_events_geom ON main.events USING gist(geom);`); // eslint-disable-line quotes
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').dropTable('events');

--- a/therr-services/maps-service/src/store/migrations/20240209204537_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20240209204537_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.index(['latitude', 'longitude']);
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240322140814_main.moments.js
+++ b/therr-services/maps-service/src/store/migrations/20240322140814_main.moments.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', (table) => {
     table.jsonb('medias');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240322140819_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20240322140819_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.jsonb('medias');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240322140823_main.events.js
+++ b/therr-services/maps-service/src/store/migrations/20240322140823_main.events.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('events', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('events', (table) => {
     table.jsonb('medias');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240404153837_main.externalMediaIntegrations.js
+++ b/therr-services/maps-service/src/store/migrations/20240404153837_main.externalMediaIntegrations.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('externalMediaIntegrations', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('externalMediaIntegrations', (table) => {
     table.primary('id');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240404153908_main.momentStats.js
+++ b/therr-services/maps-service/src/store/migrations/20240404153908_main.momentStats.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('momentStats', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('momentStats', (table) => {
     table.primary('momentId');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240404153955_main.media.js
+++ b/therr-services/maps-service/src/store/migrations/20240404153955_main.media.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('media', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('media', (table) => {
     table.primary('id');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240404154022_main.spaceIncentiveCoupons.js
+++ b/therr-services/maps-service/src/store/migrations/20240404154022_main.spaceIncentiveCoupons.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceIncentiveCoupons', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceIncentiveCoupons', (table) => {
     table.primary(['spaceIncentiveId', 'userId']);
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240408202244_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20240408202244_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.jsonb('happyHours');
 });
 

--- a/therr-services/maps-service/src/store/migrations/20240510143155_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20240510143155_main.spaces.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.jsonb('interestsKeys').notNullable().defaultTo(JSON.stringify([]));
 
     table.index('interestsKeys', 'idx_spaces_interests_keys', {

--- a/therr-services/maps-service/src/store/migrations/20240510143226_main.moments.js
+++ b/therr-services/maps-service/src/store/migrations/20240510143226_main.moments.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('moments', (table) => {
     table.jsonb('interestsKeys').notNullable().defaultTo(JSON.stringify([]));
 
     table.index('interestsKeys', 'idx_moments_interests_keys', {

--- a/therr-services/maps-service/src/store/migrations/20240510143234_main.events.js
+++ b/therr-services/maps-service/src/store/migrations/20240510143234_main.events.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('events', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('events', (table) => {
     table.jsonb('interestsKeys').notNullable().defaultTo(JSON.stringify([]));
 
     table.index('interestsKeys', 'idx_events_interests_keys', {

--- a/therr-services/maps-service/src/store/migrations/20240523210755_main.spaces.js
+++ b/therr-services/maps-service/src/store/migrations/20240523210755_main.spaces.js
@@ -1,11 +1,16 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaces', async (table) => {
-    table.index('isMatureContent');
+// Sequenced explicitly rather than nested inside an async alterTable callback: knex invokes that
+// callback synchronously and discards its promise, so the Postgis raws below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').alterTable('spaces', (table) => {
+        table.index('isMatureContent');
+    });
 
     // Postgis
     await knex.schema.raw(`SELECT AddGeometryColumn('main', 'spaces', 'geomCenter', 4326, 'POINT', 2);`); // eslint-disable-line quotes
     await knex.schema.raw(`UPDATE main.spaces SET "geomCenter" = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326);`); // eslint-disable-line quotes, max-len
     await knex.schema.raw(`CREATE INDEX idx_spaces_geom_center ON main.spaces USING gist("geomCenter");`); // eslint-disable-line quotes
-});
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').alterTable('spaces', (table) => {
     table.dropIndex('isMatureContent');

--- a/therr-services/messages-service/src/store/migrations/20231226182631_main.forums.js
+++ b/therr-services/messages-service/src/store/migrations/20231226182631_main.forums.js
@@ -23,15 +23,23 @@ const installExtensions = async (knex) => {
     await knex.schema.raw('CREATE EXTENSION IF NOT EXISTS "postgis_tiger_geocoder";');
 };
 
-exports.up = (knex) => installExtensions(knex).then(() => knex.schema.withSchema('main').alterTable('forums', async (table) => {
-    table.jsonb('media').defaultTo(JSON.stringify({})); // if type is image or video
-    table.double('localLatitude', 15).nullable();
-    table.double('localLongitude', 15).nullable();
+// Sequenced explicitly rather than nested inside an async alterTable callback: knex invokes that
+// callback synchronously and discards its promise, so the Postgis raws below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+exports.up = async (knex) => {
+    await installExtensions(knex);
+
+    await knex.schema.withSchema('main').alterTable('forums', (table) => {
+        table.jsonb('media').defaultTo(JSON.stringify({})); // if type is image or video
+        table.double('localLatitude', 15).nullable();
+        table.double('localLongitude', 15).nullable();
+    });
+
     // Postgis
     await knex.schema.raw(`SELECT AddGeometryColumn('main', 'forums', 'localLocation', 4326, 'POINT', 2);`); // eslint-disable-line quotes
     await knex.schema.raw(`UPDATE main.forums SET "localLocation" = ST_SetSRID(ST_MakePoint("localLongitude", "localLatitude"), 4326);`); // eslint-disable-line quotes
     await knex.schema.raw(`CREATE INDEX idx_forums_local_location ON main.forums USING gist("localLocation");`); // eslint-disable-line quotes
-}));
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').alterTable('forums', (table) => {
     table.dropColumn('localLatitude');

--- a/therr-services/reactions-service/src/store/migrations/20230928140540_main.momentReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20230928140540_main.momentReactions.js
@@ -23,18 +23,26 @@ const installExtensions = async (knex) => {
     await knex.schema.raw('CREATE EXTENSION IF NOT EXISTS "postgis_tiger_geocoder";');
 };
 
-exports.up = (knex) => installExtensions(knex).then(() => knex.schema.withSchema('main').alterTable('momentReactions', async (table) => {
-    table.uuid('contentAuthorId').nullable();
-    table.integer('updateCount').notNullable().defaultTo(0);
-    table.double('contentLatitude', 15).nullable();
-    table.double('contentLongitude', 15).nullable();
+// Sequenced explicitly rather than nested inside an async alterTable callback: knex invokes that
+// callback synchronously and discards its promise, so the Postgis raws below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+exports.up = async (knex) => {
+    await installExtensions(knex);
 
-    table.index('contentAuthorId');
+    await knex.schema.withSchema('main').alterTable('momentReactions', (table) => {
+        table.uuid('contentAuthorId').nullable();
+        table.integer('updateCount').notNullable().defaultTo(0);
+        table.double('contentLatitude', 15).nullable();
+        table.double('contentLongitude', 15).nullable();
+
+        table.index('contentAuthorId');
+    });
+
     // Postgis
     await knex.schema.raw(`SELECT AddGeometryColumn('main', 'momentReactions', 'contentLocation', 4326, 'POINT', 2);`); // eslint-disable-line quotes
     await knex.schema.raw(`UPDATE main."momentReactions" SET "contentLocation" = ST_SetSRID(ST_MakePoint("contentLongitude", "contentLatitude"), 4326);`); // eslint-disable-line quotes
     await knex.schema.raw(`CREATE INDEX idx_momentReactions_content_location ON main."momentReactions" USING gist("contentLocation");`); // eslint-disable-line quotes
-}));
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').alterTable('momentReactions', (table) => {
     table.dropColumn('contentAuthorId');

--- a/therr-services/reactions-service/src/store/migrations/20230928141058_main.spaceReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20230928141058_main.spaceReactions.js
@@ -23,18 +23,26 @@ const installExtensions = async (knex) => {
     await knex.schema.raw('CREATE EXTENSION IF NOT EXISTS "postgis_tiger_geocoder";');
 };
 
-exports.up = (knex) => installExtensions(knex).then(() => knex.schema.withSchema('main').alterTable('spaceReactions', async (table) => {
-    table.uuid('contentAuthorId').nullable();
-    table.integer('updateCount').notNullable().defaultTo(0);
-    table.double('contentLatitude', 15).nullable();
-    table.double('contentLongitude', 15).nullable();
+// Sequenced explicitly rather than nested inside an async alterTable callback: knex invokes that
+// callback synchronously and discards its promise, so the Postgis raws below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+exports.up = async (knex) => {
+    await installExtensions(knex);
 
-    table.index('contentAuthorId');
+    await knex.schema.withSchema('main').alterTable('spaceReactions', (table) => {
+        table.uuid('contentAuthorId').nullable();
+        table.integer('updateCount').notNullable().defaultTo(0);
+        table.double('contentLatitude', 15).nullable();
+        table.double('contentLongitude', 15).nullable();
+
+        table.index('contentAuthorId');
+    });
+
     // Postgis
     await knex.schema.raw(`SELECT AddGeometryColumn('main', 'spaceReactions', 'contentLocation', 4326, 'POINT', 2);`); // eslint-disable-line quotes
     await knex.schema.raw(`UPDATE main."spaceReactions" SET "contentLocation" = ST_SetSRID(ST_MakePoint("contentLongitude", "contentLatitude"), 4326);`); // eslint-disable-line quotes
     await knex.schema.raw(`CREATE INDEX idx_spaceReactions_content_location ON main."spaceReactions" USING gist("contentLocation");`); // eslint-disable-line quotes
-}));
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').alterTable('spaceReactions', (table) => {
     table.dropColumn('contentAuthorId');

--- a/therr-services/reactions-service/src/store/migrations/20240214152148_main.eventReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240214152148_main.eventReactions.js
@@ -23,41 +23,46 @@ const installExtensions = async (knex) => {
     await knex.schema.raw('CREATE EXTENSION IF NOT EXISTS "postgis_tiger_geocoder";');
 };
 
-exports.up = (knex) => knex.schema.withSchema('main').createTable('eventReactions', async (table) => {
-    table.uuid('id').notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
-    table.uuid('eventId').notNullable();
-    table.uuid('userId').notNullable();
-    table.boolean('userHasActivated').notNullable().defaultTo(false);
-    table.bool('userHasLiked').notNullable().defaultTo(false);
-    table.bool('userHasSuperLiked').notNullable().defaultTo(false);
-    table.bool('userHasDisliked').notNullable().defaultTo(false);
-    table.bool('userHasSuperDisliked').notNullable().defaultTo(false);
-    table.string('userLocale', 8);
-    table.string('userBookmarkCategory');
-    table.integer('userBookmarkPriority').notNullable().defaultTo(0);
-    table.boolean('userHasReported').notNullable().defaultTo(false);
-    table.boolean('isArchived').notNullable().defaultTo(false);
-    table.integer('rating');
-    table.uuid('contentAuthorId').nullable();
-    table.integer('updateCount').notNullable().defaultTo(0);
-    table.double('contentLatitude', 15).nullable();
-    table.double('contentLongitude', 15).nullable();
+// Sequenced explicitly rather than nested inside an async createTable callback: knex invokes that
+// callback synchronously and discards its promise, so the Postgis raws below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').createTable('eventReactions', (table) => {
+        table.uuid('id').notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
+        table.uuid('eventId').notNullable();
+        table.uuid('userId').notNullable();
+        table.boolean('userHasActivated').notNullable().defaultTo(false);
+        table.bool('userHasLiked').notNullable().defaultTo(false);
+        table.bool('userHasSuperLiked').notNullable().defaultTo(false);
+        table.bool('userHasDisliked').notNullable().defaultTo(false);
+        table.bool('userHasSuperDisliked').notNullable().defaultTo(false);
+        table.string('userLocale', 8);
+        table.string('userBookmarkCategory');
+        table.integer('userBookmarkPriority').notNullable().defaultTo(0);
+        table.boolean('userHasReported').notNullable().defaultTo(false);
+        table.boolean('isArchived').notNullable().defaultTo(false);
+        table.integer('rating');
+        table.uuid('contentAuthorId').nullable();
+        table.integer('updateCount').notNullable().defaultTo(0);
+        table.double('contentLatitude', 15).nullable();
+        table.double('contentLongitude', 15).nullable();
 
-    // Audit
-    table.integer('userViewCount').notNullable().defaultTo(0);
-    table.timestamp('createdAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
-    table.timestamp('updatedAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+        // Audit
+        table.integer('userViewCount').notNullable().defaultTo(0);
+        table.timestamp('createdAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+        table.timestamp('updatedAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
 
-    // Indexes
-    table.unique(['eventId', 'userId']);
-    table.index(['eventId', 'userId']);
-    table.index(['eventId', 'rating']);
-    table.index('contentAuthorId');
+        // Indexes
+        table.unique(['eventId', 'userId']);
+        table.index(['eventId', 'userId']);
+        table.index(['eventId', 'rating']);
+        table.index('contentAuthorId');
+    });
 
     // Postgis
     await knex.schema.raw(`SELECT AddGeometryColumn('main', 'eventReactions', 'contentLocation', 4326, 'POINT', 2);`); // eslint-disable-line quotes
     await knex.schema.raw(`UPDATE main."eventReactions" SET "contentLocation" = ST_SetSRID(ST_MakePoint("contentLongitude", "contentLatitude"), 4326);`); // eslint-disable-line quotes
     await knex.schema.raw(`CREATE INDEX idx_eventReactions_content_location ON main."eventReactions" USING gist("contentLocation");`); // eslint-disable-line quotes
-});
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').dropTable('eventReactions');

--- a/therr-services/reactions-service/src/store/migrations/20240219153313_main.momentReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240219153313_main.momentReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('momentReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('momentReactions', (table) => {
     table.index('createdAt');
     table.index(['momentId', 'userHasLiked']);
 });

--- a/therr-services/reactions-service/src/store/migrations/20240219154101_main.spaceReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240219154101_main.spaceReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceReactions', (table) => {
     table.index('createdAt');
     table.index(['spaceId', 'userHasLiked']);
 });

--- a/therr-services/reactions-service/src/store/migrations/20240219154106_main.thoughtReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240219154106_main.thoughtReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('thoughtReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('thoughtReactions', (table) => {
     table.index('createdAt');
     table.index(['thoughtId', 'userHasLiked']);
 });

--- a/therr-services/reactions-service/src/store/migrations/20240219154113_main.eventReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240219154113_main.eventReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('eventReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('eventReactions', (table) => {
     table.index('createdAt');
     table.index(['eventId', 'userHasLiked']);
 });

--- a/therr-services/reactions-service/src/store/migrations/20240307235900_main.momentReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240307235900_main.momentReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('momentReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('momentReactions', (table) => {
     table.index(['userId', 'userHasActivated', 'userHasReported']);
 });
 

--- a/therr-services/reactions-service/src/store/migrations/20240308001224_main.spaceReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240308001224_main.spaceReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceReactions', (table) => {
     table.index(['userId', 'userHasActivated', 'userHasReported']);
 });
 

--- a/therr-services/reactions-service/src/store/migrations/20240308001539_main.thoughtReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240308001539_main.thoughtReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('thoughtReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('thoughtReactions', (table) => {
     table.index(['userId', 'userHasActivated', 'userHasReported']);
 });
 

--- a/therr-services/reactions-service/src/store/migrations/20240308001747_main.eventReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240308001747_main.eventReactions.js
@@ -1,10 +1,19 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('eventReactions', async (table) => {
-    table.integer('attendingCount');
-    table.index(['userId', 'userHasActivated', 'userHasReported']);
-    await knex.schema.raw('CREATE INDEX idx_eventreactions_is_attending ON main."eventReactions" ("attendingCount") WHERE "attendingCount" IS NOT NULL;');
-});
+// Sequenced explicitly rather than nested inside an async alterTable callback: knex invokes that
+// callback synchronously and discards its promise, so the index raw below would escape the
+// migration and could outlive its transaction. See eslint-config/migration-rules.js.
+//
+// The ordering also has to be explicit: the partial index reads "attendingCount", so the column
+// must be committed to the DDL before the index is built.
+exports.up = async (knex) => {
+    await knex.schema.withSchema('main').alterTable('eventReactions', (table) => {
+        table.integer('attendingCount');
+        table.index(['userId', 'userHasActivated', 'userHasReported']);
+    });
 
-exports.down = (knex) => knex.schema.withSchema('main').alterTable('eventReactions', async (table) => {
+    await knex.schema.raw('CREATE INDEX idx_eventreactions_is_attending ON main."eventReactions" ("attendingCount") WHERE "attendingCount" IS NOT NULL;');
+};
+
+exports.down = (knex) => knex.schema.withSchema('main').alterTable('eventReactions', (table) => {
     table.dropColumn('attendingCount');
     table.dropIndex(['userId', 'userHasActivated', 'userHasReported']);
     table.dropIndex([], 'idx_eventreactions_is_attending');

--- a/therr-services/reactions-service/src/store/migrations/20240404151416_main.thoughtReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240404151416_main.thoughtReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('thoughtReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('thoughtReactions', (table) => {
     table.primary('id');
 });
 

--- a/therr-services/reactions-service/src/store/migrations/20240404151652_main.momentReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240404151652_main.momentReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('momentReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('momentReactions', (table) => {
     table.primary('id');
 });
 

--- a/therr-services/reactions-service/src/store/migrations/20240404151718_main.spaceReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240404151718_main.spaceReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('spaceReactions', (table) => {
     table.primary('id');
 });
 

--- a/therr-services/reactions-service/src/store/migrations/20240404151740_main.eventReactions.js
+++ b/therr-services/reactions-service/src/store/migrations/20240404151740_main.eventReactions.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('eventReactions', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('eventReactions', (table) => {
     table.primary('id');
 });
 

--- a/therr-services/users-service/src/store/migrations/20221222143544_main.thoughts.js
+++ b/therr-services/users-service/src/store/migrations/20221222143544_main.thoughts.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').createTable('thoughts', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').createTable('thoughts', (table) => {
     table.uuid('id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
     table.uuid('fromUserId').notNullable();
     table.uuid('parentId')

--- a/therr-services/users-service/src/store/migrations/20230815184654_main.users.js
+++ b/therr-services/users-service/src/store/migrations/20230815184654_main.users.js
@@ -23,14 +23,34 @@ const installExtensions = async (knex) => {
     await knex.schema.raw('CREATE EXTENSION IF NOT EXISTS "postgis_tiger_geocoder";');
 };
 
-exports.up = (knex) => installExtensions(knex).then(() => knex.schema.withSchema('main').alterTable('users', async (table) => {
-    table.double('lastKnownLatitude', 15).nullable();
-    table.double('lastKnownLongitude', 15).nullable();
+// knex runs the alterTable callback synchronously while it collects the statement list, and
+// discards whatever the callback returns. An `async` callback therefore splits this migration
+// in two: the column definitions before the first `await` land in the ALTER TABLE, and the
+// raws after it resume as floating promises that nothing awaits — `up` resolves as soon as the
+// ALTER TABLE does.
+//
+// That was survivable only while knex wrapped the entire batch in one transaction, which kept a
+// connection open long enough for the stragglers to land. 20260727000000 sets
+// `transaction: false`, and knex switches to a transaction per migration the moment any single
+// migration opts out — so this one now commits at the ALTER TABLE and the trailing raws hit a
+// closed transaction ("Transaction query already complete").
+//
+// Awaiting each step in sequence is also the order this always needed: the lat/long columns have
+// to exist before the ST_MakePoint backfill reads them, which previously held only by luck of
+// how the two overlapping statements happened to queue on the connection.
+exports.up = async (knex) => {
+    await installExtensions(knex);
+
+    await knex.schema.withSchema('main').alterTable('users', (table) => {
+        table.double('lastKnownLatitude', 15).nullable();
+        table.double('lastKnownLongitude', 15).nullable();
+    });
+
     // Postgis
     await knex.schema.raw(`SELECT AddGeometryColumn('main', 'users', 'lastKnownLocation', 4326, 'POINT', 2);`); // eslint-disable-line quotes
     await knex.schema.raw(`UPDATE main.users SET "lastKnownLocation" = ST_SetSRID(ST_MakePoint("lastKnownLongitude", "lastKnownLatitude"), 4326);`); // eslint-disable-line quotes
     await knex.schema.raw(`CREATE INDEX idx_users_last_known_location ON main.users USING gist("lastKnownLocation");`); // eslint-disable-line quotes
-}));
+};
 
 exports.down = (knex) => knex.schema.withSchema('main').alterTable('users', (table) => {
     table.dropColumn('lastKnownLatitude');

--- a/therr-services/users-service/src/store/migrations/20240404153347_main.userOrganizations.js
+++ b/therr-services/users-service/src/store/migrations/20240404153347_main.userOrganizations.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('userOrganizations', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('userOrganizations', (table) => {
     table.primary(['organizationId', 'userId']);
 });
 

--- a/therr-services/users-service/src/store/migrations/20240404153546_main.privacySettings.js
+++ b/therr-services/users-service/src/store/migrations/20240404153546_main.privacySettings.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('privacySettings', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('privacySettings', (table) => {
     table.primary('userId');
 });
 

--- a/therr-services/users-service/src/store/migrations/20240404153735_main.userStatsAggregations.js
+++ b/therr-services/users-service/src/store/migrations/20240404153735_main.userStatsAggregations.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('userStatsAggregations', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('userStatsAggregations', (table) => {
     table.primary('userId');
 });
 

--- a/therr-services/users-service/src/store/migrations/20240510144527_main.thoughts.js
+++ b/therr-services/users-service/src/store/migrations/20240510144527_main.thoughts.js
@@ -1,4 +1,4 @@
-exports.up = (knex) => knex.schema.withSchema('main').alterTable('thoughts', async (table) => {
+exports.up = (knex) => knex.schema.withSchema('main').alterTable('thoughts', (table) => {
     table.jsonb('interestsKeys').notNullable().defaultTo(JSON.stringify([]));
 
     table.index('interestsKeys', 'idx_thoughts_interests_keys', {

--- a/therr-services/users-service/src/store/migrations/20240715170432_main.users.js
+++ b/therr-services/users-service/src/store/migrations/20240715170432_main.users.js
@@ -2,7 +2,7 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = async (knex) => knex.schema.withSchema('main').alterTable('users', async (table) => {
+exports.up = async (knex) => knex.schema.withSchema('main').alterTable('users', (table) => {
     table.index('accessLevels', 'users_access_levels_index', {
         indexType: 'GIN',
     });

--- a/therr-services/users-service/src/store/migrations/20240715175554_main.userConnections.js
+++ b/therr-services/users-service/src/store/migrations/20240715175554_main.userConnections.js
@@ -2,7 +2,7 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = async (knex) => knex.schema.withSchema('main').alterTable('userConnections', async (table) => {
+exports.up = async (knex) => knex.schema.withSchema('main').alterTable('userConnections', (table) => {
     table.index('requestStatus');
 });
 

--- a/therr-services/users-service/src/store/migrations/20240721150113_main.user.js
+++ b/therr-services/users-service/src/store/migrations/20240721150113_main.user.js
@@ -2,7 +2,7 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = async (knex) => knex.schema.withSchema('main').alterTable('users', async (table) => {
+exports.up = async (knex) => knex.schema.withSchema('main').alterTable('users', (table) => {
     table.string('userName').nullable().unique().alter();
 });
 

--- a/therr-services/users-service/src/store/migrations/20240725181158_main.userMetrics.js
+++ b/therr-services/users-service/src/store/migrations/20240725181158_main.userMetrics.js
@@ -2,7 +2,7 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.up = async (knex) => knex.schema.withSchema('main').alterTable('userMetrics', async (table) => {
+exports.up = async (knex) => knex.schema.withSchema('main').alterTable('userMetrics', (table) => {
     table.index('dimensions', 'dimensions_index', {
         indexType: 'GIN',
     });


### PR DESCRIPTION
Fixes the `Transaction query already complete` failure that has been breaking the CI migration step since aa51d1682. `stage` already contains that commit, so this branch fixes stage's build as well as general's.

Cherry-picked onto `stage` so it carries **only** these two commits — the Twilio SMS test-mocking commits currently sitting on `general` are deliberately excluded and will be promoted separately.

## Root cause

Not the migrations-in-CI change, and not `CONCURRENTLY`. It is a latent defect in a 2023 migration that aa51d1682 armed.

`20230815184654_main.users.js` passed an **async** callback to `alterTable`. Knex invokes that callback synchronously while collecting the statement list and discards its return value, so the migration silently split in two:

- before the first `await` → the two `table.double(...)` columns, collected into the `ALTER TABLE`
- after it → three `knex.schema.raw(...)` calls that resumed as **floating promises nothing awaited**

That survived only because knex wrapped the whole batch in one transaction, keeping a connection open long enough for the stragglers to land. aa51d1682 set `config.transaction = false` on `20260727000000`, and per `Migrator.latest()` knex drops batch-wide transactions the moment *any* single migration opts out — giving each migration its own. This one then committed at the `ALTER TABLE` and the trailing raws hit a closed transaction.

## Changes

**`fix(users-service)`** — sequences the PostGIS raws in `20230815184654_main.users.js`. This is the commit that unbreaks CI. The ordering was always required anyway: the lat/long columns must exist before the `ST_MakePoint` backfill reads them, which previously held only by luck of how the overlapping statements queued.

**`chore(migrations)`** — adds the lint guard and clears all 67 existing instances across four services.

- `eslint-config/migration-rules.js` bans `async` on table-builder callbacks outright rather than trying to detect suspension points — an await-free async callback is harmless today but one edit away from the same bug.
- Wired into the migrations override in `eslint-config/service.js`, which previously set `no-restricted-syntax: 'off'`. It is now **re-pointed rather than disabled**, so migrations still get to name brand-scoped tables.
- 56 of the 67 had no `await` at all → `async` removed by AST codemod; verified those files differ from HEAD by *nothing but* that keyword. The other 11 issued real queries and were restructured by hand.

## Why editing already-applied migrations is safe here

Knex records completed migrations **by name only**, with no content checksum (`migration-list-resolver.js` → `select('name')`). Files a database has already recorded never execute there again, so the only consumer of the edited content is a from-scratch build (CI, local dev).

Fix-forward was not an option for this bug class: the failure is an *old* file crashing during replay on a *fresh* database, and a migration appended at position 50 cannot stop file 12 from throwing.

The line held instead was: **edit only where the resulting schema is provably unchanged.**

## Verification

Replayed all four services from empty databases and diffed `pg_dump` output against baselines captured before these changes (users baselined from `2024436b5`, the last commit that ran green):

| service | migrations | schema vs. baseline |
|---|---|---|
| users | 99 | byte-identical |
| maps | 49 | byte-identical |
| messages | 15 | byte-identical |
| reactions | 24 | byte-identical |

Also confirmed the guard catches all four async forms (`createTable` / `createTableIfNotExists` / `alterTable` / `table`, arrow and function expressions) and does **not** fire on a synchronous callback. Migration dirs lint clean.

## One thing deliberately NOT fixed

`20230316132958_main.moments.js` intended to drop and re-add a `spaceId` foreign key, but only the `dropForeign` was ever emitted — **`main.moments` has zero FK constraints**, confirmed by from-scratch replay, and production ran the same code.

Repairing it inline would give fresh databases a constraint production lacks. It keeps its shipped behavior plus a comment explaining why, and the repair is filed in `docs/WORK_IN_PROGRESS.md` as a forward migration that must first clear orphaned `moments.spaceId` rows or the `ADD CONSTRAINT` will fail.

## Note for reviewers

Pre-existing lint errors in `20260511000000_main.spaceCorrections.js` and `20260422000000_main.userLists_slug.js` were left alone — unrelated rules, untouched by this PR, but `lint-changed-files.sh` will flag them next time anyone edits those files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)