### PR TITLE
chore(ci): parameterize GKE cluster, zone, and project in deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,9 +289,13 @@ jobs:
             echo "export USE_GKE_GCLOUD_AUTH_PLUGIN=True" >> ~/.bashrc
             source ~/.bashrc
             echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-            gcloud --quiet config set project therr-app
-            gcloud --quiet config set compute/zone us-central1-a
-            gcloud container clusters get-credentials cluster-1
+            # Defaults target the current (blue) cluster, so behavior is unchanged unless
+            # overridden. Cutover to a new cluster is done by setting GKE_CLUSTER / GKE_ZONE
+            # (and optionally GKE_PROJECT) as CircleCI project env vars — no code merge needed.
+            gcloud --quiet config set project "${GKE_PROJECT:-therr-app}"
+            gcloud --quiet config set compute/zone "${GKE_ZONE:-us-central1-a}"
+            gcloud container clusters get-credentials "${GKE_CLUSTER:-cluster-1}" \
+              --zone "${GKE_ZONE:-us-central1-a}"
       - add_ssh_keys:
           fingerprints:
             - "7a:7c:76:bd:7b:be:2a:cd:de:90:c4:16:78:e1:eb:f6"


### PR DESCRIPTION
## Summary

Stage 0 of the GKE blue/green cluster migration (`therr-infra-terraform` → `docs/gke-migration/stage-0-circleci-parameterization.md`).

The `deploy` job hardcoded `cluster-1` / `us-central1-a`. Redirecting the pipeline at a different cluster would have required a **code merge racing the deploy it is trying to redirect**. After this, cutover is flipping two CircleCI project env vars — no merge, no race.

## Change

`.circleci/config.yml`, "Login to Google Cloud and connect to GKE Cluster":

```diff
-gcloud --quiet config set project therr-app
-gcloud --quiet config set compute/zone us-central1-a
-gcloud container clusters get-credentials cluster-1
+gcloud --quiet config set project "${GKE_PROJECT:-therr-app}"
+gcloud --quiet config set compute/zone "${GKE_ZONE:-us-central1-a}"
+gcloud container clusters get-credentials "${GKE_CLUSTER:-cluster-1}" +  --zone "${GKE_ZONE:-us-central1-a}"
```

The explicit `--zone` on `get-credentials` is deliberate: it makes the command self-describing and independent of the `compute/zone` config, so a stale config can't silently point the deploy at the wrong cluster.

Surrounding steps (`gke-gcloud-auth-plugin --version`, the `USE_GKE_GCLOUD_AUTH_PLUGIN` export, `gcloud auth activate-service-account`) are untouched.

## Behavior

**Defaults preserve today's exact behavior.** Nothing changes until someone sets `GKE_CLUSTER` / `GKE_ZONE` in the CircleCI UI — which is Stage 4, not now. Worth landing even if the migration never happens.

## Verification

- YAML parses; the block scalar preserves the line continuation.
- Swept the repo for other deploy-path hardcoding — the only remaining hits are `k8s/prod/migrate-main-pool.sh` (untracked; deleted in Stage 5), the dated `.prod-debug/incident-*.md` records, and `docs/PROD_DEBUG_CLAUDE.md` (updated in Stage 5). All intentionally left alone.
- Confirmed `_bin/cicd/deploy.sh` is cluster-agnostic — no cluster, zone, or project identifiers; it inherits whatever kubecontext the job sets up. (Sole match for "cluster" is a word in a comment.)
- The `deploy` job runs only on `main`, so this PR does not exercise it. The proof is the **next ordinary deploy after merge to `main`**: the log should print a `get-credentials` line naming `cluster-1`.

## After merge (Zack)

1. Promote to `main` as usual.
2. On the first post-merge deploy, confirm the CircleCI log shows `get-credentials ... cluster-1` — that validates the defaults before anything depends on the overrides.
3. **Do not** set `GKE_CLUSTER` / `GKE_ZONE` yet. That is Stage 4.

## Rollback

Revert. There is no infrastructure state to unwind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)