### PR TITLE
fix(thoughts): stop fabricating a phantom reply, and return reply reaction state

### DIFF
--- a/TherrMobile/android/app/build.gradle
+++ b/TherrMobile/android/app/build.gradle
@@ -93,8 +93,8 @@ android {
         applicationId "app.therrmobile"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 438
-        versionName "3.11.0"
+        versionCode 439
+        versionName "3.12.0"
         manifestPlaceholders = [GOOGLE_APIS_ANDROID_KEY: "${System.getenv("GOOGLE_APIS_ANDROID_KEY")}"]
         vectorDrawables.useSupportLibrary = true
     }

--- a/TherrMobile/main/components/UserContent/ThoughtDisplay.tsx
+++ b/TherrMobile/main/components/UserContent/ThoughtDisplay.tsx
@@ -46,11 +46,11 @@ interface IThoughtDisplayProps {
     topReply?: any;
     replyCount?: number;
     /**
-     * Renders a standalone reply-count icon/count for content that is not itself repliable
-     * (ie. replies rendered within the thought details view). Pressing it inspects the nested
-     * thought. Off by default so feed/carousel displays are unaffected.
+     * Renders a standalone action row for content that is not itself repliable (ie. replies
+     * rendered within the thought details view): a reply-count icon that inspects the nested
+     * thought, and a like control. Off by default so feed/carousel displays are unaffected.
      */
-    showReplyCount?: boolean;
+    showThreadActions?: boolean;
     goToViewUser: Function;
     updateThoughtReaction: Function;
     user: IUserState;
@@ -101,15 +101,20 @@ class ThoughtDisplay extends React.Component<IThoughtDisplayProps, IThoughtDispl
 
     onBookmarkPress = (thought) => {
         const { updateThoughtReaction, user } = this.props;
-        const newIsBookmarked = !this.state.isBookmarked;
+        const previousIsBookmarked = this.state.isBookmarked;
+        const newIsBookmarked = !previousIsBookmarked;
 
         this.setState({
             isBookmarked: newIsBookmarked,
         });
 
-        updateThoughtReaction(thought.id, {
+        const request = updateThoughtReaction(thought.id, {
             userBookmarkCategory: newIsBookmarked ? 'Uncategorized' : null,
         }, thought.fromUserId, user?.details?.userName);
+
+        // Not every caller returns the request (some fire-and-forget through an action sheet),
+        // so this is opt-in: when we can see the failure, undo the optimistic toggle.
+        request?.catch?.(() => this.setState({ isBookmarked: previousIsBookmarked }));
     };
 
     // TODO: Open full screen reply editor
@@ -123,18 +128,25 @@ class ThoughtDisplay extends React.Component<IThoughtDisplayProps, IThoughtDispl
         if (!thought.isDraft) {
             // ReactNativeHapticFeedback.trigger(HAPTIC_FEEDBACK_TYPE, hapticFeedbackOptions);
             const { updateThoughtReaction, user } = this.props;
-            const newIsLiked = !this.state.isLiked;
+            const previousIsLiked = this.state.isLiked;
+            const previousLikeCount = this.state.likeCount;
+            const newIsLiked = !previousIsLiked;
 
             this.setState({
                 isLiked: newIsLiked,
                 likeCount: this.props.thought.likeCount != null
-                    ? (this.state.likeCount || 0) + (newIsLiked ? 1 : -1)
-                    : this.state.likeCount,
+                    ? Math.max((previousLikeCount || 0) + (newIsLiked ? 1 : -1), 0)
+                    : previousLikeCount,
             });
 
-            updateThoughtReaction(thought.id, {
+            const request = updateThoughtReaction(thought.id, {
                 userHasLiked: newIsLiked,
             }, thought.fromUserId, user?.details?.userName);
+
+            request?.catch?.(() => this.setState({
+                isLiked: previousIsLiked,
+                likeCount: previousLikeCount,
+            }));
         }
     };
 
@@ -150,7 +162,7 @@ class ThoughtDisplay extends React.Component<IThoughtDisplayProps, IThoughtDispl
             thought,
             topReply,
             replyCount,
-            showReplyCount,
+            showThreadActions,
             goToViewUser,
             contentUserDetails,
             theme,
@@ -241,7 +253,7 @@ class ThoughtDisplay extends React.Component<IThoughtDisplayProps, IThoughtDispl
                                     onLikePress={this.onLikePress}
                                     goToViewUser={goToViewUser}
                                     replyCount={replyCount}
-                                    showReplyCount={showReplyCount}
+                                    showThreadActions={showThreadActions}
                                     theme={theme}
                                     themeForms={themeForms}
                                     themeViewContent={themeViewContent}
@@ -282,7 +294,7 @@ class ThoughtDisplay extends React.Component<IThoughtDisplayProps, IThoughtDispl
                                 onLikePress={this.onLikePress}
                                 goToViewUser={goToViewUser}
                                 replyCount={replyCount}
-                                showReplyCount={showReplyCount}
+                                showThreadActions={showThreadActions}
                                 theme={theme}
                                 themeForms={themeForms}
                                 themeViewContent={themeViewContent}
@@ -362,7 +374,7 @@ const ThoughtContent = ({
     onLikePress,
     goToViewUser,
     replyCount,
-    showReplyCount,
+    showThreadActions,
     theme,
     themeForms,
     themeViewContent,
@@ -372,9 +384,9 @@ const ThoughtContent = ({
     const totalReplies = replyCount ?? thought.replyCount ?? thought.replies?.length;
     const onMentionPress = (username: string) => handleMentionPress(username, goToViewUser);
     const hasRepliableActions = !thought.isDraft && isRepliable;
-    // The repliable action row already renders a reply icon/count, so this only fills the gap
-    // for non-repliable content (replies within the thought details view).
-    const shouldShowStandaloneReplyCount = !hasRepliableActions && !thought.isDraft && showReplyCount;
+    // The repliable action row already renders a reply icon/count and a like control, so this
+    // only fills the gap for non-repliable content (replies within the thought details view).
+    const shouldShowThreadActions = !hasRepliableActions && !thought.isDraft && showThreadActions;
 
     return (
         <Pressable style={themeViewContent.styles.thoughtContentContainer} onPress={() => inspectThought(thought)}>
@@ -398,27 +410,56 @@ const ThoughtContent = ({
                 </View>
                 <View style={isExpanded ? themeViewContent.styles.thoughtReactionsContainerExpanded : themeViewContent.styles.thoughtReactionsContainer}>
                     {
-                        shouldShowStandaloneReplyCount &&
-                        <Button
-                            containerStyle={themeViewContent.styles.thoughtReactionButtonContainer}
-                            buttonStyle={themeViewContent.styles.thoughtReactionButton}
-                            icon={
-                                <TherrIcon
-                                    name="chat"
-                                    size={22}
-                                    color={isDarkMode ? theme.colors.textWhite : theme.colors.tertiary}
-                                />
-                            }
-                            onPress={() => inspectThought(thought)}
-                            type="clear"
-                            title={`${totalReplies || 0}`}
-                            titleStyle={[
-                                themeViewContent.styles.thoughtReactionButtonTitle,
-                                { color: isDarkMode ? theme.colors.textWhite : theme.colors.tertiary },
-                            ]}
-                            accessibilityLabel={translate('components.thoughtDisplay.viewReplies', { count: totalReplies || 0 })}
-                            TouchableComponent={TouchableWithoutFeedbackComponent}
-                        />
+                        shouldShowThreadActions &&
+                        <>
+                            <Button
+                                containerStyle={themeViewContent.styles.thoughtReactionButtonContainer}
+                                buttonStyle={themeViewContent.styles.thoughtReactionButton}
+                                icon={
+                                    <TherrIcon
+                                        name="chat"
+                                        size={22}
+                                        color={isDarkMode ? theme.colors.textWhite : theme.colors.tertiary}
+                                    />
+                                }
+                                onPress={() => inspectThought(thought)}
+                                type="clear"
+                                title={`${totalReplies || 0}`}
+                                titleStyle={[
+                                    themeViewContent.styles.thoughtReactionButtonTitle,
+                                    { color: isDarkMode ? theme.colors.textWhite : theme.colors.tertiary },
+                                ]}
+                                accessibilityLabel={translate('components.thoughtDisplay.viewReplies', { count: totalReplies || 0 })}
+                                TouchableComponent={TouchableWithoutFeedbackComponent}
+                            />
+                            {/*
+                                The like control is deliberately its own pressable rather than part
+                                of the card's inspect gesture — liking a reply should not first
+                                require opening it.
+                            */}
+                            <Button
+                                containerStyle={themeViewContent.styles.thoughtReactionButtonContainer}
+                                buttonStyle={themeViewContent.styles.thoughtReactionButton}
+                                icon={
+                                    <TherrIcon
+                                        name={ isLiked ? 'heart-filled' : 'heart' }
+                                        size={22}
+                                        color={likeColor}
+                                    />
+                                }
+                                onPress={() => onLikePress(thought)}
+                                type="clear"
+                                title={(likeCount && likeCount > 0) ? likeCount.toString() : ''}
+                                titleStyle={[
+                                    themeViewContent.styles.thoughtReactionButtonTitle,
+                                    { color: isDarkMode ? theme.colors.textWhite : theme.colors.tertiary },
+                                ]}
+                                accessibilityLabel={translate(isLiked
+                                    ? 'components.thoughtDisplay.unlikeThought'
+                                    : 'components.thoughtDisplay.likeThought')}
+                                TouchableComponent={TouchableWithoutFeedbackComponent}
+                            />
+                        </>
                     }
                     {
                         hasRepliableActions &&

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -397,7 +397,9 @@
     },
     "thoughtDisplay": {
       "viewAllReplies": "View all {count} replies",
-      "viewReplies": "View {count} replies"
+      "viewReplies": "View {count} replies",
+      "likeThought": "Like this post",
+      "unlikeThought": "Remove like from this post"
     },
     "userMenu": {
       "buttons": {
@@ -1819,7 +1821,8 @@
     "viewThought": {
       "headerTitle": "Thoughts",
       "reply": "Reply",
-      "replies": "Replies"
+      "replies": "Replies",
+      "repliesFailed": "We couldn't load the replies. Try again in a moment."
     },
     "manageSpaces": {
       "headerTitle": "My Business Spaces",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -397,7 +397,9 @@
     },
     "thoughtDisplay": {
       "viewAllReplies": "Ver las {count} respuestas",
-      "viewReplies": "Ver {count} respuestas"
+      "viewReplies": "Ver {count} respuestas",
+      "likeThought": "Me gusta esta publicación",
+      "unlikeThought": "Quitar me gusta de esta publicación"
     },
     "userMenu": {
       "buttons": {
@@ -1819,7 +1821,8 @@
     "viewThought": {
       "headerTitle": "Pensamientos",
       "reply": "Responder",
-      "replies": "Respuestas"
+      "replies": "Respuestas",
+      "repliesFailed": "No pudimos cargar las respuestas. Inténtalo de nuevo en un momento."
     },
     "manageSpaces": {
       "headerTitle": "Mis Negocios",

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -397,7 +397,9 @@
     },
     "thoughtDisplay": {
       "viewAllReplies": "Voir les {count} réponses",
-      "viewReplies": "Voir {count} réponses"
+      "viewReplies": "Voir {count} réponses",
+      "likeThought": "Aimer cette publication",
+      "unlikeThought": "Retirer le « j'aime » de cette publication"
     },
     "userMenu": {
       "buttons": {
@@ -1819,7 +1821,8 @@
     "viewThought": {
       "headerTitle": "Pensées",
       "reply": "Répondre",
-      "replies": "Réponses"
+      "replies": "Réponses",
+      "repliesFailed": "Impossible de charger les réponses. Réessayez dans un instant."
     },
     "manageSpaces": {
       "headerTitle": "Mes Commerces",

--- a/TherrMobile/main/routes/ViewThought/index.tsx
+++ b/TherrMobile/main/routes/ViewThought/index.tsx
@@ -34,6 +34,7 @@ import { getReactionUpdateArgs } from '../../utilities/reactions';
 import TherrIcon from '../../components/TherrIcon';
 import { HAPTIC_FEEDBACK_TYPE } from '../../constants';
 import { navToViewContent } from '../../utilities/postViewHelpers';
+import { showToast } from '../../utilities/toasts';
 
 const localStyles = StyleSheet.create({
     contentContainer: {
@@ -148,12 +149,21 @@ const ViewThought = ({
         }).then((response) => {
             setFetchedThought(response?.thought || {});
             setReplies(
-                response?.thought?.replies?.sort(
+                // The id filter guards against a backend that has not yet shipped the
+                // phantom-reply fix: an id-less reply renders as an empty card, inflates the
+                // reply count, and cannot be opened.
+                response?.thought?.replies?.filter((reply) => !!reply?.id).sort(
                     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
                 ) || []
             );
         }).catch(() => {
-            navigation.goBack();
+            // Deliberately not navigating away: the thought passed through route params is
+            // enough to render the post itself, and bouncing the user back to the feed on a
+            // transient failure reads as "tapping a reply does nothing".
+            showToast.error({
+                text1: translate('alertTitles.backendErrorMessage'),
+                text2: translate('pages.viewThought.repliesFailed'),
+            });
         });
 
         navigation.setOptions({
@@ -172,7 +182,12 @@ const ViewThought = ({
 
     // Handlers
     const handleGoBack = useCallback(() => {
-        if (fetchedThought?.parentId) {
+        // Nested replies are pushed onto the stack, so unwinding one level is a plain pop.
+        if (previousView === 'ViewThought' && navigation.canGoBack()) {
+            navigation.goBack();
+        } else if (fetchedThought?.parentId) {
+            // Reached without a parent screen below (eg. a push notification deep link into a
+            // reply), so walk up to the parent thought explicitly.
             navToViewContent({
                 id: fetchedThought.parentId,
             }, user, navigation.replace);
@@ -198,25 +213,50 @@ const ViewThought = ({
     }, [navigation]);
 
     const handleGoToContent = useCallback((content) => {
-        navToViewContent(content, user, navigation.replace);
+        if (!content?.id) {
+            return;
+        }
+        // `push`, not `replace`: a thread is walked one level at a time, so the parent has to
+        // stay on the stack for the back gesture to return to it instead of exiting to the feed.
+        navToViewContent(content, user, navigation.push, 'ViewThought');
     }, [user, navigation]);
 
-    const handleUpdateThoughtReaction = useCallback((thoughtId, data) => {
-        navigation.setParams({
-            thought: {
-                ...thought,
-                reaction: {
-                    ...thought.reaction,
-                    ...data,
+    const handleUpdateThoughtReaction = useCallback((thoughtId, data, contentUserId) => {
+        if (thoughtId === thought.id) {
+            navigation.setParams({
+                thought: {
+                    ...thought,
+                    reaction: {
+                        ...thought.reaction,
+                        ...data,
+                    },
                 },
-            },
-        });
-        return createOrUpdateThoughtReaction(thoughtId, data, thought.fromUserId, user.details.userName);
+            });
+        } else {
+            // A reply was reacted to. Keep its reaction in local state so the control stays
+            // toggled if this screen re-renders before the next details fetch.
+            setReplies((prevReplies) => prevReplies.map((reply) => (reply.id === thoughtId
+                ? {
+                    ...reply,
+                    reaction: {
+                        ...reply.reaction,
+                        ...data,
+                    },
+                }
+                : reply)));
+        }
+
+        return createOrUpdateThoughtReaction(
+            thoughtId,
+            data,
+            contentUserId || thought.fromUserId,
+            user.details.userName,
+        );
     }, [thought, navigation, createOrUpdateThoughtReaction, user.details.userName]);
 
     const handleThoughtOptionSelect = useCallback((type: IContentSelectionType, selectedThought: any) => {
         const requestArgs: any = getReactionUpdateArgs(type);
-        handleUpdateThoughtReaction(selectedThought.id, requestArgs);
+        handleUpdateThoughtReaction(selectedThought.id, requestArgs, selectedThought.fromUserId);
     }, [handleUpdateThoughtReaction]);
 
     const handleToggleThoughtOptions = useCallback((selectedThought: any) => {
@@ -283,7 +323,9 @@ const ViewThought = ({
 
         createThought(createArgs)
             .then((newReply) => {
-                setReplies((prev) => [newReply, ...prev]);
+                // The create response has no reaction columns; seeding them keeps the new
+                // reply's like control interactive without waiting for a details refetch.
+                setReplies((prev) => [{ likeCount: 0, replyCount: 0, ...newReply }, ...prev]);
 
                 logEvent(getAnalytics(), 'thought_reply_create', {
                     parentId,
@@ -387,7 +429,7 @@ const ViewThought = ({
                                     isDarkMode={isDarkMode}
                                     isExpanded={false}
                                     inspectThought={handleGoToContent}
-                                    showReplyCount={true}
+                                    showThreadActions={true}
                                     thought={reply}
                                     goToViewUser={handleGoToViewUser}
                                     updateThoughtReaction={handleUpdateThoughtReaction}

--- a/context/memory/2026-08-01.md
+++ b/context/memory/2026-08-01.md
@@ -1,0 +1,30 @@
+# 2026-08-01
+
+## Goal
+Mobile: nested thought (reply) view redirected back to the thoughts list; like icon not
+actionable on replies in a thread.
+
+## Root cause
+`ThoughtsStore.getById` selected `replies[].replyCount` as a bare correlated `COUNT(*)`.
+On the all-NULL row a LEFT JOIN produces for a childless thought, COUNT(*) returns 0, never
+NULL — and `formatSQLJoinAsJSON` treats any non-null `replies[].*` value as proof of a reply.
+Result: a phantom `{ replyCount: 0 }` reply with no id on every childless thought. It rendered
+as an empty card, inflated the reply count, and 500'd when opened (`/thoughts/undefined/details`).
+ViewThought answered the failure with `navigation.goBack()` after having used
+`navigation.replace`, so the parent was gone from the stack -> user landed on the feed.
+
+## Deliverables (branch claude/mobile-nested-thought-issues-1t9ic2, pushed)
+- 08c6bcc backend: CASE-guard the subquery + drop id-less replies; reply access falls back to
+  the parent's activation (deep links now work); getThoughtDetails returns per-reply likeCount
+  + the caller's reaction; new bulk endpoint POST /thought-reactions/count/multiple.
+- c16317a mobile: push instead of replace for nested replies; failed fetch keeps the screen
+  (toast); like control on replies via renamed `showThreadActions`; optimistic toggle reverts
+  on failure; reaction handler targets the reacted thought, not always the root.
+
+## Decisions
+- Kept both commits landable separately (backend must reach `general`; mobile may not).
+- Client-side id filter kept as belt-and-braces so mobile is correct against an old backend.
+
+## Open threads
+- Web (`therr-client-web/src/routes/ViewThought.tsx`) inherits the phantom fix but was not
+  otherwise touched; it could surface reply like state now that the API returns it.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -49,6 +49,7 @@
 - **Ranked social feed (mobile)** — Discoveries/Thoughts tabs ordered by engagement score (recency decay × likes/replies/views × category affinity from the user's own reactions); backend stream activation ranks candidates by reply-count hot score
 - **Auto-expanded thread previews (mobile)** — engaging thought threads show their top reply inline with a "View all N replies" link (Twitter-style)
 - **Nested reply counts (mobile & web)** — in the thought details view only, each reply renders a reply icon with its own nested reply count; tapping it opens that reply's details view so threads can be walked one level at a time
+- **Inline reply likes (mobile)** — replies in the thought details view carry their own like control with an optimistic toggle (reverted if the request fails), so a reply can be liked without opening it. `getThoughtDetails` returns each reply's like count and the requesting user's reaction
 - **Content categories** — 20+ categories (food, music, nature, art, gaming, etc.)
 - **Media uploads** — image upload with CDN (ImageKit), YouTube video embedding
 

--- a/therr-services/reactions-service/src/handlers/thoughtReactions.ts
+++ b/therr-services/reactions-service/src/handlers/thoughtReactions.ts
@@ -255,6 +255,34 @@ const countThoughtReactions: RequestHandler = async (req: any, res: any) => {
         .catch((err) => handleHttpError({ err, res, message: 'SQL:THOUGHT_REACTIONS_ROUTES:ERROR' }));
 };
 
+/**
+ * Like counts for a batch of thoughts, keyed by thoughtId.
+ *
+ * The single-thought variant above is fine for a details view's root thought, but the same
+ * view renders every reply with its own like control — fanning that out into one internal
+ * request per reply is what this exists to avoid.
+ */
+const countMultiThoughtReactions: RequestHandler = async (req: any, res: any) => {
+    const { thoughtIds } = req.body;
+
+    if (!Array.isArray(thoughtIds)) {
+        return handleHttpError({ res, message: 'thoughtIds is required', statusCode: 400 });
+    }
+
+    const validThoughtIds = thoughtIds.filter((id) => !!id);
+
+    return Store.thoughtReactions.getCounts(validThoughtIds, {})
+        .then((results) => res.status(200).send({
+            // Thoughts with zero likes have no rows to group, so they are absent here rather
+            // than zero — callers should default a missing key to 0.
+            counts: results.reduce((acc: any, result: any) => ({
+                ...acc,
+                [result.thoughtId]: parseInt(result.count || 0, 10),
+            }), {}),
+        }))
+        .catch((err) => handleHttpError({ err, res, message: 'SQL:THOUGHT_REACTIONS_ROUTES:ERROR' }));
+};
+
 export {
     getThoughtReactions,
     getReactionsByThoughtId,
@@ -262,4 +290,5 @@ export {
     createOrUpdateMultiThoughtReactions,
     findThoughtReactions,
     countThoughtReactions,
+    countMultiThoughtReactions,
 };

--- a/therr-services/reactions-service/src/routes/thoughtReactionsRouter.ts
+++ b/therr-services/reactions-service/src/routes/thoughtReactionsRouter.ts
@@ -5,6 +5,7 @@ import {
     getThoughtReactions,
     getReactionsByThoughtId,
     countThoughtReactions,
+    countMultiThoughtReactions,
     findThoughtReactions,
 } from '../handlers/thoughtReactions';
 
@@ -24,5 +25,7 @@ router.get('/:thoughtId/count', countThoughtReactions);
 
 // POST
 router.post('/find/dynamic', findThoughtReactions);
+// Two path segments, so this cannot be swallowed by the single-segment `POST /:thoughtId` above.
+router.post('/count/multiple', countMultiThoughtReactions);
 
 export default router;

--- a/therr-services/users-service/src/api/reactions.ts
+++ b/therr-services/users-service/src/api/reactions.ts
@@ -10,15 +10,30 @@ const getReactions = (thoughtId: string, headers: InternalConfigHeaders) => inte
     url: `${baseReactionsServiceRoute}/thought-reactions/${thoughtId}`,
 });
 
-const findReactions = (thoughtId: string, headers: InternalConfigHeaders) => internalRestRequest({
-    headers,
-}, {
-    method: 'post',
-    url: `${baseReactionsServiceRoute}/thought-reactions/find/dynamic`,
-    data: {
-        thoughtIds: [thoughtId],
-    },
-});
+/**
+ * The requesting user's own reactions for a batch of thoughts, keyed by thoughtId.
+ * Used to render each reply's like/bookmark control in its already-toggled state.
+ */
+const findReactionsByUser = (thoughtIds: string[], headers: InternalConfigHeaders) => {
+    if (!thoughtIds?.length) {
+        return Promise.resolve({});
+    }
+
+    return internalRestRequest({
+        headers,
+    }, {
+        method: 'post',
+        url: `${baseReactionsServiceRoute}/thought-reactions/find/dynamic`,
+        data: {
+            thoughtIds,
+        },
+    })
+        .then(({ data }) => (data?.reactions || []).reduce((acc: any, reaction: any) => ({
+            ...acc,
+            [reaction.thoughtId]: reaction,
+        }), {}))
+        .catch(() => ({}));
+};
 
 const countReactions = (thoughtId: string, headers: InternalConfigHeaders) => internalRestRequest({
     headers,
@@ -27,6 +42,28 @@ const countReactions = (thoughtId: string, headers: InternalConfigHeaders) => in
     url: `${baseReactionsServiceRoute}/thought-reactions/${thoughtId}/count`,
 })
     .then(({ data: countResult }) => countResult);
+
+/**
+ * Like counts for a batch of thoughts, keyed by thoughtId. Missing keys mean zero likes.
+ * A failure here degrades to "no counts" rather than failing the whole details view.
+ */
+const countReactionsByThoughtId = (thoughtIds: string[], headers: InternalConfigHeaders) => {
+    if (!thoughtIds?.length) {
+        return Promise.resolve({});
+    }
+
+    return internalRestRequest({
+        headers,
+    }, {
+        method: 'post',
+        url: `${baseReactionsServiceRoute}/thought-reactions/count/multiple`,
+        data: {
+            thoughtIds,
+        },
+    })
+        .then(({ data }) => data?.counts || {})
+        .catch(() => ({}));
+};
 
 const hasUserReacted = (thoughtId: string, headers) => getReactions(thoughtId, headers)
     .then(({ data: thoughtReaction }) => !!(thoughtReaction && thoughtReaction.userHasActivated))
@@ -78,8 +115,9 @@ const createReactions = (
 
 export {
     createReactions,
-    findReactions,
+    findReactionsByUser,
     countReactions,
+    countReactionsByThoughtId,
     getReactions,
     hasUserReacted,
 };

--- a/therr-services/users-service/src/handlers/thoughts.ts
+++ b/therr-services/users-service/src/handlers/thoughts.ts
@@ -15,7 +15,9 @@ import userMetricsService from '../api/userMetricsService';
 import * as globalConfig from '../../../../global-config';
 import {
     countReactions,
+    countReactionsByThoughtId,
     createReactions,
+    findReactionsByUser,
     hasUserReacted,
 } from '../api/reactions';
 import handleHttpError from '../utilities/handleHttpError';
@@ -315,7 +317,15 @@ const getThoughtDetails = (req, res) => {
 
             // Verify that user has activated thought and has access to view it
             if (!thought.isPublic && !isOwnThought) {
-                userHasAccessPromise = hasUserReacted(thoughtId, req.headers);
+                // Replies are always minted with isPublic=false, so the flag is not a privacy
+                // signal on them — their visibility follows the parent thought. Falling back to
+                // the parent's activation is what lets a thread be opened from a deep link (or
+                // any order other than parent-then-reply) instead of 400ing on a reply the user
+                // is plainly allowed to read.
+                userHasAccessPromise = hasUserReacted(thoughtId, req.headers)
+                    .then((hasActivated) => (hasActivated || !thought.parentId
+                        ? hasActivated
+                        : hasUserReacted(thought.parentId, req.headers)));
             }
 
             return userHasAccessPromise.then((isActivated) => {
@@ -331,18 +341,38 @@ const getThoughtDetails = (req, res) => {
                 let createReactionsPromise = Promise.resolve({});
                 countReactionsPromise = countReactions(thoughtId, req.headers);
 
+                const replyIds = (thought.replies || []).map((reply) => reply.id).filter((id) => !!id);
+                // Activating this thought too (when it is itself a reply) keeps a reply reachable
+                // on its own after it was first opened via the parent's access.
+                const idsToActivate = thought.parentId ? [thought.id, ...replyIds] : replyIds;
+
                 // Activate child thoughts otherwise
-                if (thought.replies?.length) {
-                    createReactionsPromise = createReactions(thought.replies.map((reply) => reply.id), req.headers);
+                if (idsToActivate.length) {
+                    createReactionsPromise = createReactions(idsToActivate, req.headers);
                 }
 
-                return Promise.all([countReactionsPromise, createReactionsPromise]).then(([thoughtCounts]) => {
+                // Replies render their own like control, so they need the same reaction state the
+                // root thought gets — the count across all users, plus this user's own reaction.
+                const replyCountsPromise = countReactionsByThoughtId(replyIds, req.headers);
+                const replyReactionsPromise = findReactionsByUser(replyIds, req.headers);
+
+                return Promise.all([
+                    countReactionsPromise,
+                    createReactionsPromise,
+                    replyCountsPromise,
+                    replyReactionsPromise,
+                ]).then(([thoughtCounts, , replyLikeCounts, replyReactions]) => {
                     const thoughtResult = {
                         ...thought,
                     };
 
                     thoughtResult.viewCount = parseInt(viewCount || '0', 10);
                     thoughtResult.likeCount = parseInt(thoughtCounts?.count || '0', 10);
+                    thoughtResult.replies = (thought.replies || []).map((reply) => ({
+                        ...reply,
+                        likeCount: replyLikeCounts[reply.id] || 0,
+                        reaction: replyReactions[reply.id],
+                    }));
 
                     if (userId && userId !== thought.fromUserId) {
                         Store.userConnections.incrementUserConnection(userId, thought.fromUserId, 1)

--- a/therr-services/users-service/src/store/ThoughtsStore.ts
+++ b/therr-services/users-service/src/store/ThoughtsStore.ts
@@ -277,9 +277,16 @@ export default class ThoughtsStore {
                 })
                 .columns([
                     `${THOUGHTS_TABLE_NAME}.*`,
+                    // The CASE is load-bearing, not defensive: on a thought with no replies the
+                    // left join yields a row of NULL reply columns, but COUNT(*) still returns 0
+                    // — never NULL. formatSQLJoinAsJSON treats any non-null `replies[].*` value as
+                    // proof a reply exists, so an unguarded count fabricates a phantom reply
+                    // `{ replyCount: 0 }` with no id, which then renders as an empty card and
+                    // 404s the moment it is opened.
                     knexBuilder.raw(
-                        `(SELECT COUNT(*) FROM ${THOUGHTS_TABLE_NAME} AS nested `
-                        + `WHERE nested."parentId" = replies.id${nestedRepliesBrandClause}) AS "replies[].replyCount"`,
+                        'CASE WHEN replies.id IS NULL THEN NULL ELSE '
+                        + `(SELECT COUNT(*) FROM ${THOUGHTS_TABLE_NAME} AS nested `
+                        + `WHERE nested."parentId" = replies.id${nestedRepliesBrandClause}) END AS "replies[].replyCount"`,
                     ),
                     'replies.id as replies[].id',
                     'replies.fromUserId as replies[].fromUserId',
@@ -312,9 +319,14 @@ export default class ThoughtsStore {
             const thoughts = formatSQLJoinAsJSON(rows, [{ propKey: 'replies', propId: 'id' }]);
 
             if (options.withReplies) {
-                // pg returns COUNT(*) as a bigint string; clients render/compare it as a number
                 thoughts.forEach((thought) => {
-                    (thought.replies || []).forEach((reply) => {
+                    const modifiedThought = thought;
+                    // Every consumer of `replies` assumes an addressable row. Dropping id-less
+                    // entries keeps that invariant even if a future always-non-null aliased
+                    // column re-introduces the phantom the CASE above guards against.
+                    modifiedThought.replies = (modifiedThought.replies || []).filter((reply) => !!reply.id);
+                    // pg returns COUNT(*) as a bigint string; clients render/compare it as a number
+                    modifiedThought.replies.forEach((reply) => {
                         const modifiedReply = reply;
                         modifiedReply.replyCount = parseInt(modifiedReply.replyCount || 0, 10);
                     });

--- a/therr-services/users-service/tests/unit/ThoughtsStore.test.ts
+++ b/therr-services/users-service/tests/unit/ThoughtsStore.test.ts
@@ -350,6 +350,52 @@ describe('ThoughtsStore brand filtering', () => {
             expect(thoughts[0].replies[0].replyCount).to.equal(3);
             expect(thoughts[0].replies[1].replyCount).to.equal(0);
         });
+
+        it('nulls the nested reply count when the left join produced no reply', () => {
+            const { connection, readStub } = buildMockConnection();
+            const store = new ThoughtsStore(connection, stubUsersStore);
+            store.getById(BrandVariations.THERR, 'thought-1', {}, { withReplies: true });
+
+            const sql = readStub.args[0][0] as string;
+            // Without this, COUNT(*) returns 0 (never NULL) on the all-NULL join row, which
+            // formatSQLJoinAsJSON reads as proof a reply exists.
+            expect(sql).to.include('CASE WHEN replies.id IS NULL THEN NULL ELSE');
+        });
+
+        it('returns no replies for a thought that has none (no phantom reply row)', async () => {
+            const { connection, readStub } = buildMockConnection();
+            // The shape pg returns for a left join that matched nothing.
+            readStub.callsFake(() => Promise.resolve({
+                rows: [{
+                    id: 'thought-1',
+                    message: 'a reply with no replies of its own',
+                    'replies[].replyCount': null,
+                    'replies[].id': null,
+                    'replies[].message': null,
+                }],
+            }));
+            const store = new ThoughtsStore(connection, stubUsersStore);
+
+            const { thoughts } = await store.getById(BrandVariations.THERR, 'thought-1', {}, { withReplies: true });
+
+            expect(thoughts[0].replies).to.deep.equal([]);
+        });
+
+        it('drops id-less reply rows even if a column sneaks through as non-null', async () => {
+            const { connection, readStub } = buildMockConnection();
+            readStub.callsFake(() => Promise.resolve({
+                rows: [{
+                    id: 'thought-1',
+                    'replies[].replyCount': '0',
+                    'replies[].id': null,
+                }],
+            }));
+            const store = new ThoughtsStore(connection, stubUsersStore);
+
+            const { thoughts } = await store.getById(BrandVariations.THERR, 'thought-1', {}, { withReplies: true });
+
+            expect(thoughts[0].replies).to.deep.equal([]);
+        });
     });
 
     describe('create', () => {


### PR DESCRIPTION
A thought with no replies came back from getThoughtDetails carrying one
reply: `{ replyCount: 0 }`, with no id. The nested reply-count subquery in
ThoughtsStore.getById is a plain COUNT(*), so on the all-NULL row a left
join produces for a childless thought it still returns 0 rather than NULL —
and formatSQLJoinAsJSON treats any non-null `replies[].*` value as proof a
reply exists. That phantom rendered as an empty card under every reply
(replies rarely have replies of their own), reported a bogus reply count,
and 500'd when opened because its id reached the route as the literal
string "undefined".

- Guard the subquery with CASE WHEN replies.id IS NULL, and drop id-less
  rows after formatting so the invariant survives future column additions.
- Access check now falls back to the parent thought's activation when the
  requested thought is a reply. Replies are always minted isPublic=false,
  so the flag is not a privacy signal on them and visibility follows the
  parent — previously a reply could only be opened in the exact order that
  happened to activate it, never from a deep link. Replies opened this way
  are activated in the same pass so they stay reachable on their own.
- getThoughtDetails now returns each reply's like count and the requesting
  user's own reaction, so clients can render a reply's like control in its
  already-toggled state. Backed by a new bulk count endpoint in
  reactions-service rather than one internal request per reply.

Regression tests cover the childless-thought shape and the CASE guard.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GnyznMZL8Cmyox6aajeGkX