### PR TITLE
fix(habits): repair push notifications on Friends with Habits

### DIFF
--- a/TherrMobile/__tests__/androidNotificationIntentFilters.test.ts
+++ b/TherrMobile/__tests__/androidNotificationIntentFilters.test.ts
@@ -1,0 +1,155 @@
+import fs from 'fs';
+import path from 'path';
+
+// Note: import explicitly to use the types shipped with jest.
+import { it, describe, expect } from '@jest/globals';
+
+/**
+ * Guards the coupling between the backend's push-notification click actions and the
+ * Android manifest.
+ *
+ * push-notifications-service stamps `android.notification.clickAction` onto every FCM
+ * display notification, using the per-brand strings in `AndroidIntentActions`
+ * (therr-js-utilities). The Firebase SDK turns that into
+ * `new Intent(action).setPackage(applicationId)`. When no activity declares the action,
+ * the notification still posts — so nothing looks broken from the server side — but
+ * tapping it does nothing at all.
+ *
+ * That is exactly how Friends with Habits shipped: the manifest hardcoded the
+ * `app.therrmobile.*` (Therr) prefix while its backend sent `com.therr.mobile.habits.*`,
+ * so not one notification on the app was tappable.
+ *
+ * These assertions read the real manifest and build.gradle rather than a copy, so they
+ * fail if either the prefix mapping or the action list drifts from the enum again.
+ *
+ * The action-name list is intentionally duplicated here rather than imported from
+ * therr-js-utilities: this suite has to keep working when the shared library's `lib/`
+ * output is stale, and a literal list is what makes an accidental deletion from the
+ * enum visible instead of silently shrinking the expectation set.
+ */
+
+const ANDROID_APP_DIR = path.resolve(__dirname, '../android/app');
+const MANIFEST_PATH = path.join(ANDROID_APP_DIR, 'src/main/AndroidManifest.xml');
+const BUILD_GRADLE_PATH = path.join(ANDROID_APP_DIR, 'build.gradle');
+
+const manifest = fs.readFileSync(MANIFEST_PATH, 'utf8');
+const buildGradle = fs.readFileSync(BUILD_GRADLE_PATH, 'utf8');
+
+// Every IntentActionKey in therr-js-utilities' PushNotifications module.
+const INTENT_ACTION_KEYS = [
+    'ACHIEVEMENT_COMPLETED',
+    'CREATE_YOUR_PROFILE_REMINDER',
+    'CREATE_A_MOMENT_REMINDER',
+    'COMPLETE_DRAFT_REMINDER',
+    'LATEST_POST_LIKES_STATS',
+    'LATEST_POST_VIEWCOUNT_STATS',
+    'NEW_AREAS_ACTIVATED',
+    'NUDGE_SPACE_ENGAGEMENT',
+    'POST_VISIT_REVIEW_REMINDER',
+    'NEW_CONNECTION',
+    'NEW_CONNECTION_REQUEST',
+    'NEW_DIRECT_MESSAGE',
+    'NEW_GROUP_MESSAGE',
+    'NEW_GROUP_INVITE',
+    'NEW_GROUP_MEMBERS',
+    'NEW_LIKE_RECEIVED',
+    'NEW_THOUGHT_REPLY_RECEIVED',
+    'NEW_SUPER_LIKE_RECEIVED',
+    'UNREAD_NOTIFICATIONS_REMINDER',
+    'UNCLAIMED_ACHIEVEMENTS_REMINDER',
+    'INVITE_FRIENDS_REMINDER',
+    'REPORT_CONFIRMED',
+    'LEADERBOARD_RANK_MILESTONE',
+];
+
+// HABITS-only keys. These are the retention loop — the whole reason the app exists —
+// and they were the ones most conspicuously absent from the manifest.
+const HABITS_INTENT_ACTION_KEYS = [
+    'PACT_INVITATION',
+    'PACT_NUDGE',
+    'PACT_ACCEPTED',
+    'PACT_DECLINED',
+    'PACT_COMPLETED',
+    'PACT_EXPIRING',
+    'PARTNER_CHECKED_IN',
+    'PARTNER_MISSED_DAY',
+    'PARTNER_CELEBRATED',
+    'STREAK_MILESTONE',
+    'STREAK_AT_RISK',
+    'STREAK_BROKEN',
+    'NEW_PERSONAL_RECORD',
+    'DAILY_HABIT_REMINDER',
+    'MORNING_MOTIVATION',
+    'EVENING_CHECK_IN',
+];
+
+const declaredActions = new Set(
+    Array.from(manifest.matchAll(/<action android:name="([^"]+)"\s*\/>/g)).map((m) => m[1]),
+);
+
+describe('AndroidManifest push-notification intent filters', () => {
+    it('declares an intent filter for every shared intent action key', () => {
+        const missing = INTENT_ACTION_KEYS.filter(
+            (key) => !declaredActions.has(`\${notificationActionPrefix}.${key}`),
+        );
+
+        expect(missing).toEqual([]);
+    });
+
+    it('declares an intent filter for every HABITS intent action key', () => {
+        const missing = HABITS_INTENT_ACTION_KEYS.filter(
+            (key) => !declaredActions.has(`\${notificationActionPrefix}.${key}`),
+        );
+
+        expect(missing).toEqual([]);
+    });
+
+    it('uses the brand placeholder, never a hardcoded brand prefix, for notification actions', () => {
+        // The app-shortcut actions are deliberately exempt: res/xml/shortcuts.xml cannot
+        // expand manifest placeholders, so those two stay literal on every brand.
+        const shortcutActions = ['app.therrmobile.QUICK_CREATE_MOMENT', 'app.therrmobile.QUICK_CREATE_THOUGHT'];
+        const hardcoded = Array.from(declaredActions).filter(
+            (action) => /^(app\.therrmobile|com\.therr\.mobile)\./.test(action)
+                && !shortcutActions.includes(action),
+        );
+
+        expect(hardcoded).toEqual([]);
+    });
+
+    it('keeps the shortcut intent filters literal so res/xml/shortcuts.xml still resolves', () => {
+        expect(declaredActions.has('app.therrmobile.QUICK_CREATE_MOMENT')).toBe(true);
+        expect(declaredActions.has('app.therrmobile.QUICK_CREATE_THOUGHT')).toBe(true);
+    });
+});
+
+describe('build.gradle notificationActionPrefix placeholder', () => {
+    it('defines the placeholder the manifest interpolates', () => {
+        expect(buildGradle).toContain('notificationActionPrefix:');
+    });
+
+    it('maps the Habits applicationId to the prefix its backend actually sends', () => {
+        // Deliberately not derived from applicationId: Habits ships as `com.therr.habits`
+        // but publishes `com.therr.mobile.habits.*` actions.
+        expect(buildGradle).toMatch(/'com\.therr\.habits':\s*'com\.therr\.mobile\.habits'/);
+    });
+
+    it('falls back to the Therr prefix for any unmapped applicationId', () => {
+        expect(buildGradle).toMatch(/getOrDefault\(applicationId, 'app\.therrmobile'\)/);
+    });
+
+    it('resolves to the Habits prefix for this build', () => {
+        // This branch builds Friends with Habits. If applicationId ever changes without
+        // a matching entry in notificationActionPrefixByAppId, the app silently reverts
+        // to Therr actions and every notification becomes untappable again.
+        const applicationIdMatch = buildGradle.match(/applicationId "([^"]+)"/);
+        expect(applicationIdMatch).not.toBeNull();
+
+        const applicationId = applicationIdMatch![1];
+        const prefixEntry = buildGradle.match(
+            new RegExp(`'${applicationId.replace(/\./g, '\\.')}':\\s*'([^']+)'`),
+        );
+
+        expect(prefixEntry).not.toBeNull();
+        expect(prefixEntry![1]).toBe('com.therr.mobile.habits');
+    });
+});

--- a/TherrMobile/__tests__/utilities/habitsPushChannelRouting.test.ts
+++ b/TherrMobile/__tests__/utilities/habitsPushChannelRouting.test.ts
@@ -1,0 +1,95 @@
+import 'react-native';
+
+// Note: import explicitly to use the types shipped with jest.
+import { it, describe, expect, jest } from '@jest/globals';
+
+import { AndroidChannelIds, getAndroidChannelFromClickActionId } from '../../main/constants';
+
+// Notifee reaches for its native module at import time, which throws under Jest.
+// Only the importance enum is read at module scope in main/constants.
+// babel-plugin-jest-hoist lifts this above the import above.
+jest.mock('@notifee/react-native', () => ({
+    __esModule: true,
+    default: {},
+    AndroidImportance: {
+        NONE: 0, MIN: 1, LOW: 2, DEFAULT: 3, HIGH: 4,
+    },
+}));
+
+/**
+ * Channel routing for the HABITS push notifications.
+ *
+ * Every HABITS notification used to fall through to the `default` channel ("General"),
+ * because `REMINDER_ACTION_KEYS` / `REWARD_ACTION_KEYS` only listed the Therr social
+ * actions. The three habit-specific channels the app creates — "Habit Reminders",
+ * "Streak Updates", "Friend Activity" — existed but nothing was ever routed to them,
+ * so streak-at-risk and pact invites posted silently alongside everything else.
+ *
+ * Unlike the older pushNotifications suite (which re-implements the mapping inline),
+ * this imports the real function, so a regression here fails the build.
+ */
+
+const habitsAction = (key: string) => `com.therr.mobile.habits.${key}`;
+const therrAction = (key: string) => `app.therrmobile.${key}`;
+
+describe('getAndroidChannelFromClickActionId — HABITS actions', () => {
+    describe('time-sensitive nudges route to the reminders channel', () => {
+        it.each([
+            'STREAK_AT_RISK',
+            'PACT_INVITATION',
+            'PACT_NUDGE',
+            'PACT_EXPIRING',
+        ])('%s', (key) => {
+            expect(getAndroidChannelFromClickActionId(habitsAction(key)).id)
+                .toBe(AndroidChannelIds.reminders);
+        });
+    });
+
+    describe('milestones route to the rewardUpdates ("Streak Updates") channel', () => {
+        it.each([
+            'STREAK_MILESTONE',
+            'NEW_PERSONAL_RECORD',
+            'LEADERBOARD_RANK_MILESTONE',
+        ])('%s', (key) => {
+            expect(getAndroidChannelFromClickActionId(habitsAction(key)).id)
+                .toBe(AndroidChannelIds.rewardUpdates);
+        });
+    });
+
+    describe('partner activity routes to the contentDiscovery ("Friend Activity") channel', () => {
+        it.each([
+            'PARTNER_CHECKED_IN',
+            'PARTNER_MISSED_DAY',
+            'PARTNER_CELEBRATED',
+            'PACT_ACCEPTED',
+            'PACT_COMPLETED',
+        ])('%s', (key) => {
+            expect(getAndroidChannelFromClickActionId(habitsAction(key)).id)
+                .toBe(AndroidChannelIds.contentDiscovery);
+        });
+    });
+
+    it('classifies by action suffix, so a key resolves identically across brand prefixes', () => {
+        expect(getAndroidChannelFromClickActionId(habitsAction('NEW_DIRECT_MESSAGE')).id)
+            .toBe(getAndroidChannelFromClickActionId(therrAction('NEW_DIRECT_MESSAGE')).id);
+    });
+
+    it('still falls back to the default channel for an unrecognized action', () => {
+        expect(getAndroidChannelFromClickActionId(habitsAction('SOMETHING_NEW')).id)
+            .toBe(AndroidChannelIds.default);
+    });
+
+    it('tolerates a missing or malformed click action', () => {
+        expect(getAndroidChannelFromClickActionId('').id).toBe(AndroidChannelIds.default);
+        expect(getAndroidChannelFromClickActionId(undefined as any).id).toBe(AndroidChannelIds.default);
+    });
+
+    it('carries the channel\'s declared importance through, rather than a flat default', () => {
+        // sendForegroundNotification now creates the channel with this importance instead
+        // of overriding it, so a wrong value here silences the retention loop.
+        const reminders = getAndroidChannelFromClickActionId(habitsAction('STREAK_AT_RISK'));
+        const partnerActivity = getAndroidChannelFromClickActionId(habitsAction('PARTNER_CHECKED_IN'));
+
+        expect(reminders.importance).toBeGreaterThan(partnerActivity.importance as number);
+    });
+});

--- a/TherrMobile/__tests__/utilities/permissionsOrchestratorCustomPrimer.test.ts
+++ b/TherrMobile/__tests__/utilities/permissionsOrchestratorCustomPrimer.test.ts
@@ -1,0 +1,184 @@
+import 'react-native';
+
+// Note: import explicitly to use the types shipped with jest.
+import { it, describe, expect, beforeEach, jest } from '@jest/globals';
+
+/**
+ * `requestAfterCustomPrimer` — the entry point for screens that render their own
+ * full-screen explainer instead of the shared primer modal.
+ *
+ * The HABITS onboarding push opt-in screen used to call
+ * `PermissionsAndroid.request` / `notifee.requestPermission()` directly. That asks
+ * the OS correctly, but nothing else in the app finds out: Layout registers the FCM
+ * device token from `permissions.onGranted('notifications')`, so a brand-new user who
+ * tapped "Enable" had no device token stored server-side until their next cold start
+ * — no push notifications at all for the rest of that session. And because
+ * `osAskedAt` was never stamped, the second-session fallback re-prompted someone who
+ * had already answered.
+ */
+
+const mockHasPermission = jest.fn();
+const mockRequestPermission = jest.fn();
+const mockNotifeeRequestPermission = jest.fn();
+const mockAndroidRequest = jest.fn();
+const mockSecureGetItem = jest.fn();
+const mockSecureSetItem = jest.fn();
+
+const AUTHORIZED = 1;
+const DENIED = 0;
+
+jest.mock('@react-native-firebase/messaging', () => ({
+    AuthorizationStatus: { NOT_DETERMINED: -1, DENIED: 0, AUTHORIZED: 1, PROVISIONAL: 2 },
+    getMessaging: () => ({}),
+    hasPermission: (...args: any[]) => mockHasPermission(...args),
+    requestPermission: (...args: any[]) => mockRequestPermission(...args),
+}));
+
+jest.mock('@notifee/react-native', () => ({
+    __esModule: true,
+    default: { requestPermission: (...args: any[]) => mockNotifeeRequestPermission(...args) },
+}));
+
+jest.mock('../../main/utilities/SecureStorage', () => ({
+    __esModule: true,
+    default: {
+        getItem: (...args: any[]) => mockSecureGetItem(...args),
+        setItem: (...args: any[]) => mockSecureSetItem(...args),
+    },
+}));
+
+jest.mock('react-native-permissions', () => ({
+    check: jest.fn(),
+    PERMISSIONS: { IOS: {}, ANDROID: {} },
+    RESULTS: { GRANTED: 'granted', BLOCKED: 'blocked', DENIED: 'denied' },
+}));
+
+jest.mock('../../main/utilities/requestOSPermissions', () => ({
+    requestOSCameraPermissions: jest.fn(),
+    requestOSContactsPermissions: jest.fn(),
+}));
+
+jest.mock('react-native', () => ({
+    Platform: { OS: 'android', Version: 34 },
+    PermissionsAndroid: {
+        PERMISSIONS: { POST_NOTIFICATIONS: 'android.permission.POST_NOTIFICATIONS' },
+        request: (...args: any[]) => mockAndroidRequest(...args),
+    },
+}));
+
+// Re-required per test so the orchestrator's module-level state cache and granted-listener
+// registry start clean; jest.resetModules() in beforeEach is what makes that work.
+const loadOrchestrator = () => require('../../main/utilities/permissionsOrchestrator');
+
+describe('permissions.requestAfterCustomPrimer', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        mockSecureGetItem.mockResolvedValue(null as never);
+        mockSecureSetItem.mockResolvedValue(undefined as never);
+        mockAndroidRequest.mockResolvedValue('granted' as never);
+        mockNotifeeRequestPermission.mockResolvedValue({} as never);
+        mockRequestPermission.mockResolvedValue(AUTHORIZED as never);
+    });
+
+    it('fires onGranted listeners so Layout registers the FCM device token', async () => {
+        // Denied before the ask, authorized after it — the real opt-in sequence.
+        mockHasPermission
+            .mockResolvedValueOnce(DENIED as never)
+            .mockResolvedValue(AUTHORIZED as never);
+
+        const permissions = loadOrchestrator();
+        const listener = jest.fn();
+        permissions.onGranted('notifications', listener);
+
+        const status = await permissions.default.requestAfterCustomPrimer('notifications', {
+            trigger: 'habitsOnboarding',
+        });
+
+        expect(status).toBe('granted');
+        expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('actually asks the OS rather than assuming the caller did', async () => {
+        mockHasPermission
+            .mockResolvedValueOnce(DENIED as never)
+            .mockResolvedValue(AUTHORIZED as never);
+
+        const permissions = loadOrchestrator();
+        await permissions.default.requestAfterCustomPrimer('notifications', { trigger: 'habitsOnboarding' });
+
+        expect(mockAndroidRequest).toHaveBeenCalledWith('android.permission.POST_NOTIFICATIONS');
+        expect(mockNotifeeRequestPermission).toHaveBeenCalled();
+        expect(mockRequestPermission).toHaveBeenCalled();
+    });
+
+    it('stamps osAskedAt so the second-session fallback does not re-prompt', async () => {
+        mockHasPermission
+            .mockResolvedValueOnce(DENIED as never)
+            .mockResolvedValue(AUTHORIZED as never);
+
+        const permissions = loadOrchestrator();
+        await permissions.default.requestAfterCustomPrimer('notifications', { trigger: 'habitsOnboarding' });
+
+        expect(mockSecureSetItem).toHaveBeenCalled();
+        const persisted = JSON.parse((mockSecureSetItem.mock.calls.at(-1) as any[])[1]);
+        expect(persisted.notifications.osAskedAt).toEqual(expect.any(Number));
+        expect(persisted.notifications.lastStatus).toBe('granted');
+    });
+
+    it('does not show the shared primer modal — the caller is the primer', async () => {
+        mockHasPermission
+            .mockResolvedValueOnce(DENIED as never)
+            .mockResolvedValue(AUTHORIZED as never);
+
+        const permissions = loadOrchestrator();
+        const primerListener = jest.fn();
+        permissions.registerPrimerListener(primerListener);
+
+        await permissions.default.requestAfterCustomPrimer('notifications', { trigger: 'habitsOnboarding' });
+
+        expect(primerListener).not.toHaveBeenCalled();
+    });
+
+    it('reports denial and calls onDenied when the user refuses at the OS prompt', async () => {
+        mockHasPermission.mockResolvedValue(DENIED as never);
+
+        const permissions = loadOrchestrator();
+        const listener = jest.fn();
+        permissions.onGranted('notifications', listener);
+        const onDenied = jest.fn();
+
+        const status = await permissions.default.requestAfterCustomPrimer('notifications', {
+            trigger: 'habitsOnboarding',
+            onDenied,
+        });
+
+        expect(status).toBe('denied');
+        expect(onDenied).toHaveBeenCalledWith('os');
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits when already granted, but still fires the listeners', async () => {
+        mockHasPermission.mockResolvedValue(AUTHORIZED as never);
+
+        const permissions = loadOrchestrator();
+        const listener = jest.fn();
+        permissions.onGranted('notifications', listener);
+
+        const status = await permissions.default.requestAfterCustomPrimer('notifications', {
+            trigger: 'habitsOnboarding',
+        });
+
+        expect(status).toBe('granted');
+        // Token registration must still happen for a user who granted on a previous install.
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(mockAndroidRequest).not.toHaveBeenCalled();
+    });
+
+    it('is callable with no options at all', async () => {
+        mockHasPermission.mockResolvedValue(AUTHORIZED as never);
+
+        const permissions = loadOrchestrator();
+        await expect(permissions.default.requestAfterCustomPrimer('notifications')).resolves.toBe('granted');
+    });
+});

--- a/TherrMobile/android/app/build.gradle
+++ b/TherrMobile/android/app/build.gradle
@@ -103,10 +103,26 @@ android {
             'com.therr.habits': ['habits.therr.com', 'www.habits.therr.com'],
         ]
         def appLinkHosts = appLinkHostsByAppId.getOrDefault(applicationId, ['therr.com', 'www.therr.com'])
+
+        // Prefix for the push-notification click-action intent filters in
+        // AndroidManifest.xml. MUST stay byte-identical to the corresponding enum in
+        // therr-public-library/therr-js-utilities/src/constants/enums/PushNotifications.ts
+        // (`AndroidIntentActions`) — the backend stamps those exact strings onto FCM
+        // display notifications as `android.notification.clickAction`, and an action with
+        // no matching intent-filter makes the notification tap a silent no-op.
+        //
+        // Note this is deliberately NOT derived from applicationId: Habits ships as
+        // `com.therr.habits` but its published intent actions are `com.therr.mobile.habits.*`.
+        def notificationActionPrefixByAppId = [
+            'com.therr.habits': 'com.therr.mobile.habits',
+            'com.therr.mobile.Teem': 'com.therr.mobile',
+        ]
         manifestPlaceholders = [
             GOOGLE_APIS_ANDROID_KEY: "${System.getenv("GOOGLE_APIS_ANDROID_KEY")}",
             appLinkHost: appLinkHosts[0],
             appLinkHostWww: appLinkHosts[1],
+            notificationActionPrefix: notificationActionPrefixByAppId
+                .getOrDefault(applicationId, 'app.therrmobile'),
         ]
         vectorDrawables.useSupportLibrary = true
     }

--- a/TherrMobile/android/app/src/main/AndroidManifest.xml
+++ b/TherrMobile/android/app/src/main/AndroidManifest.xml
@@ -78,80 +78,185 @@
           android:scheme="https"
           android:host="${appLinkHost}" />
       </intent-filter>
+      <!--
+        Push-notification click actions.
+
+        FCM display notifications (push-notifications-service
+        createNotificationMessage) carry an `android.notification.clickAction`.
+        The Firebase SDK turns it into `new Intent(action).setPackage(appId)`;
+        if no activity here declares that action, the notification still posts
+        but tapping it does nothing at all.
+
+        The action prefix is brand-specific — it comes from
+        `PushNotifications.AndroidIntentActions` in therr-js-utilities
+        (Therr: app.therrmobile, Teem: com.therr.mobile,
+        Habits: com.therr.mobile.habits). Hardcoding `app.therrmobile` here
+        meant the Friends with Habits build declared none of the actions its
+        own backend sends, so every reminder, streak and pact notification was
+        untappable. `notificationActionPrefix` is a manifest placeholder keyed
+        off applicationId in app/build.gradle, same pattern as appLinkHost.
+
+        Data-only notifications (createDataOnlyMessage) are rendered locally by
+        Notifee with `launchActivity: 'default'` and do NOT need a filter here —
+        but every type below is listed anyway, so flipping one from data-only to
+        display on the backend can't silently reintroduce the dead-tap bug.
+      -->
       <intent-filter>
-        <action android:name="app.therrmobile.ACHIEVEMENT_COMPLETED" />
+        <action android:name="${notificationActionPrefix}.ACHIEVEMENT_COMPLETED" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.CREATE_YOUR_PROFILE_REMINDER" />
+        <action android:name="${notificationActionPrefix}.CREATE_YOUR_PROFILE_REMINDER" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.CREATE_A_MOMENT_REMINDER" />
+        <action android:name="${notificationActionPrefix}.CREATE_A_MOMENT_REMINDER" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.LATEST_POST_LIKES_STATS" />
+        <action android:name="${notificationActionPrefix}.COMPLETE_DRAFT_REMINDER" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.LATEST_POST_VIEWCOUNT_STATS" />
+        <action android:name="${notificationActionPrefix}.LATEST_POST_LIKES_STATS" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_AREAS_ACTIVATED" />
+        <action android:name="${notificationActionPrefix}.LATEST_POST_VIEWCOUNT_STATS" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NUDGE_SPACE_ENGAGEMENT" />
+        <action android:name="${notificationActionPrefix}.NEW_AREAS_ACTIVATED" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_CONNECTION" />
+        <action android:name="${notificationActionPrefix}.NUDGE_SPACE_ENGAGEMENT" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_CONNECTION_REQUEST" />
+        <action android:name="${notificationActionPrefix}.POST_VISIT_REVIEW_REMINDER" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_DIRECT_MESSAGE" />
+        <action android:name="${notificationActionPrefix}.NEW_CONNECTION" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_GROUP_MESSAGE" />
+        <action android:name="${notificationActionPrefix}.NEW_CONNECTION_REQUEST" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_GROUP_INVITE" />
+        <action android:name="${notificationActionPrefix}.NEW_DIRECT_MESSAGE" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_GROUP_MEMBERS" />
+        <action android:name="${notificationActionPrefix}.NEW_GROUP_MESSAGE" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_LIKE_RECEIVED" />
+        <action android:name="${notificationActionPrefix}.NEW_GROUP_INVITE" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_SUPER_LIKE_RECEIVED" />
+        <action android:name="${notificationActionPrefix}.NEW_GROUP_MEMBERS" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.NEW_THOUGHT_REPLY_RECEIVED" />
+        <action android:name="${notificationActionPrefix}.NEW_LIKE_RECEIVED" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.UNREAD_NOTIFICATIONS_REMINDER" />
+        <action android:name="${notificationActionPrefix}.NEW_SUPER_LIKE_RECEIVED" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.UNCLAIMED_ACHIEVEMENTS_REMINDER" />
+        <action android:name="${notificationActionPrefix}.NEW_THOUGHT_REPLY_RECEIVED" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
       <intent-filter>
-        <action android:name="app.therrmobile.INVITE_FRIENDS_REMINDER" />
+        <action android:name="${notificationActionPrefix}.UNREAD_NOTIFICATIONS_REMINDER" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.UNCLAIMED_ACHIEVEMENTS_REMINDER" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.INVITE_FRIENDS_REMINDER" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.REPORT_CONFIRMED" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.LEADERBOARD_RANK_MILESTONE" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+
+      <!-- HABITS: pact lifecycle, partner activity, streaks and habit reminders. -->
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.PACT_INVITATION" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.PACT_NUDGE" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.PACT_ACCEPTED" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.PACT_DECLINED" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.PACT_COMPLETED" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.PACT_EXPIRING" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.PARTNER_CHECKED_IN" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.PARTNER_MISSED_DAY" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.PARTNER_CELEBRATED" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.STREAK_MILESTONE" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.STREAK_AT_RISK" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.STREAK_BROKEN" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.NEW_PERSONAL_RECORD" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.DAILY_HABIT_REMINDER" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.MORNING_MOTIVATION" />
+        <category android:name="android.intent.category.DEFAULT" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="${notificationActionPrefix}.EVENING_CHECK_IN" />
         <category android:name="android.intent.category.DEFAULT" />
       </intent-filter>
 

--- a/TherrMobile/main/constants/index.tsx
+++ b/TherrMobile/main/constants/index.tsx
@@ -131,10 +131,31 @@ const REMINDER_ACTION_KEYS = new Set<string>([
     'NEW_LIKE_RECEIVED',
     'NEW_SUPER_LIKE_RECEIVED',
     'NEW_THOUGHT_REPLY_RECEIVED',
+    // HABITS — time-sensitive nudges. These are the retention loop; on the
+    // DEFAULT-importance channel they post silently with no heads-up banner,
+    // which is indistinguishable from "push isn't working" to a user.
+    'STREAK_AT_RISK',
+    'PACT_INVITATION',
+    'PACT_NUDGE',
+    'PACT_EXPIRING',
 ]);
 
 const REWARD_ACTION_KEYS = new Set<string>([
     'NUDGE_SPACE_ENGAGEMENT',
+    // HABITS — "Streak Updates" channel. Celebratory milestones.
+    'STREAK_MILESTONE',
+    'NEW_PERSONAL_RECORD',
+    'LEADERBOARD_RANK_MILESTONE',
+]);
+
+// HABITS — "Friend Activity" channel. Partner/pact state changes: worth
+// surfacing, but not urgent enough for a HIGH-importance heads-up.
+const CONTENT_DISCOVERY_ACTION_KEYS = new Set<string>([
+    'PARTNER_CHECKED_IN',
+    'PARTNER_MISSED_DAY',
+    'PARTNER_CELEBRATED',
+    'PACT_ACCEPTED',
+    'PACT_COMPLETED',
 ]);
 
 const getIntentActionKey = (clickActionId: string): string => {
@@ -152,6 +173,10 @@ const getAndroidChannelFromClickActionId = (clickActionId: string): AndroidChann
 
     if (REWARD_ACTION_KEYS.has(key)) {
         return getAndroidChannel(AndroidChannelIds.rewardUpdates);
+    }
+
+    if (CONTENT_DISCOVERY_ACTION_KEYS.has(key)) {
+        return getAndroidChannel(AndroidChannelIds.contentDiscovery);
     }
 
     return getAndroidChannel(AndroidChannelIds.default);

--- a/TherrMobile/main/routes/Pacts/HabitsPushOptIn.tsx
+++ b/TherrMobile/main/routes/Pacts/HabitsPushOptIn.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { SafeAreaView, ScrollView, View, Text, Pressable, Platform, PermissionsAndroid } from 'react-native';
+import { SafeAreaView, ScrollView, View, Text, Pressable } from 'react-native';
 import { connect } from 'react-redux';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import notifee from '@notifee/react-native';
 import { IUserState } from 'therr-react/types';
+import permissions from '../../utilities/permissionsOrchestrator';
 import translator from '../../utilities/translator';
 import { buildStyles } from '../../styles';
 import { buildStyles as buildButtonStyles } from '../../styles/buttons';
@@ -49,12 +49,19 @@ class HabitsPushOptIn extends React.Component<IHabitsPushOptInProps> {
         this.props.navigation.reset({ index: 0, routes: [{ name: 'HabitsDashboard' }] });
     };
 
+    // This screen is itself the soft-ask primer, so it goes through the orchestrator's
+    // custom-primer entry point rather than `permissions.request` (which would stack a
+    // second explainer modal on top of it) and rather than calling notifee/PermissionsAndroid
+    // directly (which asks the OS but never tells the rest of the app about it).
+    //
+    // Going through the orchestrator is what registers the FCM device token: Layout
+    // subscribes via `permissions.onGranted('notifications')`. Requesting the OS
+    // permission here in isolation left the token unregistered server-side until the
+    // next cold start, so a brand-new user who opted in during onboarding got no push
+    // notifications at all for the remainder of that session.
     requestPermissions = async () => {
         try {
-            if (Platform.OS === 'android' && Number(Platform.Version) >= 33) {
-                await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
-            }
-            await notifee.requestPermission();
+            await permissions.requestAfterCustomPrimer('notifications', { trigger: 'habitsOnboarding' });
         } catch {
             // user denied or error — proceed regardless; we don't block onboarding
         }

--- a/TherrMobile/main/utilities/permissionsOrchestrator.ts
+++ b/TherrMobile/main/utilities/permissionsOrchestrator.ts
@@ -24,6 +24,7 @@ export type Trigger =
     | 'firstConnectionAccepted'
     | 'pactCreate'
     | 'pactAccept'
+    | 'habitsOnboarding'
     | 'secondSession';
 
 type Status = 'granted' | 'denied' | 'blocked';
@@ -259,6 +260,46 @@ const request = async (type: PermType, opts: RequestOptions): Promise<RequestRes
     return { status, source: 'os' };
 };
 
+/**
+ * For call sites that render their own full-screen explainer instead of the shared
+ * primer modal (e.g. the HABITS onboarding push opt-in screen). Skips `showPrimer`
+ * — the caller IS the primer — but keeps everything else the orchestrator owns:
+ * the persisted `osAskedAt` / `lastStatus` state, and the `onGranted` fan-out that
+ * triggers FCM device-token registration in Layout.
+ *
+ * Calling `notifee.requestPermission()` directly instead of this leaves the device
+ * token unregistered until the next cold start (Layout only registers on mount or
+ * on an auth transition), so the user receives no pushes at all for the rest of the
+ * session they opted in — and, because `osAskedAt` never gets stamped, the
+ * second-session fallback re-prompts someone who already answered.
+ */
+const requestAfterCustomPrimer = async (
+    type: PermType,
+    opts: Partial<RequestOptions> = {},
+): Promise<Status> => {
+    const native = await nativeCheck(type);
+    if (native === 'granted') {
+        await updateStateFor(type, { lastStatus: 'granted' });
+        opts.onGranted?.();
+        fireGrantedListeners(type);
+        return 'granted';
+    }
+
+    const status = await performOSRequest(type, opts.storePermissionsResponse || noopStore);
+    await updateStateFor(type, {
+        osAskedAt: Date.now(),
+        lastStatus: status,
+        appVersionAtLastAsk: DeviceInfo.getVersion(),
+    });
+    if (status === 'granted') {
+        opts.onGranted?.();
+        fireGrantedListeners(type);
+    } else {
+        opts.onDenied?.('os');
+    }
+    return status;
+};
+
 const requestIfAppropriate = async (type: PermType, opts: RequestOptions): Promise<void> => {
     const native = await nativeCheck(type);
     if (native === 'granted') {
@@ -296,6 +337,7 @@ export const onGranted = (type: PermType, fn: () => void): (() => void) => {
 
 const permissions = {
     request,
+    requestAfterCustomPrimer,
     requestIfAppropriate,
     getStatus,
     maybeShowSecondSessionFallback,

--- a/TherrMobile/main/utilities/pushNotifications.ts
+++ b/TherrMobile/main/utilities/pushNotifications.ts
@@ -10,19 +10,28 @@ import notifee, {
     TriggerType,
 } from '@notifee/react-native';
 import { AndroidChannelIds, getAndroidChannel } from '../constants';
+import { BRAND_BLUE_GREEN } from '../styles/themes/brandConstants';
 
+// Android locks a channel's importance at creation time — later createChannel calls
+// with a different importance are ignored for the life of the install. So whichever
+// code path happened to post first used to decide, permanently, whether e.g. the
+// "Habit Reminders" channel could show a heads-up banner: the foreground path forced
+// DEFAULT, the background path forced HIGH. Importance now comes from the channel's
+// own definition in ../constants unless a caller deliberately overrides it, which
+// makes AndroidChannels the single source of truth and the outcome order-independent.
 const sendForegroundNotification = (
     notification: Notification,
     androidChannel?: AndroidChannel,
-    importance: AndroidImportance = AndroidImportance.DEFAULT,
+    importance?: AndroidImportance,
     shouldRequestPermission = true,
 ) => {
+    const channel = androidChannel || getAndroidChannel(AndroidChannelIds.default, false);
     const permissionPromise = shouldRequestPermission ? notifee.requestPermission() : Promise.resolve();
     // Request permissions (required for iOS)
     return permissionPromise
         .then(() => notifee.createChannel({
-            ...(androidChannel || getAndroidChannel(AndroidChannelIds.default, false)),
-            importance,
+            ...channel,
+            importance: importance ?? channel.importance ?? AndroidImportance.DEFAULT,
         }))
         .then((channelId: string) => {
             return notifee.displayNotification({
@@ -32,7 +41,7 @@ const sendForegroundNotification = (
                     actions: notification.android?.actions || undefined,
                     channelId,
                     smallIcon: notification.android?.smallIcon || 'ic_notification_icon', // optional, defaults to 'ic_launcher'.
-                    color: '#0f7b82',
+                    color: BRAND_BLUE_GREEN,
                     // pressAction is needed if you want the notification to open the app when pressed
                     pressAction: notification.android?.pressAction || {
                         id: PushNotifications.PressActionIds.default,
@@ -49,8 +58,10 @@ const sendForegroundNotification = (
  * Sends a Notifee push notification when a data-only Firebase notification is received in the background
  */
 const sendBackgroundNotification = (notification: Notification, androidChannel?: AndroidChannel) => {
-    // Request permissions (required for iOS)
-    return sendForegroundNotification(notification, androidChannel, AndroidImportance.HIGH, true);
+    // Importance intentionally omitted — see sendForegroundNotification. The channel
+    // picked by getAndroidChannelFromClickActionId already encodes how loud this
+    // notification should be.
+    return sendForegroundNotification(notification, androidChannel, undefined, true);
 };
 
 const sendTriggerNotification = async (
@@ -83,7 +94,7 @@ const sendTriggerNotification = async (
                     actions: notification.android?.actions || undefined,
                     channelId,
                     smallIcon: notification.android?.smallIcon || 'ic_notification_icon', // optional, defaults to 'ic_launcher'.
-                    color: '#0f7b82',
+                    color: BRAND_BLUE_GREEN,
                     // pressAction is needed if you want the notification to open the app when pressed
                     pressAction: notification.android?.pressAction || {
                         id: PushNotifications.PressActionIds.default,


### PR DESCRIPTION
Mobile half of the "push notifications don't work in Friends with Habits" investigation. The backend half is #2720 against `general`.

Four independent defects. None of them throws or logs anything, which is why this was invisible from the server side — FCM reports every one of these sends as successful.

## 1. Every notification was untappable

The manifest declared its click-action intent filters with a hardcoded `app.therrmobile.*` (Therr) prefix, but this app's backend sends `com.therr.mobile.habits.*` — the per-brand strings in `AndroidIntentActions`. The Firebase SDK builds the tap intent as `new Intent(clickAction).setPackage(appId)`, so with no matching filter the notification posts normally and **tapping it does nothing at all**.

The prefix now comes from a `notificationActionPrefix` manifest placeholder keyed off `applicationId` in `build.gradle`, mirroring the existing `appLinkHost` pattern. It is deliberately **not** derived from `applicationId`: Habits ships as `com.therr.habits` but publishes `com.therr.mobile.habits.*` actions.

Also adds the filters that were missing outright — `COMPLETE_DRAFT_REMINDER`, `REPORT_CONFIRMED`, `LEADERBOARD_RANK_MILESTONE`, and all 16 HABITS actions. Data-only notifications don't strictly need a filter (Notifee renders them with `launchActivity: 'default'`), but they're all listed anyway so flipping one to display-style on the backend can't silently reintroduce the dead-tap bug.

The two `QUICK_CREATE` shortcut actions stay literal, because `res/xml/shortcuts.xml` cannot expand manifest placeholders.

## 2. Opting in during onboarding registered no device token

`HabitsPushOptIn` is the first screen every authenticated user sees, and it called `PermissionsAndroid` / `notifee` directly. That asks the OS correctly but tells nothing else in the app: `Layout` registers the FCM token from `permissions.onGranted('notifications')`. So a new user who tapped **Enable** had no token stored server-side until their next cold start — **no pushes at all for the rest of that session**, which is exactly when someone tests whether push works. It also never stamped `osAskedAt`, so the second-session fallback re-prompted someone who had already answered.

Adds `permissions.requestAfterCustomPrimer` for call sites that render their own full-screen explainer: skips the shared primer modal (this screen *is* the primer) but keeps the persisted state and the granted-listener fan-out.

## 3. The habit channels were decorative

`REMINDER_ACTION_KEYS` / `REWARD_ACTION_KEYS` only listed the Therr social actions, so all 12 HABITS data-only pushes fell through to `default` ("General"). "Habit Reminders", "Streak Updates" and "Friend Activity" existed with nothing routed to them.

| Channel | Actions |
|---|---|
| `reminders` — "Habit Reminders" | `STREAK_AT_RISK`, `PACT_INVITATION`, `PACT_NUDGE`, `PACT_EXPIRING` |
| `rewardUpdates` — "Streak Updates" | `STREAK_MILESTONE`, `NEW_PERSONAL_RECORD`, `LEADERBOARD_RANK_MILESTONE` |
| `contentDiscovery` — "Friend Activity" | `PARTNER_CHECKED_IN`, `PARTNER_MISSED_DAY`, `PARTNER_CELEBRATED`, `PACT_ACCEPTED`, `PACT_COMPLETED` |

## 4. Channel importance depended on install history

Android locks a channel's importance at creation time. The foreground path forced `DEFAULT` and the background path forced `HIGH`, so whether "Habit Reminders" could show a heads-up banner was decided permanently by whichever code path happened to post first. Importance now comes from the channel's own definition, making `AndroidChannels` the single source of truth and the outcome order-independent.

Locally-rendered Notifee notifications also pick up the brand accent from `brandConstants` instead of a hardcoded Therr teal.

## Tests

31 new assertions across three suites, **all verified to fail against the pre-fix code**.

`androidNotificationIntentFilters.test.ts` reads the real `AndroidManifest.xml` and `build.gradle` rather than a copy, so prefix or action-list drift fails the build instead of shipping silently. It also asserts the shortcut actions stay literal, so a future refactor can't templatize them and break the launcher long-press menu.

## Verification

| Gate | Result |
|---|---|
| Mobile Jest | 1273 passing, 56 suites |
| ESLint | 0 errors |
| `pr:tsc-baseline:mobile` | 107/107, no new errors |
| `locales:check` | OK |

No new locale keys — the opt-in screen reuses its existing dictionary entries.

## Needs a native rebuild

The manifest and `build.gradle` changes do not take effect over a Metro reload. This needs a fresh Android build to verify on device, and `versionCode` will need its usual bump before the Play release.

## Not fixed here

`docs/WORK_IN_PROGRESS.md` still carries an unchecked ops item for `PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_HABITS`. `k8s/prod` wires it to secret `push-notifications-google-app-credentials-habit`, but I couldn't verify the secret exists. If it doesn't, Habits pushes go out through the **Therr** Firebase project, which rejects Habits device tokens — and that would mask all four fixes above. Worth confirming first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUFMdUUT8QSNa5AekHdk3h)_