### PR TITLE
Add unclaimed achievements badge to mobile right drawer

### DIFF
--- a/TherrMobile/__tests__/utilities/achievements.test.ts
+++ b/TherrMobile/__tests__/utilities/achievements.test.ts
@@ -1,0 +1,59 @@
+// Note: import explicitly to use the types shipped with jest.
+import { it, describe, expect } from '@jest/globals';
+
+import { getUnclaimedAchievementsCount } from '../../main/utilities/achievements';
+
+/**
+ * Unclaimed Achievements Badge Count Tests
+ *
+ * The right drawer (components/HeaderMenuRight.tsx) renders a badge next to the
+ * "Achievements" menu item using this count. It must stay in sync with the
+ * "unclaimed" section on the Achievements screen (routes/Achievements/index.tsx),
+ * which treats an achievement as unclaimed when it is completed AND still has
+ * reward points outstanding.
+ */
+
+describe('getUnclaimedAchievementsCount', () => {
+    it('returns 0 when achievements are missing', () => {
+        expect(getUnclaimedAchievementsCount(undefined)).toBe(0);
+        expect(getUnclaimedAchievementsCount({})).toBe(0);
+    });
+
+    it('counts completed achievements with outstanding reward points', () => {
+        const achievements = {
+            1: { id: 1, completedAt: '2026-07-01T00:00:00.000Z', unclaimedRewardPts: 10 },
+            2: { id: 2, completedAt: '2026-07-02T00:00:00.000Z', unclaimedRewardPts: 5 },
+        };
+
+        expect(getUnclaimedAchievementsCount(achievements)).toBe(2);
+    });
+
+    it('excludes achievements that are still in progress', () => {
+        const achievements = {
+            1: { id: 1, completedAt: null, unclaimedRewardPts: 10 },
+            2: { id: 2, completedAt: undefined, unclaimedRewardPts: 10 },
+            3: { id: 3, completedAt: '2026-07-02T00:00:00.000Z', unclaimedRewardPts: 5 },
+        };
+
+        expect(getUnclaimedAchievementsCount(achievements)).toBe(1);
+    });
+
+    it('excludes achievements whose rewards were already claimed', () => {
+        const achievements = {
+            1: { id: 1, completedAt: '2026-07-01T00:00:00.000Z', unclaimedRewardPts: 0 },
+            2: { id: 2, completedAt: '2026-07-02T00:00:00.000Z', unclaimedRewardPts: null },
+            3: { id: 3, completedAt: '2026-07-03T00:00:00.000Z', unclaimedRewardPts: 20 },
+        };
+
+        expect(getUnclaimedAchievementsCount(achievements)).toBe(1);
+    });
+
+    it('handles reward points serialized as strings', () => {
+        const achievements = {
+            1: { id: 1, completedAt: '2026-07-01T00:00:00.000Z', unclaimedRewardPts: '15' },
+            2: { id: 2, completedAt: '2026-07-02T00:00:00.000Z', unclaimedRewardPts: '0' },
+        };
+
+        expect(getUnclaimedAchievementsCount(achievements)).toBe(1);
+    });
+});

--- a/TherrMobile/main/components/HeaderMenuRight.tsx
+++ b/TherrMobile/main/components/HeaderMenuRight.tsx
@@ -19,6 +19,7 @@ import translator from '../utilities/translator';
 import { ILocationState } from '../types/redux/location';
 import requestLocationServiceActivation from '../utilities/requestLocationServiceActivation';
 import { resetInterestsRedirectBypass } from '../utilities/interestsRedirectGuard';
+import { getUnclaimedAchievementsCount } from '../utilities/achievements';
 import { ITherrThemeColors } from '../styles/themes';
 import { getUserImageUri } from '../utilities/content';
 import UsersActions from '../redux/actions/UsersActions';
@@ -443,6 +444,8 @@ class HeaderMenuRight extends React.PureComponent<
         const { isModalVisible, isPointsInfoModalVisible } = this.state;
         const unreadCount: number = notifications?.messages?.filter(m => m.isUnread)?.length || 0;
         const hasNotifications = unreadCount > 0;
+        const unclaimedAchievementsCount: number = getUnclaimedAchievementsCount(user?.achievements);
+        const hasUnclaimedAchievements = unclaimedAchievementsCount > 0;
         // let imageStyle = themeMenu.styles.toggleIcon;
 
         // if (styleName === 'light') {
@@ -658,7 +661,7 @@ class HeaderMenuRight extends React.PureComponent<
                         >
                             <Drawer.Section>
                                 <FeatureGate feature={FeatureFlags.ENABLE_NOTIFICATIONS}>
-                                    <View style={themeMenu.styles.notificationsItemContainer}>
+                                    <View style={themeMenu.styles.menuItemContainer}>
                                         <Drawer.Item
                                             label={this.translate('components.headerMenuRight.menuItems.notifications')}
                                             icon={() => (
@@ -677,7 +680,7 @@ class HeaderMenuRight extends React.PureComponent<
                                         />
                                         {
                                             hasNotifications && (
-                                                <Badge style={themeMenu.styles.notificationBadge} size={20}>
+                                                <Badge style={themeMenu.styles.menuItemBadge} size={20}>
                                                     {unreadCount}
                                                 </Badge>
                                             )
@@ -685,22 +688,31 @@ class HeaderMenuRight extends React.PureComponent<
                                     </View>
                                 </FeatureGate>
                                 <FeatureGate feature={FeatureFlags.ENABLE_ACHIEVEMENTS}>
-                                    <Drawer.Item
-                                        label={this.translate('components.headerMenuRight.menuItems.achievements')}
-                                        icon={() => (
-                                            <TherrIcon
-                                                style={
-                                                    currentScreen === 'Achievements'
-                                                        ? themeMenu.styles.iconStyleActive
-                                                        : themeMenu.styles.iconStyle
-                                                }
-                                                name="achievement"
-                                                size={24}
-                                            />
-                                        )}
-                                        active={currentScreen === 'Achievements'}
-                                        onPress={() => this.navTo('Achievements')}
-                                    />
+                                    <View style={themeMenu.styles.menuItemContainer}>
+                                        <Drawer.Item
+                                            label={this.translate('components.headerMenuRight.menuItems.achievements')}
+                                            icon={() => (
+                                                <TherrIcon
+                                                    style={
+                                                        currentScreen === 'Achievements'
+                                                            ? themeMenu.styles.iconStyleActive
+                                                            : themeMenu.styles.iconStyle
+                                                    }
+                                                    name="achievement"
+                                                    size={24}
+                                                />
+                                            )}
+                                            active={currentScreen === 'Achievements'}
+                                            onPress={() => this.navTo('Achievements')}
+                                        />
+                                        {
+                                            hasUnclaimedAchievements && (
+                                                <Badge style={themeMenu.styles.menuItemBadge} size={20}>
+                                                    {unclaimedAchievementsCount}
+                                                </Badge>
+                                            )
+                                        }
+                                    </View>
                                 </FeatureGate>
                                 <FeatureGate feature={FeatureFlags.ENABLE_CONNECT}>
                                     <Drawer.Item

--- a/TherrMobile/main/styles/modal/headerMenuModal.ts
+++ b/TherrMobile/main/styles/modal/headerMenuModal.ts
@@ -78,10 +78,10 @@ const buildStyles = (themeName?: IMobileThemeName) => {
             // left: 20
             paddingRight: 10,
         },
-        notificationsItemContainer: {
+        menuItemContainer: {
             position: 'relative',
         },
-        notificationBadge: {
+        menuItemBadge: {
             position: 'absolute',
             top: 14,
             right: 8,

--- a/TherrMobile/main/utilities/achievements.ts
+++ b/TherrMobile/main/utilities/achievements.ts
@@ -1,0 +1,10 @@
+/**
+ * Counts achievements the user has completed but not yet claimed rewards for.
+ * Mirrors the "unclaimed" section criteria on the Achievements screen
+ * (routes/Achievements/index.tsx) so the drawer badge always matches what
+ * that screen lists.
+ */
+export const getUnclaimedAchievementsCount = (achievements?: { [key: string]: any }): number => Object
+    .values(achievements || {})
+    .filter((ach: any) => !!ach?.completedAt && Number(ach?.unclaimedRewardPts) > 0)
+    .length;


### PR DESCRIPTION
The Achievements menu item in the right drawer now renders a count badge
for achievements the user has completed but not yet claimed rewards for,
matching the existing notifications badge treatment.

- Add getUnclaimedAchievementsCount utility mirroring the "unclaimed"
  section criteria on the Achievements screen (completedAt set AND
  unclaimedRewardPts > 0), so the badge and that screen never disagree.
- Wrap the Achievements Drawer.Item in a relative container and render
  the same react-native-paper Badge used for notifications.
- Rename notificationsItemContainer/notificationBadge styles to
  menuItemContainer/menuItemBadge now that both rows share them.
- Add unit tests covering in-progress, already-claimed, missing, and
  string-serialized reward point cases.

Achievements are already prefetched into Redux on Layout mount and
refetched after a claim, so the badge stays current without new requests.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019ZuJTRkBb5nG1ywtepJzpN