### PR TITLE
fix(mobile): make the Habits dashboard pact-aware

### DIFF
--- a/TherrMobile/__tests__/routes/HabitsDashboardPactState.test.ts
+++ b/TherrMobile/__tests__/routes/HabitsDashboardPactState.test.ts
@@ -1,0 +1,193 @@
+import { it, describe, expect } from '@jest/globals';
+import { splitHabitsByPactState } from '../../main/routes/Habits/pactState';
+
+/**
+ * Habits dashboard pact-state regression tests.
+ *
+ * The dashboard used to render `habits.habitGoals` with no pact awareness at
+ * all, which produced two visible bugs at once:
+ *
+ *   1. Goals whose pact was still awaiting an invitee's acceptance were shown
+ *      with a live "Check In" button, as though the pact had started.
+ *   2. Goals joined by accepting someone else's invite never appeared, because
+ *      the goal row belongs to the inviter. The pact the user had actually
+ *      committed to was the one habit they could not see or check into.
+ *
+ * `splitHabitsByPactState` is the fix's decision point: it pairs each goal
+ * with the state of its pacts so live habits and pending ones render
+ * differently. (The companion server fix makes joined goals appear in
+ * `habitGoals` in the first place — see HabitGoalsStore.getByUserId.)
+ */
+
+const goal = (id: string): any => ({
+    id,
+    name: `Habit ${id}`,
+    goalType: 'build_good',
+    frequencyType: 'daily',
+    frequencyCount: 1,
+    createdByUserId: 'inviter-1',
+    isTemplate: false,
+    isPublic: false,
+    usageCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const member = (userId: string, role: string, status: string, firstName?: string, userName?: string): any => ({
+    id: `member-${userId}`,
+    pactId: 'pact-x',
+    userId,
+    role,
+    status,
+    firstName,
+    userName,
+    totalCheckins: 0,
+    completedCheckins: 0,
+    currentStreak: 0,
+    longestStreak: 0,
+});
+
+const pact = (id: string, habitGoalId: string, status: string, members: any[]): any => ({
+    id,
+    creatorUserId: 'inviter-1',
+    habitGoalId,
+    pactType: 'accountability',
+    status,
+    durationDays: 30,
+    members,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+describe('splitHabitsByPactState', () => {
+    it('lists a habit whose pact is active as live', () => {
+        const activePact = pact('pact-1', 'goal-1', 'active', [
+            member('me', 'creator', 'active'),
+            member('friend', 'partner', 'active', 'Dana'),
+        ]);
+
+        const { live, pending } = splitHabitsByPactState(
+            [goal('goal-1')],
+            [activePact],
+            [activePact],
+            'me',
+        );
+
+        expect(pending).toHaveLength(0);
+        expect(live).toHaveLength(1);
+        expect(live[0].goal.id).toBe('goal-1');
+        expect(live[0].partnerNames).toEqual(['Dana']);
+        expect(live[0].awaitingPartnerNames).toEqual([]);
+    });
+
+    it('lists a habit whose only pact is awaiting acceptance as pending', () => {
+        const pendingPact = pact('pact-1', 'goal-1', 'pending', [
+            member('me', 'creator', 'active'),
+            member('friend', 'partner', 'pending', 'Dana'),
+        ]);
+
+        const { live, pending } = splitHabitsByPactState(
+            [goal('goal-1')],
+            [],
+            [pendingPact],
+            'me',
+        );
+
+        expect(live).toHaveLength(0);
+        expect(pending).toHaveLength(1);
+        expect(pending[0].awaitingPartnerNames).toEqual(['Dana']);
+    });
+
+    // The reported bug: two outstanding invites rendered as checkin-able while
+    // the pact the user had accepted was missing entirely.
+    it('separates outstanding invites from the pact the user accepted', () => {
+        const pendingA = pact('pact-a', 'goal-a', 'pending', [
+            member('me', 'creator', 'active'),
+            member('friend-a', 'partner', 'pending', 'Dana'),
+        ]);
+        const pendingB = pact('pact-b', 'goal-b', 'pending', [
+            member('me', 'creator', 'active'),
+            member('friend-b', 'partner', 'pending', undefined, 'sam99'),
+        ]);
+        const joined = pact('pact-c', 'goal-c', 'active', [
+            member('inviter-1', 'creator', 'active', 'Riley'),
+            member('me', 'partner', 'active'),
+        ]);
+
+        const { live, pending } = splitHabitsByPactState(
+            [goal('goal-a'), goal('goal-b'), goal('goal-c')],
+            [joined],
+            [pendingA, pendingB, joined],
+            'me',
+        );
+
+        expect(live.map((h) => h.goal.id)).toEqual(['goal-c']);
+        expect(pending.map((h) => h.goal.id)).toEqual(['goal-a', 'goal-b']);
+        expect(pending[0].awaitingPartnerNames).toEqual(['Dana']);
+        // Falls back to the username when the invitee has no name on file.
+        expect(pending[1].awaitingPartnerNames).toEqual(['sam99']);
+    });
+
+    it('keeps a habit live once any one of its pacts is active', () => {
+        const pendingPact = pact('pact-1', 'goal-1', 'pending', [
+            member('me', 'creator', 'active'),
+            member('friend-b', 'partner', 'pending', 'Sam'),
+        ]);
+        const activePact = pact('pact-2', 'goal-1', 'active', [
+            member('me', 'creator', 'active'),
+            member('friend-a', 'partner', 'active', 'Dana'),
+        ]);
+
+        const { live, pending } = splitHabitsByPactState(
+            [goal('goal-1')],
+            [activePact],
+            [pendingPact, activePact],
+            'me',
+        );
+
+        expect(pending).toHaveLength(0);
+        expect(live[0].partnerNames).toEqual(['Dana']);
+    });
+
+    // Defensive: never strand a habit behind a pact state we can't see.
+    it('treats a habit with no pacts at all as live', () => {
+        const { live, pending } = splitHabitsByPactState([goal('goal-1')], [], [], 'me');
+
+        expect(pending).toHaveLength(0);
+        expect(live).toHaveLength(1);
+        expect(live[0].partnerNames).toEqual([]);
+    });
+
+    it('excludes the current user and non-partner roles from partner names', () => {
+        const activePact = pact('pact-1', 'goal-1', 'active', [
+            member('inviter-1', 'creator', 'active', 'Riley'),
+            member('me', 'partner', 'active', 'Me'),
+            member('friend', 'partner', 'active', 'Dana'),
+        ]);
+
+        const { live } = splitHabitsByPactState([goal('goal-1')], [activePact], [activePact], 'me');
+
+        expect(live[0].partnerNames).toEqual(['Dana']);
+    });
+
+    it('does not name partners who have not accepted on an active pact', () => {
+        const activePact = pact('pact-1', 'goal-1', 'active', [
+            member('me', 'creator', 'active'),
+            member('friend-a', 'partner', 'active', 'Dana'),
+            member('friend-b', 'partner', 'pending', 'Sam'),
+        ]);
+
+        const { live } = splitHabitsByPactState([goal('goal-1')], [activePact], [activePact], 'me');
+
+        expect(live[0].partnerNames).toEqual(['Dana']);
+    });
+
+    it('tolerates pacts that arrive without hydrated members', () => {
+        const pendingPact = pact('pact-1', 'goal-1', 'pending', undefined as any);
+
+        const { live, pending } = splitHabitsByPactState([goal('goal-1')], [], [pendingPact], 'me');
+
+        expect(live).toHaveLength(0);
+        expect(pending[0].awaitingPartnerNames).toEqual([]);
+    });
+});

--- a/TherrMobile/main/components/Habits/HabitCard.tsx
+++ b/TherrMobile/main/components/Habits/HabitCard.tsx
@@ -13,6 +13,16 @@ interface IHabitCardProps {
     onCheckin?: () => void;
     isCheckinLoading?: boolean;
     showStreak?: boolean;
+    /**
+     * Set when the habit's only pacts are still awaiting an invitee's
+     * acceptance. The card then explains who it is waiting on instead of
+     * offering a check-in for a pact that has not started.
+     */
+    isAwaitingPartner?: boolean;
+    /** Invitees yet to accept. May be empty when their names are unknown. */
+    awaitingPartnerNames?: string[];
+    /** Partners already checked into this habit's active pact. */
+    partnerNames?: string[];
     themeHabits: {
         colors: ITherrThemeColors;
         styles: any;
@@ -60,6 +70,9 @@ const HabitCard: React.FC<IHabitCardProps> = ({
     onCheckin,
     isCheckinLoading = false,
     showStreak = true,
+    isAwaitingPartner = false,
+    awaitingPartnerNames,
+    partnerNames,
     themeHabits,
     translate,
 }) => {
@@ -92,7 +105,15 @@ const HabitCard: React.FC<IHabitCardProps> = ({
                 </View>
             )}
 
-            {showStreak && streak && streak.currentStreak > 0 && (
+            {!!partnerNames?.length && (
+                <Text style={themeHabits.styles.habitCardPartnerText}>
+                    {translate('pages.habits.pactWithPartners', {
+                        partners: partnerNames.join(', '),
+                    })}
+                </Text>
+            )}
+
+            {showStreak && !isAwaitingPartner && streak && streak.currentStreak > 0 && (
                 <StreakWidget
                     streak={streak}
                     themeHabits={themeHabits}
@@ -100,7 +121,17 @@ const HabitCard: React.FC<IHabitCardProps> = ({
                 />
             )}
 
-            {onCheckin && (
+            {isAwaitingPartner && (
+                <Text style={themeHabits.styles.habitCardAwaitingText}>
+                    {awaitingPartnerNames?.length
+                        ? translate('pages.habits.awaitingPartnerAcceptance', {
+                            partners: awaitingPartnerNames.join(', '),
+                        })
+                        : translate('pages.habits.awaitingAnyPartnerAcceptance')}
+                </Text>
+            )}
+
+            {onCheckin && !isAwaitingPartner && (
                 <View style={themeHabits.styles.habitCardFooter}>
                     <CheckinButton
                         isCompleted={isCompleted}

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1857,6 +1857,10 @@
       "completed": "Completed!",
       "noHabitsTitle": "No habits yet",
       "noHabitsSubtitle": "Create a habit to start tracking your progress",
+      "pendingHabits": "Waiting on Partners",
+      "pactWithPartners": "Pact with {partners}",
+      "awaitingPartnerAcceptance": "Waiting for {partners} to accept before this pact starts.",
+      "awaitingAnyPartnerAcceptance": "Waiting for your invite to be accepted before this pact starts.",
       "habitNotFound": "Habit not found",
       "checkinProof": {
         "title": "Check In",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1857,6 +1857,10 @@
       "completed": "¡Completado!",
       "noHabitsTitle": "Aún no hay hábitos",
       "noHabitsSubtitle": "Crea un hábito para comenzar a seguir tu progreso",
+      "pendingHabits": "Esperando a los compañeros",
+      "pactWithPartners": "Pacto con {partners}",
+      "awaitingPartnerAcceptance": "Esperando a que {partners} acepte para que comience este pacto.",
+      "awaitingAnyPartnerAcceptance": "Esperando a que se acepte tu invitación para que comience este pacto.",
       "habitNotFound": "Hábito no encontrado",
       "checkinProof": {
         "title": "Registrar",

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -1857,6 +1857,10 @@
       "completed": "Complété!",
       "noHabitsTitle": "Aucune habitude pour le moment",
       "noHabitsSubtitle": "Créez une habitude pour commencer à suivre vos progrès",
+      "pendingHabits": "En attente des partenaires",
+      "pactWithPartners": "Pacte avec {partners}",
+      "awaitingPartnerAcceptance": "En attente de l'acceptation de {partners} pour démarrer ce pacte.",
+      "awaitingAnyPartnerAcceptance": "En attente de l'acceptation de votre invitation pour démarrer ce pacte.",
       "habitNotFound": "Habitude introuvable",
       "checkinProof": {
         "title": "Enregistrer",

--- a/TherrMobile/main/routes/Habits/Dashboard.tsx
+++ b/TherrMobile/main/routes/Habits/Dashboard.tsx
@@ -20,12 +20,14 @@ import { ISelectedProofImage } from '../../components/Habits/CheckinProofSheet';
 import PactOnboardingGuard from '../../components/Habits/PactOnboardingGuard';
 import { signImageUrl } from '../../utilities/content';
 import { showToast } from '../../utilities/toasts';
+import { IHabitWithPactState, splitHabitsByPactState } from './pactState';
 
 interface IHabitsDashboardDispatchProps {
     getUserGoals: Function;
     getTodayCheckins: Function;
     getActiveStreaks: Function;
     getActivePacts: Function;
+    getUserPacts: Function;
     createCheckin: Function;
 }
 
@@ -55,6 +57,7 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
     getTodayCheckins: HabitActions.getTodayCheckins,
     getActiveStreaks: HabitActions.getActiveStreaks,
     getActivePacts: HabitActions.getActivePacts,
+    getUserPacts: HabitActions.getUserPacts,
     createCheckin: HabitActions.createCheckin,
 }, dispatch);
 
@@ -105,7 +108,7 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
 
     handleRefresh = () => {
         const {
-            getUserGoals, getTodayCheckins, getActiveStreaks, getActivePacts,
+            getUserGoals, getTodayCheckins, getActiveStreaks, getActivePacts, getUserPacts,
         } = this.props;
 
         this.setState({ isRefreshing: true });
@@ -115,6 +118,9 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
             getTodayCheckins(),
             getActiveStreaks(),
             getActivePacts(),
+            // Needed to tell a habit whose pact is live apart from one whose
+            // invite is still outstanding — getActivePacts only returns the former.
+            getUserPacts(),
         ]).finally(() => {
             this.setState({ isRefreshing: false });
         });
@@ -215,6 +221,17 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
         return habits.activeStreaks.find((s: IStreak) => s.habitGoalId === habitGoalId);
     };
 
+    getHabitsByPactState = () => {
+        const { habits, user } = this.props;
+
+        return splitHabitsByPactState(
+            habits.habitGoals || [],
+            habits.activePacts || [],
+            habits.pacts || [],
+            user.details?.id,
+        );
+    };
+
     getGreeting = (): string => {
         const hour = new Date().getHours();
         if (hour < 12) {return this.translate('pages.habits.greetingMorning');}
@@ -222,58 +239,55 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
         return this.translate('pages.habits.greetingEvening');
     };
 
-    renderHabitsList = () => {
-        const { habits } = this.props;
+    renderEmptyState = () => (
+        <View style={this.themeHabits.styles.emptyStateContainer}>
+            <Text style={this.themeHabits.styles.emptyStateEmoji}>{'\uD83C\uDFAF'}</Text>
+            <Text style={this.themeHabits.styles.emptyStateTitle}>
+                {this.translate('pages.habits.noHabitsTitle')}
+            </Text>
+            <Text style={this.themeHabits.styles.emptyStateSubtitle}>
+                {this.translate('pages.habits.noHabitsSubtitle')}
+            </Text>
+        </View>
+    );
+
+    renderHabitCard = ({ goal, partnerNames, awaitingPartnerNames }: IHabitWithPactState, isAwaitingPartner: boolean) => {
         const { checkinLoadingIds } = this.state;
-        const { habitGoals } = habits;
 
-        if (!habitGoals || habitGoals.length === 0) {
-            return (
-                <View style={this.themeHabits.styles.emptyStateContainer}>
-                    <Text style={this.themeHabits.styles.emptyStateEmoji}>{'\uD83C\uDFAF'}</Text>
-                    <Text style={this.themeHabits.styles.emptyStateTitle}>
-                        {this.translate('pages.habits.noHabitsTitle')}
-                    </Text>
-                    <Text style={this.themeHabits.styles.emptyStateSubtitle}>
-                        {this.translate('pages.habits.noHabitsSubtitle')}
-                    </Text>
-                </View>
-            );
-        }
-
-        return habitGoals.map((goal: IHabitGoal) => {
-            const todayCheckin = this.getTodayCheckinForHabit(goal.id);
-            const streak = this.getStreakForHabit(goal.id);
-
-            return (
-                <HabitCard
-                    key={goal.id}
-                    habitGoal={goal}
-                    todayCheckin={todayCheckin}
-                    streak={streak}
-                    onPress={() => this.handleHabitPress(goal)}
-                    onCheckin={() => this.handleCheckin(goal)}
-                    isCheckinLoading={checkinLoadingIds.has(goal.id)}
-                    showStreak={true}
-                    themeHabits={this.themeHabits}
-                    translate={this.translate}
-                />
-            );
-        });
+        return (
+            <HabitCard
+                key={goal.id}
+                habitGoal={goal}
+                todayCheckin={this.getTodayCheckinForHabit(goal.id)}
+                streak={this.getStreakForHabit(goal.id)}
+                onPress={() => this.handleHabitPress(goal)}
+                onCheckin={() => this.handleCheckin(goal)}
+                isCheckinLoading={checkinLoadingIds.has(goal.id)}
+                showStreak={true}
+                isAwaitingPartner={isAwaitingPartner}
+                awaitingPartnerNames={awaitingPartnerNames}
+                partnerNames={partnerNames}
+                themeHabits={this.themeHabits}
+                translate={this.translate}
+            />
+        );
     };
 
-    renderOverallProgress = () => {
+    renderOverallProgress = (liveHabits: IHabitWithPactState[]) => {
         const { habits } = this.props;
-        const { activeStreaks, todayCheckins, habitGoals } = habits;
+        const { activeStreaks, todayCheckins } = habits;
 
-        if (!habitGoals || habitGoals.length === 0) {
+        if (liveHabits.length === 0) {
             return null;
         }
 
+        // Only habits with a live pact are checkin-able, so counting the
+        // pending ones in the denominator would make "today" unreachable.
+        const liveGoalIds = liveHabits.map(({ goal }) => goal.id);
         const completedToday = todayCheckins.filter(
-            (c: IHabitCheckin) => c.status === 'completed',
+            (c: IHabitCheckin) => c.status === 'completed' && liveGoalIds.includes(c.habitGoalId),
         ).length;
-        const totalHabits = habitGoals.length;
+        const totalHabits = liveHabits.length;
         const longestStreak = activeStreaks.reduce(
             (max: number, s: IStreak) => Math.max(max, s.currentStreak),
             0,
@@ -306,6 +320,8 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
     render() {
         const { navigation, user } = this.props;
         const { isRefreshing, proofSheetHabit, isSubmittingCheckin } = this.state;
+        const { live, pending } = this.getHabitsByPactState();
+        const hasAnyHabits = live.length > 0 || pending.length > 0;
 
         return (
             <PactOnboardingGuard navigation={navigation}>
@@ -328,14 +344,27 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
                             </Text>
                         </View>
 
-                        {this.renderOverallProgress()}
+                        {this.renderOverallProgress(live)}
 
-                        <View style={this.themeHabits.styles.dashboardSection}>
-                            <Text style={this.themeHabits.styles.dashboardSectionTitle}>
-                                {this.translate('pages.habits.yourHabits')}
-                            </Text>
-                            {this.renderHabitsList()}
-                        </View>
+                        {!hasAnyHabits && this.renderEmptyState()}
+
+                        {live.length > 0 && (
+                            <View style={this.themeHabits.styles.dashboardSection}>
+                                <Text style={this.themeHabits.styles.dashboardSectionTitle}>
+                                    {this.translate('pages.habits.yourHabits')}
+                                </Text>
+                                {live.map((habit) => this.renderHabitCard(habit, false))}
+                            </View>
+                        )}
+
+                        {pending.length > 0 && (
+                            <View style={this.themeHabits.styles.dashboardSection}>
+                                <Text style={this.themeHabits.styles.dashboardSectionTitle}>
+                                    {this.translate('pages.habits.pendingHabits')}
+                                </Text>
+                                {pending.map((habit) => this.renderHabitCard(habit, true))}
+                            </View>
+                        )}
                     </ScrollView>
                 </SafeAreaView>
                 <MainButtonMenu

--- a/TherrMobile/main/routes/Habits/pactState.ts
+++ b/TherrMobile/main/routes/Habits/pactState.ts
@@ -1,0 +1,80 @@
+import { IHabitGoal, IPact, IPactMember } from 'therr-react/types';
+
+/**
+ * A habit goal paired with the state of the pact(s) it belongs to. A goal is
+ * only checkin-able once one of its pacts is live; while every pact is still
+ * awaiting an invitee, the habit is listed separately as pending.
+ *
+ * Kept free of react-native imports so it stays unit-testable without the
+ * native module graph the dashboard route pulls in.
+ */
+export interface IHabitWithPactState {
+    goal: IHabitGoal;
+    partnerNames: string[];
+    awaitingPartnerNames: string[];
+}
+
+const getMemberDisplayName = (member: IPactMember): string => {
+    const fullName = `${member.firstName || ''} ${member.lastName || ''}`.trim();
+    return fullName || member.userName || '';
+};
+
+/**
+ * Names of everyone but the current user who is a partner on the given pacts,
+ * optionally narrowed to a single membership status.
+ */
+export const getPartnerNames = (
+    pacts: IPact[],
+    currentUserId?: string,
+    memberStatus?: string,
+): string[] => pacts.reduce((acc: string[], pact: IPact) => {
+    (pact.members || []).forEach((member: IPactMember) => {
+        if (member.userId === currentUserId || member.role !== 'partner') {
+            return;
+        }
+        if (memberStatus && member.status !== memberStatus) {
+            return;
+        }
+        const name = getMemberDisplayName(member);
+        if (name && !acc.includes(name)) {
+            acc.push(name);
+        }
+    });
+    return acc;
+}, []);
+
+/**
+ * Splits the habit list by whether its pact has started. Goals with no pact at
+ * all are treated as live so a habit can never become un-checkin-able through
+ * missing pact data.
+ */
+export const splitHabitsByPactState = (
+    habitGoals: IHabitGoal[],
+    activePacts: IPact[],
+    allPacts: IPact[],
+    currentUserId?: string,
+): { live: IHabitWithPactState[]; pending: IHabitWithPactState[] } => habitGoals.reduce(
+    (acc: { live: IHabitWithPactState[]; pending: IHabitWithPactState[] }, goal) => {
+        const goalActivePacts = activePacts.filter((p) => p.habitGoalId === goal.id);
+        const goalPendingPacts = allPacts.filter(
+            (p) => p.habitGoalId === goal.id && p.status === 'pending',
+        );
+
+        if (goalActivePacts.length > 0 || goalPendingPacts.length === 0) {
+            acc.live.push({
+                goal,
+                partnerNames: getPartnerNames(goalActivePacts, currentUserId, 'active'),
+                awaitingPartnerNames: [],
+            });
+        } else {
+            acc.pending.push({
+                goal,
+                partnerNames: [],
+                awaitingPartnerNames: getPartnerNames(goalPendingPacts, currentUserId),
+            });
+        }
+
+        return acc;
+    },
+    { live: [], pending: [] },
+);

--- a/TherrMobile/main/styles/habits/index.ts
+++ b/TherrMobile/main/styles/habits/index.ts
@@ -183,6 +183,22 @@ const buildStyles = (themeName?: IMobileThemeName) => {
             borderTopWidth: 1,
             borderTopColor: therrTheme.colors.primary4,
         },
+        habitCardPartnerText: {
+            fontFamily: therrFontFamily,
+            fontSize: 13,
+            color: therrTheme.colors.textGray,
+            marginTop: 8,
+        },
+        habitCardAwaitingText: {
+            fontFamily: therrFontFamily,
+            fontSize: 13,
+            fontStyle: 'italic',
+            color: therrTheme.colors.textGray,
+            marginTop: 16,
+            paddingTop: 12,
+            borderTopWidth: 1,
+            borderTopColor: therrTheme.colors.primary4,
+        },
 
         // Calendar
         calendarContainer: {


### PR DESCRIPTION
Mobile half of a two-PR fix. The backend half targets `general` in #2686.

**This PR alone does not fully fix the report** — #2686 is what makes an accepted pact's goal appear in the list at all. This PR fixes how the list is rendered once it is correct.

## Problem

The dashboard rendered `habits.habitGoals` with no knowledge of the pacts behind them, so every habit got a live "Check In" button — including habits whose pact was still waiting on an invitee to accept. Reported as: *"it lists two pending pacts and lets me check in but doesn't show the active pact."*

## Changes

**`main/routes/Habits/pactState.ts`** (new) — `splitHabitsByPactState` pairs each goal with the state of its pacts and splits the list. Kept free of react-native imports so it is unit-testable without the native module graph the route pulls in.

**`main/routes/Habits/Dashboard.tsx`** — renders two sections: habits with a live pact (check-in button, partners named) and a "Waiting on Partners" section for habits whose pacts are all still outstanding. Today's progress ratio counts only checkin-able habits, so it stays reachable. Also fetches `getUserPacts` on refresh — `getActivePacts` alone cannot distinguish a pending pact from an absent one.

**`main/components/Habits/HabitCard.tsx`** — new `isAwaitingPartner` / `awaitingPartnerNames` / `partnerNames` props. While awaiting, the card explains who it is waiting on instead of offering a check-in. The pending state is driven by an explicit flag rather than by whether names resolved, so an unnamed invitee cannot flip the card back to checkin-able.

A habit with no pacts at all is treated as live, so a habit can never be stranded by missing pact data.

## Behavior change worth a look

Check-in is now **hidden** for habits whose pacts are all pending, on the reading that checking in against a pact that has not started is the bug. The alternative — keep the button and only relabel the card — is a small change if that is preferred.

## Testing

- `TherrMobile/__tests__/routes/HabitsDashboardPactState.test.ts` — 8 tests, including the exact reported scenario (two outstanding invites plus one accepted pact).
- Full mobile suite: 1157 passing.
- `npm run pr:tsc-baseline:mobile`: 108 errors vs 108 baseline, no new errors.
- eslint clean; `npm run locales:check` clean (4 new keys across `en-us`, `es`, `fr-ca`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cxwq2aHoKh1tsAigiFT6Hc)_