### PR TITLE
fix(habits): return habit goals joined via an accepted pact invite

### DIFF
--- a/context/MEMORY.md
+++ b/context/MEMORY.md
@@ -4,5 +4,12 @@
 ## Active Threads
 
 ## Environment Notes
+- When a change touches both shared/backend code (`therr-services/**`,
+  `therr-public-library/**`, migrations, root config) and niche-only code
+  (`TherrMobile/**`, brand-scoped web UI, brand assets/locales), always open
+  TWO separate PRs: one targeting `general`, one targeting the niche branch
+  (e.g. `niche/HABITS-general`). Never one mixed PR — niche branches have no
+  CI path to `main`, so shared code merged there is dead code. Keep each
+  commit landable on a single branch so the split is a clean cherry-pick.
 
 ## Pending Decisions

--- a/context/memory/2026-08-01.md
+++ b/context/memory/2026-08-01.md
@@ -28,3 +28,40 @@ ViewThought answered the failure with `navigation.goBack()` after having used
 ## Open threads
 - Web (`therr-client-web/src/routes/ViewThought.tsx`) inherits the phantom fix but was not
   otherwise touched; it could surface reply like state now that the API returns it.
+
+---
+
+# 2026-08-01 (session 2)
+
+## Goal
+Habits dashboard (Friends with Habits) showed pacts still pending an invitee's
+acceptance as checkin-able, and never showed pacts the user had accepted
+(where someone else was the inviter).
+
+## Root cause
+`HabitGoalsStore.getByUserId` filtered on `createdByUserId` only. A goal row
+belongs to whoever sent the invite, so an invitee who accepted never saw the
+habit. `routes/Habits/Dashboard.tsx` rendered `habits.habitGoals` with no pact
+awareness at all, so pending pacts got a live Check In button.
+
+## Deliverables
+- Backend (general, PR): `getByUserId` now also returns goals reachable via an
+  active pact membership (legacy `pacts.partnerUserId` fallback retained).
+  Added batched `PactMembersStore.getByPactIds` and hydrated `members` on
+  `getUserPacts` / `getActivePacts`. +8 unit tests.
+- Mobile (niche/HABITS-general, PR): extracted `routes/Habits/pactState.ts`
+  (`splitHabitsByPactState`); dashboard splits live vs "Waiting on Partners",
+  check-in hidden while pending, progress ratio counts live habits only.
+  +8 jest tests, 4 locale keys x 3 dictionaries.
+
+Verified: users-service 455 unit tests pass, mobile 1157 pass, eslint clean,
+`pr:typecheck:users` clean, mobile tsc baseline 108 = 108.
+
+## Decisions
+- Split into two PRs against two bases (see MEMORY.md rule) rather than one
+  mixed branch, since `therr-services/**` never deploys from a niche branch.
+- Judgment call to confirm with maintainer: check-in is now hidden for habits
+  whose pacts are all pending. Alternative was to keep check-in and relabel.
+
+## Open threads
+- `getPendingInvitesForUser` still does not hydrate `members`; left alone.

--- a/therr-services/users-service/src/handlers/pacts.ts
+++ b/therr-services/users-service/src/handlers/pacts.ts
@@ -426,6 +426,26 @@ const getPact: RequestHandler = async (req: any, res: any) => {
         .catch((err) => handleHttpError({ err, res, message: 'SQL:PACTS_ROUTES:ERROR' }));
 };
 
+/**
+ * Attaches `members` to a list of pacts in a single query. Clients rely on it
+ * to name the partner they're waiting on (or partnered with) without having to
+ * fetch each pact's details individually.
+ */
+const withMembers = async (pacts: any[]) => {
+    if (!pacts.length) {
+        return pacts;
+    }
+
+    const members = await Store.pactMembers.getByPactIds(pacts.map((pact) => pact.id));
+    const membersByPactId = members.reduce((acc: any, member: any) => {
+        acc[member.pactId] = acc[member.pactId] || [];
+        acc[member.pactId].push(member);
+        return acc;
+    }, {});
+
+    return pacts.map((pact) => ({ ...pact, members: membersByPactId[pact.id] || [] }));
+};
+
 const getUserPacts: RequestHandler = async (req: any, res: any) => {
     const { userId } = parseHeaders(req.headers);
     const { status, limit, offset } = req.query;
@@ -436,6 +456,7 @@ const getUserPacts: RequestHandler = async (req: any, res: any) => {
         limit ? parseInt(limit, 10) : undefined,
         offset ? parseInt(offset, 10) : undefined,
     )
+        .then(withMembers)
         .then((pacts) => res.status(200).send(pacts))
         .catch((err) => handleHttpError({ err, res, message: 'SQL:PACTS_ROUTES:ERROR' }));
 };
@@ -444,6 +465,7 @@ const getActivePacts: RequestHandler = async (req: any, res: any) => {
     const { userId } = parseHeaders(req.headers);
 
     return Store.pacts.getActivePactsByUserId(userId)
+        .then(withMembers)
         .then((pacts) => res.status(200).send(pacts))
         .catch((err) => handleHttpError({ err, res, message: 'SQL:PACTS_ROUTES:ERROR' }));
 };

--- a/therr-services/users-service/src/store/HabitGoalsStore.ts
+++ b/therr-services/users-service/src/store/HabitGoalsStore.ts
@@ -1,7 +1,7 @@
 import KnexBuilder, { Knex } from 'knex';
 import { HabitGoalType } from 'therr-js-utilities/constants';
 import { IConnection } from './connection';
-import { HABIT_GOALS_TABLE_NAME } from './tableNames';
+import { HABIT_GOALS_TABLE_NAME, PACTS_TABLE_NAME, PACT_MEMBERS_TABLE_NAME } from './tableNames';
 
 const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
 
@@ -64,8 +64,52 @@ export default class HabitGoalsStore {
         return this.get({ id }).then((results) => results[0]);
     }
 
+    /**
+     * A user's habit list is everything they created, plus every goal they
+     * joined by accepting a pact invite. Invitees never own the goal row —
+     * it belongs to whoever sent the invite — so filtering on
+     * `createdByUserId` alone hides the habit they actually signed up for.
+     *
+     * Membership is the source of truth, with a fallback to the legacy
+     * `pacts.partnerUserId` column for 1:1 pacts that pre-date pact_members.
+     */
     getByUserId(userId: string, limit?: number, offset?: number) {
-        return this.get({ createdByUserId: userId }, 'createdAt', limit, offset);
+        const joinedGoalIds = knexBuilder
+            .distinct(`${PACTS_TABLE_NAME}.habitGoalId`)
+            .from(PACTS_TABLE_NAME)
+            .leftJoin(PACT_MEMBERS_TABLE_NAME, function joinMembers() {
+                this.on(`${PACT_MEMBERS_TABLE_NAME}.pactId`, '=', `${PACTS_TABLE_NAME}.id`)
+                    .andOn(`${PACT_MEMBERS_TABLE_NAME}.userId`, '=', knexBuilder.raw('?', [userId]));
+            })
+            .whereNotNull(`${PACTS_TABLE_NAME}.habitGoalId`)
+            .andWhere((builder) => {
+                builder.where((b1) => {
+                    b1.where(`${PACT_MEMBERS_TABLE_NAME}.userId`, userId)
+                        .andWhere(`${PACT_MEMBERS_TABLE_NAME}.status`, 'active');
+                }).orWhere((b2) => {
+                    b2.where(`${PACTS_TABLE_NAME}.partnerUserId`, userId)
+                        .andWhere(`${PACTS_TABLE_NAME}.status`, 'active');
+                });
+            });
+
+        let queryString = knexBuilder
+            .from(HABIT_GOALS_TABLE_NAME)
+            .where((builder) => {
+                builder.where(`${HABIT_GOALS_TABLE_NAME}.createdByUserId`, userId)
+                    .orWhereIn(`${HABIT_GOALS_TABLE_NAME}.id`, joinedGoalIds);
+            })
+            .orderBy('createdAt', 'desc');
+
+        if (limit) {
+            queryString = queryString.limit(limit);
+        }
+
+        if (offset) {
+            queryString = queryString.offset(offset);
+        }
+
+        return this.db.read.query(queryString.toString())
+            .then((response) => response.rows);
     }
 
     getTemplates(category?: string, limit?: number, offset?: number) {

--- a/therr-services/users-service/src/store/PactMembersStore.ts
+++ b/therr-services/users-service/src/store/PactMembersStore.ts
@@ -86,6 +86,32 @@ export default class PactMembersStore {
             .then((response) => response.rows);
     }
 
+    /**
+     * Batch equivalent of getByPactId for list endpoints — one query for the
+     * whole page of pacts instead of an N+1 fan-out.
+     */
+    getByPactIds(pactIds: string[]) {
+        if (!pactIds.length) {
+            return Promise.resolve([]);
+        }
+
+        const queryString = knexBuilder
+            .select([
+                `${PACT_MEMBERS_TABLE_NAME}.*`,
+                `${USERS_TABLE_NAME}.userName`,
+                `${USERS_TABLE_NAME}.firstName`,
+                `${USERS_TABLE_NAME}.lastName`,
+                `${USERS_TABLE_NAME}.media as userMedia`,
+            ])
+            .from(PACT_MEMBERS_TABLE_NAME)
+            .leftJoin(USERS_TABLE_NAME, `${PACT_MEMBERS_TABLE_NAME}.userId`, `${USERS_TABLE_NAME}.id`)
+            .whereIn(`${PACT_MEMBERS_TABLE_NAME}.pactId`, pactIds)
+            .orderBy(`${PACT_MEMBERS_TABLE_NAME}.role`, 'asc');
+
+        return this.db.read.query(queryString.toString())
+            .then((response) => response.rows);
+    }
+
     getByPactAndUser(pactId: string, userId: string) {
         return this.get({ pactId, userId }).then((results) => results[0]);
     }

--- a/therr-services/users-service/tests/unit/HabitGoalsStore.test.ts
+++ b/therr-services/users-service/tests/unit/HabitGoalsStore.test.ts
@@ -1,0 +1,82 @@
+/* eslint-disable quotes, max-len */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import HabitGoalsStore from '../../src/store/HabitGoalsStore';
+
+const buildStore = () => {
+    const mockConnection = {
+        read: {
+            query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
+        },
+        write: {
+            query: sinon.stub().callsFake(() => Promise.resolve({ rows: [] })),
+        },
+    };
+
+    return { store: new HabitGoalsStore(mockConnection as any), mockConnection };
+};
+
+describe('HabitGoalsStore', () => {
+    describe('getByUserId', () => {
+        // Regression: the Habits dashboard renders this list and offers a
+        // check-in per row. Filtering on createdByUserId alone meant an invitee
+        // who accepted a pact never saw the habit they joined — the goal row
+        // belongs to whoever sent the invite — so the dashboard showed only the
+        // inviter's own goals (including ones whose pacts were still pending)
+        // and silently omitted the active pact.
+        it('includes goals joined through an active pact membership', async () => {
+            const { store, mockConnection } = buildStore();
+
+            await store.getByUserId('user-1');
+
+            const queryString = mockConnection.read.query.args[0][0];
+            expect(queryString).to.contain('"habits"."habit_goals"');
+            expect(queryString).to.contain('"createdByUserId" = \'user-1\'');
+            expect(queryString).to.contain('"habits"."pact_members"');
+            expect(queryString).to.contain('"habits"."pacts"');
+            expect(queryString).to.contain('"habitGoalId"');
+        });
+
+        it('only counts memberships the user has actually accepted', async () => {
+            const { store, mockConnection } = buildStore();
+
+            await store.getByUserId('user-1');
+
+            const queryString = mockConnection.read.query.args[0][0];
+            // An invite the user has not accepted yet leaves pact_members.status
+            // as 'pending'; that habit must stay out of their list.
+            expect(queryString).to.contain('"habits"."pact_members"."status" = \'active\'');
+        });
+
+        it('falls back to the legacy partnerUserId column for pre-pact_members pacts', async () => {
+            const { store, mockConnection } = buildStore();
+
+            await store.getByUserId('user-1');
+
+            const queryString = mockConnection.read.query.args[0][0];
+            expect(queryString).to.contain('"partnerUserId" = \'user-1\'');
+            expect(queryString).to.contain('"habits"."pacts"."status" = \'active\'');
+        });
+
+        it('applies limit and offset to the outer goal query', async () => {
+            const { store, mockConnection } = buildStore();
+
+            await store.getByUserId('user-1', 10, 20);
+
+            const queryString = mockConnection.read.query.args[0][0];
+            expect(queryString).to.contain('limit 10');
+            expect(queryString).to.contain('offset 20');
+        });
+
+        it('returns the queried rows', async () => {
+            const { store, mockConnection } = buildStore();
+            mockConnection.read.query.callsFake(() => Promise.resolve({
+                rows: [{ id: 'goal-1' }, { id: 'goal-2' }],
+            }));
+
+            const result = await store.getByUserId('user-1');
+
+            expect(result).to.deep.equal([{ id: 'goal-1' }, { id: 'goal-2' }]);
+        });
+    });
+});

--- a/therr-services/users-service/tests/unit/PactMembersStore.test.ts
+++ b/therr-services/users-service/tests/unit/PactMembersStore.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable quotes, max-len */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import PactMembersStore from '../../src/store/PactMembersStore';
+
+const buildStore = (rows: any[] = []) => {
+    const mockConnection = {
+        read: {
+            query: sinon.stub().callsFake(() => Promise.resolve({ rows })),
+        },
+        write: {
+            query: sinon.stub().callsFake(() => Promise.resolve({ rows })),
+        },
+    };
+
+    return { store: new PactMembersStore(mockConnection as any), mockConnection };
+};
+
+describe('PactMembersStore', () => {
+    describe('getByPactIds', () => {
+        // The pact list endpoints hydrate `members` so the client can name the
+        // partner it is waiting on. Doing that per pact would be an N+1; this
+        // batches the whole page into one query.
+        it('fetches members for every pact in one query, joined to user names', async () => {
+            const { store, mockConnection } = buildStore();
+
+            await store.getByPactIds(['pact-1', 'pact-2']);
+
+            expect(mockConnection.read.query.callCount).to.be.equal(1);
+            const queryString = mockConnection.read.query.args[0][0];
+            expect(queryString).to.contain('"habits"."pact_members"');
+            expect(queryString).to.contain('in (\'pact-1\', \'pact-2\')');
+            expect(queryString).to.contain('"main"."users"');
+            expect(queryString).to.contain('"userName"');
+        });
+
+        // knex emits an empty string for `.whereIn(col, [])` operands in some
+        // builder positions and pg rejects an empty query; a user with no pacts
+        // is the common case on a fresh account.
+        it('resolves empty without querying when there are no pact ids', async () => {
+            const { store, mockConnection } = buildStore();
+
+            const result = await store.getByPactIds([]);
+
+            expect(result).to.deep.equal([]);
+            expect(mockConnection.read.query.called).to.be.equal(false);
+        });
+
+        it('returns the queried rows', async () => {
+            const { store } = buildStore([
+                { id: 'member-1', pactId: 'pact-1', role: 'creator' },
+                { id: 'member-2', pactId: 'pact-1', role: 'partner' },
+            ]);
+
+            const result = await store.getByPactIds(['pact-1']);
+
+            expect(result).to.have.lengthOf(2);
+            expect(result[1].role).to.be.equal('partner');
+        });
+    });
+});


### PR DESCRIPTION
Backend half of a two-PR fix. The mobile half targets `niche/HABITS-general` in #2687.

## Problem

On the Friends with Habits dashboard, a user saw their own pacts that were still *pending* an invitee's acceptance, but the pact they had themselves accepted (where someone else sent the invite) never appeared at all — so the one pact they were actually committed to was the one habit they could not see or check into.

`HabitGoalsStore.getByUserId` filtered on `createdByUserId` alone. A habit goal row belongs to whoever sent the invite, so an invitee never owns the goal they joined. The dashboard renders exactly this list.

## Changes

**`HabitGoalsStore.getByUserId`** now returns goals the user created *plus* goals reachable through an active pact membership. Only `pact_members.status = 'active'` counts, so an invite the user has not accepted yet still does not leak in. Keeps a fallback to the legacy `pacts.partnerUserId` column for 1:1 pacts predating `pact_members`, mirroring what `PactsStore.getByUserId` already does.

**`PactMembersStore.getByPactIds`** (new) batches member hydration for a page of pacts in one query, and short-circuits on an empty id list.

**`getUserPacts` / `getActivePacts`** now hydrate `members` via that batch. These endpoints never returned members, so clients could not name the partner a pact is waiting on without a per-pact details fetch — `MyHabits` reads `pact.members` and was silently rendering nothing.

## Testing

- `therr-services/users-service/tests/unit/HabitGoalsStore.test.ts` — 5 tests covering the joined-goal path, the accepted-only membership filter, the legacy fallback, and pagination.
- `therr-services/users-service/tests/unit/PactMembersStore.test.ts` — 3 tests covering the batch query, the empty-input short circuit, and row passthrough.
- Full users-service unit suite: 467 passing.
- `npm run pr:typecheck:users` clean; eslint clean on all touched files.

## Notes

Both Cloud Function repos query this database directly but neither reads these code paths — no coordinated change needed. No migration; this is a read-path change only.