### PR TITLE
Link habits landing to the Google Play listing; fix wrong app on verify page

### DIFF
--- a/therr-client-web/src/views/habits/landing.hbs
+++ b/therr-client-web/src/views/habits/landing.hbs
@@ -98,11 +98,6 @@
             text-decoration: none;
             color: #fff;
         }
-        .cta--placeholder {
-            background: var(--habits-text-muted);
-            cursor: not-allowed;
-        }
-        .cta--placeholder:hover { background: var(--habits-text-muted); }
         .cta-note {
             font-size: 0.875rem;
             color: var(--habits-text-muted);
@@ -215,8 +210,14 @@
             <div class="container">
                 <h1>Habits that stick when a friend's on the hook too.</h1>
                 <p class="lede">Most habit apps let you give up in private. Friends with Habits doesn't. Pact with a friend, check in daily, and keep each other on streak.</p>
-                <a class="cta cta--placeholder" href="#" aria-disabled="true">Coming soon to Google Play</a>
-                <div class="cta-note">Internal testing in progress. iOS coming next.</div>
+                <!--
+                    Friends with Habits applicationId — NOT app.therrmobile. Sending a
+                    visitor to the Therr listing installs an app that cannot open a
+                    Friends with Habits account. Hardcoded rather than interpolated
+                    because Handlebars escapes '=' in an attribute to &#x3D;.
+                -->
+                <a class="cta" href="https://play.google.com/store/apps/details?id=com.therr.habits" rel="noopener">Get it on Google Play</a>
+                <div class="cta-note">Free to install &mdash; currently in open testing on Google Play. iOS coming next.</div>
             </div>
         </section>
 

--- a/therr-client-web/src/views/habits/verify-account.hbs
+++ b/therr-client-web/src/views/habits/verify-account.hbs
@@ -162,13 +162,19 @@
                 <h1>You&rsquo;re in.</h1>
                 <div class="alert alert--success">Email verified. Open the Friends with Habits app to start your first pact.</div>
                 <p class="lede">Already installed? Open the app and sign in &mdash; you&rsquo;re all set.</p>
-                <a class="cta" href="https://play.google.com/store/apps/details?id=app.therrmobile" rel="noopener">Get the app</a>
+                <!--
+                    Friends with Habits applicationId — NOT app.therrmobile. The Therr
+                    listing installs an app that cannot open the account just verified
+                    here. Hardcoded rather than interpolated because Handlebars escapes
+                    '=' in an attribute to &#x3D;.
+                -->
+                <a class="cta" href="https://play.google.com/store/apps/details?id=com.therr.habits" rel="noopener">Get the app</a>
             </div>
 
             <div id="state-already-verified" hidden>
                 <h1>Already verified</h1>
                 <div class="alert alert--info">This account&rsquo;s email is already confirmed. Open the app and sign in.</div>
-                <a class="cta" href="https://play.google.com/store/apps/details?id=app.therrmobile" rel="noopener">Get the app</a>
+                <a class="cta" href="https://play.google.com/store/apps/details?id=com.therr.habits" rel="noopener">Get the app</a>
             </div>
 
             <div id="state-failed" hidden>


### PR DESCRIPTION
habits.therr.com's landing page still showed a disabled "Coming soon to
Google Play" button with the note "Internal testing in progress. iOS coming
next." Friends with Habits is now in open testing, so the listing is public
and installable.

- landing.hbs: replace the disabled placeholder CTA with a real link to
  play.google.com/store/apps/details?id=com.therr.habits, and reword the
  note to "Free to install — currently in open testing on Google Play.
  iOS coming next." Drop the now-unused .cta--placeholder CSS.
- verify-account.hbs: both "Get the app" CTAs pointed at app.therrmobile,
  which installs Therr rather than Friends with Habits — the account just
  verified on that page cannot be opened there. Point them at
  com.therr.habits, matching invite.hbs and ClaimPactLanding.tsx.

The applicationId is the one pinned by
therr-client-web/src/_static/.well-known/assetlinks.habits.json and already
shipping in invite.hbs and ClaimPactLanding.tsx.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B8vs8Q2k2CDLbz7D3FJ3jb