### PR TITLE
mobile: replace area detail sub-lists with horizontal card rails

### DIFF
--- a/_bin/push-debug.sh
+++ b/_bin/push-debug.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Walk the push-notification delivery chain for one user and report where it breaks.
+#
+# Chains the three SUPER_ADMIN diagnostics endpoints so you don't have to remember
+# which one answers which question. Full explanation of each link, and of the FCM
+# error codes, is in docs/PUSH_NOTIFICATIONS_DEBUGGING.md.
+#
+# Usage:
+#   ./_bin/push-debug.sh --user <userId> --token <jwt> [--brand habits] [--send] [--type <type>]
+#   ./_bin/push-debug.sh --user <userId> --token <jwt> --device-token <fcmToken>
+#
+# By default the test send is a DRY RUN: FCM validates the token and credentials
+# without delivering anything. Pass --send to make the handset actually buzz.
+
+set -euo pipefail
+
+API_HOST="${THERR_API_HOST:-https://api.therr.com}"
+BRAND="therr"
+USER_ID=""
+JWT=""
+DEVICE_TOKEN=""
+TYPE="pact-invitation"
+DRY_RUN="true"
+
+usage() {
+    sed -n '3,14p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --user) USER_ID="$2"; shift 2 ;;
+        --token) JWT="$2"; shift 2 ;;
+        --brand) BRAND="$2"; shift 2 ;;
+        --device-token) DEVICE_TOKEN="$2"; shift 2 ;;
+        --type) TYPE="$2"; shift 2 ;;
+        --send) DRY_RUN="false"; shift ;;
+        --host) API_HOST="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown argument: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$JWT" ]]; then
+    echo "ERROR: --token <jwt> is required (a SUPER_ADMIN access token)." >&2
+    exit 1
+fi
+if [[ -z "$USER_ID" && -z "$DEVICE_TOKEN" ]]; then
+    echo "ERROR: pass --user <userId>, or --device-token <fcmToken> to skip straight to the send." >&2
+    exit 1
+fi
+
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required." >&2; exit 1; }
+
+HDRS=(-H "authorization: Bearer ${JWT}" -H "x-brand-variation: ${BRAND}" -H "x-localecode: en-us")
+
+echo "==> Brand: ${BRAND}    Host: ${API_HOST}"
+echo
+
+# ---------------------------------------------------------------- link 3
+echo "==> [3/5] Firebase routing for this brand"
+ROUTING="$(curl -sS "${API_HOST}/v1/push-notifications-service/notifications/diagnostics" "${HDRS[@]}")"
+echo "$ROUTING" | jq '{
+    distinctFirebaseProjects,
+    thisBrand: (.byBrand[] | select(.brandVariation == "'"${BRAND}"'"))
+}'
+echo
+
+# ---------------------------------------------------------------- link 2
+if [[ -n "$USER_ID" ]]; then
+    echo "==> [2/5] Device-token registration for user ${USER_ID}"
+    REG="$(curl -sS "${API_HOST}/v1/users-service/users/${USER_ID}/push-diagnostics" "${HDRS[@]}")"
+    echo "$REG" | jq '{ requestedBrand, isRegisteredForRequestedBrand, brandsRegistered, deviceTokens, legacy }'
+
+    if [[ "$(echo "$REG" | jq -r '.isRegisteredForRequestedBrand // false')" != "true" ]]; then
+        echo
+        echo "    !! No device token registered for brand '${BRAND}'."
+        echo "       Either the app never registered (check OS notification permission),"
+        echo "       or its CURRENT_BRAND_VARIATION differs from the brand sending the push."
+        echo "       See docs/PUSH_NOTIFICATIONS_DEBUGGING.md, links 1-2."
+    fi
+    echo
+fi
+
+# ---------------------------------------------------------------- links 4-5
+if [[ -z "$DEVICE_TOKEN" ]]; then
+    echo "==> [4/5] Skipping test send — pass --device-token <fcmToken> to exercise FCM."
+    echo "    (Token values are never returned by the endpoints above, by design.)"
+    echo "    Read it off the device: adb logcat | grep -i 'x-user-device-token', or"
+    echo "    from the app's Redux user.details.deviceMobileFirebaseToken in a debug build."
+    exit 0
+fi
+
+echo "==> [4/5] Test send (dryRun=${DRY_RUN}, type=${TYPE})"
+RESULT="$(curl -sS -X POST \
+    "${API_HOST}/v1/push-notifications-service/notifications/diagnostics/send-test" \
+    "${HDRS[@]}" \
+    -H "content-type: application/json" \
+    -d "{\"deviceToken\":\"${DEVICE_TOKEN}\",\"type\":\"${TYPE}\",\"dryRun\":${DRY_RUN}}")"
+
+echo "$RESULT" | jq '{ result, apnsTopic: .envelope.apns.headers["apns-topic"], androidChannel: .envelope.android.notification.channelId }'
+echo
+
+if [[ "$(echo "$RESULT" | jq -r '.result.ok // false')" == "true" ]]; then
+    echo "==> [5/5] FCM accepted the message."
+    echo "    If nothing arrived on iOS, compare the apns-topic above against the"
+    echo "    installed build's bundle id — APNS drops a mismatch silently and FCM"
+    echo "    still reports success. That is the one failure no error code covers."
+else
+    echo "==> [4/5] FCM rejected the message:"
+    echo "$RESULT" | jq -r '"    " + (.result.errorCode // "?") + ": " + (.result.errorMessage // "")'
+    echo "    Error-code table: docs/PUSH_NOTIFICATIONS_DEBUGGING.md"
+fi

--- a/_bin/push-debug.sh
+++ b/_bin/push-debug.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   ./_bin/push-debug.sh --user <userId> --token <jwt> [--brand habits] [--send] [--type <type>]
-#   ./_bin/push-debug.sh --user <userId> --token <jwt> --device-token <fcmToken>
+#   ./_bin/push-debug.sh --user <userId> --token <jwt> --device-token <fcmToken>   # target one handset
 #
 # By default the test send is a DRY RUN: FCM validates the token and credentials
 # without delivering anything. Pass --send to make the handset actually buzz.
@@ -84,20 +84,29 @@ if [[ -n "$USER_ID" ]]; then
 fi
 
 # ---------------------------------------------------------------- links 4-5
-if [[ -z "$DEVICE_TOKEN" ]]; then
-    echo "==> [4/5] Skipping test send — pass --device-token <fcmToken> to exercise FCM."
-    echo "    (Token values are never returned by the endpoints above, by design.)"
-    echo "    Read it off the device: adb logcat | grep -i 'x-user-device-token', or"
-    echo "    from the app's Redux user.details.deviceMobileFirebaseToken in a debug build."
-    exit 0
-fi
-
 echo "==> [4/5] Test send (dryRun=${DRY_RUN}, type=${TYPE})"
-RESULT="$(curl -sS -X POST \
-    "${API_HOST}/v1/push-notifications-service/notifications/diagnostics/send-test" \
-    "${HDRS[@]}" \
-    -H "content-type: application/json" \
-    -d "{\"deviceToken\":\"${DEVICE_TOKEN}\",\"type\":\"${TYPE}\",\"dryRun\":${DRY_RUN}}")"
+
+if [[ -n "$DEVICE_TOKEN" ]]; then
+    # Explicit token: addresses a specific handset, useful when a user has several.
+    RESULT="$(curl -sS -X POST \
+        "${API_HOST}/v1/push-notifications-service/notifications/diagnostics/send-test" \
+        "${HDRS[@]}" \
+        -H "content-type: application/json" \
+        -d "{\"deviceToken\":\"${DEVICE_TOKEN}\",\"type\":\"${TYPE}\",\"dryRun\":${DRY_RUN}}")"
+else
+    # By user id: users-service resolves the brand-scoped token the same way the
+    # real notification path does, so no token wrangling off the device.
+    RESULT="$(curl -sS -X POST \
+        "${API_HOST}/v1/users-service/users/${USER_ID}/push-diagnostics/send-test" \
+        "${HDRS[@]}" \
+        -H "content-type: application/json" \
+        -d "{\"type\":\"${TYPE}\",\"dryRun\":${DRY_RUN}}")"
+
+    if [[ "$(echo "$RESULT" | jq -r '.reason // ""')" == "no-device-token" ]]; then
+        echo "$RESULT" | jq -r '"    " + .message'
+        exit 0
+    fi
+fi
 
 echo "$RESULT" | jq '{ result, apnsTopic: .envelope.apns.headers["apns-topic"], androidChannel: .envelope.android.notification.channelId }'
 echo

--- a/docs/MULTI_BRAND_ARCHITECTURE.md
+++ b/docs/MULTI_BRAND_ARCHITECTURE.md
@@ -335,6 +335,15 @@ This is **fine for MVP** but becomes painful once any brand needs:
 
 ### Migration path: when to split into per-brand Firebase projects
 
+> **Not receiving push notifications is not a trigger.** A shared project
+> delivers to every app registered in it, and splitting makes the existing
+> service account a stranger to the brand's tokens — every send then fails with
+> `messaging/mismatched-credential`, and the invalid-token cleanup path deletes
+> the registrations on its way out. Diagnose first with
+> [`PUSH_NOTIFICATIONS_DEBUGGING.md`](./PUSH_NOTIFICATIONS_DEBUGGING.md); the
+> cause is usually `apns-topic`, a wrong-brand device-token row, or a missing
+> APNS auth key — none of which a new project fixes.
+
 Triggers that warrant splitting:
 - A brand variant reaches its first 1k+ MAU and analytics signal noise
   becomes a real obstacle to product decisions

--- a/docs/NOTIFICATION_QUEUE_DESIGN.md
+++ b/docs/NOTIFICATION_QUEUE_DESIGN.md
@@ -1,0 +1,210 @@
+# Notification queue — design
+
+**Status:** scaffolded, deploys dark (`NOTIFICATION_QUEUE_WORKER_ENABLED` unset)
+**Scope:** all brands; the immediate driver is HABITS send frequency
+**Companion docs:** [`PUSH_NOTIFICATIONS_ENGAGEMENT_ROADMAP.md`](./PUSH_NOTIFICATIONS_ENGAGEMENT_ROADMAP.md) (what to send), [`PUSH_NOTIFICATIONS_DEBUGGING.md`](./PUSH_NOTIFICATIONS_DEBUGGING.md) (why one didn't arrive)
+
+---
+
+## Why
+
+The goal is Duolingo-style engagement cadence. The obstacle is not the pipes —
+delivery works — it is that today a notification is **sent inline at the moment
+its triggering event happens, with no record that it happened.** Three
+consequences, each of which independently blocks raising frequency:
+
+**1. No dedup.** The habits digest re-sends everything if it runs twice. Root
+`CLAUDE.md` carries a standing rule — *"the habits digest has no server-side
+dedup. Once-a-day is a property of there being a single Cloud Scheduler job, not
+of the code. Never add a second trigger path."* That rule is a convention
+enforced by nothing. A `UNIQUE (brandVariation, userId, dedupeKey)` index
+replaces it with a constraint, which is what makes it safe to have more than one
+producer at all.
+
+**2. No scheduling.** "Send in the evening" means one global Cloud Scheduler
+firing — evening in exactly one timezone. There is no user timezone column
+anywhere in the schema. `scheduledFor` decouples *deciding* to notify from
+*notifying*, which is the prerequisite for send-time personalization (roadmap
+item #2, 15–40% on opens).
+
+**3. No cross-type rate limit.** `MIN_TIME_BETWEEN_PUSH_NOTIFICATIONS_MS` guards
+only location/area pushes inside push-notifications-service. Nothing counts what
+a user received today across all types. The roadmap caps at 3–5/day and warns
+that past that point frequency *reduces* DAU — a cap with no enforcement point
+is a hope. A single queue is the only place that check can exist.
+
+Raising frequency without these is a one-way bet on user tolerance, where the
+opt-out is uninstall.
+
+---
+
+## Shape
+
+```
+producers                  queue                     worker                sender
+─────────                  ─────                     ──────                ──────
+handlers, digest  ──►  main.notificationQueue  ──►  users-service  ──►  push-notifications
+enqueueNotification()   (dedup + scheduledFor)      30s interval         -service
+                                                    daily cap
+      ▲
+      │
+Cloud Scheduler ──► therr-messaging-automator ──► POST /habits/pacts/digest/run-daily
+                    (a clock, nothing more)
+```
+
+### The automator stays a clock
+
+It must not send. Sending needs the copy, all three locales, the per-brand
+Firebase app, Android channel routing and brand intent actions — all in
+push-notifications-service. A Cloud Function sending directly would duplicate
+that surface in a repo with **no CI checking the coupling**
+([`CROSS_REPO_INTEGRATION.md`](./CROSS_REPO_INTEGRATION.md)). It already pokes
+users-service over the internal LB; that is the right role.
+
+### Why not pg-boss
+
+pg-boss is a good library and its `sendOnce`/cron would give dedup and
+scheduling for free. Two things ruled it out here:
+
+- **It self-migrates its own `pgboss` schema at boot**, outside the Knex
+  migration system that `therr/require-idempotent-migration` and the
+  expand/contract discipline exist to protect — in a database two sibling repos
+  read directly. That is precisely the coupling hazard this repo has already
+  been bitten by.
+- **What we needed from it is small**: dedup (a unique index), delayed
+  scheduling (a timestamp column), bounded retry and `SKIP LOCKED`. That is
+  ~150 lines in `NotificationQueueStore`, in our migration system, greppable by
+  the automators.
+
+pg-boss also wants a long-running process, which rules out hosting it in the
+Cloud Function regardless. Revisit if job types multiply or multi-step workflows
+appear.
+
+### Why the worker lives in users-service
+
+It is long-running, runs at `replicas: 1`, and already owns
+`sendEmailAndOrPushNotification`. `SKIP LOCKED` is insurance against a future
+scale-up rather than a present requirement.
+
+---
+
+## Data model
+
+`main.notificationQueue` — brand-scoped from birth, registered in
+`eslint-config/brand-scoped-tables.js` with `NotificationQueueStore` as its
+sanctioned accessor.
+
+| Column | Notes |
+|---|---|
+| `brandVariation` | **No default**, unlike other brand-scoped tables. They default to `'therr'` so backfilled rows stay visible; this table has no legacy rows, so a default would only let a caller that forgot the brand silently file under Therr. |
+| `dedupeKey` | Caller-supplied. The entire dedup mechanism — see below. |
+| `payload` | `jsonb`. Carries the `ISendPushNotification` extras (habitName, streakCount, …), which vary per type and change with copy. Never queried on, so nothing to gain from columns and a schema change per notification type to lose. |
+| `status` | `pending` / `sent` / `failed` / `skipped`. `skipped` = deliberately not sent (cap, preference, no token) — distinct from `failed` so suppression is measurable rather than looking like breakage. |
+| `scheduledFor` | Defaults to `now()`. The send-time personalization hook. |
+
+Indexes: the claim index is **partial** (`WHERE status = 'pending'`) — the table
+will be overwhelmingly `sent` rows awaiting retention, and the hot path should
+scale with the backlog, not with history.
+
+### dedupeKey is the one thing callers must get right
+
+It must encode everything that makes the notification distinct **including its
+period**:
+
+- once-per-day → `streak-at-risk:<pactId>:2026-08-08`
+- once-per-event → `pact-accepted:<pactId>:<memberId>`
+- **never** interpolate `Date.now()` or a random value — that makes every
+  enqueue unique, which silently turns dedup off
+
+Enqueue is `ON CONFLICT DO NOTHING` (not `DO UPDATE`): a re-run must not reset
+`scheduledFor` or resurrect a row already sent.
+
+### Claim semantics
+
+`claimDue` flips rows straight to `failed` with `attempts + 1`, not to a
+`processing` state. A worker that crashes mid-batch therefore leaves rows in a
+terminal, *visible* state with the attempt counted, instead of a limbo needing
+its own reaper. The happy path overwrites with `sent` moments later;
+`requeueFailed` is the explicit, bounded retry (`MAX_ATTEMPTS = 3`).
+
+---
+
+## What is NOT built yet
+
+The scaffold is deliberately inert. Nothing enqueues, and the worker no-ops
+unless `NOTIFICATION_QUEUE_WORKER_ENABLED=true`, so this can deploy, be observed,
+and only then be allowed to send.
+
+### Blockers to clear before raising frequency
+
+**1. No push preference is honored server-side.** `settingsPushMarketing`,
+`settingsPushBackground`, `settingsPushInvites`, `settingsPushLikes`,
+`settingsPushMentions`, `settingsPushTopics` all exist as columns, are settable
+through the API, and flow through `therr-react`.
+`sendEmailAndOrPushNotification` reads exactly one thing: `isUnclaimed`. And
+`ManageNotifications.tsx` renders **email** toggles only — there is no push
+category UI at all. A user's only control today is the OS switch, which is
+all-or-nothing. **This must land before volume goes up**, and the worker is the
+natural enforcement point (mark `skipped`, don't drop silently).
+
+**2. No user timezone.** No timezone or UTC-offset column exists. Needed before
+`scheduledFor` can mean anything but "now".
+
+**3. Producers.** Nothing calls `enqueueNotification` yet. Migrating the digest's
+three types (`streakAtRisk`, `partnerMissedDay`, `pactExpiring`) is the natural
+first move — it is the path that most needs dedup, and it retires the "never add
+a second trigger path" rule.
+
+### Where the frequency actually is
+
+- **Seven types are delivery-half-only** — `dailyHabitReminder`,
+  `morningMotivation`, `eveningCheckIn`, `streakBroken`, `newPersonalRecord`,
+  `partnerCelebrated`, `pactCompleted`. Copy in three locales, channels, intent
+  actions, tests, and no caller anywhere. The largest block of ready volume.
+- **Silent reward moments** — `habitCheckins.ts` awards a streak freeze at every
+  7+ day milestone and says nothing. Exactly the loss-aversion mechanic Duolingo
+  leans on, with the state already persisted.
+- **`habits.proofs` / `habits.pact_activities`** — partner-visible events with no
+  notification path.
+- **`main.thoughts`** — ai-automator already drips content over ~30h, with no
+  notification attached.
+
+Note what a solo tester can currently trigger: essentially nothing. Every live
+type needs a second human or the digest, and the digest iterates `activePacts`,
+so an account with no pact generates zero sends. The only self-triggered push is
+`streakMilestone`, at exactly 3/7/14/30/… consecutive days.
+
+---
+
+## Suggested sequence
+
+1. Queue + worker land dark. **(done)**
+2. Migrate the digest's three types to `enqueueNotification`; enable the worker;
+   confirm dedup by running the digest twice.
+3. Honor `settingsPush*` in the worker; add the push category UI.
+4. Add user timezone; start setting `scheduledFor` per user.
+5. Wire the seven orphaned types and the silent reward moments.
+6. Revisit the 5/day cap with real data.
+
+Steps 3 and 4 are what earn the right to step 5. Doing 5 first is how you find
+the frequency cap by hitting it.
+
+---
+
+## Operational notes
+
+- **`NOTIFICATION_QUEUE_WORKER_ENABLED=true`** on users-service turns the worker
+  on. Absent = inert.
+- Tunables (`TICK_INTERVAL_MS` 30s, `CLAIM_BATCH_SIZE` 25, `MAX_ATTEMPTS` 3,
+  `MAX_SENDS_PER_USER_PER_DAY` 5) are module constants, not env vars — there is
+  no production experience to configure against yet, and an env var implies a
+  knob someone has a reason to turn.
+- Sends are sequential within a batch. A burst of 25 concurrent sends from a
+  `replicas: 1` pod is a good way to exhaust the write pool, and throughput is
+  not the constraint: 30s × 25 is ~3,000/hour/brand.
+- **Retention is not scheduled yet.** `deleteCompletedBefore` exists and nothing
+  calls it. Wire it before the table gets large.
+- If the automator ever needs to *read* this table, mirror the entry into its
+  `src/store/brandScoped.ts` — the lint rule cannot see across repos
+  ([`CROSS_REPO_INTEGRATION.md`](./CROSS_REPO_INTEGRATION.md) rule 2). Under this
+  design it does not read it.

--- a/docs/PUSH_NOTIFICATIONS_DEBUGGING.md
+++ b/docs/PUSH_NOTIFICATIONS_DEBUGGING.md
@@ -1,0 +1,201 @@
+# Debugging push notifications
+
+How to find out *why* a push didn't arrive, rather than guessing.
+
+Read this before changing Firebase configuration. The most common instinct —
+"our Firebase setup must be wrong, let's make a new project" — is usually the
+wrong move, and § Do we need a separate Firebase project? explains why.
+
+## The delivery chain
+
+A push crosses five links. Only one of them used to produce any signal.
+
+| # | Link | Fails when | Observable? |
+|---|---|---|---|
+| 1 | OS permission granted, FCM issues a device token | user denied notifications; `getToken` threw | device-side only (`NOTIFICATIONS_ERROR` in logs / Crashlytics) |
+| 2 | Token reaches `main.userDeviceTokens` **under the right brand** | `x-brand-variation` mismatch; the fire-and-forget upsert failed | ✅ `GET /users/:id/push-diagnostics` |
+| 3 | push-notifications-service resolves the brand to a Firebase app | brand's credential env var unset or wrong project | ✅ `GET /notifications/diagnostics` |
+| 4 | FCM accepts the message | stale token; credentials address another project | ✅ `POST /notifications/diagnostics/send-test` |
+| 5 | APNS / Android accepts it and the device renders it | **`apns-topic` ≠ the app's bundle id**; missing Android channel | ⚠️ never reported — see below |
+
+**Link 5 is the trap.** APNS silently discards a push whose `apns-topic` is not
+the receiving app's own bundle id. FCM still accepts the send, `messaging.send()`
+still resolves with a message id, and the service still logs
+`Push successfully sent`. Every signal says delivered; the user gets nothing.
+This exact bug shipped: HABITS pushes were addressed to `com.therr.mobile.habits`,
+a bundle id no Xcode target builds.
+
+`predictAndSendNotification` also catches every error by design, so a bad token
+can't fail a user-facing request. Good for production, useless for debugging —
+which is what the diagnostics endpoints below are for.
+
+## Endpoints
+
+All are `SUPER_ADMIN`-only at the gateway, and available in production (unlike
+`/notifications/test`, which is compiled out when `NODE_ENV === 'production'` —
+precisely the environment where delivery problems live).
+
+### 1. Is the device registered, and under which brand?
+
+```bash
+curl -sS "https://api.therr.com/v1/users-service/users/$USER_ID/push-diagnostics" \
+  -H "authorization: Bearer $TOKEN" \
+  -H "x-brand-variation: habits" | jq
+```
+
+```jsonc
+{
+  "requestedBrand": "habits",
+  "isRegisteredForRequestedBrand": false,   // ← the smoking gun
+  "brandsRegistered": ["therr"],
+  "deviceTokens": [
+    { "brandVariation": "therr", "platform": "mobile",
+      "updatedAt": "2026-08-01T...", "token": { "prefix": "eGEh3WckRjy", "length": 163 } }
+  ],
+  "legacy": { "hasDeviceMobileFirebaseToken": true, "token": { "prefix": "eGEh3WckRjy", "length": 163 } }
+}
+```
+
+Reads across brands on purpose: a brand-scoped read returns empty for both a
+wrong-brand registration and no registration at all, which are very different
+problems. Token values are never returned, only a prefix and length — enough to
+confirm the row matches the handset in front of you.
+
+- `brandsRegistered: []` → link 1 or 2. The app never registered. Check OS
+  permission and `registerDeviceForFCM` in `TherrMobile/main/components/Layout.tsx`.
+- `isRegisteredForRequestedBrand: false` with rows present → the build's
+  `CURRENT_BRAND_VARIATION` disagrees with the brand doing the sending.
+- Rows present and correct → move to link 3.
+
+### 2. Where do this brand's pushes actually go?
+
+```bash
+curl -sS "https://api.therr.com/v1/push-notifications-service/notifications/diagnostics" \
+  -H "authorization: Bearer $TOKEN" -H "x-brand-variation: habits" | jq
+```
+
+```jsonc
+{
+  "distinctFirebaseProjects": ["therr-app"],
+  "byBrand": [
+    { "brandVariation": "habits",
+      "credentialEnvKey": "PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_HABITS",
+      "isCredentialEnvKeySet": false,
+      "isFallbackToTherr": true,        // expected on a shared project
+      "firebaseProjectId": "therr-app",
+      "iosApnsTopic": "com.therr.mobile.Therr",
+      "androidAccentColor": "#1C7F8A" }
+  ]
+}
+```
+
+`isFallbackToTherr: true` is **not an error** while all brands share one Firebase
+project — see below. `iosApnsTopic` is the field that silently breaks link 5:
+it must equal the `PRODUCT_BUNDLE_IDENTIFIER` of the build receiving the push.
+
+### 3. Send a real test push
+
+`dryRun` defaults to `true`: FCM validates the token and credentials without
+delivering. Set it to `false` once the dry run is clean and you want the handset
+to buzz.
+
+```bash
+curl -sS -X POST \
+  "https://api.therr.com/v1/push-notifications-service/notifications/diagnostics/send-test" \
+  -H "authorization: Bearer $TOKEN" \
+  -H "x-brand-variation: habits" \
+  -H "content-type: application/json" \
+  -d '{"deviceToken":"'"$DEVICE_TOKEN"'","type":"pact-invitation","dryRun":false}' | jq
+```
+
+The response echoes the full envelope (minus the token) plus the raw FCM result.
+Error codes worth knowing:
+
+| `result.errorCode` | Means |
+|---|---|
+| `messaging/registration-token-not-registered` | Token is stale — app reinstalled or data cleared. Re-open the app to re-register. |
+| `messaging/invalid-registration-token`, `messaging/invalid-argument` | Malformed token. Usually a truncated copy-paste. |
+| `messaging/mismatched-credential` | **The service account belongs to a different Firebase project than the token.** This is what a premature project split produces. |
+| `messaging/third-party-auth-error` | Firebase has no APNS auth key for this iOS app, or the key is expired. |
+
+An `ok: true` result only proves FCM accepted the message. If the handset still
+shows nothing, you are at link 5: compare `routing.iosApnsTopic` against the
+installed build's bundle id.
+
+### Convenience script
+
+`_bin/push-debug.sh` chains all three:
+
+```bash
+./_bin/push-debug.sh --user <userId> --brand habits --token "$JWT"           # inspect only
+./_bin/push-debug.sh --user <userId> --brand habits --token "$JWT" --send    # deliver for real
+```
+
+## Do we need a separate Firebase project per brand?
+
+**No — and splitting today would break push rather than fix it.**
+
+One Firebase project hosts many apps. `therr-app` already contains a separate
+app entry per `package_name` / bundle id, which is the supported multi-app
+setup and what `_bin/firebase/README.md` documents.
+
+The mechanics that matter:
+
+- **An FCM token identifies an app instance.** `messaging().send({ token })`
+  routes by the token itself; there is no per-brand addressing to get wrong.
+- **A service account is scoped to its project, and can address every app in
+  it.** One credential correctly delivers to Therr and Habits alike.
+- **`isFallbackToTherr: true` is therefore correct**, not a degradation. A brand
+  without its own `PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_<BRAND>` uses the
+  Therr service account, which already has authority over the Habits app because
+  they live in the same project.
+
+Splitting Habits into its own project makes the Therr service account a stranger
+to Habits tokens. Every send then fails with `messaging/mismatched-credential` —
+and worse, `isInvalidTokenError` treats some of those failures as a dead token
+and **deletes the user's registration**, so recovery needs every user to reopen
+the app. It only becomes safe once
+`PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_HABITS` holds a service account
+from the new project *and* every device has re-registered against a build
+carrying the new `google-services.json`.
+
+Reasons that would genuinely justify a split — none of which is "pushes aren't
+arriving":
+
+- Analytics/Crashlytics data must be separated for legal or reporting reasons.
+- The apps need different Google Sign-In OAuth consent screens.
+- A brand is being sold or spun out.
+
+The migration procedure lives in `docs/MULTI_BRAND_ARCHITECTURE.md`
+→ "Migration path: when to split into per-brand Firebase projects".
+
+### What *is* worth checking in Firebase Console
+
+Within the single shared project:
+
+- The **APNS auth key** is uploaded for the iOS app (Project Settings → Cloud
+  Messaging → iOS app). Missing or expired ⇒ `messaging/third-party-auth-error`.
+- The **Android app entry exists** for each `applicationId`
+  (`app.therrmobile`, `com.therr.habits`) and the SHA-1 fingerprints are
+  registered — see `_bin/firebase/README.md`.
+
+## Known sharp edges
+
+- **A niche brand with no iOS target runs as the Therr binary.** `niche/*`
+  branches change `brandConfig.ts`, `app.json` and `build.gradle`; they do not
+  change `PRODUCT_BUNDLE_IDENTIFIER`. So an iOS Habits build *is*
+  `com.therr.mobile.Therr` and its pushes must be addressed there. This is
+  pinned by `apns-topic matches a shipped iOS target` in
+  `push-notifications-service/tests/unit/api/brandRouting.test.ts`, which reads
+  the Xcode project and fails if any brand's topic isn't a bundle id something
+  actually builds. Change the topic in the same commit that adds the iOS target.
+- **Android channels must exist before a display notification names one.**
+  `createAndroidNotificationChannels()` registers them at app start; without it
+  the OS drops the notification onto an auto-created "Miscellaneous" channel at
+  DEFAULT importance (no heads-up banner). See
+  `TherrMobile/main/utilities/pushNotifications.ts`.
+- **`getCredentialEnvKey` uppercases the brand but does not replace hyphens**,
+  so `appy-social` maps to `..._APPY-SOCIAL` — not a settable env var name in
+  most shells or in Kubernetes. Harmless today (those brands ship no app and
+  correctly fall back), but it must be fixed before any hyphenated brand gets
+  its own Firebase project.

--- a/docs/PUSH_NOTIFICATIONS_DEBUGGING.md
+++ b/docs/PUSH_NOTIFICATIONS_DEBUGGING.md
@@ -6,6 +6,48 @@ Read this before changing Firebase configuration. The most common instinct —
 "our Firebase setup must be wrong, let's make a new project" — is usually the
 wrong move, and § Do we need a separate Firebase project? explains why.
 
+## Link 0: did anything actually try to send?
+
+Before debugging delivery, rule this out — on HABITS it is the most likely
+answer, and it looks identical to a broken pipeline.
+
+**A solo tester with no pact partner can trigger almost nothing.** Every HABITS
+notification needs either a second human or the daily digest:
+
+| Type | Goes to | Triggered by |
+|---|---|---|
+| `streakMilestone` | yourself | a check-in landing on **exactly** 3, 7, 14, 30, 60, 90, 180 or 365 consecutive days (`STREAK_MILESTONES`) — so day 3 at the earliest, on 3 separate calendar days |
+| `leaderboardRankMilestone` | yourself | weekly rank crossing a milestone |
+| `partnerCheckedIn`, `partnerMissedDay` | pact partners | someone *else* acting |
+| `pactInvitation`, `pactAccepted`, `pactDeclined`, `pactNudge` | the other party | someone *else* acting |
+| `streakAtRisk`, `partnerMissedDay`, `pactExpiring` | members | the **daily digest only** — and it iterates `activePacts`, so no pact means no sends at all |
+
+So on a fresh single-user account with no pact: check in once, twice — nothing
+fires. That is correct behavior, not a bug.
+
+The digest (`POST /v1/habits/pacts/digest/run-daily`) is not on a k8s CronJob;
+it is called by the `therr-messaging-automator` Cloud Function via Cloud
+Scheduler, over the internal LB (see `k8s/prod/users-service-network-policy.yaml`).
+It is deliberately unreachable from the public internet, and has **no
+server-side dedup** — a second trigger path re-sends every notification.
+
+### Types with no sender at all
+
+These have copy in all three locales, channel routing, brand intent actions and
+tests — and **nothing in this repo ever sends them**:
+
+`dailyHabitReminder`, `morningMotivation`, `eveningCheckIn`, `streakBroken`,
+`newPersonalRecord`, `partnerCelebrated`, `pactCompleted`
+
+They are not scheduled locally on-device either (`sendTriggerNotification` is
+used only by Moments and Events). If you expected a daily habit reminder, that
+loop is not wired up — the delivery half exists and the trigger half does not.
+Verify with:
+
+```bash
+grep -rn "Types.dailyHabitReminder" --include=*.ts therr-services/ | grep -v push-notifications-service
+```
+
 ## The delivery chain
 
 A push crosses five links. Only one of them used to produce any signal.
@@ -95,9 +137,32 @@ it must equal the `PRODUCT_BUNDLE_IDENTIFIER` of the build receiving the push.
 
 ### 3. Send a real test push
 
+This is the fastest way to separate "delivery is broken" from "nothing ever
+fired" — it bypasses every trigger condition above and puts a real notification
+on the handset.
+
 `dryRun` defaults to `true`: FCM validates the token and credentials without
 delivering. Set it to `false` once the dry run is clean and you want the handset
 to buzz.
+
+**By user id** (resolves the device token server-side — no adb, no token
+wrangling; this is the one to reach for):
+
+```bash
+curl -sS -X POST \
+  "https://api.therr.com/v1/users-service/users/$USER_ID/push-diagnostics/send-test" \
+  -H "authorization: Bearer $TOKEN" \
+  -H "x-brand-variation: habits" \
+  -H "content-type: application/json" \
+  -d '{"type":"pact-invitation","dryRun":false}' | jq
+```
+
+A `{"sent": false, "reason": "no-device-token"}` response *is* the diagnosis:
+the app never completed FCM registration for that brand. It resolves the token
+through the same `resolveDeviceTokenForBrand` the real notification path uses,
+so a token this can't find is one production can't find either.
+
+**By raw token**, when a user has several devices and you need a specific one:
 
 ```bash
 curl -sS -X POST \
@@ -178,6 +243,30 @@ Within the single shared project:
 - The **Android app entry exists** for each `applicationId`
   (`app.therrmobile`, `com.therr.habits`) and the SHA-1 fingerprints are
   registered — see `_bin/firebase/README.md`.
+
+## Platform notes
+
+**Android** is unaffected by the `apns-topic` class of bug entirely — it ignores
+the `apns` block. Its own link-5 failure modes, and where each is handled:
+
+| Requirement | Where | Status |
+|---|---|---|
+| `POST_NOTIFICATIONS` declared and requested (API 33+) | `AndroidManifest.xml`; `requestNotificationsOS()` in `permissionsOrchestrator.ts` | wired |
+| Channels exist before a display push names one | `createAndroidNotificationChannels()` at app start | wired |
+| `ic_notification_icon` drawable present | `res/drawable-*/` (all densities) | present |
+| Data-only pushes converted to a visible notification | `setBackgroundMessageHandler` in `TherrMobile/index.js` | wired |
+| Fallback channel for pushes naming an unknown channel | `default_notification_channel_id` = `reminders` | wired |
+
+So when nothing arrives on Android, suspect link 0 (nothing fired) or link 2
+(token filed under the wrong brand) before suspecting delivery. Confirm with a
+`send-test` — if the handset buzzes, delivery is fine and the question is what
+was supposed to trigger.
+
+Two things `send-test` cannot rule out, both user-side: notifications disabled
+for the app or for one channel in Android Settings (a channel's importance is
+locked at first creation and only the user can raise it afterwards), and
+aggressive OEM battery optimization on Samsung/Xiaomi/OnePlus, which can delay
+or drop FCM for a backgrounded app.
 
 ## Known sharp edges
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ went unread.
 ### Operations & debugging
 - [PROD_DEBUG_CLAUDE.md](./PROD_DEBUG_CLAUDE.md) — production debugging runbook
 - [PUSH_NOTIFICATIONS_DEBUGGING.md](./PUSH_NOTIFICATIONS_DEBUGGING.md) — why a push didn't arrive; the diagnostics endpoints, and why a separate Firebase project per brand is usually the wrong fix
+- [NOTIFICATION_QUEUE_DESIGN.md](./NOTIFICATION_QUEUE_DESIGN.md) — the deduplicated, schedulable notification queue; what must land before send frequency goes up
 - [CLOUDFLARE_CDN.md](./CLOUDFLARE_CDN.md) — CDN configuration
 - [AUTOMATION_ROADMAP.md](./AUTOMATION_ROADMAP.md) — cross-repo automation priorities, ranked
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ went unread.
 
 ### Operations & debugging
 - [PROD_DEBUG_CLAUDE.md](./PROD_DEBUG_CLAUDE.md) — production debugging runbook
+- [PUSH_NOTIFICATIONS_DEBUGGING.md](./PUSH_NOTIFICATIONS_DEBUGGING.md) — why a push didn't arrive; the diagnostics endpoints, and why a separate Firebase project per brand is usually the wrong fix
 - [CLOUDFLARE_CDN.md](./CLOUDFLARE_CDN.md) — CDN configuration
 - [AUTOMATION_ROADMAP.md](./AUTOMATION_ROADMAP.md) — cross-repo automation priorities, ranked
 

--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -76,7 +76,10 @@ append new items here rather than only printing them once.
 - [ ] **Confirm Firebase / FCM credentials match the brand variation being
   deployed** (`therr-services/push-notifications-service/src/api/firebaseAdmin.ts`).
   Per-brand Firebase apps are loaded by env var; a stale value will silently
-  send pushes from the wrong project.
+  send pushes from the wrong project. Verify without guessing:
+  `GET /v1/push-notifications-service/notifications/diagnostics` (SUPER_ADMIN)
+  reports the resolved project id and apns topic per brand — see
+  `docs/PUSH_NOTIFICATIONS_DEBUGGING.md`.
 - [ ] **Run unconsumed migrations** on each service after any change under
   `therr-services/<service>/src/migrations/**` lands on `main`.
   **Now automated for `main` deploys** via `_bin/cicd/run-migrations.sh`
@@ -139,6 +142,19 @@ append new items here rather than only printing them once.
 
 <!-- skill-followups:start -->
 - [ ] (2026-08-04) **Finish credential sharing now that `/.well-known/assetlinks.json` actually serves.** The `delegate_permission/common.get_login_creds` relation is live on `therr.com`/`www.therr.com` (`app.therrmobile`) and `dashboard.therr.com`, and the web login form now sends `autocomplete="username"` / `"current-password"` so Chrome has a credential worth sharing. Three gaps remain, each a decision rather than an oversight: (1) `assetlinks.habits.json` still declares only `handle_all_urls`, so Friends with Habits (`com.therr.habits`) gets App Links but no credential sharing — add the relation there if HABITS should share credentials with `habits.therr.com`. (2) `get_login_creds` is Android-only; the iOS equivalent is shared web credentials, which needs `webcredentials:therr.com` in `TherrMobile/ios/Therr/Therr{Debug,Release}.entitlements` (currently `applinks:therr.com` only) **and** a `webcredentials: { apps: ['22AN4MZ6H5.com.therr.mobile.Therr'] }` block alongside `applinks` in the `appLinksJson` object in `therr-client-web/src/server-client.tsx`. (3) That same AASA is served at `/apple-app-site-association` but its `/.well-known/` twin is still commented out one line below — Apple's CDN fetches the `.well-known` path, which now works, so uncomment it. Verify on-device after deploy: save a password on the website, then confirm Android offers it in the app — that is the only end-to-end proof the association resolved.
+- [ ] (2026-08-07, push-notifications-debug) **Verify the iOS APNS-topic fix on a real
+  Habits handset after this deploys.** `apns-topic` for HABITS/TEEM was
+  `com.therr.mobile.habits` / `com.therr.mobile.Teem` — bundle ids no Xcode target
+  builds — so APNS silently dropped every *data-only* push to an iOS Habits install
+  (streakAtRisk, partnerCheckedIn, all 21 pact/partner types) while FCM reported
+  success and the service logged "Push successfully sent". Display-type pushes
+  (dailyHabitReminder, morningMotivation, eveningCheckIn, streakBroken, pactDeclined)
+  set no apns block and were unaffected, as was all of Android. Now addressed to
+  `com.therr.mobile.Therr`, which is what an iOS Habits build actually is.
+  Confirm with `./_bin/push-debug.sh --user <id> --brand habits --device-token <t> --send`
+  and a `pact-invitation`. If Habits later ships its own iOS target, change
+  `iosApnsTopic` in the same commit — the pbxproj-reading test in
+  `brandRouting.test.ts` will fail until you do.
 - [ ] (2026-08-03, /quality-peer-review) **Habits partner push volume will rise after this deploy — expected, watch it anyway.** `createCheckin` now resolves the active pacts backing a check-in's habit goal (`PactsStore.getActiveByUserAndHabitGoal`) instead of relying on a `pactId` no client has ever sent. Three code paths behind the old `if (pactId)` guard were dead and go live at once: the `partnerCheckedIn` push, mid-pact Wing Person achievement credit, and writes to `habit_checkins.pactId`. A per-pact mute already applies to the push (`shouldMuteNotifs` / `celebratePartnerCheckins`, honored via `selectPactPartnerIds({ onlyCelebrating: true })`) and recipients are deduplicated across pacts, so the ceiling is one push per check-in per active pact-mate — but nobody has ever received one, so treat the first days' volume as the real baseline rather than a regression. No migration, no env var.
 - [ ] (2026-08-03, /quality-peer-review) Optional one-off backfill of `habits.habit_checkins."pactId"`. Every check-in row written before the deploy above has a NULL `pactId`, so `GET /pacts/:pactId/checkins` stays empty for all historical activity even though new check-ins populate it. `HabitCheckinsStore.createOrUpdate` backfills the column on conflict, so a row self-heals only if that user re-submits the same (habitGoalId, scheduledDate). A backfill would set `pactId` from the earliest-started active pact on each row's `habitGoalId` for that user — the same attribution rule the handler uses. Purely cosmetic for pact history views; derived progress stats do not read this column (see `utilities/pactMemberStats`), so nothing is blocked on it.
 - [ ] (2026-08-03, /quality-peer-review) Web/mobile users carry one stale `user.userInView` through the first load after the persistConfig transform deploys. `stripUserInView` drops the key on the way *into* storage only — the outbound transform is deliberately identity (`persistConfig.test.ts`: "rehydrates whatever is in storage without alteration") — so a blob already in localStorage/AsyncStorage rehydrates its old `userInView` once, and is clean from the next persist write onward. This is the same one-launch window the `version` bump in the 2026-08-02 entry above would close for every persisted slice at once; decide the two together rather than adding an outbound strip just for this key.
@@ -178,12 +194,18 @@ append new items here rather than only printing them once.
   deliberately not exposed through the API gateway. Running it more than once
   a day duplicates streakAtRisk/partnerMissedDay/pactExpiring pushes.
 - [ ] (2026-06-11, /memory-management) Activate MemSearch recall — on your local machine, run `pip install 'memsearch[onnx]'` then `scripts/memsearch-index.sh`. First run downloads the bge-m3-onnx-int8 model (~558 MB, HuggingFace, cached permanently at `~/.cache/memsearch/`). No API key needed — fully local ONNX inference on CPU. Re-run after `git pull` to pick up new session logs and external docs. See `docs/MEMORY_SYSTEM_SETUP.md` for team-sharing and Notion/Confluence ingestion setup.
-- [ ] (2026-04-27, /quality-peer-review) Configure per-brand Firebase service
-  account env vars on push-notifications-service production
-  (`PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_HABITS`,
-  `PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_TEEM`) — until set, HABITS/TEEM
-  pushes fall back to the THERR Firebase project, which is wrong for token
-  routing once niche apps go live.
+- [ ] (2026-04-27, /quality-peer-review; corrected 2026-08-07) Per-brand Firebase
+  service account env vars
+  (`PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_HABITS`, `..._TEEM`) on
+  push-notifications-service production. **Only needed if the brand moves to its
+  own Firebase project** — the original wording ("the THERR fallback is wrong for
+  token routing once niche apps go live") was mistaken. Every brand is an app
+  inside the single `therr-app` project, and one service account can address
+  every app in its own project, so the fallback is correct today. Setting these
+  to a service account from `therr-app` changes nothing; setting them to one from
+  a *different* project without also re-registering every device breaks delivery
+  outright. See `docs/PUSH_NOTIFICATIONS_DEBUGGING.md` → "Do we need a separate
+  Firebase project per brand?".
 - [ ] (2026-04-27, /quality-peer-review) After one release cycle with clean
   shadow logs, flip `BrandScopedStore` mode from `'shadow'` to `'enforce'` in
   `NotificationsStore`, `UserAchievementsStore`, `UserDeviceTokensStore`,
@@ -345,16 +367,6 @@ append new items here rather than only printing them once.
   it is tunable without a mobile release only on the server — the client compiles the
   defaults in (`ALGO_*` env overrides are deliberately server-side), so a client-side
   correction needs a new build. Introduced by 787472c3e.
-- [ ] (2026-08-04, /quality-peer-review) Confirm the HABITS iOS app's real bundle
-  identifier matches `getAppBundleIdentifier(BrandVariations.HABITS)` —
-  `com.therr.mobile.habits` in `push-notifications-service/src/api/firebaseAdmin.ts`.
-  `TherrMobile/ios` pbxproj still carries `com.therr.mobile.Therr`, so the Habits iOS
-  target may not exist yet. APNS rejects any push whose `apns-topic` is not the
-  receiving app's own bundle id, and the rejection is silent — FCM accepts the send.
-  6453beb9c made `leaderboardRankMilestone` the last of 21 data-only types to address
-  its topic per brand, so if the Habits iOS app ships under a different bundle id,
-  every data-only iOS push to it is dropped with no error anywhere. Verify before
-  the first Habits iOS release; Android is unaffected either way.
 - [ ] (2026-08-05, /quality-peer-review) Re-submit `sitemap-static.xml` in Google Search
   Console after the web deploy. f3b1556a7 adds `/api-access` to the static sitemap and to
   `publicRoutePatterns` in `therr-client-web/src/server-client.tsx`; it is the SEO landing

--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -142,6 +142,31 @@ append new items here rather than only printing them once.
 
 <!-- skill-followups:start -->
 - [ ] (2026-08-04) **Finish credential sharing now that `/.well-known/assetlinks.json` actually serves.** The `delegate_permission/common.get_login_creds` relation is live on `therr.com`/`www.therr.com` (`app.therrmobile`) and `dashboard.therr.com`, and the web login form now sends `autocomplete="username"` / `"current-password"` so Chrome has a credential worth sharing. Three gaps remain, each a decision rather than an oversight: (1) `assetlinks.habits.json` still declares only `handle_all_urls`, so Friends with Habits (`com.therr.habits`) gets App Links but no credential sharing — add the relation there if HABITS should share credentials with `habits.therr.com`. (2) `get_login_creds` is Android-only; the iOS equivalent is shared web credentials, which needs `webcredentials:therr.com` in `TherrMobile/ios/Therr/Therr{Debug,Release}.entitlements` (currently `applinks:therr.com` only) **and** a `webcredentials: { apps: ['22AN4MZ6H5.com.therr.mobile.Therr'] }` block alongside `applinks` in the `appLinksJson` object in `therr-client-web/src/server-client.tsx`. (3) That same AASA is served at `/apple-app-site-association` but its `/.well-known/` twin is still commented out one line below — Apple's CDN fetches the `.well-known` path, which now works, so uncomment it. Verify on-device after deploy: save a password on the website, then confirm Android offers it in the app — that is the only end-to-end proof the association resolved.
+- [ ] (2026-08-08, notification-queue) **Enable the notification queue worker and migrate
+  the digest onto it.** `main.notificationQueue` + `NotificationQueueStore` +
+  `startNotificationQueueWorker` are deployed but inert: nothing enqueues, and the worker
+  no-ops unless `NOTIFICATION_QUEUE_WORKER_ENABLED=true` on users-service. Next step is to
+  move the digest's three types (`streakAtRisk`, `partnerMissedDay`, `pactExpiring`) to
+  `enqueueNotification`, turn the worker on, and confirm dedup by running the digest twice
+  — which retires the standing "never add a second trigger path" rule in root CLAUDE.md,
+  since dedup becomes a UNIQUE constraint rather than a convention. Also wire
+  `deleteCompletedBefore` to something before the table grows. Design and sequencing:
+  `docs/NOTIFICATION_QUEUE_DESIGN.md`.
+- [ ] (2026-08-08, notification-queue) **No push preference is honored server-side — fix
+  before raising send frequency.** `settingsPushMarketing`, `settingsPushBackground`,
+  `settingsPushInvites`, `settingsPushLikes`, `settingsPushMentions` and
+  `settingsPushTopics` are real columns, settable through the API and carried by
+  `therr-react`, and `sendEmailAndOrPushNotification` reads none of them (it checks only
+  `isUnclaimed`). `TherrMobile/main/routes/Settings/ManageNotifications.tsx` renders email
+  toggles only. So a user's sole control over push is the OS switch, which is
+  all-or-nothing. The queue worker is the natural enforcement point — mark such rows
+  `skipped`, not `failed`, so suppression stays measurable.
+- [ ] (2026-08-08, notification-queue) **Add a user timezone column.** Nothing in the
+  schema records one, so the daily digest's "run it in the evening" is evening in exactly
+  one timezone worldwide. `notificationQueue.scheduledFor` exists and cannot mean anything
+  but "now" until this lands. Prerequisite for roadmap item #2 (send-time personalization,
+  15-40% on opens).
+
 - [ ] (2026-08-07, push-notifications-debug) **Seven HABITS notification types have no
   sender.** `dailyHabitReminder`, `morningMotivation`, `eveningCheckIn`, `streakBroken`,
   `newPersonalRecord`, `partnerCelebrated` and `pactCompleted` have copy in all three

--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -142,6 +142,19 @@ append new items here rather than only printing them once.
 
 <!-- skill-followups:start -->
 - [ ] (2026-08-04) **Finish credential sharing now that `/.well-known/assetlinks.json` actually serves.** The `delegate_permission/common.get_login_creds` relation is live on `therr.com`/`www.therr.com` (`app.therrmobile`) and `dashboard.therr.com`, and the web login form now sends `autocomplete="username"` / `"current-password"` so Chrome has a credential worth sharing. Three gaps remain, each a decision rather than an oversight: (1) `assetlinks.habits.json` still declares only `handle_all_urls`, so Friends with Habits (`com.therr.habits`) gets App Links but no credential sharing — add the relation there if HABITS should share credentials with `habits.therr.com`. (2) `get_login_creds` is Android-only; the iOS equivalent is shared web credentials, which needs `webcredentials:therr.com` in `TherrMobile/ios/Therr/Therr{Debug,Release}.entitlements` (currently `applinks:therr.com` only) **and** a `webcredentials: { apps: ['22AN4MZ6H5.com.therr.mobile.Therr'] }` block alongside `applinks` in the `appLinksJson` object in `therr-client-web/src/server-client.tsx`. (3) That same AASA is served at `/apple-app-site-association` but its `/.well-known/` twin is still commented out one line below — Apple's CDN fetches the `.well-known` path, which now works, so uncomment it. Verify on-device after deploy: save a password on the website, then confirm Android offers it in the app — that is the only end-to-end proof the association resolved.
+- [ ] (2026-08-07, push-notifications-debug) **Seven HABITS notification types have no
+  sender.** `dailyHabitReminder`, `morningMotivation`, `eveningCheckIn`, `streakBroken`,
+  `newPersonalRecord`, `partnerCelebrated` and `pactCompleted` have copy in all three
+  locales, Android channel routing, per-brand intent actions and test coverage — and
+  nothing in this repo ever calls them. They are not scheduled on-device either
+  (`sendTriggerNotification` is used only by Moments/Events). The daily-reminder loop,
+  which `docs/PUSH_NOTIFICATIONS_ENGAGEMENT_ROADMAP.md` treats as the core HABITS
+  retention mechanic, is therefore delivery-half-only. Decide per type: wire a trigger
+  (the digest at `habitsDigest.ts` is the natural home for the daily three, but note it
+  has no server-side dedup and runs from a single Cloud Scheduler job), schedule them
+  locally via Notifee, or delete the dead copy. Verify with:
+  `grep -rn "Types.dailyHabitReminder" --include=*.ts therr-services/ | grep -v push-notifications-service`
+
 - [ ] (2026-08-07, push-notifications-debug) **Verify the iOS APNS-topic fix on a real
   Habits handset after this deploys.** `apns-topic` for HABITS/TEEM was
   `com.therr.mobile.habits` / `com.therr.mobile.Teem` — bundle ids no Xcode target

--- a/eslint-config/brand-scoped-tables.js
+++ b/eslint-config/brand-scoped-tables.js
@@ -7,6 +7,7 @@
 //   Phase 3: main.directMessages, main.forums, main.forumMessages
 //   Phase 5: main.userAchievements
 //   Leaderboards (2026-07): main.userLeaderboardScores (brand-scoped from birth)
+//   Notification queue (2026-08): main.notificationQueue (brand-scoped from birth)
 //
 // (The original Phase 4 set — main.moments / spaces / events / *Reactions — was reclassified
 // Identity-shared after a niche-app audit confirmed Habits and Teem don't read or write those
@@ -22,6 +23,7 @@ const BRAND_SCOPED_TABLES = [
     'main.forumMessages',
     'main.userAchievements',
     'main.userLeaderboardScores',
+    'main.notificationQueue',
 ];
 
 module.exports = {

--- a/therr-api-gateway/src/services/push-notifications/router.ts
+++ b/therr-api-gateway/src/services/push-notifications/router.ts
@@ -1,12 +1,48 @@
 import express from 'express';
+import { AccessLevels } from 'therr-js-utilities/constants';
 import * as globalConfig from '../../../../global-config';
 import handleServiceRequest from '../../middleware/handleServiceRequest';
+import authorize, { AccessCheckType } from '../../middleware/authorize';
 import { validate } from '../../validation';
 import {
     postLocationChangeValidation,
 } from './validation/location';
+import {
+    sendTestPushNotificationValidation,
+} from './validation/diagnostics';
 
 const reactionsServiceRouter = express.Router();
+
+// Push diagnostics (SUPER_ADMIN only).
+//
+// These are the only externally reachable window into push delivery:
+// push-notifications-service is internal to the VPC, and its `/notifications/test`
+// route is compiled out when NODE_ENV === 'production' — which is exactly where
+// delivery problems live, since they depend on deployed credentials and real
+// device tokens. See therr-services/push-notifications-service/src/handlers/diagnostics.ts
+// and docs/PUSH_NOTIFICATIONS_DEBUGGING.md.
+const superAdminOnly = authorize({
+    type: AccessCheckType.ALL,
+    levels: [
+        AccessLevels.SUPER_ADMIN,
+    ],
+});
+
+reactionsServiceRouter.get('/notifications/diagnostics', superAdminOnly, handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].basePushNotificationsServiceRoute}`,
+    method: 'get',
+}));
+
+reactionsServiceRouter.post(
+    '/notifications/diagnostics/send-test',
+    superAdminOnly,
+    sendTestPushNotificationValidation,
+    validate,
+    handleServiceRequest({
+        basePath: `${globalConfig[process.env.NODE_ENV].basePushNotificationsServiceRoute}`,
+        method: 'post',
+    }),
+);
 
 // Reactions
 reactionsServiceRouter.post('/location/process-user-location', postLocationChangeValidation, validate, handleServiceRequest({

--- a/therr-api-gateway/src/services/push-notifications/validation/diagnostics.ts
+++ b/therr-api-gateway/src/services/push-notifications/validation/diagnostics.ts
@@ -1,0 +1,18 @@
+import {
+    body,
+} from 'express-validator';
+
+export const sendTestPushNotificationValidation = [
+    body('deviceToken').isString().notEmpty().exists(),
+    body('type').isString().optional(),
+    // Defaults to true in the handler: a dry run asks FCM to validate the token
+    // and credentials without delivering, which is what you want on a first pass
+    // against a real user's device.
+    body('dryRun').isBoolean().optional(),
+    body('fromUserName').isString().optional(),
+    body('habitName').isString().optional(),
+    body('partnerName').isString().optional(),
+    body('streakCount').isNumeric().optional(),
+];
+
+export default sendTestPushNotificationValidation;

--- a/therr-api-gateway/src/services/users/router.ts
+++ b/therr-api-gateway/src/services/users/router.ts
@@ -401,6 +401,20 @@ usersServiceRouter.get('/users/:id/push-diagnostics', authorize(
     method: 'get',
 }));
 
+// Sends a real push by user id — resolves the device token server-side so
+// verifying delivery never requires reading an FCM token off a handset.
+usersServiceRouter.post('/users/:id/push-diagnostics/send-test', authorize(
+    {
+        type: AccessCheckType.ALL,
+        levels: [
+            AccessLevels.SUPER_ADMIN,
+        ],
+    },
+), handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
+}));
+
 usersServiceRouter.get('/users/:id', authenticateOptional, handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
     method: 'get',

--- a/therr-api-gateway/src/services/users/router.ts
+++ b/therr-api-gateway/src/services/users/router.ts
@@ -386,6 +386,21 @@ usersServiceRouter.get('/users/me', handleServiceRequest({
     method: 'get',
 }));
 
+// Push-delivery diagnostics. Declared before '/users/:id' so the more specific
+// path is matched first, and gated to SUPER_ADMIN — it reports another user's
+// device-registration state. See docs/PUSH_NOTIFICATIONS_DEBUGGING.md.
+usersServiceRouter.get('/users/:id/push-diagnostics', authorize(
+    {
+        type: AccessCheckType.ALL,
+        levels: [
+            AccessLevels.SUPER_ADMIN,
+        ],
+    },
+), handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'get',
+}));
+
 usersServiceRouter.get('/users/:id', authenticateOptional, handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
     method: 'get',

--- a/therr-services/push-notifications-service/CLAUDE.md
+++ b/therr-services/push-notifications-service/CLAUDE.md
@@ -39,9 +39,12 @@ src/
 ### Firebase Admin Setup
 - `src/api/firebaseAdmin.ts` initializes one `admin.app` instance per brand,
   cached in `brandAppCache` and looked up per send via `getAdminAppForBrand(brandVariation)`.
-- Each brand has its own Firebase project (separate FCM keys, APNS auth keys,
-  analytics). Credentials are base64-encoded service account JSON supplied in
-  environment variables:
+- Every brand is an **app inside the single shared `therr-app` Firebase project**
+  today, not a project of its own. One service account can address every app in
+  its own project, which is why the THERR fallback below is correct rather than a
+  degradation. Do not split a brand into its own project to fix undelivered
+  pushes — see `docs/PUSH_NOTIFICATIONS_DEBUGGING.md`. Credentials are
+  base64-encoded service account JSON supplied in environment variables:
   - `PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64` — THERR (required at startup;
     also the fallback for any brand whose own env var is not set).
   - `PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_TEEM` — TEEM (optional).
@@ -52,6 +55,30 @@ src/
   have not yet provisioned per-brand Firebase projects.
 - THERR credentials are validated at module load (project_id / client_email /
   private_key); a missing or malformed THERR JSON fails the service at startup.
+
+### Debugging delivery
+
+`src/handlers/diagnostics.ts` exposes two SUPER_ADMIN endpoints (routed through
+the gateway, and **available in production**, unlike `/notifications/test` which
+is compiled out there):
+
+- `GET /notifications/diagnostics` — per-brand Firebase project, credential env
+  key, fallback status, and the `apns-topic` each brand's iOS pushes carry.
+- `POST /notifications/diagnostics/send-test` — builds the real envelope for a
+  type and sends it, returning the **raw** FCM result. `dryRun` defaults to true.
+
+They exist because `predictAndSendNotification` swallows every FCM error by
+design, and because APNS drops a push whose `apns-topic` isn't the receiving
+app's bundle id without reporting anything — so "Push successfully sent" in the
+logs is compatible with the user receiving nothing.
+
+A brand's `apns-topic` must be a bundle id some iOS target actually builds. Niche
+branches don't change `PRODUCT_BUNDLE_IDENTIFIER`, so a brand with no iOS target
+of its own runs as the Therr binary and must use Therr's bundle id.
+`brandRouting.test.ts` reads the Xcode project and enforces this.
+
+Full runbook: `docs/PUSH_NOTIFICATIONS_DEBUGGING.md`. Driver script:
+`./_bin/push-debug.sh`.
 
 ### Location Caching
 - User locations cached in Redis with TTL

--- a/therr-services/push-notifications-service/src/api/firebaseAdmin.ts
+++ b/therr-services/push-notifications-service/src/api/firebaseAdmin.ts
@@ -70,6 +70,23 @@ const defaultApp = admin.initializeApp({
 const brandAppCache = new Map<BrandVariations, admin.app.App>();
 brandAppCache.set(BrandVariations.THERR, defaultApp);
 
+// Which Firebase project each brand's sends actually resolve to. Populated
+// alongside brandAppCache purely so the diagnostics endpoint can answer "is this
+// brand sending through its own project, or falling back to Therr's?" without
+// re-reading (and re-parsing) credentials. `admin.app.App.options.credential`
+// does not expose project_id, so it has to be captured at parse time.
+interface IBrandCredentialResolution {
+    projectId: string;
+    clientEmail: string;
+    isFallbackToTherr: boolean;
+}
+const brandCredentialResolution = new Map<BrandVariations, IBrandCredentialResolution>();
+brandCredentialResolution.set(BrandVariations.THERR, {
+    projectId: (therrServiceAccount as any).project_id,
+    clientEmail: (therrServiceAccount as any).client_email,
+    isFallbackToTherr: false,
+});
+
 // Tracks brands we've already warned about falling back to the default app,
 // so we don't spam the logs on every send to a brand whose env var is unset.
 const brandsWithLoggedFallback = new Set<BrandVariations>();
@@ -98,6 +115,11 @@ const getAdminAppForBrand = (brandVariation: BrandVariations): admin.app.App => 
         }
         // Cache the fallback so subsequent sends skip the env lookup.
         brandAppCache.set(brandVariation, defaultApp);
+        brandCredentialResolution.set(brandVariation, {
+            projectId: (therrServiceAccount as any).project_id,
+            clientEmail: (therrServiceAccount as any).client_email,
+            isFallbackToTherr: true,
+        });
         return defaultApp;
     }
 
@@ -106,6 +128,11 @@ const getAdminAppForBrand = (brandVariation: BrandVariations): admin.app.App => 
         String(brandVariation), // name this admin app uniquely per brand
     );
     brandAppCache.set(brandVariation, app);
+    brandCredentialResolution.set(brandVariation, {
+        projectId: (serviceAccount as any).project_id,
+        clientEmail: (serviceAccount as any).client_email,
+        isFallbackToTherr: false,
+    });
     return app;
 };
 
@@ -180,9 +207,23 @@ const getPostActionId = (postType?: string) => {
 };
 
 interface IBrandAppIdentity {
+    // The `apns-topic` header value for this brand's iOS pushes.
+    //
     // APNS rejects any push whose `apns-topic` is not the receiving app's own
-    // bundle id, and does so silently — FCM still accepts the send.
-    bundleId: string;
+    // bundle id, and does so silently — FCM still accepts the send and
+    // `messaging.send()` resolves with a message id, so nothing in our logs
+    // distinguishes "delivered" from "dropped at APNS".
+    //
+    // CRITICAL: this must be a bundle id that an actual iOS target in
+    // TherrMobile/ios/TherrMobile.xcodeproj builds, NOT the brand's Android
+    // `applicationId` and not an aspirational id for an app that hasn't
+    // shipped. A niche brand with no iOS target of its own runs as the Therr
+    // binary (the niche branch only changes JS/brandConfig, not
+    // PRODUCT_BUNDLE_IDENTIFIER), so its device tokens belong to
+    // `com.therr.mobile.Therr` and its pushes must be addressed there.
+    // `apnsTopicMatchesShippedIosTarget` in tests/unit/api/brandRouting.test.ts
+    // pins every value here against the Xcode project.
+    iosApnsTopic: string;
     // Android notification small-icon tint. Mirrors each app's primary accent
     // (see TherrMobile/main/styles/themes/brandConstants.ts on the
     // corresponding niche branch).
@@ -192,8 +233,12 @@ interface IBrandAppIdentity {
     intentActions: Record<string, string>;
 }
 
+// The only iOS bundle id this repo actually builds today — TherrMobile.xcodeproj
+// has a single app target and every niche branch inherits it unchanged.
+const THERR_IOS_BUNDLE_ID = 'com.therr.mobile.Therr';
+
 const THERR_APP_IDENTITY: IBrandAppIdentity = {
-    bundleId: 'com.therr.mobile.Therr',
+    iosApnsTopic: THERR_IOS_BUNDLE_ID,
     accentColor: '#0f7b82',
     intentActions: PushNotifications.AndroidIntentActions.Therr,
 };
@@ -205,13 +250,30 @@ const THERR_APP_IDENTITY: IBrandAppIdentity = {
 const BRAND_APP_IDENTITIES: Record<BrandVariations, IBrandAppIdentity> = {
     [BrandVariations.THERR]: THERR_APP_IDENTITY,
     [BrandVariations.TEEM]: {
-        bundleId: 'com.therr.mobile.Teem',
+        // No `com.therr.mobile.Teem` iOS target exists (Teem is shelved), so its
+        // iOS pushes must be addressed to the binary that actually receives them.
+        iosApnsTopic: THERR_IOS_BUNDLE_ID,
         // Same value as Therr's: Teem's accent matches it. Intentional, not a placeholder.
         accentColor: '#0f7b82',
         intentActions: PushNotifications.AndroidIntentActions.Teem,
     },
     [BrandVariations.HABITS]: {
-        bundleId: 'com.therr.mobile.habits',
+        // Friends with Habits ships its own *Android* app (applicationId
+        // com.therr.habits) but has no iOS target: niche/HABITS-general changes
+        // brandConfig.ts, app.json and build.gradle, and leaves
+        // PRODUCT_BUNDLE_IDENTIFIER as com.therr.mobile.Therr. An iOS Habits
+        // build is therefore the Therr binary running Habits JS, and its FCM
+        // tokens are registered against the Therr iOS app.
+        //
+        // This previously read 'com.therr.mobile.habits' — a bundle id nothing
+        // builds — which made APNS silently drop every data-only push to an iOS
+        // Habits install while FCM still reported success. Android was
+        // unaffected (it ignores the apns block), which is why the failure
+        // looked like "iOS gets nothing, Android is fine".
+        //
+        // When Habits does ship an iOS target, change this in the same commit
+        // that adds the target and registers the app in Firebase.
+        iosApnsTopic: THERR_IOS_BUNDLE_ID,
         accentColor: '#1C7F8A',
         intentActions: PushNotifications.AndroidIntentActions.Habits,
     },
@@ -229,7 +291,7 @@ const BRAND_APP_IDENTITIES: Record<BrandVariations, IBrandAppIdentity> = {
 const getBrandAppIdentity = (brandVariation: BrandVariations): IBrandAppIdentity => BRAND_APP_IDENTITIES[brandVariation]
     || THERR_APP_IDENTITY;
 
-const getAppBundleIdentifier = (brandVariation: BrandVariations) => getBrandAppIdentity(brandVariation).bundleId;
+const getApnsTopic = (brandVariation: BrandVariations) => getBrandAppIdentity(brandVariation).iosApnsTopic;
 
 const getBrandAccentColor = (brandVariation: BrandVariations): string => getBrandAppIdentity(brandVariation).accentColor;
 
@@ -237,6 +299,90 @@ const getAppBrandingClickAction = (
     brandVariation: BrandVariations,
     clickActionKey: string,
 ) => getBrandAppIdentity(brandVariation).intentActions[clickActionKey];
+
+export interface IBrandPushDiagnostics {
+    brandVariation: string;
+    credentialEnvKey: string;
+    isCredentialEnvKeySet: boolean;
+    // The Firebase project this brand's pushes are actually sent through.
+    firebaseProjectId: string;
+    // Masked — enough to tell two service accounts apart in a report, never enough to use.
+    firebaseClientEmail: string;
+    // True when the brand has no credentials of its own and rides the Therr app.
+    // With a single shared Firebase project this is the *expected* state, not an error:
+    // one service account can address every app registered in its own project.
+    isFallbackToTherr: boolean;
+    // What an iOS push for this brand would be addressed to. Must equal the
+    // receiving build's PRODUCT_BUNDLE_IDENTIFIER or APNS drops it silently.
+    iosApnsTopic: string;
+    androidAccentColor: string;
+    androidIntentActionSample: string;
+}
+
+const maskEmail = (email: string | undefined): string => {
+    if (!email) return '';
+    const [local, domain] = String(email).split('@');
+    if (!domain) return '***';
+    const head = local.slice(0, 6);
+    return `${head}***@${domain}`;
+};
+
+// Describes how a brand's push would be routed, without sending anything.
+// Initializing the admin app is idempotent and already cached, so this is safe
+// to call repeatedly from a diagnostics endpoint.
+const describeBrandPushRouting = (brandVariation: BrandVariations): IBrandPushDiagnostics => {
+    const credentialEnvKey = getCredentialEnvKey(brandVariation);
+    // Force resolution so the cache is populated for brands not yet used this process.
+    getAdminAppForBrand(brandVariation);
+    const resolution = brandCredentialResolution.get(brandVariation);
+    const identity = getBrandAppIdentity(brandVariation);
+
+    return {
+        brandVariation: String(brandVariation),
+        credentialEnvKey,
+        isCredentialEnvKeySet: !!process.env[credentialEnvKey],
+        firebaseProjectId: resolution?.projectId || '',
+        firebaseClientEmail: maskEmail(resolution?.clientEmail),
+        isFallbackToTherr: !!resolution?.isFallbackToTherr,
+        iosApnsTopic: identity.iosApnsTopic,
+        androidAccentColor: identity.accentColor,
+        androidIntentActionSample: Object.values(identity.intentActions)[0] || '',
+    };
+};
+
+export interface IRawSendResult {
+    ok: boolean;
+    messageId?: string;
+    errorCode?: string;
+    errorMessage?: string;
+}
+
+// Sends a message and *surfaces* the FCM outcome instead of swallowing it.
+//
+// predictAndSendNotification deliberately catches everything so a bad token can
+// never fail the caller's request. That is right for production traffic and
+// useless for debugging: the only signal it leaves is a log line. This variant
+// exists for the diagnostics endpoint, which needs the raw FCM error code
+// (`messaging/registration-token-not-registered`, `messaging/mismatched-credential`,
+// `messaging/third-party-auth-error`, …) in the HTTP response.
+//
+// Note the limit of *any* FCM-level check: a successful messageId means FCM
+// accepted the message, not that APNS or the device accepted it. An
+// `apns-topic` that doesn't match the app is dropped after this point with no
+// error, which is why describeBrandPushRouting reports the topic too.
+const sendMessageForBrandRaw = (
+    brandVariation: BrandVariations,
+    message: admin.messaging.Message,
+    dryRun = false,
+): Promise<IRawSendResult> => getAdminAppForBrand(brandVariation)
+    .messaging()
+    .send(message, dryRun)
+    .then((messageId) => ({ ok: true, messageId }))
+    .catch((error) => ({
+        ok: false,
+        errorCode: error?.code || error?.errorInfo?.code || 'unknown',
+        errorMessage: error?.message || String(error),
+    }));
 
 const createBaseMessage = (
     {
@@ -320,7 +466,7 @@ const createDataOnlyMessage = (
         headers: {
             'apns-push-type': 'alert',
             'apns-priority': '10',
-            'apns-topic': getAppBundleIdentifier(brandVariation), // your app bundle identifier
+            'apns-topic': getApnsTopic(brandVariation),
         },
     };
 
@@ -1169,4 +1315,6 @@ export default admin;
 export {
     createMessage,
     predictAndSendNotification,
+    describeBrandPushRouting,
+    sendMessageForBrandRaw,
 };

--- a/therr-services/push-notifications-service/src/handlers/diagnostics.ts
+++ b/therr-services/push-notifications-service/src/handlers/diagnostics.ts
@@ -1,0 +1,171 @@
+import { RequestHandler } from 'express';
+import { BrandVariations, PushNotifications } from 'therr-js-utilities/constants';
+import { parseHeaders } from 'therr-js-utilities/http';
+import logSpan from 'therr-js-utilities/log-or-update-span';
+import handleHttpError from '../utilities/handleHttpError';
+import {
+    createMessage,
+    describeBrandPushRouting,
+    sendMessageForBrandRaw,
+} from '../api/firebaseAdmin';
+
+/**
+ * Push-notification diagnostics.
+ *
+ * The delivery chain has five links and, until this existed, four of them were
+ * unobservable in production:
+ *
+ *   1. mobile grants OS permission and FCM issues a device token
+ *   2. the token reaches `main.userDeviceTokens` under the *right brand*
+ *      (users-service `GET /users/:userId/push-diagnostics` covers this link)
+ *   3. push-notifications-service resolves that brand to a Firebase app
+ *   4. FCM accepts the message
+ *   5. APNS/Android accepts it and the device renders it
+ *
+ * Link 4 is the only one that ever produced a signal, and
+ * `predictAndSendNotification` swallows even that so a bad token can't fail a
+ * user-facing request. Link 5 fails *silently by design*: APNS drops a push
+ * whose `apns-topic` isn't the receiving app's bundle id and reports nothing
+ * back through FCM, so "Push successfully sent" in the logs is compatible with
+ * the user seeing nothing at all.
+ *
+ * These endpoints make links 3–5 inspectable: the exact envelope that would be
+ * sent, which Firebase project it goes through, and the raw FCM result.
+ *
+ * Exposed via the gateway behind SUPER_ADMIN. Deliberately never returns
+ * credential material — only a project id and a masked client email, which are
+ * enough to tell two service accounts apart in a report.
+ */
+
+// GET /v1/notifications/diagnostics
+// Reports how each brand's pushes are routed. Uses `x-brand-variation` for the
+// `requestedBrand` summary but reports every brand, since the most common real
+// finding is that two brands resolve to the same place when they shouldn't (or
+// vice versa).
+const getPushDiagnostics: RequestHandler = (req, res) => {
+    const { brandVariation } = parseHeaders(req.headers);
+
+    try {
+        const brands = Object.values(BrandVariations) as BrandVariations[];
+        const byBrand = brands.map((brand) => describeBrandPushRouting(brand));
+
+        return res.status(200).send({
+            requestedBrand: String(brandVariation || ''),
+            // Distinct Firebase projects in play. A single entry means every
+            // brand shares one project — which is the supported configuration:
+            // one project can host many apps, and one service account can
+            // address every app inside its own project.
+            distinctFirebaseProjects: Array.from(
+                new Set(byBrand.map((b) => b.firebaseProjectId).filter(Boolean)),
+            ),
+            byBrand,
+        });
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'PUSH_NOTIFICATIONS:DIAGNOSTICS_ERROR' });
+    }
+};
+
+// POST /v1/notifications/diagnostics/send-test
+// Body: { deviceToken, type?, dryRun?, habitName?, partnerName?, streakCount?, fromUserName? }
+//
+// Builds the real envelope for `type` under the request's brand and either
+// validates it against FCM (`dryRun: true`, the default — FCM checks the token
+// and credentials without delivering) or actually delivers it.
+const sendTestPushNotification: RequestHandler = (req, res) => {
+    const { brandVariation, locale } = parseHeaders(req.headers);
+
+    const {
+        deviceToken,
+        type,
+        dryRun = true,
+        fromUserName = 'Diagnostics',
+        habitName = 'Morning run',
+        partnerName = 'Diagnostics',
+        streakCount = 3,
+    } = req.body || {};
+
+    if (!deviceToken) {
+        return handleHttpError({
+            err: new Error('deviceToken is required'),
+            res,
+            message: 'deviceToken is required',
+            statusCode: 400,
+        });
+    }
+
+    const resolvedType: PushNotifications.Types = type || PushNotifications.Types.newLikeReceived;
+    const resolvedBrand = (brandVariation || BrandVariations.THERR) as BrandVariations;
+
+    const message = createMessage(
+        resolvedType,
+        {
+            fromUser: {
+                id: '00000000-0000-4000-8000-000000000000',
+                userName: fromUserName,
+            },
+        },
+        {
+            deviceToken,
+            userId: '00000000-0000-4000-8000-000000000000',
+            userLocale: (locale as string) || 'en-us',
+            fromUserName,
+            habitName,
+            partnerName,
+            streakCount,
+        },
+        resolvedBrand,
+    );
+
+    if (!message) {
+        return handleHttpError({
+            err: new Error(`createMessage returned false for type "${resolvedType}"`),
+            res,
+            message: `Unsupported notification type "${resolvedType}". `
+                + 'It has no case in createMessage, so nothing would ever be sent for it.',
+            statusCode: 400,
+        });
+    }
+
+    const routing = describeBrandPushRouting(resolvedBrand);
+
+    // Echo the envelope minus the token so the caller can see exactly what was
+    // addressed where — particularly `apns.headers['apns-topic']`, the field
+    // whose mismatch is invisible everywhere else.
+    const envelope = { ...(message as any) };
+    delete envelope.token;
+
+    return sendMessageForBrandRaw(resolvedBrand, message, !!dryRun)
+        .then((result) => {
+            logSpan({
+                level: result.ok ? 'info' : 'warn',
+                messageOrigin: 'API_SERVER',
+                messages: ['Push diagnostics test send'],
+                traceArgs: {
+                    'pushNotification.brandVariation': String(resolvedBrand),
+                    'pushNotification.type': String(resolvedType),
+                    'pushNotification.dryRun': !!dryRun,
+                    'pushNotification.ok': result.ok,
+                    'error.code': result.errorCode,
+                },
+            });
+
+            return res.status(result.ok ? 200 : 502).send({
+                brandVariation: String(resolvedBrand),
+                type: String(resolvedType),
+                dryRun: !!dryRun,
+                result,
+                routing,
+                envelope,
+                // The one thing an FCM success cannot tell you.
+                caveat: 'A successful messageId means FCM accepted the message. On iOS it can '
+                    + 'still be dropped by APNS without any error if routing.iosApnsTopic is not '
+                    + "the receiving build's PRODUCT_BUNDLE_IDENTIFIER.",
+            });
+        })
+        .catch((err) => handleHttpError({ err, res, message: 'PUSH_NOTIFICATIONS:DIAGNOSTICS_SEND_ERROR' }));
+};
+
+export {
+    getPushDiagnostics,
+    sendTestPushNotification,
+};

--- a/therr-services/push-notifications-service/src/routes/notificationsRouter.ts
+++ b/therr-services/push-notifications-service/src/routes/notificationsRouter.ts
@@ -4,6 +4,10 @@ import {
     predictAndSendMultiPushNotification,
     testPushNotification,
 } from '../handlers/notifications';
+import {
+    getPushDiagnostics,
+    sendTestPushNotification,
+} from '../handlers/diagnostics';
 
 const router = express.Router();
 
@@ -11,6 +15,12 @@ const router = express.Router();
 router.post('/send', predictAndSendPushNotification);
 // Send a push notification to multiple users
 router.post('/send-multiple', predictAndSendMultiPushNotification);
+
+// Diagnostics. Available in production (unlike /test below) because the failure
+// these exist to diagnose is a production-only one — it depends on the deployed
+// credentials and on real device tokens. Gated to SUPER_ADMIN at the gateway.
+router.get('/diagnostics', getPushDiagnostics);
+router.post('/diagnostics/send-test', sendTestPushNotification);
 
 // For local testing (can send notifications to a production device)
 if (process.env.NODE_ENV !== 'production') {

--- a/therr-services/push-notifications-service/tests/unit/api/brandRouting.test.ts
+++ b/therr-services/push-notifications-service/tests/unit/api/brandRouting.test.ts
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import path from 'path';
 import { expect } from 'chai';
 import { BrandVariations, PushNotifications } from 'therr-js-utilities/constants';
 import { createMessage } from '../../../src/api/firebaseAdmin';
@@ -31,7 +33,10 @@ const config = {
     rank: 4,
 };
 
-const HABITS_BUNDLE_ID = 'com.therr.mobile.habits';
+// The only iOS bundle id TherrMobile.xcodeproj builds. Niche branches change
+// brandConfig.ts / app.json / build.gradle and leave PRODUCT_BUNDLE_IDENTIFIER
+// alone, so an iOS build of any brand is this binary — and every brand's
+// apns-topic must therefore be this value until a brand adds its own iOS target.
 const THERR_BUNDLE_ID = 'com.therr.mobile.Therr';
 const HABITS_ACCENT_COLOR = '#1C7F8A';
 
@@ -85,11 +90,16 @@ const DISPLAY_TYPES = [
 describe('firebaseAdmin brand routing', () => {
     describe('createDataOnlyMessage — apns-topic', () => {
         DATA_ONLY_TYPES.forEach((type) => {
-            it(`addresses "${type}" to the HABITS bundle id`, () => {
+            // Regression: this used to assert 'com.therr.mobile.habits' — a bundle id
+            // no target in TherrMobile.xcodeproj builds. APNS silently dropped every
+            // data-only push to an iOS Habits install while FCM still returned a
+            // message id, so the service logged "Push successfully sent" for
+            // notifications no one ever received.
+            it(`addresses "${type}" for HABITS to the bundle id that actually ships`, () => {
                 const message: any = createMessage(type, {}, config, BrandVariations.HABITS);
 
                 expect(message, `${type} produced no message`).to.not.equal(false);
-                expect(message.apns.headers['apns-topic']).to.equal(HABITS_BUNDLE_ID);
+                expect(message.apns.headers['apns-topic']).to.equal(THERR_BUNDLE_ID);
             });
         });
 
@@ -162,6 +172,56 @@ describe('firebaseAdmin brand routing', () => {
 
             expect(message.data.clickActionId)
                 .to.equal(PushNotifications.AndroidIntentActions.Habits.PACT_INVITATION);
+        });
+    });
+
+    // The assertions above pin apns-topic to a constant. This one pins that constant
+    // to reality: it reads the Xcode project and fails if the topic we address every
+    // brand's iOS pushes to is not a bundle id the project actually builds.
+    //
+    // Without this, the previous bug is fully reproducible — someone adds a brand,
+    // writes the "obvious" bundle id for it, every unit test agrees with them, and
+    // APNS silently discards that brand's pushes in production.
+    describe('apns-topic matches a shipped iOS target', () => {
+        const pbxprojPath = path.resolve(
+            __dirname,
+            '../../../../../TherrMobile/ios/Therr.xcodeproj/project.pbxproj',
+        );
+
+        it('addresses every brand to a PRODUCT_BUNDLE_IDENTIFIER declared in Therr.xcodeproj', function test() {
+            if (!fs.existsSync(pbxprojPath)) {
+                // The service is also built and tested in a container that only
+                // copies therr-services/ — skip rather than fail on a missing peer package.
+                // `this.skip()` throws, so nothing below runs.
+                this.skip();
+            }
+
+            const pbxproj = fs.readFileSync(pbxprojPath, 'utf8');
+            const declaredBundleIds = new Set(
+                Array.from(pbxproj.matchAll(/PRODUCT_BUNDLE_IDENTIFIER = "?([\w.$()<>:]+)"?;/g))
+                    .map((match) => match[1])
+                    // The RN template leaves a placeholder on the test target.
+                    .filter((id) => !id.includes('org.reactjs.native.example')),
+            );
+
+            expect(declaredBundleIds.size, 'found no bundle ids — the pbxproj regex needs updating').to.be.greaterThan(0);
+
+            (Object.values(BrandVariations) as BrandVariations[]).forEach((brand) => {
+                const message: any = createMessage(
+                    PushNotifications.Types.newDirectMessage,
+                    {},
+                    config,
+                    brand,
+                );
+                const topic = message.apns.headers['apns-topic'];
+
+                expect(
+                    Array.from(declaredBundleIds),
+                    `apns-topic "${topic}" for brand "${brand}" is not built by any iOS target. `
+                    + 'APNS drops such pushes silently. Either point the brand at the bundle id its '
+                    + 'iOS build actually uses, or add the iOS target in the same change.',
+                ).to.include(topic);
+            });
         });
     });
 

--- a/therr-services/push-notifications-service/tests/unit/handlers/diagnostics.test.ts
+++ b/therr-services/push-notifications-service/tests/unit/handlers/diagnostics.test.ts
@@ -1,0 +1,190 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { BrandVariations, PushNotifications } from 'therr-js-utilities/constants';
+import { getPushDiagnostics, sendTestPushNotification } from '../../../src/handlers/diagnostics';
+import { pushOutbox } from '../../helpers/outboundStubs';
+
+/**
+ * The diagnostics endpoints exist to make push delivery observable, so the
+ * property under test is not "does it return 200" but "does it report the
+ * fields that distinguish the failure modes from each other".
+ *
+ * Each assertion below corresponds to a question that was unanswerable in
+ * production before these endpoints existed.
+ */
+
+const buildRes = () => {
+    const res: any = {};
+    res.status = sinon.stub().returns(res);
+    res.send = sinon.stub().returns(res);
+    return res;
+};
+
+const buildReq = (overrides: any = {}) => ({
+    headers: {
+        'x-brand-variation': BrandVariations.HABITS,
+        'x-localecode': 'en-us',
+        ...(overrides.headers || {}),
+    },
+    body: overrides.body || {},
+    query: overrides.query || {},
+});
+
+describe('push diagnostics handlers', () => {
+    describe('getPushDiagnostics', () => {
+        it('reports the apns topic each brand would be addressed to', () => {
+            const req: any = buildReq();
+            const res = buildRes();
+
+            getPushDiagnostics(req, res, () => undefined);
+
+            expect(res.status.firstCall.args[0]).to.equal(200);
+            const payload = res.send.firstCall.args[0];
+
+            const habits = payload.byBrand.find((b: any) => b.brandVariation === BrandVariations.HABITS);
+            expect(habits.iosApnsTopic).to.equal('com.therr.mobile.Therr');
+        });
+
+        it('reports whether a brand rides the Therr Firebase app rather than its own', () => {
+            // The test env sets only PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64, so every
+            // non-THERR brand falls back — which is exactly the shared-project configuration
+            // production runs. The point is that the report says so out loud instead of
+            // leaving it to be inferred from an absent log line.
+            const req: any = buildReq();
+            const res = buildRes();
+
+            getPushDiagnostics(req, res, () => undefined);
+            const payload = res.send.firstCall.args[0];
+
+            const habits = payload.byBrand.find((b: any) => b.brandVariation === BrandVariations.HABITS);
+            expect(habits.isFallbackToTherr).to.equal(true);
+            expect(habits.credentialEnvKey).to.equal('PUSH_NOTIFICATIONS_GOOGLE_CREDENTIALS_BASE64_HABITS');
+            expect(habits.isCredentialEnvKeySet).to.equal(false);
+        });
+
+        it('collapses brands onto the set of Firebase projects actually in use', () => {
+            const req: any = buildReq();
+            const res = buildRes();
+
+            getPushDiagnostics(req, res, () => undefined);
+            const payload = res.send.firstCall.args[0];
+
+            // One shared project is the supported setup; the field exists so an
+            // unintended split (or an unintended merge) is visible at a glance.
+            expect(payload.distinctFirebaseProjects).to.have.lengthOf(1);
+        });
+
+        it('never returns credential material', () => {
+            const req: any = buildReq();
+            const res = buildRes();
+
+            getPushDiagnostics(req, res, () => undefined);
+            const serialized = JSON.stringify(res.send.firstCall.args[0]);
+
+            expect(serialized).to.not.have.string('PRIVATE KEY');
+            expect(serialized).to.not.have.string('private_key');
+            // Client email is masked, not omitted — it identifies a service account
+            // without being usable.
+            expect(serialized).to.not.have.string('@therr-app.iam.gserviceaccount.com');
+        });
+    });
+
+    describe('sendTestPushNotification', () => {
+        it('rejects a request with no device token rather than sending into the void', () => {
+            const req: any = buildReq({ body: {} });
+            const res = buildRes();
+
+            sendTestPushNotification(req, res, () => undefined);
+
+            expect(res.status.firstCall.args[0]).to.equal(400);
+        });
+
+        it('rejects a type that createMessage does not handle', async () => {
+            const req: any = buildReq({
+                body: { deviceToken: 'token-abc', type: 'not-a-real-type' },
+            });
+            const res = buildRes();
+
+            await sendTestPushNotification(req, res, () => undefined);
+
+            expect(res.status.firstCall.args[0]).to.equal(400);
+            // A type with no case returns false from createMessage and is silently
+            // dropped in production. Saying so is the whole point.
+            expect(res.send.firstCall.args[0].message).to.have.string('no case in createMessage');
+        });
+
+        it('echoes the apns topic the message was actually addressed to', async () => {
+            const req: any = buildReq({
+                body: {
+                    deviceToken: 'token-abc',
+                    type: PushNotifications.Types.pactInvitation,
+                    dryRun: true,
+                },
+            });
+            const res = buildRes();
+
+            await sendTestPushNotification(req, res, () => undefined);
+
+            const payload = res.send.firstCall.args[0];
+            expect(payload.envelope.apns.headers['apns-topic']).to.equal('com.therr.mobile.Therr');
+            expect(payload.routing.iosApnsTopic).to.equal('com.therr.mobile.Therr');
+        });
+
+        it('does not echo the device token back in the envelope', async () => {
+            const req: any = buildReq({
+                body: { deviceToken: 'super-secret-token', type: PushNotifications.Types.pactInvitation },
+            });
+            const res = buildRes();
+
+            await sendTestPushNotification(req, res, () => undefined);
+
+            const payload = res.send.firstCall.args[0];
+            expect(JSON.stringify(payload.envelope)).to.not.have.string('super-secret-token');
+        });
+
+        it('surfaces the FCM result instead of swallowing it', async () => {
+            const req: any = buildReq({
+                body: { deviceToken: 'token-abc', type: PushNotifications.Types.pactInvitation },
+            });
+            const res = buildRes();
+
+            await sendTestPushNotification(req, res, () => undefined);
+
+            const payload = res.send.firstCall.args[0];
+            expect(payload.result.ok).to.equal(true);
+            expect(payload.result.messageId).to.be.a('string');
+            // predictAndSendNotification catches everything by design; this path must not.
+            expect(pushOutbox.map((p) => p.token)).to.include('token-abc');
+        });
+
+        it('reports an FCM failure as a non-2xx with the raw error code', async () => {
+            const sendStub = sinon.stub().rejects(
+                Object.assign(new Error('Requested entity was not found.'), {
+                    code: 'messaging/registration-token-not-registered',
+                }),
+            );
+            // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+            const { Messaging } = require('firebase-admin/messaging');
+            const original = Messaging.prototype.send;
+            Messaging.prototype.send = sendStub;
+
+            try {
+                const req: any = buildReq({
+                    body: { deviceToken: 'stale-token', type: PushNotifications.Types.pactInvitation },
+                });
+                const res = buildRes();
+
+                await sendTestPushNotification(req, res, () => undefined);
+
+                expect(res.status.firstCall.args[0]).to.equal(502);
+                const payload = res.send.firstCall.args[0];
+                expect(payload.result.ok).to.equal(false);
+                // This exact code is the difference between "the user reinstalled and the
+                // token is stale" and "the credentials address the wrong Firebase project".
+                expect(payload.result.errorCode).to.equal('messaging/registration-token-not-registered');
+            } finally {
+                Messaging.prototype.send = original;
+            }
+        });
+    });
+});

--- a/therr-services/users-service/src/handlers/users.ts
+++ b/therr-services/users-service/src/handlers/users.ts
@@ -1552,12 +1552,80 @@ const clearUserDeviceToken: RequestHandler = (req, res) => {
         .catch((err) => handleHttpError({ err, res, message: 'SQL:USER_ROUTES:ERROR' }));
 };
 
+// Diagnostics (SUPER_ADMIN at the gateway): does this user have a device token
+// registered, and under which brand?
+//
+// This is the link in the push chain that fails most quietly. `syncDeviceTokenForBrand`
+// is fire-and-forget by design, so a failed write leaves no trace in the user-facing
+// response; and the brand it files under comes from the client's `x-brand-variation`
+// header, so a mismatched build registers a perfectly valid token that push routing
+// will never look up.
+//
+// Token values are never returned — only a fingerprint (prefix + length), which is
+// enough to confirm the device the user is holding matches the row, and useless to
+// anyone who intercepts the response.
+const getUserPushDiagnostics: RequestHandler = (req, res) => {
+    const { id } = req.params;
+    const { brandVariation } = getBrandContext(req.headers);
+
+    return Promise.all([
+        Store.users.findUser({ id }, ['id', 'deviceMobileFirebaseToken', 'settingsLocale']),
+        Store.userDeviceTokens.getAllTokensForUserAcrossBrands(id),
+    ])
+        .then(([userResults, tokenRows]) => {
+            const user = userResults?.[0];
+            if (!user) {
+                return handleHttpError({
+                    res,
+                    message: 'User not found',
+                    statusCode: 404,
+                });
+            }
+
+            const fingerprint = (token?: string | null) => (token
+                ? { prefix: String(token).slice(0, 12), length: String(token).length }
+                : null);
+
+            const rows = (tokenRows || []).map((row: any) => ({
+                brandVariation: row.brandVariation,
+                platform: row.platform,
+                updatedAt: row.updatedAt,
+                createdAt: row.createdAt,
+                token: fingerprint(row.token),
+            }));
+
+            const brandsRegistered = Array.from(new Set(rows.map((r) => r.brandVariation)));
+
+            return res.status(200).send({
+                userId: id,
+                // The brand this request was made under, for comparison against
+                // brandsRegistered — a user who only appears under 'therr' will
+                // never receive a 'habits' push, and vice versa.
+                requestedBrand: String(brandVariation || ''),
+                isRegisteredForRequestedBrand: brandsRegistered.includes(String(brandVariation)),
+                brandsRegistered,
+                deviceTokens: rows,
+                legacy: {
+                    // Pre-Phase-2 column. Push routing falls back to it when no
+                    // brand-scoped row exists, which means a user can receive
+                    // pushes for the *wrong* brand while looking correctly
+                    // unregistered above.
+                    hasDeviceMobileFirebaseToken: !!user.deviceMobileFirebaseToken,
+                    token: fingerprint(user.deviceMobileFirebaseToken),
+                },
+                settingsLocale: user.settingsLocale || null,
+            });
+        })
+        .catch((err) => handleHttpError({ err, res, message: 'SQL:USER_ROUTES:ERROR' }));
+};
+
 export {
     createUser,
     getMe,
     getUser,
     getUserByPhoneNumber,
     getUserByUserName,
+    getUserPushDiagnostics,
     getUsers,
     findUsers,
     searchUsers,

--- a/therr-services/users-service/src/handlers/users.ts
+++ b/therr-services/users-service/src/handlers/users.ts
@@ -14,7 +14,9 @@ import {
 import logSpan from 'therr-js-utilities/log-or-update-span';
 import { verifyPhoneVerificationToken } from 'therr-js-utilities/phone-verification-token';
 import { getBrandContext, parseHeaders } from 'therr-js-utilities/http';
+import { internalRestRequest } from 'therr-js-utilities/internal-rest-request';
 import handleHttpError from '../utilities/handleHttpError';
+import * as globalConfig from '../../../../global-config';
 import Store from '../store';
 import translate from '../utilities/translator';
 import { updatePassword } from '../utilities/passwordUtils';
@@ -1619,6 +1621,74 @@ const getUserPushDiagnostics: RequestHandler = (req, res) => {
         .catch((err) => handleHttpError({ err, res, message: 'SQL:USER_ROUTES:ERROR' }));
 };
 
+// Diagnostics (SUPER_ADMIN at the gateway): send a real test push to a user by id.
+//
+// The push-notifications-service test endpoint takes a raw FCM device token, which
+// nothing in the system hands you — the diagnostics endpoints deliberately return
+// only a fingerprint, and reading one off a handset means adb/Xcode. This variant
+// resolves the brand-scoped token server-side, so verifying delivery needs only a
+// user id and takes seconds.
+//
+// It resolves the token through the same `resolveDeviceTokenForBrand` the real
+// notification path uses, so a token this can't find is a token production can't
+// find either — a negative result here is itself the diagnosis.
+const sendUserPushDiagnosticsTest: RequestHandler = (req, res) => {
+    const { id } = req.params;
+    const {
+        authorization,
+        brandVariation,
+        locale,
+    } = parseHeaders(req.headers);
+
+    const { type, dryRun = true } = req.body || {};
+
+    return Store.users.findUser({ id }, ['id', 'deviceMobileFirebaseToken'])
+        .then(async (userResults: any[]) => {
+            const user = userResults?.[0];
+            if (!user) {
+                return handleHttpError({ res, message: 'User not found', statusCode: 404 });
+            }
+
+            const deviceToken = await resolveDeviceTokenForBrand(
+                brandVariation as string,
+                id,
+                user.deviceMobileFirebaseToken,
+            );
+
+            if (!deviceToken) {
+                // Not an error condition to paper over — this IS the answer when a
+                // user reports missing pushes, and it stops the caller chasing FCM.
+                return res.status(200).send({
+                    sent: false,
+                    reason: 'no-device-token',
+                    message: `No device token is registered for user ${id} under brand `
+                        + `"${brandVariation}". The app has never completed FCM registration for `
+                        + 'this brand — check OS notification permission and that the build\'s '
+                        + 'CURRENT_BRAND_VARIATION matches. Nothing would reach this device.',
+                });
+            }
+
+            return internalRestRequest({ headers: req.headers as any }, {
+                method: 'post',
+                url: `${globalConfig[process.env.NODE_ENV].basePushNotificationsServiceRoute}`
+                    + '/notifications/diagnostics/send-test',
+                headers: {
+                    authorization,
+                    'x-localecode': locale,
+                    'x-userid': id,
+                },
+                data: { deviceToken, type, dryRun },
+            })
+                .then((response: any) => res.status(200).send({ sent: true, ...response.data }))
+                // A non-2xx from the push service is a real diagnostic result, not a
+                // gateway failure — forward its body verbatim so the FCM error code survives.
+                .catch((err: any) => res.status(err?.response?.status || 502).send(
+                    err?.response?.data || { sent: false, reason: 'push-service-unreachable', message: err?.message },
+                ));
+        })
+        .catch((err) => handleHttpError({ err, res, message: 'SQL:USER_ROUTES:ERROR' }));
+};
+
 export {
     createUser,
     getMe,
@@ -1626,6 +1696,7 @@ export {
     getUserByPhoneNumber,
     getUserByUserName,
     getUserPushDiagnostics,
+    sendUserPushDiagnosticsTest,
     getUsers,
     findUsers,
     searchUsers,

--- a/therr-services/users-service/src/index.ts
+++ b/therr-services/users-service/src/index.ts
@@ -10,6 +10,7 @@ import reqLogDecorator from './middleware/reqLogDecorator';
 import { version as packageVersion } from '../package.json';
 import config, { validateEnv } from './config';
 import { drainPools } from './store/connection';
+import { startNotificationQueueWorker } from './utilities/notificationQueueWorker';
 
 validateEnv();
 tracing.start();
@@ -90,6 +91,12 @@ const server = app.listen(config.port, () => {
 server.keepAliveTimeout = 30000;
 server.headersTimeout = 35000;
 
+// Background drain of main.notificationQueue. Started after listen() so a slow
+// first tick can never delay readiness, and no-ops unless
+// NOTIFICATION_QUEUE_WORKER_ENABLED=true so the queue can deploy dark and be
+// observed filling before it is allowed to send.
+const stopNotificationQueueWorker = startNotificationQueueWorker();
+
 // Graceful shutdown on pod eviction.
 //
 // k8s removes the pod from Service endpoints and sends SIGTERM concurrently, so
@@ -136,6 +143,9 @@ const gracefulShutdown = (signal: string) => {
 
     server.close(() => {
         clearInterval(sweepIdle);
+        // Stop claiming new work before the pools go away, so an in-flight tick
+        // is the only thing racing the drain rather than a fresh batch.
+        stopNotificationQueueWorker();
         drainPools()
             .then(() => process.exit(0))
             .catch(() => process.exit(1));

--- a/therr-services/users-service/src/routes/usersRouter.ts
+++ b/therr-services/users-service/src/routes/usersRouter.ts
@@ -24,6 +24,7 @@ import {
     updateLastKnownLocation,
     clearUserDeviceToken,
     getUserPushDiagnostics,
+    sendUserPushDiagnosticsTest,
 } from '../handlers/users';
 import { getInviteByToken } from '../handlers/userConnections';
 
@@ -39,6 +40,7 @@ router.get('/invites/:token', getInviteByToken);
 // Push-delivery diagnostics (SUPER_ADMIN at the gateway).
 // See docs/PUSH_NOTIFICATIONS_DEBUGGING.md.
 router.get('/:id/push-diagnostics', getUserPushDiagnostics);
+router.post('/:id/push-diagnostics/send-test', sendUserPushDiagnosticsTest);
 router.get('/:id', getUser);
 router.get('/', getUsers);
 router.get('/by-phone/:phoneNumber', getUserByPhoneNumber);

--- a/therr-services/users-service/src/routes/usersRouter.ts
+++ b/therr-services/users-service/src/routes/usersRouter.ts
@@ -23,6 +23,7 @@ import {
     approveSpaceRequest,
     updateLastKnownLocation,
     clearUserDeviceToken,
+    getUserPushDiagnostics,
 } from '../handlers/users';
 import { getInviteByToken } from '../handlers/userConnections';
 
@@ -35,6 +36,9 @@ router.post('/', createUser);
 router.get('/me', getMe);
 // PUBLIC: resolve a magic invite-link token to pre-fill signup data
 router.get('/invites/:token', getInviteByToken);
+// Push-delivery diagnostics (SUPER_ADMIN at the gateway).
+// See docs/PUSH_NOTIFICATIONS_DEBUGGING.md.
+router.get('/:id/push-diagnostics', getUserPushDiagnostics);
 router.get('/:id', getUser);
 router.get('/', getUsers);
 router.get('/by-phone/:phoneNumber', getUserByPhoneNumber);

--- a/therr-services/users-service/src/store/NotificationQueueStore.ts
+++ b/therr-services/users-service/src/store/NotificationQueueStore.ts
@@ -1,0 +1,216 @@
+import KnexBuilder, { Knex } from 'knex';
+import BrandScopedStore, { BrandValue } from './BrandScopedStore';
+import { IConnection } from './connection';
+
+const knexBuilder: Knex = KnexBuilder({ client: 'pg' });
+
+// eslint-disable-next-line therr/no-direct-brand-scoped-table
+export const NOTIFICATION_QUEUE_TABLE_NAME = 'main.notificationQueue';
+
+export type NotificationQueueStatus = 'pending' | 'sent' | 'failed' | 'skipped';
+
+export interface INotificationQueueRow {
+    id: string;
+    userId: string;
+    brandVariation: string;
+    type: string;
+    dedupeKey: string;
+    payload: Record<string, any>;
+    status: NotificationQueueStatus;
+    scheduledFor: Date;
+    attempts: number;
+    lastError: string | null;
+    sentAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export interface IEnqueueArgs {
+    userId: string;
+    type: string;
+    // Must encode everything that makes this notification distinct, *including
+    // its period*. See the migration for why this is the caller's job.
+    dedupeKey: string;
+    payload?: Record<string, any>;
+    scheduledFor?: Date;
+}
+
+/**
+ * The durable queue every deferred notification passes through.
+ *
+ * Design notes live in docs/NOTIFICATION_QUEUE_DESIGN.md; the two that matter
+ * when reading this file:
+ *
+ *  - Enqueue is ON CONFLICT DO NOTHING against (brandVariation, userId,
+ *    dedupeKey). Enqueuing is therefore safe to retry and safe to run twice,
+ *    which is what lets the producers be at-least-once without duplicate sends.
+ *  - Claiming uses FOR UPDATE SKIP LOCKED inside the UPDATE's subquery, so a
+ *    second worker (or a second replica after a scale-up) can never hand the
+ *    same row to two senders. users-service runs at replicas: 1 today, so this
+ *    is insurance rather than a live requirement — but it is the cheap kind,
+ *    and getting it wrong is only discoverable in production under load.
+ */
+export default class NotificationQueueStore extends BrandScopedStore {
+    constructor(dbConnection: IConnection) {
+        // 'shadow' matches the other Phase 2 stores: assertBrand warns rather
+        // than throws until the cohort flips to 'enforce' together.
+        super(dbConnection, NOTIFICATION_QUEUE_TABLE_NAME, 'shadow');
+    }
+
+    // Returns the inserted row, or undefined when the dedupe key already exists
+    // (i.e. this notification was already queued for this period). Callers can
+    // treat undefined as "already handled" rather than as an error.
+    enqueue(brand: BrandValue, args: IEnqueueArgs): Promise<INotificationQueueRow | undefined> {
+        this.assertBrand(brand);
+        const queryString = knexBuilder
+            .raw(
+                `INSERT INTO ?? ("userId", "brandVariation", "type", "dedupeKey", "payload", "scheduledFor")
+                 VALUES (?::uuid, ?, ?, ?, ?::jsonb, COALESCE(?::timestamptz, now()))
+                 ON CONFLICT ("brandVariation", "userId", "dedupeKey") DO NOTHING
+                 RETURNING *`,
+                [
+                    NOTIFICATION_QUEUE_TABLE_NAME,
+                    args.userId,
+                    brand,
+                    args.type,
+                    args.dedupeKey,
+                    JSON.stringify(args.payload || {}),
+                    args.scheduledFor ? args.scheduledFor.toISOString() : null,
+                ],
+            )
+            .toString();
+        return this.db.write.query(queryString).then((response) => response.rows[0]);
+    }
+
+    /**
+     * Atomically claim up to `limit` due rows, flipping them out of 'pending' so
+     * no other worker can pick them up.
+     *
+     * Claimed rows go to 'failed' immediately, not to an intermediate
+     * 'processing' state. That is deliberate: a worker that crashes mid-batch
+     * leaves rows in a terminal, *visible* state with the attempt counted,
+     * rather than in a limbo state that needs a separate reaper to time out.
+     * The happy path overwrites 'failed' with 'sent' moments later, and
+     * `requeueFailed` below is the explicit, bounded retry.
+     */
+    claimDue(brand: BrandValue, limit: number): Promise<INotificationQueueRow[]> {
+        this.assertBrand(brand);
+        const queryString = knexBuilder
+            .raw(
+                `UPDATE ?? AS q
+                 SET "status" = 'failed',
+                     "attempts" = q."attempts" + 1,
+                     "lastError" = 'claimed but not completed',
+                     "updatedAt" = now()
+                 WHERE q."id" IN (
+                     SELECT inner_q."id" FROM ?? AS inner_q
+                     WHERE inner_q."status" = 'pending'
+                       AND inner_q."brandVariation" = ?
+                       AND inner_q."scheduledFor" <= now()
+                     ORDER BY inner_q."scheduledFor" ASC
+                     LIMIT ?
+                     FOR UPDATE SKIP LOCKED
+                 )
+                 RETURNING q.*`,
+                [NOTIFICATION_QUEUE_TABLE_NAME, NOTIFICATION_QUEUE_TABLE_NAME, brand, limit],
+            )
+            .toString();
+        return this.db.write.query(queryString).then((response) => response.rows as INotificationQueueRow[]);
+    }
+
+    markSent(id: string) {
+        const queryString = knexBuilder
+            .raw(
+                `UPDATE ?? SET "status" = 'sent', "sentAt" = now(), "lastError" = NULL, "updatedAt" = now()
+                 WHERE "id" = ?::uuid`,
+                [NOTIFICATION_QUEUE_TABLE_NAME, id],
+            )
+            .toString();
+        return this.db.write.query(queryString).then((response) => response.rowCount ?? 0);
+    }
+
+    // `skipped` records a deliberate non-send (rate cap, preference, no device
+    // token) so suppression shows up in metrics instead of looking like failure.
+    markSkipped(id: string, reason: string) {
+        const queryString = knexBuilder
+            .raw(
+                `UPDATE ?? SET "status" = 'skipped', "lastError" = ?, "updatedAt" = now()
+                 WHERE "id" = ?::uuid`,
+                [NOTIFICATION_QUEUE_TABLE_NAME, reason, id],
+            )
+            .toString();
+        return this.db.write.query(queryString).then((response) => response.rowCount ?? 0);
+    }
+
+    markFailed(id: string, error: string) {
+        const queryString = knexBuilder
+            .raw(
+                `UPDATE ?? SET "status" = 'failed', "lastError" = ?, "updatedAt" = now()
+                 WHERE "id" = ?::uuid`,
+                [NOTIFICATION_QUEUE_TABLE_NAME, error, id],
+            )
+            .toString();
+        return this.db.write.query(queryString).then((response) => response.rowCount ?? 0);
+    }
+
+    // How many notifications this user has actually been sent since `since`.
+    // Backs the per-user daily cap — the safety valve that makes raising send
+    // frequency reversible rather than a one-way bet on user tolerance.
+    countSentSince(brand: BrandValue, userId: string, since: Date): Promise<number> {
+        const queryString = this.scopedQuery(brand)
+            .where('userId', '=', userId)
+            .where('status', '=', 'sent')
+            .where('sentAt', '>=', since.toISOString())
+            .count('* as count')
+            .toString();
+        return this.db.read.query(queryString).then((response) => Number(response.rows[0]?.count || 0));
+    }
+
+    // Bounded retry for rows a worker claimed but never completed (crash, pod
+    // eviction mid-batch) and for transient send failures.
+    requeueFailed(brand: BrandValue, maxAttempts: number, limit: number): Promise<number> {
+        this.assertBrand(brand);
+        const queryString = knexBuilder
+            .raw(
+                `UPDATE ?? AS q
+                 SET "status" = 'pending', "updatedAt" = now()
+                 WHERE q."id" IN (
+                     SELECT inner_q."id" FROM ?? AS inner_q
+                     WHERE inner_q."status" = 'failed'
+                       AND inner_q."brandVariation" = ?
+                       AND inner_q."attempts" < ?
+                     ORDER BY inner_q."updatedAt" ASC
+                     LIMIT ?
+                     FOR UPDATE SKIP LOCKED
+                 )`,
+                [NOTIFICATION_QUEUE_TABLE_NAME, NOTIFICATION_QUEUE_TABLE_NAME, brand, maxAttempts, limit],
+            )
+            .toString();
+        return this.db.write.query(queryString).then((response) => response.rowCount ?? 0);
+    }
+
+    // Retention. Sent/skipped rows are kept long enough to answer "why did this
+    // user get that?" and to serve the rate-limit window, then dropped — the
+    // partial claim index means history costs reads nothing, but it still costs
+    // disk. Not brand-scoped: retention is uniform across brands and a per-brand
+    // sweep would just be N times the work for the same outcome.
+    deleteCompletedBefore(before: Date, limit: number): Promise<number> {
+        const queryString = knexBuilder
+            .raw(
+                `DELETE FROM ?? WHERE "id" IN (
+                     SELECT "id" FROM ??
+                     WHERE "status" IN ('sent', 'skipped')
+                       AND "updatedAt" < ?::timestamptz
+                     LIMIT ?
+                 )`,
+                [
+                    NOTIFICATION_QUEUE_TABLE_NAME,
+                    NOTIFICATION_QUEUE_TABLE_NAME,
+                    before.toISOString(),
+                    limit,
+                ],
+            )
+            .toString();
+        return this.db.write.query(queryString).then((response) => response.rowCount ?? 0);
+    }
+}

--- a/therr-services/users-service/src/store/UserDeviceTokensStore.ts
+++ b/therr-services/users-service/src/store/UserDeviceTokensStore.ts
@@ -64,6 +64,27 @@ export default class UserDeviceTokensStore extends BrandScopedStore {
         return this.db.read.query(queryString).then((response) => response.rows as IUserDeviceTokenRow[]);
     }
 
+    // Diagnostics only: every row for this user across *all* brands.
+    //
+    // Deliberately not brand-scoped. The failure this is built to expose is a
+    // token filed under the wrong brand — a device that registered as 'therr'
+    // while the app sends `x-brand-variation: habits` gets no pushes, and a
+    // brand-scoped read returns an empty set for both brands, which looks
+    // identical to "never registered at all". Reading across brands is what
+    // makes those two cases distinguishable.
+    //
+    // Callers must not use this for delivery routing; getTokensForUser is the
+    // routing path and stays scoped.
+    getAllTokensForUserAcrossBrands(userId: string) {
+        const queryString = knexBuilder
+            .from(USER_DEVICE_TOKENS_TABLE_NAME)
+            .select('*')
+            .where('userId', '=', userId)
+            .orderBy('updatedAt', 'desc')
+            .toString();
+        return this.db.read.query(queryString).then((response) => response.rows as IUserDeviceTokenRow[]);
+    }
+
     // Removes any (any-brand) token row matching this exact token string. Used during invalid-token
     // cleanup when FCM tells us a token has been invalidated. The token value is globally unique to
     // a device install regardless of brand, so we wipe all matching rows defensively. Brand is not

--- a/therr-services/users-service/src/store/index.ts
+++ b/therr-services/users-service/src/store/index.ts
@@ -12,6 +12,7 @@ import NotificationsStore from './NotificationsStore';
 import OrganizationsStore from './OrganizationsStore';
 import SocialSyncsStore from './SocialSyncsStore';
 import SubscribersStore from './SubscribersStore';
+import NotificationQueueStore from './NotificationQueueStore';
 import ThoughtsStore from './ThoughtsStore';
 import UserAchievementsStore from './UserAchievementsStore';
 import UserConnectionsStore from './UserConnectionsStore';
@@ -57,6 +58,8 @@ class Store {
     users: UsersStore;
 
     userAchievements: UserAchievementsStore;
+
+    notificationQueue: NotificationQueueStore;
 
     userConnections: UserConnectionsStore;
 
@@ -112,6 +115,7 @@ class Store {
         this.config = new ConfigStore(this.db);
         this.users = new UsersStore(this.db);
         this.userAchievements = new UserAchievementsStore(this.db);
+        this.notificationQueue = new NotificationQueueStore(this.db);
         this.userConnections = new UserConnectionsStore(this.db);
         this.userLeaderboardScores = new UserLeaderboardScoresStore(this.db);
         this.userDeviceTokens = new UserDeviceTokensStore(this.db);

--- a/therr-services/users-service/src/store/migrations/20260808000001_main.notificationQueue.js
+++ b/therr-services/users-service/src/store/migrations/20260808000001_main.notificationQueue.js
@@ -1,0 +1,125 @@
+// Create main.notificationQueue — the durable, deduplicated queue that every
+// scheduled/deferred notification passes through before it is sent.
+//
+// Archetype: Brand-scoped (per docs/NICHE_APP_DATABASE_GUIDELINES.md). A queued
+// notification belongs to exactly one app — a Habits streak reminder must never
+// be readable, or sendable, as a Therr notification.
+//
+// WHY THIS EXISTS (see docs/NOTIFICATION_QUEUE_DESIGN.md)
+//
+// Today a notification is sent inline, at the moment the triggering event
+// happens, with no record that it happened. Three consequences:
+//
+//   1. No dedup. The habits digest re-sends everything if it runs twice; root
+//      CLAUDE.md carries a standing rule ("never add a second trigger path")
+//      whose only enforcement is that exactly one Cloud Scheduler job exists.
+//      The UNIQUE index below replaces that convention with a constraint.
+//   2. No scheduling. "Send in the evening" means one global Cloud Scheduler
+//      firing — evening in exactly one timezone. `scheduledFor` decouples
+//      "decide to notify" from "notify", which is what send-time
+//      personalization needs.
+//   3. No rate limiting across types. Nothing counts what a user has already
+//      received today, so raising send frequency has no safety valve. A single
+//      queue is the chokepoint where a per-user daily cap can exist at all.
+//
+// Index / constraint strategy:
+//   - UNIQUE (brandVariation, userId, dedupeKey) is the load-bearing one.
+//     `dedupeKey` is caller-supplied and must encode everything that makes the
+//     notification distinct, including its period — e.g.
+//     `streak-at-risk:<pactId>:2026-08-08`. Enqueue is ON CONFLICT DO NOTHING,
+//     so a re-run inserts nothing and re-sends nothing. Getting this key wrong
+//     is the one way to reintroduce duplicate sends, so it is the caller's
+//     explicit responsibility rather than something derived implicitly here.
+//   - The claim index is PARTIAL, on ('pending') rows only, leading with
+//     scheduledFor. The queue is expected to be almost entirely 'sent' rows
+//     awaiting retention cleanup, and a partial index keeps the hot path
+//     proportional to the backlog rather than to history.
+//   - (brandVariation, userId, sentAt) supports the per-user rate-limit count.
+//
+// `payload` is jsonb rather than columns per field because it carries the
+// ISendPushNotification extras (habitName, partnerName, streakCount, …), which
+// differ per notification type and change whenever copy changes. Those fields
+// are never queried on — only read back and forwarded — so there is nothing to
+// gain from promoting them to columns, and a schema change per new
+// notification type to lose.
+//
+// Idempotent (hasTable probe, CREATE INDEX IF NOT EXISTS) per
+// therr/require-idempotent-migration. Note createTable is guarded rather than
+// using createTableIfNotExists, which Knex itself warns against and the lint
+// rule flags.
+
+const TABLE = 'main."notificationQueue"';
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async (knex) => {
+    const exists = await knex.schema.withSchema('main').hasTable('notificationQueue');
+
+    if (!exists) {
+        await knex.schema.withSchema('main').createTable('notificationQueue', (table) => {
+            table.uuid('id').primary().notNullable().defaultTo(knex.raw('uuid_generate_v4()'));
+
+            table.uuid('userId').notNullable()
+                .references('id').inTable('main.users')
+                .onUpdate('CASCADE')
+                .onDelete('CASCADE');
+
+            // No default. Every other brand-scoped table defaults to 'therr' so
+            // pre-existing rows stay visible after a backfill; this table is
+            // brand-scoped from birth with no legacy rows, so a default would
+            // only let a caller that forgot the brand silently file its
+            // notification as Therr's.
+            table.string('brandVariation', 50).notNullable();
+
+            // PushNotifications.Types value. Deliberately not a pg enum: the set
+            // grows with every new notification, and adding an enum value is DDL
+            // that cannot share a transaction with other DDL.
+            table.string('type', 100).notNullable();
+
+            table.string('dedupeKey', 255).notNullable();
+
+            table.jsonb('payload').notNullable().defaultTo('{}');
+
+            // pending | sent | failed | skipped
+            //   skipped = deliberately not sent (rate cap, user preference,
+            //   no device token). Distinct from failed so that suppression is
+            //   measurable rather than looking like breakage.
+            table.string('status', 20).notNullable().defaultTo('pending');
+
+            // When this becomes eligible to send. Defaults to now() so an
+            // "as soon as possible" enqueue needs no argument.
+            table.timestamp('scheduledFor', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+
+            table.integer('attempts').notNullable().defaultTo(0);
+            table.text('lastError');
+
+            table.timestamp('sentAt', { useTz: true });
+            table.timestamp('createdAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+            table.timestamp('updatedAt', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+
+            table.unique(['brandVariation', 'userId', 'dedupeKey']);
+        });
+    }
+
+    // Created outside the table builder so re-running against a table that
+    // already exists still converges on the full index set.
+    await knex.raw(
+        `CREATE INDEX IF NOT EXISTS "notificationQueue_claim_idx"
+         ON ${TABLE} ("scheduledFor", "brandVariation")
+         WHERE "status" = 'pending'`,
+    );
+    await knex.raw(
+        `CREATE INDEX IF NOT EXISTS "notificationQueue_rate_idx"
+         ON ${TABLE} ("brandVariation", "userId", "sentAt")`,
+    );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS main."notificationQueue_claim_idx"');
+    await knex.raw('DROP INDEX IF EXISTS main."notificationQueue_rate_idx"');
+    await knex.schema.withSchema('main').dropTableIfExists('notificationQueue');
+};

--- a/therr-services/users-service/src/utilities/enqueueNotification.ts
+++ b/therr-services/users-service/src/utilities/enqueueNotification.ts
@@ -1,0 +1,80 @@
+import { BrandVariations, PushNotifications } from 'therr-js-utilities/constants';
+import logSpan from 'therr-js-utilities/log-or-update-span';
+import Store from '../store';
+
+/**
+ * The one entry point producers use to schedule a notification.
+ *
+ * Prefer this over calling `sendEmailAndOrPushNotification` inline whenever the
+ * notification is *not* an immediate reaction to something the recipient will
+ * see happen. Inline sending is still correct for tightly-coupled feedback (a
+ * pact invite the sender is watching for); everything periodic, batched, or
+ * deferred belongs in the queue, where it gets dedup, scheduling and the
+ * per-user daily cap for free.
+ *
+ * See docs/NOTIFICATION_QUEUE_DESIGN.md.
+ */
+
+export interface IEnqueueNotificationArgs {
+    brandVariation: BrandVariations | string;
+    toUserId: string;
+    type: PushNotifications.Types;
+    /**
+     * What makes this notification distinct — INCLUDING its period.
+     *
+     * This is the whole dedup mechanism, and the one thing a caller can get
+     * wrong in a way that reintroduces duplicate sends. Rules of thumb:
+     *
+     *   - A once-per-day notification must contain the date:
+     *       `streak-at-risk:<pactId>:2026-08-08`
+     *   - A once-per-event notification must contain the event id and nothing
+     *     time-varying:
+     *       `pact-accepted:<pactId>:<memberId>`
+     *   - Never interpolate `Date.now()` or a random value. That makes every
+     *     enqueue unique, which silently turns dedup off.
+     */
+    dedupeKey: string;
+    /** Forwarded verbatim to sendEmailAndOrPushNotification (habitName, streakCount, …). */
+    payload?: Record<string, any>;
+    /** Defaults to now(). Set it to defer — this is the send-time personalization hook. */
+    scheduledFor?: Date;
+}
+
+/**
+ * Returns true when a new row was queued, false when an identical one already
+ * existed for this period. `false` is a normal outcome, not an error — it is
+ * what makes a producer safe to re-run.
+ *
+ * Never throws. A producer is typically inside a request that must succeed
+ * whether or not a notification gets scheduled, so failures are logged and
+ * swallowed — matching how the existing inline send path already behaves.
+ */
+const enqueueNotification = async (args: IEnqueueNotificationArgs): Promise<boolean> => {
+    try {
+        const row = await Store.notificationQueue.enqueue(args.brandVariation, {
+            userId: args.toUserId,
+            type: String(args.type),
+            dedupeKey: args.dedupeKey,
+            payload: args.payload,
+            scheduledFor: args.scheduledFor,
+        });
+        return !!row;
+    } catch (err: any) {
+        logSpan({
+            level: 'error',
+            messageOrigin: 'API_SERVER',
+            messages: ['Failed to enqueue notification'],
+            traceArgs: {
+                'error.message': err?.message,
+                'notificationQueue.type': String(args.type),
+                'notificationQueue.dedupeKey': args.dedupeKey,
+                'pushNotification.brandVariation': String(args.brandVariation),
+                'user.id': args.toUserId,
+                source: 'users-service',
+            },
+        });
+        return false;
+    }
+};
+
+export default enqueueNotification;

--- a/therr-services/users-service/src/utilities/notificationQueueWorker.ts
+++ b/therr-services/users-service/src/utilities/notificationQueueWorker.ts
@@ -1,0 +1,224 @@
+import { BrandVariations } from 'therr-js-utilities/constants';
+import logSpan from 'therr-js-utilities/log-or-update-span';
+import Store from '../store';
+import { INotificationQueueRow } from '../store/NotificationQueueStore';
+import sendEmailAndOrPushNotification from './sendEmailAndOrPushNotification';
+
+/**
+ * Drains main.notificationQueue and sends what is due.
+ *
+ * WHY IT LIVES HERE, not in therr-messaging-automator
+ *
+ * Sending needs the notification copy, all three locales, the per-brand Firebase
+ * app, the Android channel routing and the brand intent actions — everything in
+ * push-notifications-service, reached through `sendEmailAndOrPushNotification`.
+ * A Cloud Function that sent directly would have to duplicate that surface in a
+ * repo with no CI checking the coupling (docs/CROSS_REPO_INTEGRATION.md). The
+ * automator stays a *clock* that pokes this service; the send stays behind it.
+ *
+ * WHY NOT pg-boss
+ *
+ * pg-boss self-migrates its own `pgboss` schema at boot, outside the Knex
+ * migration system that `therr/require-idempotent-migration` and the
+ * expand/contract discipline exist to protect — in a database two sibling repos
+ * read directly. What we actually needed from it (dedup, delayed scheduling,
+ * bounded retry, SKIP LOCKED) is a unique index and the ~150 lines in
+ * NotificationQueueStore. Revisit if job types multiply or workflows appear.
+ *
+ * SHAPE
+ *
+ * A single interval timer, started from index.ts and cleared on SIGTERM. Each
+ * tick claims a bounded batch per brand, sends, and records the outcome. Ticks
+ * never overlap: `isTicking` skips a tick that arrives while the previous one is
+ * still going, which matters because a slow push service would otherwise stack
+ * ticks until the pod runs out of connections.
+ */
+
+// Tunables. Deliberately module constants rather than env vars for now: nothing
+// has run in production yet, so there is no operational experience to configure
+// against, and an env var implies a knob someone has reason to turn.
+const TICK_INTERVAL_MS = 30 * 1000;
+const CLAIM_BATCH_SIZE = 25;
+const MAX_ATTEMPTS = 3;
+const REQUEUE_BATCH_SIZE = 25;
+
+// The safety valve on send frequency. docs/PUSH_NOTIFICATIONS_ENGAGEMENT_ROADMAP.md
+// caps at 3-5/day per user across all types and notes that past that point
+// frequency *reduces* DAU. 5 is the top of that range, enforced here rather than
+// trusted to each producer, because a cap that every caller has to remember is
+// not a cap.
+const MAX_SENDS_PER_USER_PER_DAY = 5;
+const RATE_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+let timer: NodeJS.Timeout | undefined;
+let isTicking = false;
+
+const sendOne = async (row: INotificationQueueRow): Promise<void> => {
+    const since = new Date(Date.now() - RATE_WINDOW_MS);
+    const sentToday = await Store.notificationQueue
+        .countSentSince(row.brandVariation, row.userId, since)
+        .catch(() => 0);
+
+    if (sentToday >= MAX_SENDS_PER_USER_PER_DAY) {
+        // Dropped, not deferred. Deferring would just move the same notification
+        // into tomorrow's budget and crowd out whatever is timely then — and a
+        // reminder that arrives a day late is worse than one that never arrives.
+        await Store.notificationQueue.markSkipped(row.id, `daily cap reached (${sentToday})`);
+        return;
+    }
+
+    const payload = row.payload || {};
+
+    // Synthetic internal headers. This is a background job with no originating
+    // request; push-notifications-service is VPC-internal and mounts no
+    // authenticate middleware, so there is no token to forward and nothing that
+    // would verify one. Kept explicit so it is obvious that the absence of
+    // `authorization` here is a fact about the internal network, not an
+    // oversight.
+    const headers: any = {
+        'x-platform': 'mobile',
+        'x-brand-variation': row.brandVariation,
+        'x-localecode': payload.locale || 'en-us',
+        'x-userid': payload.fromUserId || '',
+    };
+
+    await sendEmailAndOrPushNotification(
+        Store.users.findUser,
+        headers,
+        {
+            authorization: '',
+            locale: payload.locale || 'en-us',
+            toUserId: row.userId,
+            type: row.type as any,
+            whiteLabelOrigin: payload.whiteLabelOrigin || '',
+            brandVariation: row.brandVariation,
+            ...payload,
+        },
+        // Queue entries are push-only. The retention emails have their own
+        // triggers and their own unsubscribe semantics; routing them through
+        // here too would double-send.
+        { shouldSendPushNotification: true, shouldSendEmail: false },
+    );
+
+    await Store.notificationQueue.markSent(row.id);
+};
+
+const drainBrand = async (brand: BrandVariations): Promise<number> => {
+    // Bounded retry first, so a batch orphaned by a crashed tick becomes
+    // eligible again before this tick claims new work.
+    await Store.notificationQueue.requeueFailed(brand, MAX_ATTEMPTS, REQUEUE_BATCH_SIZE).catch(() => 0);
+
+    const rows = await Store.notificationQueue.claimDue(brand, CLAIM_BATCH_SIZE);
+    if (!rows.length) return 0;
+
+    // Sequential, not Promise.all: each send fans out to push-notifications-service
+    // and the DB, and a burst of 25 concurrent sends from a replicas:1 pod is a
+    // good way to exhaust the write pool. Throughput is not the constraint here —
+    // a 30s tick with batches of 25 is 3,000/hour/brand, far past current volume.
+    // eslint-disable-next-line no-restricted-syntax
+    for (const row of rows) {
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            await sendOne(row);
+        } catch (err: any) {
+            // claimDue already set status='failed' and incremented attempts, so
+            // an exception escaping here leaves the row correct for requeue.
+            // eslint-disable-next-line no-await-in-loop
+            await Store.notificationQueue
+                .markFailed(row.id, String(err?.message || err).slice(0, 500))
+                .catch(() => undefined);
+            logSpan({
+                level: 'error',
+                messageOrigin: 'API_SERVER',
+                messages: ['Notification queue: send failed'],
+                traceArgs: {
+                    'error.message': err?.message,
+                    'notificationQueue.id': row.id,
+                    'notificationQueue.type': row.type,
+                    'pushNotification.brandVariation': row.brandVariation,
+                    'user.id': row.userId,
+                    source: 'users-service',
+                },
+            });
+        }
+    }
+
+    return rows.length;
+};
+
+const tick = async (): Promise<void> => {
+    if (isTicking) return;
+    isTicking = true;
+    try {
+        const brands = Object.values(BrandVariations) as BrandVariations[];
+        // eslint-disable-next-line no-restricted-syntax
+        for (const brand of brands) {
+            // eslint-disable-next-line no-await-in-loop
+            await drainBrand(brand).catch((err: any) => {
+                logSpan({
+                    level: 'error',
+                    messageOrigin: 'API_SERVER',
+                    messages: ['Notification queue: brand drain failed'],
+                    traceArgs: {
+                        'error.message': err?.message,
+                        'pushNotification.brandVariation': String(brand),
+                        source: 'users-service',
+                    },
+                });
+            });
+        }
+    } finally {
+        isTicking = false;
+    }
+};
+
+/**
+ * Starts the drain loop. Safe to call once, from index.ts after the server is
+ * listening. Returns a stop function for the shutdown path.
+ *
+ * Disabled by default via NOTIFICATION_QUEUE_WORKER_ENABLED so this can deploy
+ * dark: the table and the producers can land, be observed filling up, and only
+ * then be allowed to send. An always-on worker on first deploy would make the
+ * first thing anyone learns about this system a user-visible one.
+ */
+const startNotificationQueueWorker = (): (() => void) => {
+    if (process.env.NOTIFICATION_QUEUE_WORKER_ENABLED !== 'true') {
+        logSpan({
+            level: 'info',
+            messageOrigin: 'API_SERVER',
+            messages: ['Notification queue worker disabled (NOTIFICATION_QUEUE_WORKER_ENABLED != true)'],
+            traceArgs: { source: 'users-service' },
+        });
+        return () => undefined;
+    }
+
+    logSpan({
+        level: 'info',
+        messageOrigin: 'API_SERVER',
+        messages: ['Notification queue worker started'],
+        traceArgs: {
+            'notificationQueue.tickIntervalMs': TICK_INTERVAL_MS,
+            'notificationQueue.batchSize': CLAIM_BATCH_SIZE,
+            'notificationQueue.maxSendsPerUserPerDay': MAX_SENDS_PER_USER_PER_DAY,
+            source: 'users-service',
+        },
+    });
+
+    timer = setInterval(() => { tick(); }, TICK_INTERVAL_MS);
+    // Never hold the event loop open on shutdown.
+    timer.unref();
+
+    return () => {
+        if (timer) clearInterval(timer);
+        timer = undefined;
+    };
+};
+
+export {
+    startNotificationQueueWorker,
+    // Exported for tests — lets a single tick be driven deterministically
+    // instead of waiting on the interval.
+    tick as runNotificationQueueTick,
+    MAX_SENDS_PER_USER_PER_DAY,
+    MAX_ATTEMPTS,
+};

--- a/therr-services/users-service/tests/unit/notificationQueueStore.test.ts
+++ b/therr-services/users-service/tests/unit/notificationQueueStore.test.ts
@@ -1,0 +1,197 @@
+/* eslint-disable quotes, max-len */
+import { expect } from 'chai';
+import { BrandVariations } from 'therr-js-utilities/constants';
+import NotificationQueueStore from '../../src/store/NotificationQueueStore';
+
+/**
+ * NotificationQueueStore — the SQL, not the plumbing.
+ *
+ * Everything that makes this queue correct is expressed in the emitted SQL:
+ * dedup lives in an ON CONFLICT clause, worker safety lives in FOR UPDATE SKIP
+ * LOCKED, and brand isolation lives in a WHERE predicate. None of that is
+ * visible from the method signatures, and all of it is the kind of thing that
+ * survives a careless refactor syntactically while losing its meaning. So these
+ * tests capture the generated query strings against a stub connection rather
+ * than standing up Postgres — the integration suite covers round-trips.
+ */
+
+const buildStore = () => {
+    const queries: { pool: 'read' | 'write'; sql: string }[] = [];
+    const makeRunner = (pool: 'read' | 'write') => ({
+        query: (sql: string) => {
+            queries.push({ pool, sql });
+            return Promise.resolve({ rows: [], rowCount: 0 });
+        },
+    });
+    const store = new NotificationQueueStore({
+        read: makeRunner('read'),
+        write: makeRunner('write'),
+    } as any);
+
+    return { store, queries, last: () => queries[queries.length - 1].sql };
+};
+
+describe('NotificationQueueStore', () => {
+    describe('enqueue', () => {
+        it('dedupes on (brandVariation, userId, dedupeKey) instead of inserting a second row', async () => {
+            const { store, last } = buildStore();
+
+            await store.enqueue(BrandVariations.HABITS, {
+                userId: 'a2b1c0d9-0000-4000-8000-000000000001',
+                type: 'streak-at-risk',
+                dedupeKey: 'streak-at-risk:pact-1:2026-08-08',
+            });
+
+            const sql = last();
+            expect(sql).to.have.string('ON CONFLICT');
+            expect(sql).to.have.string('"brandVariation", "userId", "dedupeKey"');
+            // DO NOTHING, not DO UPDATE: a re-run must not reset scheduledFor or
+            // resurrect a row the worker already sent.
+            expect(sql).to.have.string('DO NOTHING');
+        });
+
+        it('writes the brand from the argument, so a producer cannot file under the wrong app', async () => {
+            const { store, last } = buildStore();
+
+            await store.enqueue(BrandVariations.HABITS, {
+                userId: 'a2b1c0d9-0000-4000-8000-000000000001',
+                type: 'pact-nudge',
+                dedupeKey: 'pact-nudge:pact-1',
+            });
+
+            expect(last()).to.have.string("'habits'");
+        });
+
+        it('defaults scheduledFor to now() when the caller does not defer', async () => {
+            const { store, last } = buildStore();
+
+            await store.enqueue(BrandVariations.THERR, {
+                userId: 'a2b1c0d9-0000-4000-8000-000000000001',
+                type: 'new-like-received',
+                dedupeKey: 'like:post-1',
+            });
+
+            expect(last()).to.have.string('COALESCE');
+            expect(last()).to.have.string('now()');
+        });
+
+        it('carries an explicit scheduledFor through, which is the send-time personalization hook', async () => {
+            const { store, last } = buildStore();
+            const when = new Date('2026-08-09T01:30:00.000Z');
+
+            await store.enqueue(BrandVariations.HABITS, {
+                userId: 'a2b1c0d9-0000-4000-8000-000000000001',
+                type: 'daily-habit-reminder',
+                dedupeKey: 'daily:2026-08-09',
+                scheduledFor: when,
+            });
+
+            expect(last()).to.have.string('2026-08-09T01:30:00.000Z');
+        });
+
+        it('goes to the write pool', async () => {
+            const { store, queries } = buildStore();
+
+            await store.enqueue(BrandVariations.THERR, {
+                userId: 'a2b1c0d9-0000-4000-8000-000000000001',
+                type: 'new-like-received',
+                dedupeKey: 'like:post-2',
+            });
+
+            expect(queries[queries.length - 1].pool).to.equal('write');
+        });
+    });
+
+    describe('claimDue', () => {
+        it('claims with FOR UPDATE SKIP LOCKED so two workers cannot send the same row', async () => {
+            const { store, last } = buildStore();
+
+            await store.claimDue(BrandVariations.HABITS, 25);
+
+            expect(last()).to.have.string('FOR UPDATE SKIP LOCKED');
+        });
+
+        it('only claims rows that are pending and actually due', async () => {
+            const { store, last } = buildStore();
+
+            await store.claimDue(BrandVariations.HABITS, 25);
+
+            const sql = last();
+            expect(sql).to.have.string(`"status" = 'pending'`);
+            expect(sql).to.have.string('"scheduledFor" <= now()');
+        });
+
+        it('scopes the claim to one brand', async () => {
+            const { store, last } = buildStore();
+
+            await store.claimDue(BrandVariations.HABITS, 25);
+
+            expect(last()).to.have.string(`"brandVariation" = 'habits'`);
+        });
+
+        it('counts the attempt at claim time, so a crashed worker cannot retry forever', async () => {
+            const { store, last } = buildStore();
+
+            await store.claimDue(BrandVariations.HABITS, 25);
+
+            const sql = last();
+            expect(sql).to.have.string('"attempts" = q."attempts" + 1');
+            // Claimed rows land in a terminal, visible state rather than a
+            // 'processing' limbo that would need its own reaper.
+            expect(sql).to.have.string(`SET "status" = 'failed'`);
+        });
+
+        it('honors the batch limit', async () => {
+            const { store, last } = buildStore();
+
+            await store.claimDue(BrandVariations.HABITS, 7);
+
+            expect(last()).to.have.string('LIMIT 7');
+        });
+    });
+
+    describe('requeueFailed', () => {
+        it('is bounded by attempts so a permanently broken row stops being retried', async () => {
+            const { store, last } = buildStore();
+
+            await store.requeueFailed(BrandVariations.HABITS, 3, 25);
+
+            const sql = last();
+            expect(sql).to.have.string('"attempts" <');
+            expect(sql).to.have.string('3');
+            expect(sql).to.have.string(`SET "status" = 'pending'`);
+        });
+    });
+
+    describe('countSentSince', () => {
+        it('counts only rows actually sent, scoped to the brand and user', async () => {
+            const { store, last, queries } = buildStore();
+
+            await store.countSentSince(
+                BrandVariations.HABITS,
+                'a2b1c0d9-0000-4000-8000-000000000001',
+                new Date('2026-08-07T00:00:00.000Z'),
+            );
+
+            const sql = last();
+            expect(sql).to.have.string(`"status" = 'sent'`);
+            expect(sql).to.have.string(`"brandVariation" = 'habits'`);
+            expect(sql).to.have.string('2026-08-07T00:00:00.000Z');
+            // The rate check is a read — it must not burden the write pool on
+            // every single send.
+            expect(queries[queries.length - 1].pool).to.equal('read');
+        });
+    });
+
+    describe('deleteCompletedBefore', () => {
+        it('only ever removes terminal rows, never pending work', async () => {
+            const { store, last } = buildStore();
+
+            await store.deleteCompletedBefore(new Date('2026-07-01T00:00:00.000Z'), 500);
+
+            const sql = last();
+            expect(sql).to.have.string(`IN ('sent', 'skipped')`);
+            expect(sql).to.not.have.string("'pending'");
+        });
+    });
+});


### PR DESCRIPTION
The Local Pairings, Upcoming Events and Guest Posts sections on the area
detail screens each stacked full-width cards vertically, so a space with a
handful of related items pushed its own content far off-screen and gave the
reader no signal that a section had ended.

Replace all three with a shared horizontal rail:

- `HorizontalCardScroller` — snapping, section-headed rail with a fixed
  height regardless of item count. Cards stop short of the viewport so the
  next one peeks in, which is the affordance telling the user it scrolls.
- `AreaScrollerCard` — one card for all three sections (they differed only
  in which meta lines they filled), with overlay actions on the media,
  a category pill, meta lines, rating and an avatar/label footer.
- `BrandedMediaPlaceholder` — theme-derived stand-in for missing media.
  Every color reads from the active theme rather than a baked asset, so a
  niche brand picks up its own palette by filling in `brandColorOverrides`
  with no per-brand image to ship. The composition is seeded off the content
  id so a row of media-less cards reads as distinct tiles, stably across
  sessions. Deliberately avoids the `therr-logo` glyph, which is brand
  identity and must not ride along on shared code.

Uncategorized content previously fell back to a generic grey "broken image"
PNG, which read as a load failure rather than as "no photo yet";
`MissingImagePlaceholder` now uses the branded placeholder there instead.
ViewEvent and ViewMoment also opt into placeholder media — without it a
media-less event or moment rendered an empty gap where the image belongs.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PCuSmfdYehwPt2eBPu3HN7