### PR TITLE
feat: fix the API key onboarding flow end to end

### DIFF
--- a/TherrMobile/env-config.js
+++ b/TherrMobile/env-config.js
@@ -13,6 +13,11 @@ const devLanHost = null;
 // localhost; the iOS simulator shares the host's network and uses localhost.
 const hostDev = devLanHost || (Platform.OS === 'android' ? '10.0.2.2' : 'localhost');
 const hostProd = 'therr.com';
+// The web dashboard is a separate host on purpose: therr.com / www.therr.com are
+// auto-verified App Links captured by this app, so a dashboard link on therr.com would
+// re-open the app instead of the browser. dashboard.therr.com is not in the intent filter.
+const dashboardHostDev = `http://${hostDev}:7071`;
+const dashboardHostProd = 'https://dashboard.therr.com';
 const googleOAuth2WebClientId = '718962923226-k1ejo7drgp89h7b375ifkda4l1vapevr.apps.googleusercontent.com';
 
 // Feature flags for enabling/disabling app features
@@ -62,6 +67,7 @@ module.exports = {
         googleOAuth2WebClientIdAndroid: '718962923226-k1ejo7drgp89h7b375ifkda4l1vapevr.apps.googleusercontent.com',
         googleOAuth2WebClientIdiOS: '718962923226-os68t9a1pi6giap1l447r3vtshf2ie3c.apps.googleusercontent.com',
         host: hostDev,
+        dashboardHostFull: dashboardHostDev,
         socket: {
             clientPath: '/socketio',
             pingInterval: 1000 * 10,
@@ -83,6 +89,7 @@ module.exports = {
         googleOAuth2WebClientIdiOS: '718962923226-1rhet8adgsvuviutj7ja2006bhcncr87.apps.googleusercontent.com',
         host: hostProd,
         hostFull: `https://${hostProd}`,
+        dashboardHostFull: dashboardHostProd,
         socket: {
             clientPath: '/socketio',
             pingInterval: 1000 * 10,

--- a/TherrMobile/main/components/Layout.tsx
+++ b/TherrMobile/main/components/Layout.tsx
@@ -1639,6 +1639,13 @@ class Layout extends React.Component<ILayoutProps, ILayoutState> {
                     targetRouteView: 'Achievements',
                 });
             }
+        } else if (url?.includes('therr.com/api-access') || url?.includes('therr.com/api-keys')) {
+            // therr.com is an auto-verified App Link, so the marketing site's "Get an API key"
+            // CTA opens this app instead of the browser. Without this branch it fell through
+            // to handleOpenByNotifeeNotification and the user hit a dead end. The screen is
+            // public, so route signed-out users there too rather than deferring to targetRouteView.
+            // '/api-keys' is matched as well because older marketing links still point at it.
+            RootNavigation.navigate('ApiAccess');
         } else if (url?.includes('therr.com/app-feedback')) {
             if (isUserLoggedIn && !isUserMissingProps) {
                 RootNavigation.navigate('Home');

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1247,6 +1247,36 @@
         "thoughts": "Thoughts"
       }
     },
+    "apiAccess": {
+      "headerTitle": "API Access",
+      "pageTitle": "Get a Therr API Key",
+      "intro": "API keys are managed on the Therr web dashboard. Here is what the process looks like.",
+      "steps": {
+        "one": {
+          "title": "Create a business account",
+          "description": "Sign up on the Therr dashboard with your business email. A personal Therr profile cannot generate API keys."
+        },
+        "two": {
+          "title": "Choose a plan",
+          "description": "Open Settings on the dashboard and pick a subscription. Every paid plan includes API access."
+        },
+        "three": {
+          "title": "Generate your key",
+          "description": "Go to Settings, then API Keys, and create a key. It is shown once, at creation — copy it somewhere safe."
+        },
+        "four": {
+          "title": "Start building",
+          "description": "Send your key as the x-api-key header on any request. The API reference covers every endpoint."
+        }
+      },
+      "statusEligible": "Your account can create API keys. Open the dashboard to manage them.",
+      "statusNotEligible": "You will need a business account with a paid plan to create API keys.",
+      "buttons": {
+        "manageKeys": "Manage API keys",
+        "openDashboard": "Open the web dashboard",
+        "viewDocs": "Read the API reference"
+      }
+    },
     "advancedSettings": {
       "headerTitle": "Manage Account",
       "pageHeaderAccountActions": "Account Actions",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1247,6 +1247,36 @@
         "thoughts": "Pensamientos"
       }
     },
+    "apiAccess": {
+      "headerTitle": "Acceso a la API",
+      "pageTitle": "Obtén una clave de API de Therr",
+      "intro": "Las claves de API se administran en el panel web de Therr. Así funciona el proceso.",
+      "steps": {
+        "one": {
+          "title": "Crea una cuenta de negocio",
+          "description": "Regístrate en el panel de Therr con el correo de tu negocio. Un perfil personal de Therr no puede generar claves de API."
+        },
+        "two": {
+          "title": "Elige un plan",
+          "description": "Abre Configuración en el panel y elige una suscripción. Todos los planes de pago incluyen acceso a la API."
+        },
+        "three": {
+          "title": "Genera tu clave",
+          "description": "Ve a Configuración y luego a Claves de API para crear una clave. Se muestra una sola vez, al crearla: cópiala en un lugar seguro."
+        },
+        "four": {
+          "title": "Empieza a construir",
+          "description": "Envía tu clave en el encabezado x-api-key de cada solicitud. La referencia de la API describe todos los endpoints."
+        }
+      },
+      "statusEligible": "Tu cuenta puede crear claves de API. Abre el panel para administrarlas.",
+      "statusNotEligible": "Necesitarás una cuenta de negocio con un plan de pago para crear claves de API.",
+      "buttons": {
+        "manageKeys": "Administrar claves de API",
+        "openDashboard": "Abrir el panel web",
+        "viewDocs": "Leer la referencia de la API"
+      }
+    },
     "advancedSettings": {
       "headerTitle": "Administrar cuenta",
       "pageHeaderAccountActions": "Acciones de cuenta",

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -1247,6 +1247,36 @@
         "thoughts": "Pensées"
       }
     },
+    "apiAccess": {
+      "headerTitle": "Accès à l'API",
+      "pageTitle": "Obtenir une clé API Therr",
+      "intro": "Les clés API se gèrent dans le tableau de bord web de Therr. Voici comment se déroule le processus.",
+      "steps": {
+        "one": {
+          "title": "Créez un compte entreprise",
+          "description": "Inscrivez-vous au tableau de bord Therr avec le courriel de votre entreprise. Un profil Therr personnel ne peut pas générer de clés API."
+        },
+        "two": {
+          "title": "Choisissez un forfait",
+          "description": "Ouvrez Paramètres dans le tableau de bord et choisissez un abonnement. Tous les forfaits payants incluent l'accès à l'API."
+        },
+        "three": {
+          "title": "Générez votre clé",
+          "description": "Allez dans Paramètres, puis Clés API, et créez une clé. Elle n'est affichée qu'une seule fois, à la création : copiez-la en lieu sûr."
+        },
+        "four": {
+          "title": "Commencez à créer",
+          "description": "Envoyez votre clé dans l'en-tête x-api-key de chaque requête. La référence de l'API décrit tous les points d'accès."
+        }
+      },
+      "statusEligible": "Votre compte peut créer des clés API. Ouvrez le tableau de bord pour les gérer.",
+      "statusNotEligible": "Vous aurez besoin d'un compte entreprise avec un forfait payant pour créer des clés API.",
+      "buttons": {
+        "manageKeys": "Gérer les clés API",
+        "openDashboard": "Ouvrir le tableau de bord web",
+        "viewDocs": "Consulter la référence de l'API"
+      }
+    },
     "advancedSettings": {
       "headerTitle": "Gérer le compte",
       "pageHeaderAccountActions": "Actions du compte",

--- a/TherrMobile/main/routes/ApiAccess/index.tsx
+++ b/TherrMobile/main/routes/ApiAccess/index.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { Linking, ScrollView, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { connect } from 'react-redux';
+import { IUserState } from 'therr-react/types';
+import { AccessLevels } from 'therr-js-utilities/constants';
+import { Button } from '../../components/BaseButton';
+import BaseStatusBar from '../../components/BaseStatusBar';
+import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
+import translator from '../../utilities/translator';
+import { buildStyles } from '../../styles';
+import { buildStyles as buildMenuStyles } from '../../styles/navigation/buttonMenu';
+import { buildStyles as buildFormStyles } from '../../styles/forms';
+import spacingStyles from '../../styles/layouts/spacing';
+import getConfig from '../../utilities/getConfig';
+
+const API_DOCS_URL = 'https://api.therr.com/v1/docs';
+
+/**
+ * Deliberately NOT a therr.com URL. therr.com and www.therr.com are auto-verified Android
+ * App Links (see appLinkHostsByAppId in TherrMobile/android/app/build.gradle), so opening
+ * one here would be captured by this same app and bounce the user right back to this
+ * screen. dashboard.therr.com is not in the intent filter, so it opens in the browser.
+ */
+const getDashboardUrl = (path: string) => `${getConfig().dashboardHostFull}${path}`;
+
+// Mirrors API_KEY_ELIGIBLE_LEVELS in users-service/handlers/apiKeys.ts.
+const API_KEY_ELIGIBLE_LEVELS: string[] = [
+    AccessLevels.DASHBOARD_SUBSCRIBER_BASIC,
+    AccessLevels.DASHBOARD_SUBSCRIBER_PRO,
+    AccessLevels.DASHBOARD_SUBSCRIBER_PREMIUM,
+    AccessLevels.DASHBOARD_SUBSCRIBER_AGENCY,
+    AccessLevels.SUPER_ADMIN,
+    AccessLevels.API_ACCESS,
+];
+
+const STEP_KEYS = ['one', 'two', 'three', 'four'];
+
+interface IStoreProps {
+    user: IUserState;
+}
+
+export interface IApiAccessProps extends IStoreProps {
+    navigation: any;
+}
+
+const mapStateToProps = (state) => ({
+    user: state.user,
+});
+
+/**
+ * Landing screen for the therr.com/api-access universal link.
+ *
+ * API keys are issued from the web dashboard, and there is no in-app equivalent — but the
+ * link is app-linked, so tapping it on a device with the app installed opens the app. Before
+ * this screen existed that fell through to handleOpenByNotifeeNotification and the user was
+ * left staring at whatever screen happened to be mounted. This explains the steps in-app and
+ * hands off to the browser for the part that genuinely requires the dashboard.
+ */
+export class ApiAccessComponent extends React.Component<IApiAccessProps> {
+    private theme = buildStyles();
+
+    private themeMenu = buildMenuStyles();
+
+    private themeForms = buildFormStyles();
+
+    private translate: Function;
+
+    constructor(props: IApiAccessProps) {
+        super(props);
+
+        this.reloadTheme();
+        this.translate = (key: string, params?: any) => translator('en-us', key, params);
+    }
+
+    componentDidMount() {
+        const { navigation } = this.props;
+        navigation.setOptions({
+            title: this.translate('pages.apiAccess.headerTitle'),
+        });
+    }
+
+    reloadTheme = () => {
+        const themeName = this.props.user.settings?.mobileThemeName;
+
+        this.theme = buildStyles(themeName);
+        this.themeMenu = buildMenuStyles(themeName);
+        this.themeForms = buildFormStyles(themeName);
+    };
+
+    get isEligible(): boolean {
+        const accessLevels: string[] = this.props.user?.details?.accessLevels || [];
+        return API_KEY_ELIGIBLE_LEVELS.some((level) => accessLevels.includes(level));
+    }
+
+    onOpenDashboard = () => {
+        // Eligible accounts go straight to the key generator; everyone else needs to
+        // register or subscribe first, so send them to the dashboard entry point.
+        const path = this.isEligible ? '/settings/api-keys' : '/register';
+        Linking.openURL(getDashboardUrl(path)).catch(() => {});
+    };
+
+    onOpenDocs = () => {
+        Linking.openURL(API_DOCS_URL).catch(() => {});
+    };
+
+    render() {
+        const { navigation, user } = this.props;
+
+        return (
+            <>
+                <BaseStatusBar therrThemeName={user.settings?.mobileThemeName} />
+                <SafeAreaView edges={[]} style={this.theme.styles.safeAreaView}>
+                    <ScrollView
+                        contentInsetAdjustmentBehavior="automatic"
+                        style={this.theme.styles.scrollView}
+                    >
+                        <View style={this.theme.styles.body}>
+                            <View style={this.theme.styles.sectionContainer}>
+                                <Text style={this.theme.styles.sectionTitle}>
+                                    {this.translate('pages.apiAccess.pageTitle')}
+                                </Text>
+                                <Text style={this.theme.styles.sectionDescription}>
+                                    {this.translate('pages.apiAccess.intro')}
+                                </Text>
+                            </View>
+
+                            {STEP_KEYS.map((stepKey, index) => (
+                                <View key={stepKey} style={this.theme.styles.sectionContainer}>
+                                    <Text style={this.theme.styles.sectionTitleSmall}>
+                                        {`${index + 1}. ${this.translate(`pages.apiAccess.steps.${stepKey}.title`)}`}
+                                    </Text>
+                                    <Text style={this.theme.styles.sectionDescription}>
+                                        {this.translate(`pages.apiAccess.steps.${stepKey}.description`)}
+                                    </Text>
+                                </View>
+                            ))}
+
+                            <View style={this.theme.styles.sectionContainer}>
+                                <Text style={this.theme.styles.sectionDescription}>
+                                    {this.isEligible
+                                        ? this.translate('pages.apiAccess.statusEligible')
+                                        : this.translate('pages.apiAccess.statusNotEligible')}
+                                </Text>
+                            </View>
+
+                            <View style={[this.theme.styles.sectionContainer, spacingStyles.padHorizSm]}>
+                                <Button
+                                    buttonStyle={this.themeForms.styles.buttonPrimary}
+                                    titleStyle={this.themeForms.styles.buttonTitle}
+                                    title={this.isEligible
+                                        ? this.translate('pages.apiAccess.buttons.manageKeys')
+                                        : this.translate('pages.apiAccess.buttons.openDashboard')}
+                                    onPress={this.onOpenDashboard}
+                                />
+                            </View>
+
+                            <View style={[this.theme.styles.sectionContainer, spacingStyles.padHorizSm]}>
+                                <Button
+                                    type="clear"
+                                    titleStyle={this.themeForms.styles.buttonLink}
+                                    title={this.translate('pages.apiAccess.buttons.viewDocs')}
+                                    onPress={this.onOpenDocs}
+                                />
+                            </View>
+                        </View>
+                    </ScrollView>
+                    <MainButtonMenu
+                        navigation={navigation}
+                        translate={this.translate}
+                        user={user}
+                        themeMenu={this.themeMenu}
+                    />
+                </SafeAreaView>
+            </>
+        );
+    }
+}
+
+export default connect(mapStateToProps, null)(ApiAccessComponent);

--- a/TherrMobile/main/routes/index.tsx
+++ b/TherrMobile/main/routes/index.tsx
@@ -21,6 +21,7 @@ import Landing from './Landing';
 import Login from './Login';
 import Map from './Map';
 import Achievements from './Achievements';
+import ApiAccess from './ApiAccess';
 import AchievementClaim from './Achievements/AchievementClaim';
 import Leaderboard from './Leaderboard';
 import ActivatedAreas from './Areas/ActivatedAreas';
@@ -331,6 +332,17 @@ const routes: RouteConfig<
         options: () => ({
             title: 'Settings',
             access: AccessPresets.EMAIL_VERIFIED,
+        }),
+    },
+    {
+        // Public on purpose: this screen is the landing target for the therr.com/api-access
+        // App Link, and a signed-out visitor who taps that link must see the instructions
+        // rather than be bounced to a login wall with no explanation.
+        name: 'ApiAccess',
+        component: ApiAccess,
+        options: () => ({
+            title: 'API Access',
+            access: AccessPresets.PUBLIC_DEFAULT,
         }),
     },
     {

--- a/therr-client-web-dashboard/src/components/Sidebar.tsx
+++ b/therr-client-web-dashboard/src/components/Sidebar.tsx
@@ -38,6 +38,7 @@ import {
     faTasks,
     faNetworkWired,
     faPeopleArrows,
+    faKey,
 } from '@fortawesome/free-solid-svg-icons';
 import {
     Nav,
@@ -241,6 +242,7 @@ const Sidebar = (props: ISidebarProps) => {
                             <Dropdown.Divider className="my-3 border-indigo" />
 
                             <NavItem title="Settings" icon={faCog} link={'/settings'} />
+                            <NavItem title="API Keys" icon={faKey} link={'/settings/api-keys'} />
                             <CollapsableNavItem eventKey="documentation/" title="Getting Started" icon={faBook}>
                                 <NavItem title="Overview" link={'/documentation/overview'} />
                                 <NavItem title="Quick Start" link={'/claim-a-space'} />

--- a/therr-client-web-dashboard/src/locales/en-us/dictionary.json
+++ b/therr-client-web-dashboard/src/locales/en-us/dictionary.json
@@ -242,7 +242,47 @@
       "successVerifiedMessage": "Check your e-mail for a link to reset your password"
     },
     "settings": {
-      "pageTitle": "Settings"
+      "pageTitle": "Settings",
+      "apiKeys": {
+        "title": "API Keys",
+        "description": "Generate keys for your applications to call the Therr API, and revoke keys you no longer use.",
+        "manageButton": "Manage API keys"
+      }
+    },
+    "apiKeys": {
+      "pageTitle": "API Keys",
+      "pageDescription": "Create and manage the keys your applications use to call the Therr API.",
+      "viewDocs": "View the API reference",
+      "createTitle": "Create a new key",
+      "nameLabel": "Key name",
+      "namePlaceholder": "e.g. Production server",
+      "createButton": "Create key",
+      "atLimit": "You have reached the limit of {max} active keys. Revoke one to create another.",
+      "listTitle": "Your keys",
+      "emptyState": "You have not created any API keys yet.",
+      "unnamed": "Unnamed key",
+      "neverUsed": "Never used",
+      "revoke": "Revoke",
+      "confirmRevoke": "Revoke \"{keyName}\"? Any application using this key will stop working immediately.",
+      "createdTitle": "Copy your new key now",
+      "createdWarning": "This is the only time the full key will be shown. Store it somewhere safe — if you lose it, you will need to revoke it and create a new one.",
+      "copy": "Copy",
+      "copied": "Copied",
+      "upgradeTitle": "API access requires a subscription",
+      "upgradeDescription": "API keys are included with every paid plan. Choose a plan to start building with the Therr API.",
+      "upgradeButton": "View plans",
+      "table": {
+        "name": "Name",
+        "prefix": "Key prefix",
+        "created": "Created",
+        "lastUsed": "Last used",
+        "actions": "Actions"
+      },
+      "errors": {
+        "loadFailed": "We could not load your API keys. Please refresh and try again.",
+        "createFailed": "We could not create the key. Please try again.",
+        "revokeFailed": "We could not revoke the key. Please try again."
+      }
     },
     "home": {
       "pageTitle": "Home"

--- a/therr-client-web-dashboard/src/routes/ApiKeys/index.tsx
+++ b/therr-client-web-dashboard/src/routes/ApiKeys/index.tsx
@@ -1,0 +1,374 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Link, NavigateFunction } from 'react-router-dom';
+import {
+    Alert,
+    Button,
+    Card,
+    Col,
+    Form,
+    InputGroup,
+    Row,
+    Spinner,
+    Table,
+} from 'react-bootstrap';
+import { IUserState } from 'therr-react/types';
+import { AccessLevels } from 'therr-js-utilities/constants';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCopy, faKey, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
+import translator from '../../services/translator';
+import withNavigation from '../../wrappers/withNavigation';
+import ApiKeysService, { IApiKey } from '../../services/ApiKeysService';
+import { getWebsiteName } from '../../utilities/getHostContext';
+
+const API_DOCS_URL = 'https://api.therr.com/v1/docs';
+
+// Mirrors MAX_KEYS_PER_USER in users-service/handlers/apiKeys.ts. Enforced server-side;
+// duplicated here only so the button can be disabled before the user hits a 400.
+const MAX_KEYS_PER_USER = 5;
+
+// Mirrors API_KEY_ELIGIBLE_LEVELS in users-service/handlers/apiKeys.ts.
+const API_KEY_ELIGIBLE_LEVELS: string[] = [
+    AccessLevels.DASHBOARD_SUBSCRIBER_BASIC,
+    AccessLevels.DASHBOARD_SUBSCRIBER_PRO,
+    AccessLevels.DASHBOARD_SUBSCRIBER_PREMIUM,
+    AccessLevels.DASHBOARD_SUBSCRIBER_AGENCY,
+    AccessLevels.SUPER_ADMIN,
+    AccessLevels.API_ACCESS,
+];
+
+interface IApiKeysRouterProps {
+    navigation: {
+        navigate: NavigateFunction;
+    };
+}
+
+interface IStoreProps {
+    user: IUserState;
+}
+
+interface IApiKeysProps extends IApiKeysRouterProps, IStoreProps {
+}
+
+interface IApiKeysState {
+    apiKeys: IApiKey[];
+    isLoading: boolean;
+    isCreating: boolean;
+    revokingKeyId: string;
+    newKeyName: string;
+    // The raw key from the most recent create call. Held in component state only —
+    // the server hashes it and can never return it again.
+    createdKey: string;
+    didCopy: boolean;
+    errorMessage: string;
+}
+
+const mapStateToProps = (state: any) => ({
+    user: state.user,
+});
+
+export class ApiKeysComponent extends React.Component<IApiKeysProps, IApiKeysState> {
+    private translate: Function;
+
+    constructor(props: IApiKeysProps) {
+        super(props);
+
+        this.state = {
+            apiKeys: [],
+            isLoading: true,
+            isCreating: false,
+            revokingKeyId: '',
+            newKeyName: '',
+            createdKey: '',
+            didCopy: false,
+            errorMessage: '',
+        };
+
+        this.translate = (key: string, params?: any) => translator('en-us', key, params);
+    }
+
+    componentDidMount() {
+        document.title = `${getWebsiteName()} | ${this.translate('pages.apiKeys.pageTitle')}`;
+        this.fetchApiKeys();
+    }
+
+    get isEligible(): boolean {
+        const accessLevels: string[] = this.props.user?.details?.accessLevels || [];
+        return API_KEY_ELIGIBLE_LEVELS.some((level) => accessLevels.includes(level));
+    }
+
+    fetchApiKeys = () => {
+        // An ineligible user gets a 403 from create, but list is harmless — still, skip
+        // the call so the upgrade prompt renders immediately instead of after a spinner.
+        if (!this.isEligible) {
+            this.setState({ isLoading: false });
+            return;
+        }
+
+        ApiKeysService.list()
+            .then((response) => {
+                this.setState({
+                    apiKeys: response.data || [],
+                    isLoading: false,
+                });
+            })
+            .catch(() => {
+                this.setState({
+                    errorMessage: this.translate('pages.apiKeys.errors.loadFailed'),
+                    isLoading: false,
+                });
+            });
+    };
+
+    onCreateKey = (event: React.FormEvent) => {
+        event.preventDefault();
+        const { newKeyName } = this.state;
+
+        this.setState({ isCreating: true, errorMessage: '', createdKey: '' });
+
+        ApiKeysService.create({ name: newKeyName.trim() || undefined })
+            .then((response) => {
+                const created: IApiKey = response.data;
+                this.setState((prevState) => ({
+                    // Strip the raw key before it lands in the list — the table is rendered
+                    // from this array and the secret should live in exactly one place.
+                    apiKeys: [{ ...created, key: undefined }, ...prevState.apiKeys],
+                    createdKey: created.key || '',
+                    newKeyName: '',
+                    isCreating: false,
+                    didCopy: false,
+                }));
+            })
+            .catch((error) => {
+                this.setState({
+                    errorMessage: error?.response?.data?.message
+                        || this.translate('pages.apiKeys.errors.createFailed'),
+                    isCreating: false,
+                });
+            });
+    };
+
+    onRevokeKey = (apiKey: IApiKey) => {
+        // eslint-disable-next-line no-alert
+        const isConfirmed = window.confirm(this.translate('pages.apiKeys.confirmRevoke', {
+            keyName: apiKey.name || apiKey.keyPrefix,
+        }));
+        if (!isConfirmed) {
+            return;
+        }
+
+        this.setState({ revokingKeyId: apiKey.id, errorMessage: '' });
+
+        ApiKeysService.revoke(apiKey.id)
+            .then(() => {
+                this.setState((prevState) => ({
+                    apiKeys: prevState.apiKeys.filter((k) => k.id !== apiKey.id),
+                    revokingKeyId: '',
+                }));
+            })
+            .catch(() => {
+                this.setState({
+                    errorMessage: this.translate('pages.apiKeys.errors.revokeFailed'),
+                    revokingKeyId: '',
+                });
+            });
+    };
+
+    onCopyKey = () => {
+        const { createdKey } = this.state;
+        if (!navigator?.clipboard) {
+            return;
+        }
+        navigator.clipboard.writeText(createdKey)
+            .then(() => this.setState({ didCopy: true }))
+            .catch(() => this.setState({ didCopy: false }));
+    };
+
+    onDismissCreatedKey = () => this.setState({ createdKey: '', didCopy: false });
+
+    renderUpgradePrompt = () => (
+        <Card border="light" className="bg-white shadow-sm mb-4">
+            <Card.Body className="text-center">
+                <FontAwesomeIcon icon={faKey} size="2x" className="mb-3" />
+                <h4>{this.translate('pages.apiKeys.upgradeTitle')}</h4>
+                <p>{this.translate('pages.apiKeys.upgradeDescription')}</p>
+                <Button variant="primary" as={Link as any} to="/settings">
+                    {this.translate('pages.apiKeys.upgradeButton')}
+                </Button>
+            </Card.Body>
+        </Card>
+    );
+
+    renderCreatedKey = () => {
+        const { createdKey, didCopy } = this.state;
+
+        return (
+            <Alert variant="warning" onClose={this.onDismissCreatedKey} dismissible>
+                <Alert.Heading>{this.translate('pages.apiKeys.createdTitle')}</Alert.Heading>
+                <p>{this.translate('pages.apiKeys.createdWarning')}</p>
+                <InputGroup>
+                    <Form.Control
+                        readOnly
+                        value={createdKey}
+                        onFocus={(e: React.FocusEvent<HTMLInputElement>) => e.target.select()}
+                        aria-label={this.translate('pages.apiKeys.createdTitle')}
+                    />
+                    <Button variant="outline-dark" onClick={this.onCopyKey}>
+                        <FontAwesomeIcon icon={faCopy} className="me-1" />
+                        {didCopy
+                            ? this.translate('pages.apiKeys.copied')
+                            : this.translate('pages.apiKeys.copy')}
+                    </Button>
+                </InputGroup>
+            </Alert>
+        );
+    };
+
+    renderKeysTable = () => {
+        const { apiKeys, revokingKeyId } = this.state;
+
+        if (!apiKeys.length) {
+            return <p className="text-center py-4">{this.translate('pages.apiKeys.emptyState')}</p>;
+        }
+
+        return (
+            <Table responsive className="table-centered table-nowrap rounded mb-0">
+                <thead className="thead-light">
+                    <tr>
+                        <th className="border-0">{this.translate('pages.apiKeys.table.name')}</th>
+                        <th className="border-0">{this.translate('pages.apiKeys.table.prefix')}</th>
+                        <th className="border-0">{this.translate('pages.apiKeys.table.created')}</th>
+                        <th className="border-0">{this.translate('pages.apiKeys.table.lastUsed')}</th>
+                        <th className="border-0">{this.translate('pages.apiKeys.table.actions')}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {apiKeys.map((apiKey) => (
+                        <tr key={apiKey.id}>
+                            <td>{apiKey.name || <em>{this.translate('pages.apiKeys.unnamed')}</em>}</td>
+                            <td><code>{apiKey.keyPrefix}</code></td>
+                            <td>{apiKey.createdAt ? new Date(apiKey.createdAt).toLocaleDateString() : '—'}</td>
+                            <td>
+                                {apiKey.lastAccessed
+                                    ? new Date(apiKey.lastAccessed).toLocaleDateString()
+                                    : this.translate('pages.apiKeys.neverUsed')}
+                            </td>
+                            <td>
+                                <Button
+                                    variant="outline-danger"
+                                    size="sm"
+                                    disabled={revokingKeyId === apiKey.id}
+                                    onClick={() => this.onRevokeKey(apiKey)}
+                                >
+                                    <FontAwesomeIcon icon={faTrashAlt} className="me-1" />
+                                    {this.translate('pages.apiKeys.revoke')}
+                                </Button>
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </Table>
+        );
+    };
+
+    public render(): JSX.Element | null {
+        const {
+            apiKeys,
+            createdKey,
+            errorMessage,
+            isCreating,
+            isLoading,
+            newKeyName,
+        } = this.state;
+        const isAtKeyLimit = apiKeys.length >= MAX_KEYS_PER_USER;
+
+        return (
+            <div id="page_api_keys" className="flex-box column">
+                <div className="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center py-4">
+                    <div className="d-block mb-4 mb-md-0">
+                        <h1 className="h4">{this.translate('pages.apiKeys.pageTitle')}</h1>
+                        <p className="mb-0">
+                            {this.translate('pages.apiKeys.pageDescription')}{' '}
+                            <a href={API_DOCS_URL} target="_blank" rel="noreferrer">
+                                {this.translate('pages.apiKeys.viewDocs')}
+                            </a>
+                        </p>
+                    </div>
+                </div>
+
+                <Row className="justify-content-center">
+                    <Col xs={12} xl={10}>
+                        {errorMessage && <Alert variant="danger">{errorMessage}</Alert>}
+
+                        {isLoading && (
+                            <div className="text-center py-5">
+                                <Spinner animation="border" role="status" />
+                            </div>
+                        )}
+
+                        {!isLoading && !this.isEligible && this.renderUpgradePrompt()}
+
+                        {!isLoading && this.isEligible && (
+                            <>
+                                {createdKey && this.renderCreatedKey()}
+
+                                <Card border="light" className="bg-white shadow-sm mb-4">
+                                    <Card.Body>
+                                        <h5 className="mb-4">{this.translate('pages.apiKeys.createTitle')}</h5>
+                                        <Form onSubmit={this.onCreateKey}>
+                                            <Row className="align-items-end">
+                                                <Col xs={12} md={8} className="mb-3">
+                                                    <Form.Group id="apiKeyName">
+                                                        <Form.Label>
+                                                            {this.translate('pages.apiKeys.nameLabel')}
+                                                        </Form.Label>
+                                                        <Form.Control
+                                                            type="text"
+                                                            maxLength={128}
+                                                            value={newKeyName}
+                                                            placeholder={this.translate('pages.apiKeys.namePlaceholder')}
+                                                            onChange={(e) => this.setState({ newKeyName: e.target.value })}
+                                                        />
+                                                    </Form.Group>
+                                                </Col>
+                                                <Col xs={12} md={4} className="mb-3">
+                                                    <Button
+                                                        variant="primary"
+                                                        type="submit"
+                                                        className="w-100"
+                                                        disabled={isCreating || isAtKeyLimit}
+                                                    >
+                                                        <FontAwesomeIcon icon={faKey} className="me-1" />
+                                                        {this.translate('pages.apiKeys.createButton')}
+                                                    </Button>
+                                                </Col>
+                                            </Row>
+                                            {isAtKeyLimit && (
+                                                <p className="mb-0 text-muted">
+                                                    {this.translate('pages.apiKeys.atLimit', {
+                                                        max: `${MAX_KEYS_PER_USER}`,
+                                                    })}
+                                                </p>
+                                            )}
+                                        </Form>
+                                    </Card.Body>
+                                </Card>
+
+                                <Card border="light" className="shadow-sm mb-4">
+                                    <Card.Header>
+                                        <h5 className="mb-0">{this.translate('pages.apiKeys.listTitle')}</h5>
+                                    </Card.Header>
+                                    <Card.Body className="pt-0">
+                                        {this.renderKeysTable()}
+                                    </Card.Body>
+                                </Card>
+                            </>
+                        )}
+                    </Col>
+                </Row>
+            </div>
+        );
+    }
+}
+
+export default withNavigation(connect(mapStateToProps, null)(ApiKeysComponent));

--- a/therr-client-web-dashboard/src/routes/Login/index.tsx
+++ b/therr-client-web-dashboard/src/routes/Login/index.tsx
@@ -22,6 +22,7 @@ import UsersActions from '../../redux/actions/UsersActions';
 import withNavigation from '../../wrappers/withNavigation';
 import { getWebsiteName } from '../../utilities/getHostContext';
 import { onFBLoginPress, shouldRenderLoginForm } from '../../api/login';
+import getReturnTo from '../../utilities/getReturnTo';
 import LoginWith from '../../components/LoginWith';
 
 const BgImage = '/assets/img/illustrations/signin-v2.svg';
@@ -73,9 +74,13 @@ export class LoginComponent extends React.Component<ILoginProps, ILoginState> {
     static getDerivedStateFromProps(nextProps: ILoginProps) {
         // TODO: Choose route based on accessLevels
         if (!shouldRenderLoginForm(nextProps)) {
+            // Honor ?returnTo so an inbound deep link (e.g. the /api-access page sending a
+            // user to /settings/api-keys) survives the login detour instead of dumping
+            // them on the dashboard overview with no idea where to go next.
+            const destination = getReturnTo(nextProps.location?.search, routeAfterLogin);
             // TODO: This doesn't seem to work with react-router-dom v6 after a newly created user tries to login
             // Causes a flicker / Need to investigate further
-            setTimeout(() => nextProps.navigation.navigate(routeAfterLogin));
+            setTimeout(() => nextProps.navigation.navigate(destination));
             return null;
         }
         return {};
@@ -146,6 +151,10 @@ export class LoginComponent extends React.Component<ILoginProps, ILoginState> {
             alertIsVisible,
             alertVariation,
         } = this.state;
+        // Preserve the inbound destination across "Create account" too — a visitor sent here
+        // from /api-access usually has no dashboard account yet, so registration is their path.
+        const returnTo = getReturnTo(this.props.location?.search, '');
+        const registerPath = returnTo ? `/register?returnTo=${encodeURIComponent(returnTo)}` : '/register';
 
         return (
             <div id="page_login" className="flex-box center space-evenly row">
@@ -181,7 +190,7 @@ export class LoginComponent extends React.Component<ILoginProps, ILoginState> {
                                             <span className='fw-normal'>
                                                 {/* eslint-disable-next-line no-trailing-spaces */}
                                                 Not registered? 
-                                                <Card.Link as={Link} to={'/register'} className='fw-bolder' style={{ paddingLeft: '.5rem' }}>
+                                                <Card.Link as={Link} to={registerPath} className='fw-bolder' style={{ paddingLeft: '.5rem' }}>
                                                     {'Create account'}
                                                 </Card.Link>
                                             </span>

--- a/therr-client-web-dashboard/src/routes/Register/index.tsx
+++ b/therr-client-web-dashboard/src/routes/Register/index.tsx
@@ -22,6 +22,7 @@ import withNavigation from '../../wrappers/withNavigation';
 import { getWebsiteName } from '../../utilities/getHostContext';
 import { onFBLoginPress, shouldRenderLoginForm } from '../../api/login';
 import { routeAfterLogin } from '../Login';
+import getReturnTo from '../../utilities/getReturnTo';
 import LoginWith from '../../components/LoginWith';
 
 const BgImage = '/assets/img/illustrations/signin-v2.svg';
@@ -117,7 +118,11 @@ export class RegisterComponent extends React.Component<IRegisterProps, IRegister
             activationCode,
             paymentSessionId,
         }).then((response: any) => {
-            this.props.navigation.navigate('/login', {
+            // Keep the inbound destination attached through the login step so a business
+            // account created from the /api-access flow lands on API keys, not the overview.
+            const returnTo = getReturnTo(window?.location?.search, '');
+            const loginPath = returnTo ? `/login?returnTo=${encodeURIComponent(returnTo)}` : '/login';
+            this.props.navigation.navigate(loginPath, {
                 state: {
                     successMessage: this.translate('pages.register.registerSuccess'),
                 },

--- a/therr-client-web-dashboard/src/routes/SSOLanding.tsx
+++ b/therr-client-web-dashboard/src/routes/SSOLanding.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { UsersService } from 'therr-react/services';
 import { BrandVariations } from 'therr-js-utilities/constants';
+import getReturnTo from '../utilities/getReturnTo';
 
 // Persists the handoff/login result and reloads so the Redux store
 // re-initializes from storage on the dashboard's normal boot path.
@@ -9,14 +10,17 @@ const persistAndEnter = (
     userData: Record<string, any>,
     refreshToken: string | null,
     rememberMe: boolean,
+    returnTo: string,
 ) => {
     const storage = rememberMe ? localStorage : sessionStorage;
     storage.setItem('therrUser', JSON.stringify(userData));
     if (refreshToken) {
         storage.setItem('therrRefreshToken', refreshToken);
     }
-    // Full reload so the Redux store re-initializes from storage
-    window.location.href = '/dashboard';
+    // Full reload so the Redux store re-initializes from storage. `returnTo` lets a
+    // linking site (e.g. the /api-access page) land the user on the exact page they
+    // asked for instead of dropping everyone on the dashboard overview.
+    window.location.href = returnTo;
 };
 
 const SSOLanding = () => {
@@ -27,6 +31,7 @@ const SSOLanding = () => {
         const params = new URLSearchParams(location.search);
         const rememberMe = params.get('rm') === '1';
         const code = params.get('code');
+        const returnTo = getReturnTo(location.search);
 
         // Preferred path: exchange a single-use handoff code for a fresh,
         // dashboard-branded session. The code is the only credential in the URL
@@ -51,10 +56,13 @@ const SSOLanding = () => {
                         },
                         data.refreshToken,
                         rememberMe,
+                        returnTo,
                     );
                 })
                 .catch(() => {
-                    navigate('/login');
+                    // Carry the destination through the login detour so a failed or expired
+                    // handoff still ends where the user was headed.
+                    navigate(`/login?returnTo=${encodeURIComponent(returnTo)}`);
                 });
             return;
         }
@@ -65,7 +73,7 @@ const SSOLanding = () => {
         const token = params.get('token');
         const userId = params.get('userId');
         if (!token || !userId) {
-            navigate('/login');
+            navigate(`/login?returnTo=${encodeURIComponent(returnTo)}`);
             return;
         }
 
@@ -88,6 +96,7 @@ const SSOLanding = () => {
             },
             params.get('rt') || null,
             rememberMe,
+            returnTo,
         );
     }, []);
 

--- a/therr-client-web-dashboard/src/routes/Settings.tsx
+++ b/therr-client-web-dashboard/src/routes/Settings.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { NavigateFunction } from 'react-router-dom';
+import { Link, NavigateFunction } from 'react-router-dom';
 import {
+    Card,
     Col,
     Row,
     Button,
@@ -161,6 +162,18 @@ export class SettingsComponent extends React.Component<ISettingsProps, ISettings
                             brandContext={brandContext}
                             user={user}
                         />
+                    </Col>
+
+                    <Col xs={12} xl={10} xxl={8}>
+                        <Card border="light" className="bg-white shadow-sm mb-4 text-center">
+                            <Card.Body>
+                                <h5>{this.translate('pages.settings.apiKeys.title')}</h5>
+                                <p>{this.translate('pages.settings.apiKeys.description')}</p>
+                                <Button variant="primary" as={Link as any} to="/settings/api-keys">
+                                    {this.translate('pages.settings.apiKeys.manageButton')}
+                                </Button>
+                            </Card.Body>
+                        </Card>
                     </Col>
                 </Row>
                 <ToastContainer className="p-3" position={'bottom-end'}>

--- a/therr-client-web-dashboard/src/routes/__tests__/getReturnTo.test.ts
+++ b/therr-client-web-dashboard/src/routes/__tests__/getReturnTo.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+import getReturnTo from '../../utilities/getReturnTo';
+
+describe('getReturnTo', () => {
+    it('returns the default fallback when there is no query string', () => {
+        expect(getReturnTo()).toBe('/dashboard');
+        expect(getReturnTo('')).toBe('/dashboard');
+    });
+
+    it('returns the fallback when returnTo is absent', () => {
+        expect(getReturnTo('?rm=1&code=abc')).toBe('/dashboard');
+    });
+
+    it('honors a custom fallback', () => {
+        expect(getReturnTo('?rm=1', '/settings')).toBe('/settings');
+    });
+
+    it('returns a valid relative path', () => {
+        expect(getReturnTo('?returnTo=%2Fsettings%2Fapi-keys')).toBe('/settings/api-keys');
+    });
+
+    it('preserves a query string on the destination', () => {
+        expect(getReturnTo('?returnTo=%2Fsettings%3Ftab%3Dkeys')).toBe('/settings?tab=keys');
+    });
+
+    it.each([
+        ['//evil.com', 'protocol-relative URL'],
+        ['/\\evil.com', 'backslash authority — browsers parse \\ as /'],
+        ['https://evil.com', 'absolute URL'],
+        ['javascript:alert(1)', 'javascript scheme'], // eslint-disable-line no-script-url
+        ['settings', 'bare relative path'],
+    ])('rejects %s (%s)', (candidate) => {
+        // The handoff lands an authenticated session, so an attacker-controlled
+        // destination would be worth stealing — anything but a plain path is refused.
+        expect(getReturnTo(`?returnTo=${encodeURIComponent(candidate)}`)).toBe('/dashboard');
+    });
+});

--- a/therr-client-web-dashboard/src/routes/index.tsx
+++ b/therr-client-web-dashboard/src/routes/index.tsx
@@ -10,6 +10,7 @@ import DashboardOverview from './Dashboards/DashboardOverview';
 import PageNotFound from './PageNotFound';
 import Register from './Register';
 import Settings from './Settings';
+import ApiKeys from './ApiKeys';
 import EmailVerification from './EmailVerification';
 import ResetPassword from './ResetPassword';
 import ManageSpaces from './ManageSpaces';
@@ -295,6 +296,20 @@ const getRoutes = (routePropsConfig: IRoutePropsConfig): IRoute[] => [
         path: '/settings',
         element: <AuthRoute
             component={Settings}
+            isAuthorized={routePropsConfig.isAuthorized({
+                type: AccessCheckType.ANY,
+                levels: [AccessLevels.EMAIL_VERIFIED],
+            })}
+            redirectPath={'/login'}
+        />,
+    },
+    {
+        // Gated on EMAIL_VERIFIED only, not on subscription level: an unsubscribed user
+        // who follows the link needs to land here and see the upgrade prompt rather than
+        // be bounced to /login with no explanation of why.
+        path: '/settings/api-keys',
+        element: <AuthRoute
+            component={ApiKeys}
             isAuthorized={routePropsConfig.isAuthorized({
                 type: AccessCheckType.ANY,
                 levels: [AccessLevels.EMAIL_VERIFIED],

--- a/therr-client-web-dashboard/src/services/ApiKeysService.ts
+++ b/therr-client-web-dashboard/src/services/ApiKeysService.ts
@@ -1,0 +1,36 @@
+/* eslint-disable class-methods-use-this */
+import axios from 'axios';
+
+export interface IApiKey {
+    id: string;
+    name?: string;
+    keyPrefix: string;
+    accessLevels: string[];
+    lastAccessed?: string;
+    createdAt: string;
+    /**
+     * Only ever populated on the create response. The raw key is hashed server-side and is
+     * unrecoverable afterwards, so the UI has one chance to show it.
+     */
+    key?: string;
+}
+
+class ApiKeysService {
+    list = () => axios({
+        method: 'get',
+        url: '/users-service/api-keys',
+    });
+
+    create = (data: { name?: string; accessLevels?: string[] }) => axios({
+        method: 'post',
+        url: '/users-service/api-keys',
+        data,
+    });
+
+    revoke = (id: string) => axios({
+        method: 'delete',
+        url: `/users-service/api-keys/${id}`,
+    });
+}
+
+export default new ApiKeysService();

--- a/therr-client-web-dashboard/src/utilities/getReturnTo.ts
+++ b/therr-client-web-dashboard/src/utilities/getReturnTo.ts
@@ -1,0 +1,28 @@
+/**
+ * Extracts and validates a returnTo query parameter.
+ *
+ * Only same-origin relative paths are allowed. Rejecting protocol-relative ('//evil.com')
+ * and absolute URLs keeps this from becoming an open redirect — the handoff lands an
+ * authenticated session, so an attacker-controlled destination would be worth stealing.
+ */
+const getReturnTo = (search?: string, fallback = '/dashboard'): string => {
+    if (!search) return fallback;
+
+    let returnTo: string | null = null;
+    try {
+        returnTo = new URLSearchParams(search).get('returnTo');
+    } catch {
+        return fallback;
+    }
+
+    if (!returnTo) return fallback;
+    // Reject anything that isn't a plain path, including '//host' and '/\host' — browsers
+    // treat a backslash as a slash when parsing authority, so both escape the origin.
+    if (!returnTo.startsWith('/') || returnTo.startsWith('//') || returnTo.startsWith('/\\')) {
+        return fallback;
+    }
+
+    return returnTo;
+};
+
+export default getReturnTo;

--- a/therr-client-web/src/__tests__/apiAccess.test.ts
+++ b/therr-client-web/src/__tests__/apiAccess.test.ts
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+import { AccessLevels } from 'therr-js-utilities/constants';
+import {
+    ApiAccessStage,
+    getApiAccessStage,
+    getDashboardTargetPath,
+    hasApiKeyEligibility,
+} from '../utilities/apiAccess';
+
+const buildUser = (details: any = {}, isAuthenticated = true): any => ({
+    isAuthenticated,
+    details: {
+        accessLevels: [AccessLevels.EMAIL_VERIFIED],
+        ...details,
+    },
+});
+
+describe('apiAccess', () => {
+    describe('getApiAccessStage', () => {
+        it('treats a missing user as unauthenticated', () => {
+            expect(getApiAccessStage(undefined)).toBe(ApiAccessStage.UNAUTHENTICATED);
+        });
+
+        it('treats an authenticated user with no access levels as unauthenticated', () => {
+            // The store briefly holds { isAuthenticated: true, details: {} } during boot;
+            // rendering the "eligible" CTA there would send them to a 403.
+            expect(getApiAccessStage(buildUser({ accessLevels: [] }))).toBe(ApiAccessStage.UNAUTHENTICATED);
+        });
+
+        it('routes a half-registered account to the profile step', () => {
+            const user = buildUser({
+                accessLevels: [AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES],
+            });
+            expect(getApiAccessStage(user)).toBe(ApiAccessStage.INCOMPLETE_PROFILE);
+        });
+
+        it('does not treat a fully verified account as half-registered', () => {
+            const user = buildUser({
+                accessLevels: [
+                    AccessLevels.EMAIL_VERIFIED,
+                    AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES,
+                ],
+                isBusinessAccount: true,
+            });
+            expect(getApiAccessStage(user)).toBe(ApiAccessStage.NO_SUBSCRIPTION);
+        });
+
+        it('routes a personal profile to the business account step', () => {
+            expect(getApiAccessStage(buildUser({ isBusinessAccount: false }))).toBe(ApiAccessStage.NOT_A_BUSINESS);
+        });
+
+        it('routes an unsubscribed business account to the subscription step', () => {
+            const user = buildUser({ isBusinessAccount: true });
+            expect(getApiAccessStage(user)).toBe(ApiAccessStage.NO_SUBSCRIPTION);
+        });
+
+        it.each([
+            AccessLevels.DASHBOARD_SUBSCRIBER_BASIC,
+            AccessLevels.DASHBOARD_SUBSCRIBER_PRO,
+            AccessLevels.DASHBOARD_SUBSCRIBER_PREMIUM,
+            AccessLevels.DASHBOARD_SUBSCRIBER_AGENCY,
+            AccessLevels.API_ACCESS,
+        ])('marks a %s subscriber as eligible', (level) => {
+            const user = buildUser({
+                accessLevels: [AccessLevels.EMAIL_VERIFIED, level],
+                isBusinessAccount: true,
+            });
+            expect(getApiAccessStage(user)).toBe(ApiAccessStage.ELIGIBLE);
+        });
+
+        it('marks an eligible account as eligible even without the business flag', () => {
+            // Super admins and directly-granted API_ACCESS users can create keys; telling
+            // them to go register a business account would be a dead end.
+            const user = buildUser({
+                accessLevels: [AccessLevels.EMAIL_VERIFIED, AccessLevels.SUPER_ADMIN],
+                isBusinessAccount: false,
+            });
+            expect(getApiAccessStage(user)).toBe(ApiAccessStage.ELIGIBLE);
+        });
+    });
+
+    describe('hasApiKeyEligibility', () => {
+        it('defaults to false with no access levels', () => {
+            expect(hasApiKeyEligibility()).toBe(false);
+            expect(hasApiKeyEligibility([])).toBe(false);
+        });
+
+        it('ignores unrelated access levels', () => {
+            expect(hasApiKeyEligibility([AccessLevels.EMAIL_VERIFIED])).toBe(false);
+        });
+    });
+
+    describe('getDashboardTargetPath', () => {
+        it('sends eligible users straight to the key generator', () => {
+            expect(getDashboardTargetPath(ApiAccessStage.ELIGIBLE)).toBe('/settings/api-keys');
+        });
+
+        it('sends unsubscribed business accounts to settings', () => {
+            expect(getDashboardTargetPath(ApiAccessStage.NO_SUBSCRIPTION)).toBe('/settings');
+        });
+
+        it.each([
+            ApiAccessStage.UNAUTHENTICATED,
+            ApiAccessStage.INCOMPLETE_PROFILE,
+            ApiAccessStage.NOT_A_BUSINESS,
+        ])('has no dashboard destination for %s', (stage) => {
+            // These stages have no usable dashboard session, so the page must not
+            // attempt an SSO handoff for them.
+            expect(getDashboardTargetPath(stage)).toBeUndefined();
+        });
+    });
+});

--- a/therr-client-web/src/components/nav-menu/UserMenu.tsx
+++ b/therr-client-web/src/components/nav-menu/UserMenu.tsx
@@ -167,10 +167,15 @@ export class UserMenuComponent extends React.Component<IUserMenuProps, IUserMenu
         }
     };
 
-    navigateToDashboard = () => {
+    /**
+     * `targetPath` must be passed explicitly, never by wiring this straight to onClick —
+     * the click event would be serialized into the returnTo param.
+     */
+    navigateToDashboard = (targetPath?: string) => {
         const { settings } = this.props.user;
         const dashboardOrigin = globalConfig[process.env.NODE_ENV].dashboardHostFull;
         const rememberMe = settings?.rememberMe ? '1' : '0';
+        const returnToParam = targetPath ? `&returnTo=${encodeURIComponent(targetPath)}` : '';
 
         // Open the dashboard tab synchronously (still inside the click gesture)
         // so the browser doesn't block it as a popup, then redirect it once the
@@ -189,7 +194,7 @@ export class UserMenuComponent extends React.Component<IUserMenuProps, IUserMenu
                 if (!code) {
                     throw new Error('Missing handoff code');
                 }
-                const dashboardUrl = `${dashboardOrigin}/sso?code=${encodeURIComponent(code)}&rm=${rememberMe}`;
+                const dashboardUrl = `${dashboardOrigin}/sso?code=${encodeURIComponent(code)}&rm=${rememberMe}${returnToParam}`;
                 if (newTab) {
                     newTab.location.href = dashboardUrl;
                 } else {
@@ -218,7 +223,7 @@ export class UserMenuComponent extends React.Component<IUserMenuProps, IUserMenu
                         className="menu-item left-icon"
                         leftSection={<InlineSvg name="dashboard" />}
                         text={this.props.translate('components.userMenu.buttons.businessDashboard')}
-                        onClick={this.navigateToDashboard}
+                        onClick={() => this.navigateToDashboard()}
                         variant="subtle"
                         fullWidth
                     />

--- a/therr-client-web/src/locales/en-us/dictionary.json
+++ b/therr-client-web/src/locales/en-us/dictionary.json
@@ -263,6 +263,60 @@
       "contactDescription": "For questions or concerns about our child safety practices, please contact us at",
       "returnHome": "Return to home page"
     },
+    "apiAccess": {
+      "pageTitle": "Get a Therr API Key",
+      "intro": "Therr's location APIs give you access to nearby places, events, and community activity. Here is how to get a key, start to finish.",
+      "steps": {
+        "one": {
+          "title": "Create a business account",
+          "description": "API access is tied to a business account on the Therr dashboard. Sign up there with your business email — a personal Therr profile cannot generate keys."
+        },
+        "two": {
+          "title": "Choose a plan",
+          "description": "Open Settings in the dashboard and pick a subscription. Every paid plan includes API access; the plan you choose sets your rate limits."
+        },
+        "three": {
+          "title": "Generate your key",
+          "description": "Go to Settings, then API Keys, and create a key. The key is shown once, at creation — copy it somewhere safe before closing the page."
+        },
+        "four": {
+          "title": "Start building",
+          "description": "Send your key as the x-api-key header on any request. The API reference covers every endpoint, its parameters, and its response shape."
+        }
+      },
+      "status": {
+        "unauthenticated": "You are not signed in yet. Start by creating a business account.",
+        "incompleteProfile": "Your account still needs a few details before it can be used for API access.",
+        "notABusiness": "You are signed in with a personal profile. API keys require a separate business account.",
+        "noSubscription": "Your business account is ready. Choose a subscription plan to unlock API access.",
+        "eligible": "Your account can create API keys. Head to the dashboard to generate one."
+      },
+      "cta": {
+        "unauthenticated": "Create a business account",
+        "incompleteProfile": "Finish setting up your profile",
+        "notABusiness": "Create a business account",
+        "noSubscription": "Choose a plan",
+        "eligible": "Generate an API key"
+      },
+      "handoffError": "We could not open the dashboard. Please try again.",
+      "viewDocs": "Read the API reference",
+      "faqTitle": "Common questions",
+      "faq": {
+        "cost": {
+          "question": "Does API access cost extra?",
+          "answer": "No. API access is included with every paid dashboard plan. Your plan determines your rate limits."
+        },
+        "lost": {
+          "question": "I lost my key. Can I see it again?",
+          "answer": "No. Keys are stored hashed and shown only once at creation. Revoke the old key and create a new one."
+        },
+        "limit": {
+          "question": "How many keys can I have?",
+          "answer": "Up to five active keys per account. Revoke one you no longer use to free up a slot."
+        }
+      },
+      "returnHome": "Return home"
+    },
     "deleteAccount": {
       "pageTitle": "Delete Your Account",
       "description": "We're sorry to see you go. If you'd like to delete your Therr account and all associated data, you can do so using one of the options below.",

--- a/therr-client-web/src/locales/es/dictionary.json
+++ b/therr-client-web/src/locales/es/dictionary.json
@@ -263,6 +263,60 @@
       "contactDescription": "Para preguntas o inquietudes sobre nuestras prácticas de seguridad infantil, contáctanos en",
       "returnHome": "Volver a la página de inicio"
     },
+    "apiAccess": {
+      "pageTitle": "Obtén una clave de API de Therr",
+      "intro": "Las API de ubicación de Therr te dan acceso a lugares cercanos, eventos y actividad de la comunidad. Así se obtiene una clave, de principio a fin.",
+      "steps": {
+        "one": {
+          "title": "Crea una cuenta de negocio",
+          "description": "El acceso a la API está vinculado a una cuenta de negocio en el panel de Therr. Regístrate allí con el correo de tu negocio: un perfil personal de Therr no puede generar claves."
+        },
+        "two": {
+          "title": "Elige un plan",
+          "description": "Abre Configuración en el panel y elige una suscripción. Todos los planes de pago incluyen acceso a la API; el plan que elijas define tus límites de uso."
+        },
+        "three": {
+          "title": "Genera tu clave",
+          "description": "Ve a Configuración y luego a Claves de API para crear una clave. La clave se muestra una sola vez, al crearla: cópiala en un lugar seguro antes de cerrar la página."
+        },
+        "four": {
+          "title": "Empieza a construir",
+          "description": "Envía tu clave en el encabezado x-api-key de cada solicitud. La referencia de la API describe todos los endpoints, sus parámetros y sus respuestas."
+        }
+      },
+      "status": {
+        "unauthenticated": "Aún no has iniciado sesión. Empieza creando una cuenta de negocio.",
+        "incompleteProfile": "Tu cuenta necesita algunos datos más antes de poder usarse para el acceso a la API.",
+        "notABusiness": "Has iniciado sesión con un perfil personal. Las claves de API requieren una cuenta de negocio aparte.",
+        "noSubscription": "Tu cuenta de negocio está lista. Elige un plan de suscripción para activar el acceso a la API.",
+        "eligible": "Tu cuenta puede crear claves de API. Ve al panel para generar una."
+      },
+      "cta": {
+        "unauthenticated": "Crear una cuenta de negocio",
+        "incompleteProfile": "Termina de configurar tu perfil",
+        "notABusiness": "Crear una cuenta de negocio",
+        "noSubscription": "Elegir un plan",
+        "eligible": "Generar una clave de API"
+      },
+      "handoffError": "No pudimos abrir el panel. Inténtalo de nuevo.",
+      "viewDocs": "Leer la referencia de la API",
+      "faqTitle": "Preguntas frecuentes",
+      "faq": {
+        "cost": {
+          "question": "¿El acceso a la API tiene un costo adicional?",
+          "answer": "No. El acceso a la API está incluido en todos los planes de pago del panel. Tu plan determina tus límites de uso."
+        },
+        "lost": {
+          "question": "Perdí mi clave. ¿Puedo verla de nuevo?",
+          "answer": "No. Las claves se guardan cifradas y solo se muestran una vez, al crearlas. Revoca la clave anterior y crea una nueva."
+        },
+        "limit": {
+          "question": "¿Cuántas claves puedo tener?",
+          "answer": "Hasta cinco claves activas por cuenta. Revoca una que ya no uses para liberar espacio."
+        }
+      },
+      "returnHome": "Volver al inicio"
+    },
     "deleteAccount": {
       "pageTitle": "Eliminar tu cuenta",
       "description": "Lamentamos que te vayas. Si deseas eliminar tu cuenta de Therr y todos los datos asociados, puedes hacerlo usando una de las opciones a continuación.",

--- a/therr-client-web/src/locales/fr-ca/dictionary.json
+++ b/therr-client-web/src/locales/fr-ca/dictionary.json
@@ -263,6 +263,60 @@
       "contactDescription": "Pour toute question ou préoccupation concernant nos pratiques de sécurité des enfants, veuillez nous contacter à",
       "returnHome": "Retour à la page d'accueil"
     },
+    "apiAccess": {
+      "pageTitle": "Obtenir une clé API Therr",
+      "intro": "Les API de localisation de Therr donnent accès aux lieux à proximité, aux événements et à l'activité de la communauté. Voici comment obtenir une clé, de bout en bout.",
+      "steps": {
+        "one": {
+          "title": "Créez un compte entreprise",
+          "description": "L'accès à l'API est lié à un compte entreprise sur le tableau de bord Therr. Inscrivez-vous avec le courriel de votre entreprise : un profil Therr personnel ne peut pas générer de clés."
+        },
+        "two": {
+          "title": "Choisissez un forfait",
+          "description": "Ouvrez Paramètres dans le tableau de bord et choisissez un abonnement. Tous les forfaits payants incluent l'accès à l'API; le forfait choisi définit vos limites de débit."
+        },
+        "three": {
+          "title": "Générez votre clé",
+          "description": "Allez dans Paramètres, puis Clés API, et créez une clé. La clé n'est affichée qu'une seule fois, à la création : copiez-la en lieu sûr avant de fermer la page."
+        },
+        "four": {
+          "title": "Commencez à créer",
+          "description": "Envoyez votre clé dans l'en-tête x-api-key de chaque requête. La référence de l'API décrit tous les points d'accès, leurs paramètres et leurs réponses."
+        }
+      },
+      "status": {
+        "unauthenticated": "Vous n'êtes pas encore connecté. Commencez par créer un compte entreprise.",
+        "incompleteProfile": "Votre compte a besoin de quelques informations avant de pouvoir servir à l'accès API.",
+        "notABusiness": "Vous êtes connecté avec un profil personnel. Les clés API nécessitent un compte entreprise distinct.",
+        "noSubscription": "Votre compte entreprise est prêt. Choisissez un forfait pour activer l'accès à l'API.",
+        "eligible": "Votre compte peut créer des clés API. Rendez-vous au tableau de bord pour en générer une."
+      },
+      "cta": {
+        "unauthenticated": "Créer un compte entreprise",
+        "incompleteProfile": "Terminer la configuration du profil",
+        "notABusiness": "Créer un compte entreprise",
+        "noSubscription": "Choisir un forfait",
+        "eligible": "Générer une clé API"
+      },
+      "handoffError": "Impossible d'ouvrir le tableau de bord. Veuillez réessayer.",
+      "viewDocs": "Consulter la référence de l'API",
+      "faqTitle": "Questions fréquentes",
+      "faq": {
+        "cost": {
+          "question": "L'accès à l'API coûte-t-il plus cher?",
+          "answer": "Non. L'accès à l'API est inclus dans tous les forfaits payants du tableau de bord. Votre forfait détermine vos limites de débit."
+        },
+        "lost": {
+          "question": "J'ai perdu ma clé. Puis-je la revoir?",
+          "answer": "Non. Les clés sont stockées hachées et affichées une seule fois, à la création. Révoquez l'ancienne clé et créez-en une nouvelle."
+        },
+        "limit": {
+          "question": "Combien de clés puis-je avoir?",
+          "answer": "Jusqu'à cinq clés actives par compte. Révoquez celle que vous n'utilisez plus pour libérer une place."
+        }
+      },
+      "returnHome": "Retour à l'accueil"
+    },
     "deleteAccount": {
       "pageTitle": "Supprimer votre compte",
       "description": "Nous sommes désolés de vous voir partir. Si vous souhaitez supprimer votre compte Therr et toutes les données associées, vous pouvez le faire en utilisant l'une des options ci-dessous.",

--- a/therr-client-web/src/routeConfig.ts
+++ b/therr-client-web/src/routeConfig.ts
@@ -129,6 +129,14 @@ export default [
         view: 'index',
     },
     {
+        route: '/api-access',
+        head: {
+            title: 'Get a Therr API Key',
+            description: 'How to get a Therr API key: create a business account, choose a plan, generate your key in the dashboard, and start building with our location APIs.',
+        },
+        view: 'index',
+    },
+    {
         route: '/child-safety',
         head: {
             title: 'Child Safety Standards',

--- a/therr-client-web/src/routes/ApiAccess.tsx
+++ b/therr-client-web/src/routes/ApiAccess.tsx
@@ -1,0 +1,164 @@
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { Stack, Button } from '@mantine/core';
+import { BrandVariations } from 'therr-js-utilities/constants';
+import { UsersService } from 'therr-react/services';
+import { IUserState } from 'therr-react/types';
+import useTranslation from '../hooks/useTranslation';
+import { ApiAccessStage, getApiAccessStage, getDashboardTargetPath } from '../utilities/apiAccess';
+import * as globalConfig from '../../../global-config';
+
+const API_DOCS_URL = 'https://api.therr.com/v1/docs';
+
+const STEP_KEYS = ['one', 'two', 'three', 'four'];
+
+const ApiAccess: React.FC = () => {
+    const { t: translate } = useTranslation();
+    const user = useSelector((state: any) => state.user as IUserState);
+    const [isHandingOff, setIsHandingOff] = React.useState(false);
+    const [handoffError, setHandoffError] = React.useState('');
+
+    // SSR has no session, so it always renders the unauthenticated CTA. Deferring the
+    // real stage to an effect keeps the server and first client render identical and
+    // avoids a hydration mismatch on a page that is CDN-cached for logged-out crawlers.
+    const [stage, setStage] = React.useState<ApiAccessStage>(ApiAccessStage.UNAUTHENTICATED);
+
+    React.useEffect(() => {
+        setStage(getApiAccessStage(user));
+    }, [user]);
+
+    React.useEffect(() => {
+        document.title = `Therr | ${translate('pages.apiAccess.pageTitle')}`;
+    }, [translate]);
+
+    const dashboardOrigin = globalConfig[process.env.NODE_ENV].dashboardHostFull;
+
+    /**
+     * Mints a single-use handoff code and lands the user directly on the dashboard page
+     * they need. Without the returnTo the dashboard always drops them on /dashboard and
+     * they have to find API keys themselves — the original dead end.
+     */
+    const navigateToDashboard = (targetPath: string) => {
+        setHandoffError('');
+        setIsHandingOff(true);
+
+        // Opened synchronously inside the click gesture so the browser doesn't treat it
+        // as a blocked popup once the async mint resolves (same approach as UserMenu).
+        const newTab = window.open('', '_blank');
+        if (newTab) {
+            newTab.document.write('Loading dashboard…');
+        }
+
+        const rememberMe = user?.settings?.rememberMe ? '1' : '0';
+
+        UsersService.mintHandoff(BrandVariations.DASHBOARD_THERR)
+            .then((response) => {
+                const { code } = response?.data || {};
+                if (!code) {
+                    throw new Error('Missing handoff code');
+                }
+                const dashboardUrl = `${dashboardOrigin}/sso?code=${encodeURIComponent(code)}`
+                    + `&rm=${rememberMe}&returnTo=${encodeURIComponent(targetPath)}`;
+                if (newTab) {
+                    newTab.location.href = dashboardUrl;
+                } else {
+                    window.location.href = dashboardUrl;
+                }
+            })
+            .catch(() => {
+                // Never leave a blank tab hanging — send it somewhere it can recover from.
+                const fallbackUrl = `${dashboardOrigin}/login?returnTo=${encodeURIComponent(targetPath)}`;
+                if (newTab) {
+                    newTab.location.href = fallbackUrl;
+                } else {
+                    setHandoffError(translate('pages.apiAccess.handoffError'));
+                }
+            })
+            .finally(() => setIsHandingOff(false));
+    };
+
+    const renderCallToAction = () => {
+        const dashboardTargetPath = getDashboardTargetPath(stage);
+
+        if (dashboardTargetPath) {
+            return (
+                <Button
+                    size="lg"
+                    loading={isHandingOff}
+                    onClick={() => navigateToDashboard(dashboardTargetPath)}
+                >
+                    {translate(`pages.apiAccess.cta.${stage}`)}
+                </Button>
+            );
+        }
+
+        if (stage === ApiAccessStage.INCOMPLETE_PROFILE) {
+            return (
+                <Button size="lg" component={Link} to="/create-profile?returnTo=%2Fapi-access">
+                    {translate('pages.apiAccess.cta.incompleteProfile')}
+                </Button>
+            );
+        }
+
+        // Both remaining stages need a *business* account, which is created on the
+        // dashboard (isBusinessAccount is set at dashboard registration). A consumer
+        // account cannot be upgraded in place, so we send them to register there.
+        return (
+            <Button size="lg" component="a" href={`${dashboardOrigin}/register`}>
+                {translate(`pages.apiAccess.cta.${stage}`)}
+            </Button>
+        );
+    };
+
+    return (
+        <div id="page_api_access" className="flex-box space-evenly center row wrap-reverse">
+            <div className="register-container">
+                <div className="flex fill max-wide-30">
+                    <Stack gap="md">
+                        <h1 className="text-center">{translate('pages.apiAccess.pageTitle')}</h1>
+
+                        <p className="text-center">{translate('pages.apiAccess.intro')}</p>
+
+                        <ol>
+                            {STEP_KEYS.map((stepKey) => (
+                                <li key={stepKey}>
+                                    <strong>{translate(`pages.apiAccess.steps.${stepKey}.title`)}</strong>
+                                    <p>{translate(`pages.apiAccess.steps.${stepKey}.description`)}</p>
+                                </li>
+                            ))}
+                        </ol>
+
+                        <p className="text-center">{translate(`pages.apiAccess.status.${stage}`)}</p>
+
+                        {handoffError && <p className="text-center">{handoffError}</p>}
+
+                        <div className="text-center">
+                            {renderCallToAction()}
+                        </div>
+
+                        <div className="text-center">
+                            <a href={API_DOCS_URL} target="_blank" rel="noreferrer">
+                                {translate('pages.apiAccess.viewDocs')}
+                            </a>
+                        </div>
+
+                        <h3>{translate('pages.apiAccess.faqTitle')}</h3>
+                        <p><strong>{translate('pages.apiAccess.faq.cost.question')}</strong></p>
+                        <p>{translate('pages.apiAccess.faq.cost.answer')}</p>
+                        <p><strong>{translate('pages.apiAccess.faq.lost.question')}</strong></p>
+                        <p>{translate('pages.apiAccess.faq.lost.answer')}</p>
+                        <p><strong>{translate('pages.apiAccess.faq.limit.question')}</strong></p>
+                        <p>{translate('pages.apiAccess.faq.limit.answer')}</p>
+
+                        <div className="text-center">
+                            <Link to="/">{translate('pages.apiAccess.returnHome')}</Link>
+                        </div>
+                    </Stack>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ApiAccess;

--- a/therr-client-web/src/routes/index.tsx
+++ b/therr-client-web/src/routes/index.tsx
@@ -26,6 +26,7 @@ import ViewThought from './ViewThought';
 import ViewUser from './ViewUser';
 import AppFeedback from './AppFeedback';
 import ChildSafety from './ChildSafety';
+import ApiAccess from './ApiAccess';
 import DeleteAccount from './DeleteAccount';
 import InviteLanding from './InviteLanding';
 import InviteLinkLanding from './InviteLinkLanding';
@@ -163,6 +164,13 @@ const getRoutes = (routePropsConfig: IRoutePropsConfig): IRoute[] => [
     {
         path: '/child-safety',
         element: <ChildSafety />,
+    },
+    {
+        // Public API onboarding explainer. Intentionally unauthenticated: it is the
+        // link target from the marketing site, and its CTA adapts to the visitor's
+        // account stage rather than dumping everyone on a login page.
+        path: '/api-access',
+        element: <ApiAccess />,
     },
     {
         path: '/delete-account',

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -705,6 +705,7 @@ app.get('/sitemap-static.xml', (req, res) => {
         { loc: '/locations', priority: '0.9' },
         { loc: '/locations/cities', priority: '0.9' },
         { loc: '/locations/categories', priority: '0.9' },
+        { loc: '/api-access', priority: '0.6' },
         ...categoryUrls,
         ...cityUrls,
     ];
@@ -2704,6 +2705,7 @@ const publicRoutePatterns = [
     /^\/invite\/[^/]+$/,
     /^\/lists\/[^/]+\/[a-z0-9-]+$/,
     /^\/child-safety$/,
+    /^\/api-access$/,
     /^\/go-mobile$/,
     /^\/app-feedback$/,
     /^\/reset-password$/,

--- a/therr-client-web/src/utilities/apiAccess.ts
+++ b/therr-client-web/src/utilities/apiAccess.ts
@@ -1,0 +1,75 @@
+import { AccessLevels } from 'therr-js-utilities/constants';
+import { IUserState } from 'therr-react/types';
+
+/**
+ * Where a visitor stands in the API key onboarding flow. The /api-access page renders
+ * one CTA per stage so nobody is sent to a page they cannot use yet — the previous CTA
+ * pointed everyone at a single login URL regardless of account state.
+ */
+export enum ApiAccessStage {
+    UNAUTHENTICATED = 'unauthenticated',
+    INCOMPLETE_PROFILE = 'incompleteProfile',
+    NOT_A_BUSINESS = 'notABusiness',
+    NO_SUBSCRIPTION = 'noSubscription',
+    ELIGIBLE = 'eligible',
+}
+
+/**
+ * Mirrors API_KEY_ELIGIBLE_LEVELS in users-service/handlers/apiKeys.ts. A user without
+ * one of these gets a 403 from POST /api-keys, so the page must route them to the
+ * subscription step instead of the key generator.
+ */
+const API_KEY_ELIGIBLE_LEVELS: string[] = [
+    AccessLevels.DASHBOARD_SUBSCRIBER_BASIC,
+    AccessLevels.DASHBOARD_SUBSCRIBER_PRO,
+    AccessLevels.DASHBOARD_SUBSCRIBER_PREMIUM,
+    AccessLevels.DASHBOARD_SUBSCRIBER_AGENCY,
+    AccessLevels.SUPER_ADMIN,
+    AccessLevels.API_ACCESS,
+];
+
+export const hasApiKeyEligibility = (accessLevels: string[] = []): boolean => API_KEY_ELIGIBLE_LEVELS
+    .some((level) => accessLevels.includes(level));
+
+export const getApiAccessStage = (user?: IUserState): ApiAccessStage => {
+    const accessLevels: string[] = user?.details?.accessLevels || [];
+
+    if (!user?.isAuthenticated || !accessLevels.length) {
+        return ApiAccessStage.UNAUTHENTICATED;
+    }
+
+    // A half-registered account cannot claim a business or subscribe. Send them to finish
+    // the profile first, otherwise the dashboard bounces them back here.
+    if (accessLevels.includes(AccessLevels.EMAIL_VERIFIED_MISSING_PROPERTIES)
+        && !accessLevels.includes(AccessLevels.EMAIL_VERIFIED)) {
+        return ApiAccessStage.INCOMPLETE_PROFILE;
+    }
+
+    // Eligibility is checked before the business-account flag on purpose: super admins and
+    // accounts granted API_ACCESS directly should never be told to create a business account.
+    if (hasApiKeyEligibility(accessLevels)) {
+        return ApiAccessStage.ELIGIBLE;
+    }
+
+    if (!user?.details?.isBusinessAccount) {
+        return ApiAccessStage.NOT_A_BUSINESS;
+    }
+
+    return ApiAccessStage.NO_SUBSCRIPTION;
+};
+
+/**
+ * The dashboard path each stage should land on after the SSO handoff. Stages that have no
+ * dashboard destination (the visitor has no usable dashboard session yet) return undefined
+ * and are handled with an in-app link instead.
+ */
+export const getDashboardTargetPath = (stage: ApiAccessStage): string | undefined => {
+    switch (stage) {
+        case ApiAccessStage.ELIGIBLE:
+            return '/settings/api-keys';
+        case ApiAccessStage.NO_SUBSCRIPTION:
+            return '/settings';
+        default:
+            return undefined;
+    }
+};


### PR DESCRIPTION
The marketing site's "Get an API Key" CTA was a dead end, and not in one place — the flow was broken at every hop.

| Hop | What happened |
|---|---|
| Landing CTA → `therr.com/login?redirect=/settings` | Wrong param name (`Login.tsx` reads `returnTo`) **and** therr-client-web has no `/settings` route — 404 after signing in |
| Dashboard `/settings` | No API key UI anywhere. The users-service endpoints had **zero** frontend callers in the monorepo |
| Web → dashboard SSO handoff | `SSOLanding` hardcoded `/dashboard` after redeeming the code, so no link could land on a specific page |
| Mobile | `therr.com` is an auto-verified App Link, so the CTA opened the app, fell through to `handleOpenByNotifeeNotification()`, and stranded the user |

So the advertised path — create a business account, go to settings, request a key, read the docs — had no working step past the first click.

## therr-client-web — public `/api-access`

SSR-rendered, in `routeConfig`, the CDN public-route list, and the static sitemap. It explains the four steps and adapts its CTA to the visitor's account stage instead of sending everyone to one login URL:

| Stage | Destination |
|---|---|
| unauthenticated / personal profile | dashboard registration |
| incomplete profile | `/create-profile`, returning here |
| business, no subscription | dashboard settings (plans) |
| eligible | `/settings/api-keys` via SSO handoff |

Stage resolution is a pure helper in `utilities/apiAccess.ts` with unit tests, because it mirrors `API_KEY_ELIGIBLE_LEVELS` in users-service and silent drift means either sending eligible users into a 403 or ineligible users to a generator they cannot use. Eligibility is checked *before* the business-account flag so `SUPER_ADMIN` and directly-granted `API_ACCESS` accounts aren't told to go register a business.

The stage resolves in an effect, so SSR and first client render agree — the page is CDN-cached for logged-out crawlers.

## therr-client-web-dashboard — `/settings/api-keys`

List, create, revoke, linked from Settings and the sidebar. The create response carries the raw key exactly once (stored hashed, unrecoverable after), so it surfaces in a dismissible copy panel and is stripped before the record joins the table. Ineligible accounts get an upgrade prompt rather than a form that would 403 — the route is gated on `EMAIL_VERIFIED` only so they land here and read why, instead of bouncing to `/login` unexplained.

Entry points now carry a destination through to the end: `SSOLanding` honors `returnTo` (including on its failure paths), and Login/Register propagate it so a brand-new business account created from `/api-access` finishes on API keys.

`returnTo` is validated by a shared helper accepting only plain relative paths. The handoff lands an authenticated session, so an attacker-controlled destination would be worth stealing; protocol-relative URLs, absolute URLs, and `/\evil.com` (browsers parse the backslash as a slash when reading the authority) are all rejected, each with a test.

## TherrMobile — `ApiAccess` screen

Public on purpose, so a signed-out visitor tapping the link reads the instructions instead of hitting a login wall. Legacy `/api-keys` links are matched too, since older marketing pages still point there.

The hand-off opens `dashboard.therr.com`, deliberately **not** a `therr.com` URL — the latter is in the intent filter and would be captured by this same app, bouncing the user back to the screen they just left. The dashboard host is added to `env-config.js` for that reason.

## Commits

Split by package per the commit-separation rule; each is landable on its own. No backend, shared-library, migration, or root-config paths are touched, so nothing here needed to be split off to a different branch.

## Verification

| Gate | Result |
|---|---|
| ESLint (web, dashboard, mobile) | 0 errors |
| `pr:typecheck:web` / `pr:typecheck:dashboard` | 0 errors |
| `pr:tsc-baseline:mobile` | 104/104, no new errors |
| therr-client-web Jest | 253 passing, 19 suites |
| dashboard Jest | 11 passing, 2 suites |
| mobile Jest | 1186 passing, 45 suites |
| `locales:check` | OK — new keys in all 3 locales (dashboard is en-us only) |

All re-run after rebasing onto `general`. Remaining lint warnings in the touched files are pre-existing unused imports.

## Note on the base branch

Cut from `main` by the session harness, then rebased onto `general` — feature PRs land there, and `general → stage → main` is the only deploy path.

## Companion PR

The landing-side CTA fix is on `claude/api-key-onboarding-flow-7jx6uj` in `rili-live/therr-landing`: it repoints both CTAs at `/api-access` and corrects step copy that promised a *free personal* account, when keys require a business account on a paid plan. **Merging this one first** avoids briefly pointing the marketing site at a route that does not exist yet.

## Worth a look before merge

`AccessLevels.API_ACCESS` is commented "Granted to dashboard subscribers to enable API key management", but nothing in this repo grants it — subscribers qualify via their `DASHBOARD_SUBSCRIBER_*` level instead. Harmless (the eligibility check accepts either), but if it's meant to be issued by the Stripe webhook, that wiring appears to be missing.

---
_Generated by [Claude Code](https://claude.ai/code/session_015KasCK5pZikvXnFepxD1NR)_