### PR TITLE
feat(mobile): guided profile completion checklist with contact-sync step

### DIFF
--- a/TherrMobile/__tests__/components/PeopleYouMayKnow.test.tsx
+++ b/TherrMobile/__tests__/components/PeopleYouMayKnow.test.tsx
@@ -1,0 +1,162 @@
+import 'react-native';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+// Note: test renderer must be required after react-native.
+import renderer, { act } from 'react-test-renderer';
+
+// Note: import explicitly to use the types shipped with jest.
+import { it, describe, beforeEach, afterEach, expect } from '@jest/globals';
+
+// `main/constants` (reached through the profile-completion utility) pulls in
+// notifee, which reaches for its native module at import time.
+jest.mock('@notifee/react-native', () => ({
+    __esModule: true,
+    default: { createChannel: jest.fn() },
+    AndroidImportance: { HIGH: 4, DEFAULT: 3, LOW: 2 },
+    AndroidVisibility: { PUBLIC: 1 },
+}));
+
+jest.mock('lottie-react-native', () => 'LottieView');
+
+jest.mock('therr-react/services', () => ({
+    UsersService: {
+        getUserInterests: jest.fn().mockResolvedValue({ data: [] }),
+    },
+}));
+
+const mockSyncMobileContacts = jest.fn();
+jest.mock('../../main/utilities/contacts', () => ({
+    synceMobileContacts: (...args: any[]) => mockSyncMobileContacts(...args),
+}));
+
+import PeopleYouMayKnow from '../../main/routes/Connect/components/PeopleYouMayKnow';
+import { getProfileCompletionFlags, markContactsSynced } from '../../main/utilities/profileCompletion';
+import { buildStyles } from '../../main/styles';
+import { buildStyles as buildButtonsStyles } from '../../main/styles/buttons';
+
+const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+
+const mockStore = {
+    getState: () => ({ user: { settings: { mobileThemeName: 'light' } } }),
+    subscribe: () => () => {},
+    dispatch: () => {},
+};
+
+const translate = (key: string) => key;
+const theme = buildStyles('light');
+const themeButtons = buildButtonsStyles('light');
+
+const buildProps = (overrides: any = {}) => ({
+    mightKnowUsers: [],
+    getConnectionOrUserDetails: (u: any) => u,
+    getConnectionSubtitle: () => '',
+    goToViewUser: jest.fn(),
+    onSendConnectRequest: jest.fn(),
+    theme,
+    themeButtons,
+    translate,
+    user: { details: { id: 'user-123' } },
+    ...overrides,
+});
+
+const render = async (props: any) => {
+    let component: renderer.ReactTestRenderer;
+    await act(async () => {
+        component = renderer.create(
+            <Provider store={mockStore as any}>
+                <PeopleYouMayKnow {...props} />
+            </Provider>
+        );
+        await Promise.resolve();
+    });
+    return component!;
+};
+
+const findSyncButton = (component: renderer.ReactTestRenderer) => component.root.findAll(
+    (node) => typeof node.props?.title === 'string' && node.props.title.startsWith('pages.contacts.buttons.sync')
+);
+
+beforeEach(async () => {
+    await AsyncStorage.clear();
+    mockSyncMobileContacts.mockResolvedValue({ contacts: [], matchedUsers: [] });
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('PeopleYouMayKnow contact-sync prompt', () => {
+    it('offers the full sync prompt to a user who has never synced', async () => {
+        const component = await render(buildProps());
+
+        expect(findSyncButton(component)).toHaveLength(1);
+        expect(JSON.stringify(component.toJSON())).toContain('pages.contacts.labels.noContactsFound');
+    });
+
+    it('collapses to a re-sync link once contacts have been synced before', async () => {
+        await markContactsSynced('user-123');
+
+        const component = await render(buildProps());
+        const tree = JSON.stringify(component.toJSON());
+
+        expect(findSyncButton(component)).toHaveLength(0);
+        expect(tree).toContain('pages.contacts.buttons.resyncContacts');
+        // The "no users found" explainer is part of the full prompt, not the collapsed one.
+        expect(tree).not.toContain('pages.contacts.labels.noContactsFound');
+    });
+
+    it('re-opens the full prompt when the user taps the re-sync link', async () => {
+        await markContactsSynced('user-123');
+
+        const component = await render(buildProps());
+        const [resyncLink] = component.root.findAll(
+            (node) => node.props?.accessibilityLabel === 'pages.contacts.buttons.resyncContacts'
+                && typeof node.props?.onPress === 'function'
+        );
+
+        await act(async () => { resyncLink.props.onPress(); });
+
+        expect(findSyncButton(component)).toHaveLength(1);
+    });
+
+    it('records the sync so the prompt stays collapsed on the next visit', async () => {
+        const component = await render(buildProps());
+        const [syncButton] = findSyncButton(component);
+
+        await act(async () => {
+            syncButton.props.onPress();
+            await Promise.resolve();
+        });
+
+        await expect(getProfileCompletionFlags('user-123'))
+            .resolves.toEqual(expect.objectContaining({ hasSyncedContacts: true }));
+    });
+
+    it('keeps the prompt visible after a failed sync so the error is readable', async () => {
+        mockSyncMobileContacts.mockRejectedValue(new Error('permissions-denied'));
+
+        const component = await render(buildProps());
+        const [syncButton] = findSyncButton(component);
+
+        await act(async () => {
+            syncButton.props.onPress();
+            await Promise.resolve();
+        });
+
+        const [afterSync] = findSyncButton(component);
+        expect(afterSync.props.title).toBe('pages.contacts.buttons.syncFailed');
+        await expect(getProfileCompletionFlags('user-123'))
+            .resolves.toEqual(expect.objectContaining({ hasSyncedContacts: false }));
+    });
+
+    it('does not prompt at all when there are already people to show', async () => {
+        const component = await render(buildProps({
+            mightKnowUsers: [{ id: 'other-user', userName: 'someone' }],
+        }));
+        const tree = JSON.stringify(component.toJSON());
+
+        expect(findSyncButton(component)).toHaveLength(0);
+        expect(tree).not.toContain('pages.contacts.buttons.resyncContacts');
+    });
+});

--- a/TherrMobile/__tests__/components/ProfileCompletionCard.test.tsx
+++ b/TherrMobile/__tests__/components/ProfileCompletionCard.test.tsx
@@ -1,0 +1,221 @@
+import 'react-native';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+// Note: test renderer must be required after react-native.
+import renderer, { act } from 'react-test-renderer';
+
+// Note: import explicitly to use the types shipped with jest.
+import { it, describe, beforeEach, afterEach, expect } from '@jest/globals';
+
+// `main/constants` (the source of the onboarding name placeholders) pulls in
+// notifee, which reaches for its native module at import time.
+jest.mock('@notifee/react-native', () => ({
+    __esModule: true,
+    default: { createChannel: jest.fn() },
+    AndroidImportance: { HIGH: 4, DEFAULT: 3, LOW: 2 },
+    AndroidVisibility: { PUBLIC: 1 },
+}));
+
+jest.mock('therr-react/services', () => ({
+    UsersService: {
+        getUserInterests: jest.fn().mockResolvedValue({ data: [] }),
+    },
+}));
+
+import ProfileCompletionCard from '../../main/components/ProfileCompletionCard';
+import { markContactsSkipped, markContactsSynced, markInterestsSelected } from '../../main/utilities/profileCompletion';
+
+const AsyncStorage = require('@react-native-async-storage/async-storage').default;
+
+const mockStore = {
+    getState: () => ({ user: { settings: { mobileThemeName: 'light' } } }),
+    subscribe: () => () => {},
+    dispatch: () => {},
+};
+
+const translate = (key: string) => key;
+
+const buildUser = (details: any = {}) => ({
+    details: {
+        id: 'user-123',
+        userName: 'testuser',
+        ...details,
+    },
+    settings: { mobileThemeName: 'light', locale: 'en-us' },
+} as any);
+
+const completeUser = buildUser({
+    firstName: 'Zack',
+    lastName: 'Anselm',
+    phoneNumber: '+15555555555',
+    media: { profilePicture: { path: 'some/path.jpeg' } },
+});
+
+const buildNavigation = () => ({
+    navigate: jest.fn(),
+    addListener: jest.fn().mockReturnValue(jest.fn()),
+});
+
+const renderCard = async (props: any) => {
+    let component: renderer.ReactTestRenderer;
+    await act(async () => {
+        component = renderer.create(
+            <Provider store={mockStore as any}>
+                <ProfileCompletionCard {...props} />
+            </Provider>
+        );
+        await Promise.resolve();
+    });
+    return component!;
+};
+
+// Pressable renders a host View that carries the label but not the handler, so
+// match on the composite node that actually owns onPress.
+const findByLabel = (component: renderer.ReactTestRenderer, label: string) =>
+    component.root.findAll((node) => node.props?.accessibilityLabel === label
+        && typeof node.props?.onPress === 'function');
+
+beforeEach(async () => {
+    await AsyncStorage.clear();
+});
+
+afterEach(() => {
+    jest.clearAllMocks();
+});
+
+describe('ProfileCompletionCard', () => {
+    it('lists every outstanding step for a new profile', async () => {
+        const component = await renderCard({
+            navigation: buildNavigation(),
+            translate,
+            user: buildUser(),
+            themeName: 'light',
+        });
+
+        const tree = JSON.stringify(component.toJSON());
+        expect(tree).toContain('components.profileCompletionCard.title');
+        expect(tree).toContain('components.profileCompletionCard.steps.name.label');
+        expect(tree).toContain('components.profileCompletionCard.steps.contacts.label');
+        // 5 outstanding steps → plural copy.
+        expect(tree).toContain('components.profileCompletionCard.stepsLeft');
+    });
+
+    it('uses singular copy when a single step remains', async () => {
+        await markInterestsSelected('user-123');
+        await markContactsSynced('user-123');
+
+        const component = await renderCard({
+            navigation: buildNavigation(),
+            translate,
+            user: buildUser({
+                firstName: 'Zack',
+                lastName: 'Anselm',
+                phoneNumber: '+15555555555',
+            }),
+            themeName: 'light',
+        });
+
+        const tree = JSON.stringify(component.toJSON());
+        expect(tree).toContain('components.profileCompletionCard.stepLeft');
+        expect(tree).not.toContain('components.profileCompletionCard.stepsLeft');
+    });
+
+    it('renders nothing once every step is resolved', async () => {
+        await markInterestsSelected('user-123');
+        await markContactsSynced('user-123');
+
+        const component = await renderCard({
+            navigation: buildNavigation(),
+            translate,
+            user: completeUser,
+            themeName: 'light',
+        });
+
+        expect(component.toJSON()).toBeNull();
+    });
+
+    it('counts a skipped contact sync toward completion', async () => {
+        await markInterestsSelected('user-123');
+        await markContactsSkipped('user-123');
+
+        const component = await renderCard({
+            navigation: buildNavigation(),
+            translate,
+            user: completeUser,
+            themeName: 'light',
+        });
+
+        expect(component.toJSON()).toBeNull();
+    });
+
+    it('hands off to the guided flow at the first unfinished step', async () => {
+        const navigation = buildNavigation();
+        const component = await renderCard({
+            navigation,
+            translate,
+            user: buildUser({ firstName: 'Zack', lastName: 'Anselm' }),
+            themeName: 'light',
+        });
+
+        const [continueButton] = component.root.findAll(
+            (node) => node.props?.title === 'components.profileCompletionCard.continue'
+        );
+
+        act(() => { continueButton.props.onPress(); });
+
+        expect(navigation.navigate).toHaveBeenCalledWith('CreateProfile', {
+            stage: 'interests',
+            isGuidedStep: true,
+        });
+    });
+
+    it('jumps straight to a step the user taps out of order', async () => {
+        const navigation = buildNavigation();
+        const component = await renderCard({
+            navigation,
+            translate,
+            user: buildUser(),
+            themeName: 'light',
+        });
+
+        const [contactsRow] = findByLabel(component, 'components.profileCompletionCard.steps.contacts.label');
+
+        act(() => { contactsRow.props.onPress(); });
+
+        expect(navigation.navigate).toHaveBeenCalledWith('CreateProfile', {
+            stage: 'contacts',
+            isGuidedStep: true,
+        });
+    });
+
+    it('collapses the checklist to just the progress bar on demand', async () => {
+        const component = await renderCard({
+            navigation: buildNavigation(),
+            translate,
+            user: buildUser(),
+            themeName: 'light',
+        });
+
+        const [collapseButton] = findByLabel(component, 'components.profileCompletionCard.collapse');
+        act(() => { collapseButton.props.onPress(); });
+
+        const tree = JSON.stringify(component.toJSON());
+        expect(tree).not.toContain('components.profileCompletionCard.steps.name.label');
+        // The header and progress bar survive so the card is still re-openable.
+        expect(tree).toContain('components.profileCompletionCard.title');
+        expect(tree).toContain('components.profileCompletionCard.expand');
+    });
+
+    it('re-reads persisted progress when the screen regains focus', async () => {
+        const navigation = buildNavigation();
+        await renderCard({
+            navigation,
+            translate,
+            user: buildUser(),
+            themeName: 'light',
+        });
+
+        expect(navigation.addListener).toHaveBeenCalledWith('focus', expect.any(Function));
+    });
+});

--- a/TherrMobile/__tests__/navigation/NavigationAccessControl.test.ts
+++ b/TherrMobile/__tests__/navigation/NavigationAccessControl.test.ts
@@ -571,10 +571,12 @@ describe('Route Configuration - Authenticated Routes', () => {
 // ============================================================================
 
 describe('Email Verification Gates', () => {
-    // CreateProfile route - requires EMAIL_VERIFIED_MISSING_PROPERTIES
+    // CreateProfile route - any signed-in account. It serves both first-run
+    // onboarding and the guided re-entry from the "Finish your profile"
+    // checklist, so a fully verified user must still be able to reach it.
     const createProfileRouteAccess: IAccess = {
-        type: AccessCheckType.ALL,
-        levels: [AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
+        type: AccessCheckType.ANY,
+        levels: [AccessLevels.EMAIL_VERIFIED, AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
     };
 
     describe('CreateProfile route (profile completion gate)', () => {
@@ -603,14 +605,14 @@ describe('Email Verification Gates', () => {
             expect(isAuthorized(createProfileRouteAccess, user)).toBe(false);
         });
 
-        it('should NOT be accessible to users already fully verified', () => {
+        it('should be accessible to users already fully verified (guided re-entry)', () => {
             const user: IUserState = {
                 details: {
                     id: 'user-123',
                     accessLevels: [AccessLevels.EMAIL_VERIFIED],
                 },
             };
-            expect(isAuthorized(createProfileRouteAccess, user)).toBe(false);
+            expect(isAuthorized(createProfileRouteAccess, user)).toBe(true);
         });
     });
 
@@ -819,11 +821,23 @@ describe('Route Filtering Logic', () => {
             }),
         },
         {
+            name: 'Map',
+            options: () => ({
+                access: {
+                    type: AccessCheckType.NONE,
+                    levels: [AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
+                },
+            }),
+        },
+        {
+            // Mirrors routes/index.tsx: reachable by any signed-in account so the
+            // "Finish your profile" checklist can re-enter the guided flow, and
+            // ordered after Map so Map stays the landing screen for verified users.
             name: 'CreateProfile',
             options: () => ({
                 access: {
-                    type: AccessCheckType.ALL,
-                    levels: [AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
+                    type: AccessCheckType.ANY,
+                    levels: [AccessLevels.EMAIL_VERIFIED, AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
                 },
             }),
         },
@@ -960,9 +974,11 @@ describe('Route Filtering Logic', () => {
             expect(visibleRoutes.some(r => r.name === 'Register')).toBe(false);
         });
 
-        it('should NOT show CreateProfile route (already verified)', () => {
+        it('should show CreateProfile route (guided profile completion re-entry)', () => {
+            // The "Finish your profile" checklist navigates verified users back
+            // into the guided flow, so the route has to stay registered.
             const visibleRoutes = filterRoutes(mockRoutes, verifiedUser);
-            expect(visibleRoutes.some(r => r.name === 'CreateProfile')).toBe(false);
+            expect(visibleRoutes.some(r => r.name === 'CreateProfile')).toBe(true);
         });
 
         it('should show Areas route', () => {
@@ -978,6 +994,33 @@ describe('Route Filtering Logic', () => {
         it('should show ForgotPassword route (no access config)', () => {
             const visibleRoutes = filterRoutes(mockRoutes, verifiedUser);
             expect(visibleRoutes.some(r => r.name === 'ForgotPassword')).toBe(true);
+        });
+    });
+
+    describe('Initial route (first authorized route wins)', () => {
+        // Layout renders the filtered routes in array order and never sets
+        // `initialRouteName`, so whichever route survives filtering first becomes
+        // the screen the app opens on. Opening CreateProfile for an already
+        // onboarded user would be a hard regression, so pin the ordering here.
+        const onboardingUser: IUserState = {
+            details: {
+                id: 'user-123',
+                accessLevels: [AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
+            },
+        };
+        const verifiedUser: IUserState = {
+            details: {
+                id: 'user-123',
+                accessLevels: [AccessLevels.EMAIL_VERIFIED],
+            },
+        };
+
+        it('opens onboarding users on CreateProfile', () => {
+            expect(filterRoutes(mockRoutes, onboardingUser)[0].name).toBe('CreateProfile');
+        });
+
+        it('opens fully verified users on Map, not CreateProfile', () => {
+            expect(filterRoutes(mockRoutes, verifiedUser)[0].name).toBe('Map');
         });
     });
 });
@@ -1223,8 +1266,8 @@ describe('Complete Route Access Matrix', () => {
             isPublic: true,
         },
         CreateProfile: {
-            type: AccessCheckType.ALL,
-            levels: [AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
+            type: AccessCheckType.ANY,
+            levels: [AccessLevels.EMAIL_VERIFIED, AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
         },
         Map: {
             type: AccessCheckType.NONE,
@@ -1391,8 +1434,8 @@ describe('Complete Route Access Matrix', () => {
             expect(isAuthorized(routeConfigs.Register, user)).toBe(false);
         });
 
-        it('CreateProfile should NOT be accessible', () => {
-            expect(isAuthorized(routeConfigs.CreateProfile, user)).toBe(false);
+        it('CreateProfile should be accessible (guided profile completion)', () => {
+            expect(isAuthorized(routeConfigs.CreateProfile, user)).toBe(true);
         });
 
         it('Areas should be accessible', () => {

--- a/TherrMobile/__tests__/routes/CreateProfile.test.tsx
+++ b/TherrMobile/__tests__/routes/CreateProfile.test.tsx
@@ -82,8 +82,18 @@ jest.mock('../../main/utilities/areaUtils', () => ({
     getImagePreviewPath: jest.fn(),
 }));
 
+const mockSyncMobileContacts = jest.fn().mockResolvedValue({ contacts: [], matchedUsers: [] });
 jest.mock('../../main/utilities/contacts', () => ({
-    synceMobileContacts: jest.fn().mockResolvedValue({ contacts: [], matchedUsers: [] }),
+    synceMobileContacts: (...args: any[]) => mockSyncMobileContacts(...args),
+}));
+
+const mockMarkContactsSynced = jest.fn().mockResolvedValue({});
+const mockMarkContactsSkipped = jest.fn().mockResolvedValue({});
+const mockMarkInterestsSelected = jest.fn().mockResolvedValue({});
+jest.mock('../../main/utilities/profileCompletion', () => ({
+    markContactsSynced: (...args: any[]) => mockMarkContactsSynced(...args),
+    markContactsSkipped: (...args: any[]) => mockMarkContactsSkipped(...args),
+    markInterestsSelected: (...args: any[]) => mockMarkInterestsSelected(...args),
 }));
 
 const mockStore = {
@@ -122,6 +132,8 @@ const buildProps = (overrides: any = {}) => ({
         navigate: jest.fn(),
         push: jest.fn(),
         setOptions: jest.fn(),
+        goBack: jest.fn(),
+        canGoBack: jest.fn().mockReturnValue(true),
     },
     route: { params: {} },
     user: mockUser,
@@ -188,6 +200,105 @@ describe('CreateProfile (onboarding flow)', () => {
             const { ref } = renderCreateProfile(buildProps());
             act(() => { ref.current!.onContinue(); });
             expect(ref.current!.state.stage).toBe('phone');
+        });
+
+        it('advances phone → contacts so the contact-sync ask is a real step', async () => {
+            const { ref } = renderCreateProfile(buildProps());
+            act(() => { ref.current!.onPhoneInputChange('phoneNumber', '+15555555555', true); });
+            await act(async () => {
+                ref.current!.onSubmit('phone');
+                await Promise.resolve();
+            });
+            expect(ref.current!.state.stage).toBe('contacts');
+        });
+
+        it('starts at the stage the profile checklist hands off', () => {
+            const { ref } = renderCreateProfile(buildProps({
+                route: { params: { stage: 'contacts', isGuidedStep: true } },
+            }));
+            expect(ref.current!.state.stage).toBe('contacts');
+        });
+    });
+
+    describe('Guided progress', () => {
+        it('numbers each stage so the progress bar fills as the user advances', () => {
+            const { ref } = renderCreateProfile(buildProps());
+
+            expect(ref.current!.getStageStepNumber('details')).toBe(1);
+            expect(ref.current!.getStageStepNumber('interests')).toBe(2);
+            expect(ref.current!.getStageStepNumber('picture')).toBe(3);
+            expect(ref.current!.getStageStepNumber('phone')).toBe(4);
+            expect(ref.current!.getStageStepNumber('contacts')).toBe(5);
+            // `invite` sits past the tracked stages — the bar reads as full.
+            expect(ref.current!.getStageStepNumber('invite')).toBe(5);
+        });
+
+        it('steps backward through the flow rather than leaving the screen', () => {
+            const props = buildProps({ route: { params: { stage: 'picture' } } });
+            const { ref } = renderCreateProfile(props);
+
+            act(() => { ref.current!.onGoBackStage(); });
+
+            expect(ref.current!.state.stage).toBe('interests');
+            expect(props.navigation.goBack).not.toHaveBeenCalled();
+        });
+
+        it('leaves the screen when backing out of the first stage', () => {
+            const props = buildProps();
+            const { ref } = renderCreateProfile(props);
+
+            act(() => { ref.current!.onGoBackStage(); });
+
+            expect(props.navigation.goBack).toHaveBeenCalled();
+        });
+    });
+
+    describe('Contact sync step', () => {
+        it('records the sync so the checklist and people list both see it as done', async () => {
+            const props = buildProps();
+            const { ref } = renderCreateProfile(props);
+
+            await act(async () => {
+                await ref.current!.onSyncContacts();
+            });
+
+            expect(mockMarkContactsSynced).toHaveBeenCalledWith('user-123');
+            expect(props.navigation.navigate).toHaveBeenCalledWith('PhoneContacts', expect.any(Object));
+            expect(ref.current!.state.isSyncingContacts).toBe(false);
+        });
+
+        it('surfaces an error and clears the spinner when the sync fails', async () => {
+            mockSyncMobileContacts.mockRejectedValueOnce(new Error('permissions-denied'));
+            const props = buildProps();
+            const { ref } = renderCreateProfile(props);
+
+            await act(async () => {
+                await ref.current!.onSyncContacts();
+            });
+
+            expect(ref.current!.state.isSyncingContacts).toBe(false);
+            expect(ref.current!.state.errorMsg).toBeTruthy();
+            expect(mockMarkContactsSynced).not.toHaveBeenCalled();
+            expect(props.navigation.navigate).not.toHaveBeenCalledWith('PhoneContacts', expect.any(Object));
+        });
+
+        it('records a skip and moves on to the invite stage during first-run onboarding', () => {
+            const { ref } = renderCreateProfile(buildProps({ route: { params: { stage: 'contacts' } } }));
+
+            act(() => { ref.current!.onSkipContactsSync(); });
+
+            expect(mockMarkContactsSkipped).toHaveBeenCalledWith('user-123');
+            expect(ref.current!.state.stage).toBe('invite');
+        });
+
+        it('returns to the profile instead of the invite stage when entered from the checklist', () => {
+            const props = buildProps({ route: { params: { stage: 'contacts', isGuidedStep: true } } });
+            const { ref } = renderCreateProfile(props);
+
+            act(() => { ref.current!.onSkipContactsSync(); });
+
+            expect(props.navigation.goBack).toHaveBeenCalled();
+            expect(props.navigation.navigate).not.toHaveBeenCalledWith('Map');
         });
     });
 

--- a/TherrMobile/__tests__/utilities/profileCompletion.test.ts
+++ b/TherrMobile/__tests__/utilities/profileCompletion.test.ts
@@ -1,0 +1,226 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// Note: import explicitly to use the types shipped with jest.
+import { it, describe, beforeEach, expect } from '@jest/globals';
+
+// `main/constants` (the source of the onboarding name placeholders) pulls in
+// notifee, which reaches for its native module at import time.
+jest.mock('@notifee/react-native', () => ({
+    __esModule: true,
+    default: { createChannel: jest.fn() },
+    AndroidImportance: { HIGH: 4, DEFAULT: 3, LOW: 2 },
+    AndroidVisibility: { PUBLIC: 1 },
+}));
+
+const mockGetUserInterests = jest.fn();
+jest.mock('therr-react/services', () => ({
+    UsersService: {
+        getUserInterests: (...args: any[]) => mockGetUserInterests(...args),
+    },
+}));
+
+import {
+    DEFAULT_PROFILE_COMPLETION_FLAGS,
+    getProfileCompletionFlags,
+    getProfileCompletionSummary,
+    markContactsSkipped,
+    markContactsSynced,
+    markInterestsSelected,
+    syncInterestsFlag,
+} from '../../main/utilities/profileCompletion';
+
+const buildUser = (details: any = {}, ) => ({
+    details: {
+        id: 'user-123',
+        userName: 'testuser',
+        ...details,
+    },
+} as any);
+
+const allFlags = {
+    hasSelectedInterests: true,
+    hasSyncedContacts: true,
+    hasSkippedContacts: false,
+};
+
+beforeEach(async () => {
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+});
+
+describe('getProfileCompletionSummary', () => {
+    it('reports every step as remaining for a brand new profile', () => {
+        const summary = getProfileCompletionSummary(buildUser(), DEFAULT_PROFILE_COMPLETION_FLAGS);
+
+        expect(summary.totalCount).toBe(5);
+        expect(summary.resolvedCount).toBe(0);
+        expect(summary.remainingCount).toBe(5);
+        expect(summary.isComplete).toBe(false);
+        expect(summary.percentComplete).toBe(0);
+    });
+
+    it('walks the user through steps in order via nextStep', () => {
+        const summary = getProfileCompletionSummary(buildUser(), DEFAULT_PROFILE_COMPLETION_FLAGS);
+        expect(summary.nextStep?.key).toBe('name');
+
+        const withName = getProfileCompletionSummary(
+            buildUser({ firstName: 'Zack', lastName: 'Anselm' }),
+            DEFAULT_PROFILE_COMPLETION_FLAGS,
+        );
+        expect(withName.nextStep?.key).toBe('interests');
+        expect(withName.remainingCount).toBe(4);
+    });
+
+    it('maps each step to the CreateProfile stage that resumes it', () => {
+        const summary = getProfileCompletionSummary(buildUser(), DEFAULT_PROFILE_COMPLETION_FLAGS);
+        const stagesByKey = summary.steps.reduce((acc: any, step) => ({ ...acc, [step.key]: step.stage }), {});
+
+        expect(stagesByKey).toEqual({
+            name: 'details',
+            interests: 'interests',
+            picture: 'picture',
+            phone: 'phone',
+            contacts: 'contacts',
+        });
+    });
+
+    it('treats the iOS placeholder name as no name at all', () => {
+        // Onboarding seeds "Anonymous User" on iOS so an account can be created
+        // without a name. Counting that as a finished step would silently hide
+        // the very nudge this checklist exists for.
+        const placeholder = getProfileCompletionSummary(
+            buildUser({ firstName: 'Anonymous', lastName: 'User' }),
+            DEFAULT_PROFILE_COMPLETION_FLAGS,
+        );
+        expect(placeholder.steps.find((s) => s.key === 'name')?.isComplete).toBe(false);
+
+        // A real first name paired with the placeholder surname still counts.
+        const realName = getProfileCompletionSummary(
+            buildUser({ firstName: 'Zack', lastName: 'User' }),
+            DEFAULT_PROFILE_COMPLETION_FLAGS,
+        );
+        expect(realName.steps.find((s) => s.key === 'name')?.isComplete).toBe(true);
+    });
+
+    it('completes the picture step only when a profile picture exists', () => {
+        const withPicture = getProfileCompletionSummary(
+            buildUser({ media: { profilePicture: { path: 'some/path.jpeg' } } }),
+            DEFAULT_PROFILE_COMPLETION_FLAGS,
+        );
+
+        expect(withPicture.steps.find((s) => s.key === 'picture')?.isComplete).toBe(true);
+    });
+
+    it('counts a skipped contact sync as resolved but never as complete', () => {
+        const summary = getProfileCompletionSummary(buildUser(), {
+            ...DEFAULT_PROFILE_COMPLETION_FLAGS,
+            hasSkippedContacts: true,
+        });
+        const contactsStep = summary.steps.find((s) => s.key === 'contacts');
+
+        expect(contactsStep?.isSkipped).toBe(true);
+        expect(contactsStep?.isComplete).toBe(false);
+        expect(summary.resolvedCount).toBe(1);
+        expect(summary.nextStep?.key).toBe('name');
+    });
+
+    it('prefers a real sync over a previous skip', () => {
+        const summary = getProfileCompletionSummary(buildUser(), {
+            ...DEFAULT_PROFILE_COMPLETION_FLAGS,
+            hasSkippedContacts: true,
+            hasSyncedContacts: true,
+        });
+        const contactsStep = summary.steps.find((s) => s.key === 'contacts');
+
+        expect(contactsStep?.isComplete).toBe(true);
+        expect(contactsStep?.isSkipped).toBe(false);
+    });
+
+    it('is complete — and has no next step — once every step is resolved', () => {
+        const summary = getProfileCompletionSummary(
+            buildUser({
+                firstName: 'Zack',
+                lastName: 'Anselm',
+                phoneNumber: '+15555555555',
+                media: { profilePicture: { path: 'some/path.jpeg' } },
+            }),
+            allFlags,
+        );
+
+        expect(summary.isComplete).toBe(true);
+        expect(summary.remainingCount).toBe(0);
+        expect(summary.percentComplete).toBe(1);
+        expect(summary.nextStep).toBeUndefined();
+    });
+});
+
+describe('persisted completion flags', () => {
+    it('defaults to nothing done when no flags are stored', async () => {
+        await expect(getProfileCompletionFlags('user-123')).resolves.toEqual(DEFAULT_PROFILE_COMPLETION_FLAGS);
+    });
+
+    it('round-trips each flag through storage', async () => {
+        await markContactsSynced('user-123');
+        await markInterestsSelected('user-123');
+
+        await expect(getProfileCompletionFlags('user-123')).resolves.toEqual({
+            hasSelectedInterests: true,
+            hasSyncedContacts: true,
+            hasSkippedContacts: false,
+        });
+    });
+
+    it('clears a prior skip when contacts are actually synced', async () => {
+        await markContactsSkipped('user-123');
+        await markContactsSynced('user-123');
+
+        const flags = await getProfileCompletionFlags('user-123');
+        expect(flags.hasSyncedContacts).toBe(true);
+        expect(flags.hasSkippedContacts).toBe(false);
+    });
+
+    it('scopes flags per user so a second account starts fresh', async () => {
+        await markContactsSynced('user-123');
+
+        await expect(getProfileCompletionFlags('user-456')).resolves.toEqual(DEFAULT_PROFILE_COMPLETION_FLAGS);
+    });
+
+    it('degrades to "nothing done" rather than throwing on corrupt storage', async () => {
+        await AsyncStorage.setItem('profileCompletionFlags:user-123', 'not-json');
+
+        await expect(getProfileCompletionFlags('user-123')).resolves.toEqual(DEFAULT_PROFILE_COMPLETION_FLAGS);
+    });
+});
+
+describe('syncInterestsFlag', () => {
+    it('seeds the flag for accounts that picked interests before it existed', async () => {
+        mockGetUserInterests.mockResolvedValue({ data: [{ interestId: 'a', isEnabled: true }] });
+
+        const flags = await syncInterestsFlag('user-123');
+
+        expect(flags.hasSelectedInterests).toBe(true);
+        await expect(getProfileCompletionFlags('user-123'))
+            .resolves.toEqual(expect.objectContaining({ hasSelectedInterests: true }));
+    });
+
+    it('leaves the step open when the account has no enabled interests', async () => {
+        mockGetUserInterests.mockResolvedValue({ data: [] });
+
+        await expect(syncInterestsFlag('user-123')).resolves.toEqual(DEFAULT_PROFILE_COMPLETION_FLAGS);
+    });
+
+    it('does not re-request once the flag is already set', async () => {
+        await markInterestsSelected('user-123');
+
+        const flags = await syncInterestsFlag('user-123');
+
+        expect(flags.hasSelectedInterests).toBe(true);
+        expect(mockGetUserInterests).not.toHaveBeenCalled();
+    });
+
+    it('degrades to the stored flags when the request fails', async () => {
+        mockGetUserInterests.mockRejectedValue(new Error('offline'));
+
+        await expect(syncInterestsFlag('user-123')).resolves.toEqual(DEFAULT_PROFILE_COMPLETION_FLAGS);
+    });
+});

--- a/TherrMobile/main/components/0_First_Time_UI/StageProgressBar.tsx
+++ b/TherrMobile/main/components/0_First_Time_UI/StageProgressBar.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, Pressable, StyleSheet, View } from 'react-native';
+import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome5';
+import { ITherrThemeColors } from '../../styles/themes';
+import { radius } from '../../styles/radii';
+import { space } from '../../styles/layouts/spacing';
+
+interface IStageProgressBarProps {
+    /** 1-based index of the stage the user is on. */
+    currentStep: number;
+    totalSteps: number;
+    onBack?: () => void;
+    /** Hides the back affordance on the first stage of a fresh sign-up. */
+    canGoBack?: boolean;
+    translate: (key: string, params?: any) => string;
+    theme: {
+        colors: ITherrThemeColors;
+        styles: any;
+    };
+}
+
+const PROGRESS_ANIMATION_DURATION_MS = 350;
+
+/**
+ * Duolingo-style progress header for the guided profile flow: a back arrow and
+ * a single bar that fills as the user advances, so a multi-screen form reads as
+ * finite progress rather than an open-ended interrogation.
+ */
+const StageProgressBar: React.FC<IStageProgressBarProps> = ({
+    currentStep,
+    totalSteps,
+    onBack,
+    canGoBack = true,
+    translate,
+    theme,
+}) => {
+    const percentComplete = totalSteps > 0 ? Math.min(Math.max(currentStep / totalSteps, 0), 1) : 0;
+    const progressAnimation = useRef(new Animated.Value(percentComplete)).current;
+
+    useEffect(() => {
+        Animated.timing(progressAnimation, {
+            toValue: percentComplete,
+            duration: PROGRESS_ANIMATION_DURATION_MS,
+            // Width is not supported by the native driver.
+            useNativeDriver: false,
+        }).start();
+    }, [progressAnimation, percentComplete]);
+
+    const progressWidth = progressAnimation.interpolate({
+        inputRange: [0, 1],
+        outputRange: ['0%', '100%'],
+    });
+
+    return (
+        <View
+            style={localStyles.container}
+            accessibilityRole="progressbar"
+            accessibilityValue={{ min: 0, max: totalSteps, now: currentStep }}
+        >
+            {
+                canGoBack && !!onBack &&
+                <Pressable
+                    onPress={onBack}
+                    hitSlop={10}
+                    style={localStyles.backButton}
+                    accessibilityRole="button"
+                    accessibilityLabel={translate('pages.createProfile.progress.back')}
+                >
+                    <FontAwesomeIcon
+                        name="arrow-left"
+                        size={20}
+                        color={theme.colors.onSurfaceMuted}
+                    />
+                </Pressable>
+            }
+            <View style={[localStyles.track, { backgroundColor: theme.colors.border }]}>
+                <Animated.View
+                    style={[
+                        localStyles.fill,
+                        {
+                            backgroundColor: theme.colors.brand,
+                            width: progressWidth,
+                        },
+                    ]}
+                />
+            </View>
+        </View>
+    );
+};
+
+const localStyles = StyleSheet.create({
+    container: {
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: space.lg,
+        paddingVertical: space.md,
+    },
+    backButton: {
+        paddingRight: space.md,
+        paddingVertical: space.xs,
+    },
+    track: {
+        flex: 1,
+        height: 14,
+        borderRadius: radius.pill,
+        overflow: 'hidden',
+    },
+    fill: {
+        height: '100%',
+        borderRadius: radius.pill,
+    },
+});
+
+export default StageProgressBar;

--- a/TherrMobile/main/components/0_First_Time_UI/onboarding-stages/SyncContacts.tsx
+++ b/TherrMobile/main/components/0_First_Time_UI/onboarding-stages/SyncContacts.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import LottieView from 'lottie-react-native';
+import { Button } from '../../BaseButton';
+import { ITherrThemeColors } from '../../../styles/themes';
+import spacingStyles from '../../../styles/layouts/spacing';
+import searchLoading from '../../../assets/search-loading.json';
+
+interface ISyncContactsProps {
+    isSyncing: boolean;
+    errorMsg?: string;
+    onSyncContacts: () => void;
+    onSkip: () => void;
+    translate: Function;
+    theme: {
+        colors: ITherrThemeColors;
+        styles: any;
+    };
+    themeForms: {
+        colors: ITherrThemeColors;
+        styles: any;
+    };
+    themeSettingsForm: {
+        styles: any;
+    };
+}
+
+/**
+ * Guided onboarding step that asks permission to match phone contacts against
+ * existing users. Declining is a first-class option ("Not Now") — the step is
+ * optional and the checklist records the skip rather than nagging.
+ */
+const SyncContacts: React.FC<ISyncContactsProps> = ({
+    isSyncing,
+    errorMsg,
+    onSyncContacts,
+    onSkip,
+    translate,
+    theme,
+    themeForms,
+    themeSettingsForm,
+}) => (
+    <View style={themeSettingsForm.styles.userContainer}>
+        <View style={spacingStyles.marginBotLg}>
+            <Text style={[theme.styles.sectionDescription, localStyles.descriptionText]}>
+                {translate('pages.createProfile.syncContacts.description')}
+            </Text>
+            <View style={localStyles.graphicContainer}>
+                <LottieView
+                    source={searchLoading}
+                    resizeMode="contain"
+                    speed={1}
+                    autoPlay
+                    loop
+                    style={localStyles.graphic}
+                />
+            </View>
+            {
+                !!errorMsg &&
+                <Text style={[theme.styles.sectionDescriptionNote, localStyles.descriptionText]}>
+                    {errorMsg}
+                </Text>
+            }
+        </View>
+        <View style={themeSettingsForm.styles.submitButtonContainer}>
+            <Button
+                containerStyle={localStyles.buttonSpacing}
+                buttonStyle={themeForms.styles.buttonPrimary}
+                disabledStyle={themeForms.styles.buttonDisabled}
+                titleStyle={themeForms.styles.buttonTitle}
+                disabledTitleStyle={themeForms.styles.buttonTitleDisabled}
+                title={translate('pages.createProfile.syncContacts.continue')}
+                onPress={onSyncContacts}
+                loading={isSyncing}
+                disabled={isSyncing}
+                raised={false}
+            />
+            <Button
+                buttonStyle={themeForms.styles.buttonRoundAlt}
+                titleStyle={themeForms.styles.buttonTitleAlt}
+                title={translate('pages.createProfile.syncContacts.skip')}
+                type="clear"
+                onPress={onSkip}
+                disabled={isSyncing}
+            />
+        </View>
+    </View>
+);
+
+const localStyles = StyleSheet.create({
+    descriptionText: {
+        textAlign: 'center',
+        marginBottom: 20,
+    },
+    graphicContainer: {
+        width: '100%',
+        alignItems: 'center',
+    },
+    graphic: {
+        top: 0,
+        width: '100%',
+        height: 120,
+    },
+    buttonSpacing: {
+        marginBottom: 15,
+    },
+});
+
+export default SyncContacts;

--- a/TherrMobile/main/components/IncompleteProfileBanner.tsx
+++ b/TherrMobile/main/components/IncompleteProfileBanner.tsx
@@ -4,6 +4,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome5';
 import { IUserState } from 'therr-react/types';
 import { buildStyles } from '../styles/incompleteProfileBanner';
+import {
+    DEFAULT_PROFILE_COMPLETION_FLAGS,
+    IProfileCompletionFlags,
+    getProfileCompletionSummary,
+    syncInterestsFlag,
+} from '../utilities/profileCompletion';
 
 const DISMISSED_AT_KEY = 'incompleteProfileBannerDismissedAt';
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
@@ -16,23 +22,28 @@ interface IIncompleteProfileBannerProps {
 }
 
 interface IIncompleteProfileBannerState {
+    flags: IProfileCompletionFlags | null;
     isDismissed: boolean;
     isReady: boolean;
 }
 
 /**
- * Dismissible banner that nudges users who have not provided a first name
- * (now optional during onboarding) to add it later so friends can recognize
- * them. Dismissal is persisted to AsyncStorage with a timestamp and the banner
- * re-appears after 7 days.
+ * Dismissible banner that nudges users with an unfinished profile toward the
+ * guided completion flow. It reads the same step model as the "Finish your
+ * profile" card so the two can never disagree about what is left. Dismissal is
+ * persisted to AsyncStorage with a timestamp and the banner re-appears after
+ * 7 days.
  */
 class IncompleteProfileBanner extends React.Component<IIncompleteProfileBannerProps, IIncompleteProfileBannerState> {
     private theme = buildStyles();
+
+    private isUnmounted = false;
 
     constructor(props: IIncompleteProfileBannerProps) {
         super(props);
 
         this.state = {
+            flags: null,
             isDismissed: false,
             isReady: false,
         };
@@ -41,23 +52,42 @@ class IncompleteProfileBanner extends React.Component<IIncompleteProfileBannerPr
     }
 
     componentDidMount() {
+        const { user } = this.props;
+
         AsyncStorage.getItem(DISMISSED_AT_KEY)
             .then((value) => {
                 const dismissedAt = value ? parseInt(value, 10) : 0;
                 const isStillDismissed = !!dismissedAt && (Date.now() - dismissedAt) < SEVEN_DAYS_MS;
-                this.setState({
+                this.safeSetState({
                     isDismissed: isStillDismissed,
-                    isReady: true,
                 });
             })
-            .catch(() => {
-                this.setState({ isReady: true });
-            });
+            .catch(() => {});
+
+        syncInterestsFlag(user?.details?.id)
+            .then((flags) => this.safeSetState({ flags, isReady: true }))
+            .catch(() => this.safeSetState({ flags: DEFAULT_PROFILE_COMPLETION_FLAGS, isReady: true }));
     }
 
+    componentWillUnmount() {
+        this.isUnmounted = true;
+    }
+
+    safeSetState = (state: Partial<IIncompleteProfileBannerState>) => {
+        if (!this.isUnmounted) {
+            this.setState(state as IIncompleteProfileBannerState);
+        }
+    };
+
     handlePress = () => {
-        const { navigation } = this.props;
-        navigation.navigate('Settings');
+        const { navigation, user } = this.props;
+        const { flags } = this.state;
+        const summary = getProfileCompletionSummary(user, flags || DEFAULT_PROFILE_COMPLETION_FLAGS);
+
+        navigation.navigate('CreateProfile', {
+            stage: summary.nextStep?.stage || 'details',
+            isGuidedStep: true,
+        });
     };
 
     handleDismiss = () => {
@@ -69,20 +99,29 @@ class IncompleteProfileBanner extends React.Component<IIncompleteProfileBannerPr
 
     render() {
         const { translate, user } = this.props;
-        const { isDismissed, isReady } = this.state;
+        const { flags, isDismissed, isReady } = this.state;
 
-        // Only render once we've read the dismissal timestamp, when the user has
-        // no first name, and when not currently dismissed.
-        if (!isReady || isDismissed || user?.details?.firstName) {
+        const summary = getProfileCompletionSummary(user, flags || DEFAULT_PROFILE_COMPLETION_FLAGS);
+
+        // Only render once the persisted state has been read, when steps remain,
+        // and when not currently dismissed.
+        if (!isReady || isDismissed || summary.isComplete) {
             return null;
         }
+
+        const message = translate(
+            summary.remainingCount === 1
+                ? 'components.incompleteProfileBanner.messageSingular'
+                : 'components.incompleteProfileBanner.message',
+            { count: summary.remainingCount },
+        );
 
         return (
             <Pressable
                 style={this.theme.styles.container}
                 onPress={this.handlePress}
                 accessibilityRole="button"
-                accessibilityLabel={translate('components.incompleteProfileBanner.message')}
+                accessibilityLabel={message}
             >
                 <FontAwesomeIcon
                     name="user-edit"
@@ -90,7 +129,7 @@ class IncompleteProfileBanner extends React.Component<IIncompleteProfileBannerPr
                     style={this.theme.styles.leadingIcon}
                 />
                 <Text style={this.theme.styles.message}>
-                    {translate('components.incompleteProfileBanner.message')}
+                    {message}
                 </Text>
                 <Pressable
                     onPress={this.handleDismiss}

--- a/TherrMobile/main/components/ProfileCompletionCard.tsx
+++ b/TherrMobile/main/components/ProfileCompletionCard.tsx
@@ -1,0 +1,215 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Animated, Pressable, Text, View } from 'react-native';
+import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome5';
+import { IUserState } from 'therr-react/types';
+import { Button } from './BaseButton';
+import { buildStyles } from '../styles/profileCompletionCard';
+import {
+    DEFAULT_PROFILE_COMPLETION_FLAGS,
+    IProfileCompletionFlags,
+    IProfileCompletionStep,
+    getProfileCompletionFlags,
+    getProfileCompletionSummary,
+    syncInterestsFlag,
+} from '../utilities/profileCompletion';
+
+interface IProfileCompletionCardProps {
+    navigation: any;
+    translate: (key: string, params?: any) => string;
+    user: IUserState;
+    themeName?: string;
+}
+
+const PROGRESS_ANIMATION_DURATION_MS = 450;
+
+/**
+ * "Finish your profile" checklist card. Renders the remaining onboarding steps
+ * as a tappable checklist with a progress bar, and hands off to the guided
+ * CreateProfile flow at whichever stage the user picks. Renders nothing once
+ * every step is resolved.
+ */
+const ProfileCompletionCard: React.FC<IProfileCompletionCardProps> = ({
+    navigation,
+    translate,
+    user,
+    themeName,
+}) => {
+    const theme = buildStyles(themeName as any);
+    const [flags, setFlags] = useState<IProfileCompletionFlags | null>(null);
+    const [isCollapsed, setIsCollapsed] = useState(false);
+    const progressAnimation = useRef(new Animated.Value(0)).current;
+    const userId = user?.details?.id;
+
+    const refreshFlags = useCallback(() => {
+        getProfileCompletionFlags(userId).then(setFlags).catch(() => setFlags(DEFAULT_PROFILE_COMPLETION_FLAGS));
+    }, [userId]);
+
+    useEffect(() => {
+        // Seed the interests flag for accounts that picked interests before the
+        // checklist existed, then read the merged result.
+        syncInterestsFlag(userId)
+            .then(setFlags)
+            .catch(() => setFlags(DEFAULT_PROFILE_COMPLETION_FLAGS));
+    }, [userId]);
+
+    useEffect(() => {
+        // Steps are completed on other screens (the guided flow, contact sync),
+        // so re-read on focus rather than trusting the initial render.
+        const unsubscribe = navigation?.addListener?.('focus', refreshFlags);
+
+        return () => {
+            if (unsubscribe) {
+                unsubscribe();
+            }
+        };
+    }, [navigation, refreshFlags]);
+
+    const summary = getProfileCompletionSummary(user, flags || DEFAULT_PROFILE_COMPLETION_FLAGS);
+
+    useEffect(() => {
+        Animated.timing(progressAnimation, {
+            toValue: summary.percentComplete,
+            duration: PROGRESS_ANIMATION_DURATION_MS,
+            // Width is not supported by the native driver.
+            useNativeDriver: false,
+        }).start();
+    }, [progressAnimation, summary.percentComplete]);
+
+    const goToStage = (step?: IProfileCompletionStep) => {
+        if (!step) {
+            return;
+        }
+
+        // `isGuidedStep` tells CreateProfile it was entered from the checklist,
+        // so finishing returns here instead of dropping the user on the map.
+        navigation.navigate('CreateProfile', {
+            stage: step.stage,
+            isGuidedStep: true,
+        });
+    };
+
+    // Wait for the persisted flags so the card never flashes steps the user
+    // already finished, and drop out entirely once the profile is done.
+    if (!flags || summary.isComplete) {
+        return null;
+    }
+
+    const progressWidth = progressAnimation.interpolate({
+        inputRange: [0, 1],
+        outputRange: ['0%', '100%'],
+    });
+
+    return (
+        <View style={theme.styles.container}>
+            <View style={theme.styles.headerRow}>
+                <View style={theme.styles.headerTextContainer}>
+                    <Text style={theme.styles.title}>
+                        {translate('components.profileCompletionCard.title')}
+                    </Text>
+                    <Text style={theme.styles.stepsLeft}>
+                        {translate(
+                            summary.remainingCount === 1
+                                ? 'components.profileCompletionCard.stepLeft'
+                                : 'components.profileCompletionCard.stepsLeft',
+                            { count: summary.remainingCount },
+                        )}
+                    </Text>
+                </View>
+                <Pressable
+                    onPress={() => setIsCollapsed(!isCollapsed)}
+                    hitSlop={10}
+                    style={theme.styles.collapseButton}
+                    accessibilityRole="button"
+                    accessibilityLabel={translate(
+                        isCollapsed
+                            ? 'components.profileCompletionCard.expand'
+                            : 'components.profileCompletionCard.collapse',
+                    )}
+                >
+                    <FontAwesomeIcon
+                        name={isCollapsed ? 'chevron-down' : 'chevron-up'}
+                        size={16}
+                        style={theme.styles.collapseIcon}
+                    />
+                </Pressable>
+            </View>
+
+            <View style={theme.styles.progressTrack}>
+                <Animated.View style={[theme.styles.progressFill, { width: progressWidth }]} />
+            </View>
+
+            {
+                !isCollapsed &&
+                <View style={theme.styles.stepList}>
+                    {
+                        summary.steps.map((step) => (
+                            <Pressable
+                                key={step.key}
+                                style={theme.styles.stepRow}
+                                onPress={() => goToStage(step)}
+                                accessibilityRole="button"
+                                accessibilityLabel={translate(step.labelKey)}
+                                accessibilityState={{ checked: step.isComplete }}
+                            >
+                                <View style={[
+                                    theme.styles.stepIndicator,
+                                    step.isComplete && theme.styles.stepIndicatorComplete,
+                                    step.isSkipped && theme.styles.stepIndicatorSkipped,
+                                ]}>
+                                    <FontAwesomeIcon
+                                        name={step.isComplete ? 'check' : (step.isSkipped ? 'minus' : step.icon)}
+                                        size={12}
+                                        style={[
+                                            theme.styles.stepIndicatorIcon,
+                                            step.isComplete && theme.styles.stepIndicatorIconComplete,
+                                            step.isSkipped && theme.styles.stepIndicatorIconSkipped,
+                                        ]}
+                                    />
+                                </View>
+                                <View style={theme.styles.stepTextContainer}>
+                                    <Text style={[
+                                        theme.styles.stepLabel,
+                                        step.isComplete && theme.styles.stepLabelComplete,
+                                    ]}>
+                                        {translate(step.labelKey)}
+                                    </Text>
+                                    {
+                                        !step.isComplete &&
+                                        <Text style={theme.styles.stepDescription}>
+                                            {translate(
+                                                step.isSkipped
+                                                    ? 'components.profileCompletionCard.skipped'
+                                                    : step.descriptionKey,
+                                            )}
+                                        </Text>
+                                    }
+                                </View>
+                                {
+                                    !step.isComplete &&
+                                    <FontAwesomeIcon
+                                        name="chevron-right"
+                                        size={14}
+                                        style={theme.styles.stepChevron}
+                                    />
+                                }
+                            </Pressable>
+                        ))
+                    }
+                </View>
+            }
+
+            {
+                !!summary.nextStep &&
+                <Button
+                    containerStyle={theme.styles.continueButtonContainer}
+                    buttonStyle={theme.styles.continueButton}
+                    titleStyle={theme.styles.continueButtonTitle}
+                    title={translate('components.profileCompletionCard.continue')}
+                    onPress={() => goToStage(summary.nextStep)}
+                />
+            }
+        </View>
+    );
+};
+
+export default ProfileCompletionCard;

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -411,8 +411,40 @@
       }
     },
     "incompleteProfileBanner": {
-      "message": "Add your name so friends can recognize you",
-      "dismiss": "Dismiss"
+      "message": "Finish your profile — {count} steps left",
+      "dismiss": "Dismiss",
+      "messageSingular": "Finish your profile — 1 step left"
+    },
+    "profileCompletionCard": {
+      "title": "Finish your profile!",
+      "stepsLeft": "{count} steps left",
+      "stepLeft": "1 step left",
+      "continue": "Continue",
+      "collapse": "Collapse checklist",
+      "expand": "Expand checklist",
+      "skipped": "Skipped — tap to do it now",
+      "steps": {
+        "name": {
+          "label": "Add your name",
+          "description": "So friends can recognize you"
+        },
+        "interests": {
+          "label": "Pick your interests",
+          "description": "We use these to show you better content"
+        },
+        "picture": {
+          "label": "Add a profile photo",
+          "description": "Profiles with photos get more connections"
+        },
+        "phone": {
+          "label": "Verify your phone",
+          "description": "Keeps your account secure"
+        },
+        "contacts": {
+          "label": "Sync your contacts",
+          "description": "Find friends who are already here"
+        }
+      }
     }
   },
   "forms": {
@@ -1272,7 +1304,8 @@
       "buttons": {
         "syncSuccess": "Sync Success!",
         "syncFailed": "Failed to Sync",
-        "syncContacts": "Sync Your Contacts?"
+        "syncContacts": "Sync Your Contacts?",
+        "resyncContacts": "Sync contacts again"
       },
       "labels": {
         "allUsers": "All Users",
@@ -1305,6 +1338,18 @@
         "shareLink": "Share a Link",
         "syncContacts": "Sync Contacts",
         "skip": "Skip for Now"
+      },
+      "pageHeaderContacts": "Find your friends",
+      "pageSubHeaderContacts": "Sync your contacts to see who is already here",
+      "progress": {
+        "back": "Go back a step"
+      },
+      "syncContacts": {
+        "description": "We match your contacts against Therr accounts so you can connect right away. Your contacts are never shared with anyone else.",
+        "continue": "Continue",
+        "skip": "Not Now",
+        "errorMessage": "We could not sync your contacts. Please try again.",
+        "permissionsDenied": "Contact access is off. Enable it in your device settings to find friends."
       }
     },
     "cropImage": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -411,8 +411,40 @@
       }
     },
     "incompleteProfileBanner": {
-      "message": "Agrega tu nombre para que tus amigos puedan reconocerte",
-      "dismiss": "Descartar"
+      "message": "Termina tu perfil: quedan {count} pasos",
+      "dismiss": "Descartar",
+      "messageSingular": "Termina tu perfil: queda 1 paso"
+    },
+    "profileCompletionCard": {
+      "title": "¡Termina tu perfil!",
+      "stepsLeft": "Quedan {count} pasos",
+      "stepLeft": "Queda 1 paso",
+      "continue": "Continuar",
+      "collapse": "Contraer lista",
+      "expand": "Expandir lista",
+      "skipped": "Omitido: toca para hacerlo ahora",
+      "steps": {
+        "name": {
+          "label": "Agrega tu nombre",
+          "description": "Para que tus amigos puedan reconocerte"
+        },
+        "interests": {
+          "label": "Elige tus intereses",
+          "description": "Los usamos para mostrarte mejor contenido"
+        },
+        "picture": {
+          "label": "Agrega una foto de perfil",
+          "description": "Los perfiles con foto logran más conexiones"
+        },
+        "phone": {
+          "label": "Verifica tu teléfono",
+          "description": "Mantiene tu cuenta segura"
+        },
+        "contacts": {
+          "label": "Sincroniza tus contactos",
+          "description": "Encuentra amigos que ya están aquí"
+        }
+      }
     }
   },
   "forms": {
@@ -1272,7 +1304,8 @@
       "buttons": {
         "syncSuccess": "¡Sincronización exitosa!",
         "syncFailed": "Error al sincronizar",
-        "syncContacts": "¿Sincronizar tus contactos?"
+        "syncContacts": "¿Sincronizar tus contactos?",
+        "resyncContacts": "Sincronizar contactos de nuevo"
       },
       "labels": {
         "allUsers": "Todos los usuarios",
@@ -1305,6 +1338,18 @@
         "shareLink": "Compartir un enlace",
         "syncContacts": "Sincronizar contactos",
         "skip": "Omitir por ahora"
+      },
+      "pageHeaderContacts": "Encuentra a tus amigos",
+      "pageSubHeaderContacts": "Sincroniza tus contactos para ver quién ya está aquí",
+      "progress": {
+        "back": "Volver un paso"
+      },
+      "syncContacts": {
+        "description": "Comparamos tus contactos con las cuentas de Therr para que puedas conectarte de inmediato. Tus contactos nunca se comparten con nadie más.",
+        "continue": "Continuar",
+        "skip": "Ahora no",
+        "errorMessage": "No pudimos sincronizar tus contactos. Inténtalo de nuevo.",
+        "permissionsDenied": "El acceso a los contactos está desactivado. Actívalo en la configuración de tu dispositivo para encontrar amigos."
       }
     },
     "cropImage": {

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -411,8 +411,40 @@
       }
     },
     "incompleteProfileBanner": {
-      "message": "Ajoutez votre nom pour que vos amis puissent vous reconnaître",
-      "dismiss": "Ignorer"
+      "message": "Complétez votre profil — il reste {count} étapes",
+      "dismiss": "Ignorer",
+      "messageSingular": "Complétez votre profil — il reste 1 étape"
+    },
+    "profileCompletionCard": {
+      "title": "Complétez votre profil!",
+      "stepsLeft": "Il reste {count} étapes",
+      "stepLeft": "Il reste 1 étape",
+      "continue": "Continuer",
+      "collapse": "Réduire la liste",
+      "expand": "Afficher la liste",
+      "skipped": "Ignoré — touchez pour le faire maintenant",
+      "steps": {
+        "name": {
+          "label": "Ajoutez votre nom",
+          "description": "Pour que vos amis puissent vous reconnaître"
+        },
+        "interests": {
+          "label": "Choisissez vos intérêts",
+          "description": "Nous les utilisons pour vous montrer du meilleur contenu"
+        },
+        "picture": {
+          "label": "Ajoutez une photo de profil",
+          "description": "Les profils avec photo obtiennent plus de connexions"
+        },
+        "phone": {
+          "label": "Vérifiez votre téléphone",
+          "description": "Garde votre compte sécuritaire"
+        },
+        "contacts": {
+          "label": "Synchronisez vos contacts",
+          "description": "Trouvez des amis qui sont déjà ici"
+        }
+      }
     }
   },
   "forms": {
@@ -1272,7 +1304,8 @@
       "buttons": {
         "syncSuccess": "Synchronisation réussie!",
         "syncFailed": "Échec de la synchronisation",
-        "syncContacts": "Synchroniser vos contacts?"
+        "syncContacts": "Synchroniser vos contacts?",
+        "resyncContacts": "Synchroniser les contacts de nouveau"
       },
       "labels": {
         "allUsers": "Tous les utilisateurs",
@@ -1305,6 +1338,18 @@
         "shareLink": "Partager un lien",
         "syncContacts": "Synchroniser les contacts",
         "skip": "Passer pour le moment"
+      },
+      "pageHeaderContacts": "Trouvez vos amis",
+      "pageSubHeaderContacts": "Synchronisez vos contacts pour voir qui est déjà ici",
+      "progress": {
+        "back": "Revenir à l’étape précédente"
+      },
+      "syncContacts": {
+        "description": "Nous comparons vos contacts aux comptes Therr pour que vous puissiez vous connecter tout de suite. Vos contacts ne sont jamais partagés avec qui que ce soit.",
+        "continue": "Continuer",
+        "skip": "Pas maintenant",
+        "errorMessage": "Nous n’avons pas pu synchroniser vos contacts. Veuillez réessayer.",
+        "permissionsDenied": "L’accès aux contacts est désactivé. Activez-le dans les réglages de votre appareil pour trouver des amis."
       }
     },
     "cropImage": {

--- a/TherrMobile/main/routes/Connect/components/PeopleYouMayKnow.tsx
+++ b/TherrMobile/main/routes/Connect/components/PeopleYouMayKnow.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { Text, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
 import { Button } from '../../../components/BaseButton';
 import LottieView from 'lottie-react-native';
 import UserSearchItem from './UserSearchItem';
 import spacingStyles from '../../../styles/layouts/spacing';
 import searchLoading from '../../../assets/search-loading.json';
 import { synceMobileContacts } from '../../../utilities/contacts';
+import { getProfileCompletionFlags, markContactsSynced } from '../../../utilities/profileCompletion';
 
 const PeopleYouMayKnow = ({
     mightKnowUsers,
@@ -22,11 +23,38 @@ const PeopleYouMayKnow = ({
     const [isSyncing, setSyncing] = useState(false);
     const [hasSynced, setHasSynced] = useState(false);
     const [syncStatus, setSyncStatus] = useState('not-synced');
+    // `null` while the persisted flag is still loading, so the full sync prompt
+    // never flashes for users who already synced on a previous session.
+    const [hasSyncedPreviously, setHasSyncedPreviously] = useState<boolean | null>(null);
+    const [isExpanded, setIsExpanded] = useState(false);
+    const userId = user?.details?.id;
+
+    useEffect(() => {
+        let isMounted = true;
+
+        getProfileCompletionFlags(userId).then((flags) => {
+            if (isMounted) {
+                setHasSyncedPreviously(!!flags.hasSyncedContacts);
+            }
+        }).catch(() => {
+            if (isMounted) {
+                setHasSyncedPreviously(false);
+            }
+        });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [userId]);
+
     const syncContacts = () => {
         // TODO: Store permissions in redux
         const storePermissions = () => {};
 
         setSyncing(true);
+        // Keep the prompt open for the rest of this session so the user sees
+        // the success/failure result; it collapses again on the next visit.
+        setIsExpanded(true);
 
         // TODO: Send a websocket event and return list of discovered 'might know' users
         synceMobileContacts({
@@ -34,6 +62,8 @@ const PeopleYouMayKnow = ({
             user,
         }).then(() => {
             setSyncStatus('sync-success');
+            setHasSyncedPreviously(true);
+            return markContactsSynced(userId);
         }).catch(() => {
             setSyncStatus('sync-failed');
         }).finally(() => {
@@ -49,6 +79,11 @@ const PeopleYouMayKnow = ({
         buttonText = translate('pages.contacts.buttons.syncFailed');
     }
 
+    // Once contacts have been synced the prompt is noise: collapse it to a
+    // single re-sync link the user can expand on demand.
+    const isCollapsed = hasSyncedPreviously !== false && !isExpanded;
+    const shouldRenderSyncPrompt = !mightKnowUsers?.length && hasSyncedPreviously !== null;
+
     return (
         <>
             <Text style={[
@@ -57,10 +92,10 @@ const PeopleYouMayKnow = ({
                 spacingStyles.marginLtMd,
             ]}>{translate('pages.contacts.labels.peopleYouMightKnow')}</Text>
             {
-                !mightKnowUsers?.length &&
+                shouldRenderSyncPrompt &&
                 <>
                     {
-                        !isSyncing &&
+                        !isSyncing && !isCollapsed &&
                         <Text style={[
                             theme.styles.sectionDescriptionNote,
                             spacingStyles.marginBotMd,
@@ -73,24 +108,40 @@ const PeopleYouMayKnow = ({
                         spacingStyles.marginBotMd,
                     ]}>
                         {
-                            isSyncing ?
-                                <LottieView
-                                    source={searchLoading}
-                                    // resizeMode="cover"
-                                    resizeMode="contain"
-                                    speed={1}
-                                    autoPlay
-                                    loop
-                                    style={[{top: 0, width: '100%', height: 50}]}
-                                /> :
-                                <Button
-                                    onPress={syncContacts}
-                                    containerStyle={themeButtons.styles.buttonPillContainerSquare}
-                                    buttonStyle={themeButtons.styles.buttonPill}
-                                    titleStyle={themeButtons.styles.buttonPillTitle}
-                                    title={buttonText}
-                                    disabled={isSyncing || hasSynced}
-                                />
+                            isSyncing &&
+                            <LottieView
+                                source={searchLoading}
+                                // resizeMode="cover"
+                                resizeMode="contain"
+                                speed={1}
+                                autoPlay
+                                loop
+                                style={[{top: 0, width: '100%', height: 50}]}
+                            />
+                        }
+                        {
+                            !isSyncing && isCollapsed &&
+                            <Pressable
+                                onPress={() => setIsExpanded(true)}
+                                hitSlop={8}
+                                accessibilityRole="button"
+                                accessibilityLabel={translate('pages.contacts.buttons.resyncContacts')}
+                            >
+                                <Text style={[theme.styles.sectionDescriptionNote, theme.styles.link]}>
+                                    {translate('pages.contacts.buttons.resyncContacts')}
+                                </Text>
+                            </Pressable>
+                        }
+                        {
+                            !isSyncing && !isCollapsed &&
+                            <Button
+                                onPress={syncContacts}
+                                containerStyle={themeButtons.styles.buttonPillContainerSquare}
+                                buttonStyle={themeButtons.styles.buttonPill}
+                                titleStyle={themeButtons.styles.buttonPillTitle}
+                                title={buttonText}
+                                disabled={isSyncing || hasSynced}
+                            />
                         }
                     </View>
                 </>

--- a/TherrMobile/main/routes/CreateProfile/index.tsx
+++ b/TherrMobile/main/routes/CreateProfile/index.tsx
@@ -24,11 +24,14 @@ import CreateProfilePhoneVerify from '../../components/0_First_Time_UI/onboardin
 import CreateProfilePicture from '../../components/0_First_Time_UI/onboarding-stages/CreateProfilePicture';
 import CreateProfileInterests from '../../components/0_First_Time_UI/onboarding-stages/CreateProfileInterests';
 import InviteFriends from '../../components/0_First_Time_UI/onboarding-stages/InviteFriends';
+import SyncContacts from '../../components/0_First_Time_UI/onboarding-stages/SyncContacts';
+import StageProgressBar from '../../components/0_First_Time_UI/StageProgressBar';
 import BaseStatusBar from '../../components/BaseStatusBar';
 import { DEFAULT_FIRSTNAME, DEFAULT_LASTNAME } from '../../constants';
 import { getImagePreviewPath } from '../../utilities/areaUtils';
 import { getUserImageUri } from '../../utilities/content';
 import { synceMobileContacts } from '../../utilities/contacts';
+import { markContactsSkipped, markContactsSynced, markInterestsSelected } from '../../utilities/profileCompletion';
 
 const verifyPhoneLoader = require('../../assets/verify-phone-shield.json');
 
@@ -44,9 +47,17 @@ interface IStoreProps extends ICreateProfileDispatchProps {
 // Regular component props
 export interface ICreateProfileProps extends IStoreProps {
     navigation: any;
+    route?: any;
 }
 
-type StageType = 'details' | 'picture' | 'phone' | 'interests' | 'invite';
+type StageType = 'details' | 'picture' | 'phone' | 'interests' | 'contacts' | 'invite';
+
+/**
+ * Order the guided flow walks through. Also drives the progress bar, so the
+ * user always sees how much of the profile is left. `invite` is a closing
+ * flourish rather than a profile field, so it is excluded from the count.
+ */
+const STAGE_ORDER: StageType[] = ['details', 'interests', 'picture', 'phone', 'contacts'];
 
 interface ICreateProfileState {
     croppedImageDetails: any;
@@ -55,6 +66,7 @@ interface ICreateProfileState {
     isLoadingInterests: boolean;
     isPhoneNumberValid: boolean;
     isSubmitting: boolean;
+    isSyncingContacts: boolean;
     stage: StageType;
     interests: any;
 }
@@ -100,6 +112,7 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
             isLoadingInterests: true,
             isPhoneNumberValid: false,
             isSubmitting: false,
+            isSyncingContacts: false,
             stage: props.route?.params?.stage || 'details',
         };
 
@@ -197,6 +210,8 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
     };
 
     onSubmitInterests = (stage: StageType, interests: any) => {
+        const { user } = this.props;
+
         this.setState({
             isSubmitting: true,
         });
@@ -204,6 +219,7 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
             interests,
         })
             .then(() => {
+                markInterestsSelected(user.details?.id);
                 this.setState({
                     stage: 'picture',
                 });
@@ -289,7 +305,7 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
                             });
                         } else if (stage === 'phone') {
                             this.setState({
-                                stage: 'invite',
+                                stage: 'contacts',
                             });
                         }
                     }
@@ -372,8 +388,68 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
     };
 
     onFinishOnboarding = () => {
-        const { navigation } = this.props;
+        const { navigation, route } = this.props;
+
+        // Entered from the "Finish your profile" checklist: return the user to
+        // where they were rather than dumping them on the map mid-session.
+        if (route?.params?.isGuidedStep && navigation.canGoBack?.()) {
+            navigation.goBack();
+            return;
+        }
+
         navigation.navigate('Map');
+    };
+
+    /** Index of the current stage in the guided flow, 1-based for display. */
+    getStageStepNumber = (stage: StageType) => {
+        const index = STAGE_ORDER.indexOf(stage);
+
+        // `invite` sits past the tracked stages — show the bar as full.
+        return index === -1 ? STAGE_ORDER.length : index + 1;
+    };
+
+    onGoBackStage = () => {
+        const { navigation } = this.props;
+        const { stage } = this.state;
+        const currentIndex = STAGE_ORDER.indexOf(stage);
+
+        if (currentIndex > 0) {
+            this.setState({
+                errorMsg: '',
+                stage: STAGE_ORDER[currentIndex - 1],
+            });
+            return;
+        }
+
+        if (navigation.canGoBack?.()) {
+            navigation.goBack();
+        }
+    };
+
+    onSkipContactsSync = () => {
+        const { user } = this.props;
+
+        markContactsSkipped(user.details?.id);
+        this.advancePastContacts();
+    };
+
+    /**
+     * The invite stage is a bonus prompt during first-run onboarding. When the
+     * user arrived from the profile checklist, contact sync is the last tracked
+     * step, so finish instead of tacking on another ask.
+     */
+    advancePastContacts = () => {
+        const { route } = this.props;
+
+        if (route?.params?.isGuidedStep) {
+            this.onFinishOnboarding();
+            return;
+        }
+
+        this.setState({
+            errorMsg: '',
+            stage: 'invite',
+        });
     };
 
     onShareInviteLink = () => {
@@ -394,22 +470,50 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
         const { navigation, user } = this.props;
         const storePermissions = () => {};
 
-        synceMobileContacts({
+        this.setState({
+            errorMsg: '',
+            isSyncingContacts: true,
+        });
+
+        return synceMobileContacts({
             storePermissions,
             user,
         }).then((result) => {
+            // Recorded before navigating so the profile checklist and the
+            // people list both see the step as done on their next read.
+            markContactsSynced(user.details?.id);
             navigation.navigate('PhoneContacts', {
                 allContacts: result.contacts,
                 matchedUsers: result.matchedUsers,
             });
         }).catch((err) => {
             console.log('Sync contacts error:', err);
+            this.setState({
+                errorMsg: this.translate(
+                    err?.message === 'permissions-denied'
+                        ? 'pages.createProfile.syncContacts.permissionsDenied'
+                        : 'pages.createProfile.syncContacts.errorMessage'
+                ),
+            });
+        }).finally(() => {
+            this.setState({
+                isSyncingContacts: false,
+            });
         });
     };
 
     render() {
         const { user } = this.props;
-        const { isLoadingInterests, interests, croppedImageDetails, errorMsg, inputs, isSubmitting, stage } = this.state;
+        const {
+            isLoadingInterests,
+            interests,
+            croppedImageDetails,
+            errorMsg,
+            inputs,
+            isSubmitting,
+            isSyncingContacts,
+            stage,
+        } = this.state;
         const pageHeaderDetails = this.translate('pages.createProfile.pageHeaderDetails');
         const pageSubHeaderDetails = this.translate('pages.createProfile.pageSubHeaderDetails');
         const pageHeaderPhone = this.translate('pages.createProfile.pageHeaderPhone');
@@ -425,6 +529,14 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
             <>
                 <BaseStatusBar therrThemeName={this.props.user.settings?.mobileThemeName}/>
                 <SafeAreaView edges={[]}  style={this.theme.styles.safeAreaView}>
+                    <StageProgressBar
+                        currentStep={this.getStageStepNumber(stage)}
+                        totalSteps={STAGE_ORDER.length}
+                        onBack={this.onGoBackStage}
+                        canGoBack={stage !== STAGE_ORDER[0]}
+                        translate={this.translate as any}
+                        theme={this.theme}
+                    />
                     <KeyboardAwareScrollView
                         contentInsetAdjustmentBehavior="automatic"
                         ref={(component) => (this.scrollViewRef = component)}
@@ -475,6 +587,17 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
                                         </Text>
                                         <Text style={this.themeFTUI.styles.subtitleCenter}>
                                             {pageSubHeaderPhone}
+                                        </Text>
+                                    </>
+                                }
+                                {
+                                    stage === 'contacts' &&
+                                    <>
+                                        <Text style={this.themeFTUI.styles.title}>
+                                            {this.translate('pages.createProfile.pageHeaderContacts')}
+                                        </Text>
+                                        <Text style={this.themeFTUI.styles.subtitleCenter}>
+                                            {this.translate('pages.createProfile.pageSubHeaderContacts')}
                                         </Text>
                                     </>
                                 }
@@ -565,6 +688,19 @@ export class CreateProfile extends React.Component<ICreateProfileProps, ICreateP
                                     translate={this.translate}
                                     theme={this.theme}
                                     themeAlerts={this.themeAlerts}
+                                    themeForms={this.themeForms}
+                                    themeSettingsForm={this.themeSettingsForm}
+                                />
+                            }
+                            {
+                                stage === 'contacts' &&
+                                <SyncContacts
+                                    isSyncing={isSyncingContacts}
+                                    errorMsg={errorMsg}
+                                    onSyncContacts={this.onSyncContacts}
+                                    onSkip={this.onSkipContactsSync}
+                                    translate={this.translate}
+                                    theme={this.theme}
                                     themeForms={this.themeForms}
                                     themeSettingsForm={this.themeSettingsForm}
                                 />

--- a/TherrMobile/main/routes/ViewUser/index.tsx
+++ b/TherrMobile/main/routes/ViewUser/index.tsx
@@ -38,6 +38,7 @@ import translator from '../../utilities/translator';
 import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
 import LottieLoader, { ILottieId } from '../../components/LottieLoader';
 import UserDisplayHeader from './UserDisplayHeader';
+import ProfileCompletionCard from '../../components/ProfileCompletionCard';
 import ConfirmModal from '../../components/Modals/ConfirmModal';
 import LazyPlaceholder from '../../components/LazyPlaceholder';
 import TabViewLoadingOverlay from '../../components/TabViewLoadingOverlay';
@@ -754,6 +755,15 @@ class ViewUser extends React.Component<
                                     user={user}
                                     userInView={user.userInView || {}}
                                 />
+                                {
+                                    user.userInView?.id === user.details.id &&
+                                    <ProfileCompletionCard
+                                        navigation={navigation}
+                                        translate={this.translate as any}
+                                        user={user}
+                                        themeName={user.settings?.mobileThemeName}
+                                    />
+                                }
                                 <View style={this.theme.styles.tabviewContainer} onLayout={this.handleTabContainerLayout}>
                                     <TabView
                                         lazy

--- a/TherrMobile/main/routes/access.ts
+++ b/TherrMobile/main/routes/access.ts
@@ -10,6 +10,19 @@ export const AccessPresets: Record<string, IAccess> = {
         type: AccessCheckType.ALL,
         levels: [AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
     },
+    /**
+     * Any signed-in account, whether or not onboarding left properties unset.
+     * Needed by screens that serve both first-run onboarding and later
+     * re-entry — e.g. the guided profile-completion flow, which fully verified
+     * users reach from the "Finish your profile" checklist.
+     */
+    ANY_AUTHENTICATED: {
+        type: AccessCheckType.ANY,
+        levels: [
+            AccessLevels.EMAIL_VERIFIED,
+            AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES,
+        ],
+    },
     PUBLIC_DEFAULT: {
         type: AccessCheckType.NONE,
         levels: [

--- a/TherrMobile/main/routes/index.tsx
+++ b/TherrMobile/main/routes/index.tsx
@@ -89,20 +89,28 @@ const routes: RouteConfig<
         }),
     },
     {
-        name: 'CreateProfile',
-        component: CreateProfile,
-        options: () => ({
-            title: 'Create Profile',
-            access: AccessPresets.EMAIL_VERIFIED_MISSING_PROPERTIES,
-        }),
-    },
-    {
         name: 'Map',
         component: Map,
         options: () => ({
             title: 'Map',
             requiredFeatures: [FeatureFlags.ENABLE_MAP],
             access: AccessPresets.PUBLIC_PARTIAL,
+        }),
+    },
+    {
+        // ORDER IS LOAD-BEARING: Layout renders these in array order and does not
+        // set `initialRouteName`, so the first route the user is authorized for
+        // becomes the landing screen. `CreateProfile` must sit AFTER `Map`:
+        //   - onboarding users (missing properties) fail Landing/Login/Map, so
+        //     CreateProfile is their first surviving route — first-run onboarding;
+        //   - fully verified users now also match CreateProfile (they re-enter it
+        //     from the "Finish your profile" checklist), and Map keeps its place
+        //     as their landing screen only because it comes first.
+        name: 'CreateProfile',
+        component: CreateProfile,
+        options: () => ({
+            title: 'Create Profile',
+            access: AccessPresets.ANY_AUTHENTICATED,
         }),
     },
     {

--- a/TherrMobile/main/styles/profileCompletionCard/index.ts
+++ b/TherrMobile/main/styles/profileCompletionCard/index.ts
@@ -1,0 +1,157 @@
+import Color from 'color';
+import { StyleSheet } from 'react-native';
+import { IMobileThemeName } from 'therr-react/types';
+import { getTheme, ITherrTheme } from '../themes';
+import { shadowSm } from '../elevation';
+import { radius } from '../radii';
+import { space } from '../layouts/spacing';
+import { fontSizes, fontWeights } from '../text';
+import { therrFontFamily } from '../font';
+
+// Soft brand wash so the card reads as an invitation rather than an alert
+// (same treatment as styles/incompleteProfileBanner).
+const tint = (hex: string, opacity: number) => new Color(hex).alpha(opacity).toString();
+
+const buildStyles = (themeName?: IMobileThemeName) => {
+    const therrTheme: ITherrTheme = getTheme(themeName);
+
+    const isDark = themeName !== 'light';
+    const washOpacity = isDark ? 0.18 : 0.1;
+
+    const styles = StyleSheet.create({
+        container: {
+            ...shadowSm,
+            backgroundColor: tint(therrTheme.colors.brand, washOpacity),
+            borderRadius: radius.xl,
+            marginHorizontal: space.lg,
+            marginTop: space.md,
+            marginBottom: space.sm,
+            paddingHorizontal: space.lg,
+            paddingTop: space.md,
+            paddingBottom: space.lg,
+        },
+        headerRow: {
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+        },
+        headerTextContainer: {
+            flex: 1,
+        },
+        title: {
+            fontFamily: therrFontFamily,
+            fontSize: fontSizes.lg,
+            fontWeight: fontWeights.bold,
+            color: therrTheme.colors.brandDark,
+        },
+        stepsLeft: {
+            fontSize: fontSizes.xs,
+            fontWeight: fontWeights.semibold,
+            letterSpacing: 1,
+            textTransform: 'uppercase',
+            color: therrTheme.colors.onSurfaceMuted,
+            marginTop: space.xs,
+        },
+        collapseButton: {
+            padding: space.sm,
+            marginLeft: space.sm,
+        },
+        collapseIcon: {
+            color: therrTheme.colors.brandDark,
+        },
+        progressTrack: {
+            height: 12,
+            borderRadius: radius.pill,
+            backgroundColor: tint(therrTheme.colors.onSurfaceMuted, isDark ? 0.3 : 0.18),
+            overflow: 'hidden',
+            marginTop: space.md,
+        },
+        progressFill: {
+            height: '100%',
+            borderRadius: radius.pill,
+            backgroundColor: therrTheme.colors.brand,
+        },
+        stepList: {
+            marginTop: space.md,
+        },
+        stepRow: {
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            paddingVertical: space.sm,
+        },
+        stepIndicator: {
+            width: 28,
+            height: 28,
+            borderRadius: radius.circle,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderWidth: 2,
+            borderColor: therrTheme.colors.brand,
+            marginRight: space.md,
+        },
+        stepIndicatorComplete: {
+            backgroundColor: therrTheme.colors.brand,
+            borderColor: therrTheme.colors.brand,
+        },
+        stepIndicatorSkipped: {
+            borderColor: therrTheme.colors.onSurfaceMuted,
+        },
+        stepIndicatorIcon: {
+            color: therrTheme.colors.brand,
+        },
+        stepIndicatorIconComplete: {
+            color: therrTheme.colors.onBrand,
+        },
+        stepIndicatorIconSkipped: {
+            color: therrTheme.colors.onSurfaceMuted,
+        },
+        stepTextContainer: {
+            flex: 1,
+        },
+        stepLabel: {
+            fontSize: fontSizes.sm,
+            fontWeight: fontWeights.semibold,
+            color: therrTheme.colors.onSurface,
+        },
+        stepLabelComplete: {
+            color: therrTheme.colors.onSurfaceMuted,
+            textDecorationLine: 'line-through',
+        },
+        stepDescription: {
+            fontSize: fontSizes.xs,
+            color: therrTheme.colors.onSurfaceMuted,
+            marginTop: 2,
+        },
+        stepChevron: {
+            color: therrTheme.colors.onSurfaceMuted,
+            marginLeft: space.sm,
+        },
+        continueButtonContainer: {
+            marginTop: space.md,
+        },
+        continueButton: {
+            backgroundColor: therrTheme.colors.brand,
+            borderRadius: radius.lg,
+            paddingVertical: space.md,
+        },
+        continueButtonTitle: {
+            fontFamily: therrFontFamily,
+            fontSize: fontSizes.md,
+            fontWeight: fontWeights.bold,
+            letterSpacing: 1,
+            textTransform: 'uppercase',
+            color: therrTheme.colors.onBrand,
+        },
+    });
+
+    return ({
+        ...therrTheme,
+        styles,
+    });
+};
+
+export {
+    buildStyles,
+};

--- a/TherrMobile/main/utilities/profileCompletion.ts
+++ b/TherrMobile/main/utilities/profileCompletion.ts
@@ -1,0 +1,217 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { IUserState } from 'therr-react/types';
+import { UsersService } from 'therr-react/services';
+import { DEFAULT_FIRSTNAME, DEFAULT_LASTNAME } from '../constants';
+
+/**
+ * Profile completion model shared by the "Finish your profile" card, the
+ * incomplete-profile banner, and the guided CreateProfile flow. Keeping the
+ * step list in one place means the card, the banner, and the onboarding stages
+ * can never disagree about what is left to do.
+ */
+
+export type IProfileStepKey = 'name' | 'interests' | 'picture' | 'phone' | 'contacts';
+
+/** Stages of the guided CreateProfile flow that a step can resume at. */
+export type IProfileStage = 'details' | 'interests' | 'picture' | 'phone' | 'contacts' | 'invite';
+
+/**
+ * Completion signals that are not derivable from `user.details`. Persisted per
+ * user to AsyncStorage so the checklist survives relaunches without adding a
+ * round trip on every render.
+ */
+export interface IProfileCompletionFlags {
+    hasSelectedInterests: boolean;
+    hasSyncedContacts: boolean;
+    hasSkippedContacts: boolean;
+}
+
+export interface IProfileCompletionStep {
+    key: IProfileStepKey;
+    /** Stage the guided flow jumps to when this step is tapped. */
+    stage: IProfileStage;
+    /** FontAwesome5 icon name. */
+    icon: string;
+    labelKey: string;
+    descriptionKey: string;
+    isComplete: boolean;
+    /**
+     * Explicitly passed on (only possible for optional steps like contact
+     * sync). Counts as resolved for progress, but renders differently so the
+     * checklist never claims the user did something they declined.
+     */
+    isSkipped: boolean;
+}
+
+export interface IProfileCompletionSummary {
+    steps: IProfileCompletionStep[];
+    /** Steps that are complete OR intentionally skipped. */
+    resolvedCount: number;
+    totalCount: number;
+    remainingCount: number;
+    /** 0 - 1, used to fill the progress bar. */
+    percentComplete: number;
+    isComplete: boolean;
+    /** First unresolved step, i.e. where "Continue" should take the user. */
+    nextStep?: IProfileCompletionStep;
+}
+
+export const DEFAULT_PROFILE_COMPLETION_FLAGS: IProfileCompletionFlags = {
+    hasSelectedInterests: false,
+    hasSyncedContacts: false,
+    hasSkippedContacts: false,
+};
+
+const STORAGE_KEY_PREFIX = 'profileCompletionFlags';
+
+const getStorageKey = (userId?: string) => `${STORAGE_KEY_PREFIX}:${userId || 'anonymous'}`;
+
+export const getProfileCompletionFlags = (userId?: string): Promise<IProfileCompletionFlags> =>
+    AsyncStorage.getItem(getStorageKey(userId))
+        .then((value) => {
+            if (!value) {
+                return { ...DEFAULT_PROFILE_COMPLETION_FLAGS };
+            }
+
+            return {
+                ...DEFAULT_PROFILE_COMPLETION_FLAGS,
+                ...JSON.parse(value),
+            };
+        })
+        // Storage is a cache, never a source of truth: a read failure should
+        // degrade to "nothing done yet" rather than break the screen.
+        .catch(() => ({ ...DEFAULT_PROFILE_COMPLETION_FLAGS }));
+
+export const setProfileCompletionFlags = (
+    userId: string | undefined,
+    updates: Partial<IProfileCompletionFlags>,
+): Promise<IProfileCompletionFlags> => getProfileCompletionFlags(userId).then((flags) => {
+    const merged = { ...flags, ...updates };
+
+    return AsyncStorage.setItem(getStorageKey(userId), JSON.stringify(merged))
+        .then(() => merged)
+        .catch(() => merged);
+});
+
+export const markContactsSynced = (userId?: string) => setProfileCompletionFlags(userId, {
+    hasSyncedContacts: true,
+    hasSkippedContacts: false,
+});
+
+export const markContactsSkipped = (userId?: string) => setProfileCompletionFlags(userId, {
+    hasSkippedContacts: true,
+});
+
+export const markInterestsSelected = (userId?: string) => setProfileCompletionFlags(userId, {
+    hasSelectedInterests: true,
+});
+
+/**
+ * Interests are not mirrored into Redux, and accounts created before this
+ * checklist existed have no local flag. Seed the flag from the API once so
+ * long-standing users are not asked to redo a step they already finished.
+ */
+export const syncInterestsFlag = (userId?: string): Promise<IProfileCompletionFlags> =>
+    getProfileCompletionFlags(userId).then((flags) => {
+        if (flags.hasSelectedInterests) {
+            return flags;
+        }
+
+        return UsersService.getUserInterests()
+            .then((response: any) => {
+                const hasInterests = Array.isArray(response?.data)
+                    ? response.data.some((interest: any) => interest?.isEnabled !== false)
+                    : false;
+
+                if (!hasInterests) {
+                    return flags;
+                }
+
+                return setProfileCompletionFlags(userId, { hasSelectedInterests: true });
+            })
+            .catch(() => flags);
+    });
+
+/**
+ * iOS onboarding seeds the name inputs with a placeholder so the account can be
+ * created without one. Treat that exact placeholder pair as "no name given"
+ * rather than as a completed step.
+ */
+const hasRealName = (details: any) => {
+    const firstName = details?.firstName;
+
+    if (!firstName) {
+        return false;
+    }
+
+    return !(firstName === DEFAULT_FIRSTNAME && details?.lastName === DEFAULT_LASTNAME);
+};
+
+export const getProfileCompletionSummary = (
+    user: IUserState,
+    flags: IProfileCompletionFlags = DEFAULT_PROFILE_COMPLETION_FLAGS,
+): IProfileCompletionSummary => {
+    const details = user?.details;
+
+    const steps: IProfileCompletionStep[] = [
+        {
+            key: 'name',
+            stage: 'details',
+            icon: 'user-edit',
+            labelKey: 'components.profileCompletionCard.steps.name.label',
+            descriptionKey: 'components.profileCompletionCard.steps.name.description',
+            isComplete: hasRealName(details),
+            isSkipped: false,
+        },
+        {
+            key: 'interests',
+            stage: 'interests',
+            icon: 'heart',
+            labelKey: 'components.profileCompletionCard.steps.interests.label',
+            descriptionKey: 'components.profileCompletionCard.steps.interests.description',
+            isComplete: !!flags.hasSelectedInterests,
+            isSkipped: false,
+        },
+        {
+            key: 'picture',
+            stage: 'picture',
+            icon: 'camera',
+            labelKey: 'components.profileCompletionCard.steps.picture.label',
+            descriptionKey: 'components.profileCompletionCard.steps.picture.description',
+            isComplete: !!details?.media?.profilePicture,
+            isSkipped: false,
+        },
+        {
+            key: 'phone',
+            stage: 'phone',
+            icon: 'shield-alt',
+            labelKey: 'components.profileCompletionCard.steps.phone.label',
+            descriptionKey: 'components.profileCompletionCard.steps.phone.description',
+            isComplete: !!details?.phoneNumber,
+            isSkipped: false,
+        },
+        {
+            key: 'contacts',
+            stage: 'contacts',
+            icon: 'address-book',
+            labelKey: 'components.profileCompletionCard.steps.contacts.label',
+            descriptionKey: 'components.profileCompletionCard.steps.contacts.description',
+            isComplete: !!flags.hasSyncedContacts,
+            isSkipped: !flags.hasSyncedContacts && !!flags.hasSkippedContacts,
+        },
+    ];
+
+    const totalCount = steps.length;
+    const resolvedCount = steps.filter((step) => step.isComplete || step.isSkipped).length;
+    const nextStep = steps.find((step) => !step.isComplete && !step.isSkipped);
+
+    return {
+        steps,
+        resolvedCount,
+        totalCount,
+        remainingCount: totalCount - resolvedCount,
+        percentComplete: totalCount ? resolvedCount / totalCount : 1,
+        isComplete: resolvedCount === totalCount,
+        nextStep,
+    };
+};

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -24,6 +24,8 @@
 - **Organization management** — business account grouping
 
 ### User Profiles
+- **Guided profile completion (mobile)** — a "Finish your profile" checklist card on the user's own profile shows the remaining steps (name, interests, photo, phone, contact sync) with a progress bar; each row hands off to the matching stage of the guided `CreateProfile` flow, which carries a Duolingo-style step progress bar and per-stage back navigation. The home-feed nudge banner reads the same step model. The card disappears once every step is resolved
+- **Contact sync step (mobile)** — a first-class onboarding stage that asks to match phone contacts against existing accounts, with an explicit "Not Now". A completed sync is recorded per user, which collapses the sync prompt on the people list to a single "sync again" link
 - **Profile editing** — name, bio, profile picture, privacy settings
 - **View other users** — public profile with content tabs (spaces, events, thoughts)
 - **User search & discovery** — search by username, "people you may know" suggestions


### PR DESCRIPTION
Replace the single-message "add your name" nudge with a Duolingo-style
guided completion flow.

- Add a shared profile-completion model (`utilities/profileCompletion`)
  that derives the five onboarding steps — name, interests, photo, phone,
  contact sync — from `user.details` plus per-user flags persisted to
  AsyncStorage. The card, the home-feed banner, and the guided flow all
  read it, so they cannot disagree about what is left to do. Interests are
  not mirrored into Redux, so the flag is seeded once from the API for
  accounts that finished that step before the checklist existed.
- Add `ProfileCompletionCard`, rendered on the user's own profile: a
  progress bar, a tappable checklist, and a Continue button that hands off
  to the matching stage of the guided flow. It collapses on demand and
  disappears once every step is resolved.
- Add a first-class contact-sync stage to `CreateProfile` with an explicit
  "Not Now". A skip is recorded as resolved-but-not-done so the checklist
  never claims the user did something they declined.
- Add `StageProgressBar` to `CreateProfile` — a filling progress bar plus
  per-stage back navigation, so a multi-screen form reads as finite
  progress.
- Collapse the sync prompt on the people list to a single "sync again"
  link once contacts have been synced, expandable on demand.
- Treat the iOS "Anonymous User" onboarding placeholder as no name given,
  so the name step is not silently marked complete on iOS.

`CreateProfile` now accepts any signed-in account rather than only accounts
still missing properties, since verified users re-enter it from the
checklist. Its route entry moves after `Map` because `Layout` sets no
`initialRouteName` — the first authorized route becomes the landing screen,
and Map must keep that spot for verified users. Pinned by a regression test.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011jpsGnmbHJBN46MQiuLMqW