### PR TITLE
ci(mobile): raise EAS build no-output timeout + bump Android to versionCode 437

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,6 +205,21 @@ jobs:
           # --auto-submit submits the built AAB to the Play Internal track using
           # the `therr-internal` submit profile in eas.json. Requires the Google
           # Play service-account key to be configured on EAS (already done).
+          #
+          # no_output_timeout: EAS builds queue before they run, and the CLI
+          # prints nothing while waiting in the queue. CircleCI's default
+          # no-output timeout is 10 minutes, which kills this step on any
+          # non-trivial queue wait even though the build itself succeeds. 40m
+          # covers a long queue plus the ~15-20m Android build. Note the
+          # submission is registered with EAS server-side at build-creation
+          # time, so a killed CLI does not cancel the Play upload — but it does
+          # abort the job before the release-notes step below can run, which is
+          # why raising this matters rather than just letting it fail.
+          #
+          # Deliberately NOT using --no-wait: the release-notes step needs the
+          # build to have landed on the track before it polls, and would burn
+          # its 15m poll window against an empty track if this returned early.
+          no_output_timeout: 40m
           command: |
             cd TherrMobile
             eas build \

--- a/TherrMobile/android/app/build.gradle
+++ b/TherrMobile/android/app/build.gradle
@@ -93,8 +93,8 @@ android {
         applicationId "app.therrmobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 436
-        versionName "3.10.0"
+        versionCode 437
+        versionName "3.10.1"
         manifestPlaceholders = [GOOGLE_APIS_ANDROID_KEY: "${System.getenv("GOOGLE_APIS_ANDROID_KEY")}"]
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
Two independent failures were stacked on the last mobile release. This fixes both.

## 1. Submission rejected — versionCode collision

The EAS Submissions tab showed the upload failing outright:

```
Google Api Error: Invalid request - Version code 436 has already been used. - Retrying...
[!] Google Api Error: Invalid request - Version code 436 has already been used.
Failed to submit the app to the store
```

`versionCode 436` had already been consumed by a prior upload, so every retry was dead on arrival. Bumped to `437` in `TherrMobile/android/app/build.gradle`.

`versionName` goes `3.10.0` → `3.10.1` as well. Only the versionCode bump is strictly required — Google Play enforces uniqueness on versionCode, not versionName — but bumping it keeps the new internal-track release distinguishable from whatever shipped as 436.

This also settles an open question: the AAB carried `436`, matching `build.gradle`, which confirms versioning is **local**, not remote. No `cli.appVersionSource` change is needed.

## 2. CircleCI job killed by the default no-output timeout

The `eas_build_therr_android` job runs `eas build --auto-submit`, which blocks until the cloud build finishes. While the build sits in the EAS queue the CLI emits no output, so CircleCI's **default 10-minute no-output timeout** killed the step even though the build itself succeeded.

Set `no_output_timeout: 40m` on that step, covering a long queue wait plus the Android build.

This is genuinely separate from #1: `--auto-submit` registers the submission with EAS server-side at build-creation time, so the killed CLI never cancelled the upload ([expo/eas-cli#603](https://github.com/expo/eas-cli/pull/603), [#1240](https://github.com/expo/eas-cli/issues/1240)) — the submission ran to completion and failed on its own merits. What the timeout *did* break is the `Populate Google Play release notes` step, which never got to run, leaving the release with empty "What's new" text.

### Why not `--no-wait`

`--no-wait` would return as soon as the build is queued, but the release-notes script polls the Play track for the built `versionCode` and would exhaust its 15-minute window against a track with nothing on it yet. Keeping the blocking wait is what makes the following step meaningful.

## Verification

- `.circleci/config.yml` parses as valid YAML; the `command` body is byte-identical to before, with only `no_output_timeout` added.
- `populate-play-release-notes.mjs --dry-run` now resolves `versionCode 437` and finds notes for all three locales (`en-US`, `es-419`, `fr-CA`) via the `changelogs/default.txt` fallback.

## Branch note

`.circleci/config.yml` is shared infrastructure, so per `CLAUDE.md` this targets `general` — the only path that reaches production via `general → stage → main`. Branch is based on `origin/general`; the two changes are separate commits.