### PR TITLE
feat(thoughts): return the parent thought from getThoughtDetails

### DIFF
--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1883,7 +1883,12 @@
       "headerTitle": "Thoughts",
       "reply": "Reply",
       "replies": "Replies",
-      "repliesFailed": "We couldn't load the replies. Try again in a moment."
+      "repliesFailed": "We couldn't load the replies. Try again in a moment.",
+      "headerTitleReply": "Reply",
+      "partOfThread": "Part of a thread",
+      "replyingTo": "Replying to {userName}",
+      "viewParentThought": "View the post this replies to",
+      "backToParent": "Back to Thread"
     },
     "manageSpaces": {
       "headerTitle": "My Business Spaces",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1883,7 +1883,12 @@
       "headerTitle": "Pensamientos",
       "reply": "Responder",
       "replies": "Respuestas",
-      "repliesFailed": "No pudimos cargar las respuestas. Inténtalo de nuevo en un momento."
+      "repliesFailed": "No pudimos cargar las respuestas. Inténtalo de nuevo en un momento.",
+      "headerTitleReply": "Respuesta",
+      "partOfThread": "Parte de una conversación",
+      "replyingTo": "Respondiendo a {userName}",
+      "viewParentThought": "Ver la publicación a la que responde",
+      "backToParent": "Volver a la conversación"
     },
     "manageSpaces": {
       "headerTitle": "Mis Negocios",

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -1883,7 +1883,12 @@
       "headerTitle": "Pensées",
       "reply": "Répondre",
       "replies": "Réponses",
-      "repliesFailed": "Impossible de charger les réponses. Réessayez dans un instant."
+      "repliesFailed": "Impossible de charger les réponses. Réessayez dans un instant.",
+      "headerTitleReply": "Réponse",
+      "partOfThread": "Fait partie d'un fil",
+      "replyingTo": "En réponse à {userName}",
+      "viewParentThought": "Voir la publication à laquelle ceci répond",
+      "backToParent": "Retour au fil"
     },
     "manageSpaces": {
       "headerTitle": "Mes Commerces",

--- a/TherrMobile/main/routes/ViewThought/index.tsx
+++ b/TherrMobile/main/routes/ViewThought/index.tsx
@@ -3,7 +3,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import {
     Keyboard,
     Platform,
+    Pressable,
     StyleSheet,
+    Text,
     View} from 'react-native';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -62,6 +64,65 @@ const hapticFeedbackOptions = {
 const SendIcon = ({ disabled, colors }: { disabled: boolean; colors: { active: string; inactive: string } }) => (
     <TherrIcon name="send" size={22} color={disabled ? colors.inactive : colors.active} />
 );
+
+/**
+ * Signals that the post being viewed is a reply, and doubles as the way back up to the post it
+ * replies to. Without it a reply is indistinguishable from a top-level thought: it renders in the
+ * same card, and its own replies read as the whole conversation.
+ */
+const ParentThoughtBanner = ({
+    isDarkMode,
+    onPress,
+    parentThought,
+    theme,
+    themeViewContent,
+    translate,
+}: {
+    isDarkMode: boolean;
+    onPress: () => void;
+    parentThought: any;
+    theme: any;
+    themeViewContent: any;
+    translate: Function;
+}) => {
+    const mutedColor = isDarkMode ? theme.colorVariations?.accentTextWhiteFade : theme.colors.tertiary;
+    // The author is only known once the details fetch resolves (and never for a deleted account),
+    // so the label degrades to the generic wording rather than rendering "Replying to undefined".
+    const label = parentThought.fromUserName
+        ? translate('pages.viewThought.replyingTo', { userName: parentThought.fromUserName })
+        : translate('pages.viewThought.partOfThread');
+
+    return (
+        <Pressable
+            style={themeViewContent.styles.parentThoughtContainer}
+            onPress={onPress}
+            accessibilityRole="button"
+            accessibilityLabel={translate('pages.viewThought.viewParentThought')}
+        >
+            <TherrIcon
+                name="chat"
+                size={18}
+                color={theme.colors.brand}
+            />
+            <View style={themeViewContent.styles.parentThoughtTextContainer}>
+                <Text style={themeViewContent.styles.parentThoughtLabel} numberOfLines={1}>
+                    {label}
+                </Text>
+                {
+                    !!parentThought.message &&
+                        <Text style={themeViewContent.styles.parentThoughtMessage} numberOfLines={2}>
+                            {parentThought.message}
+                        </Text>
+                }
+            </View>
+            <TherrIcon
+                name="chevron-right"
+                size={18}
+                color={mutedColor}
+            />
+        </Pressable>
+    );
+};
 
 interface IViewThoughtDispatchProps {
     getThoughtDetails: Function;
@@ -138,6 +199,10 @@ const ViewThought = ({
         () => (thought.hashTags ? thought.hashTags.split(',') : []),
         [thought.hashTags]
     );
+    // Present only when this post is a reply. The details fetch is the source of truth, but a
+    // thought handed over through route params (eg. a reply opened from within a thread) can
+    // already carry it, so the banner renders before the fetch resolves.
+    const parentThought = fetchedThought?.parent || thought.parent;
     const isFormDisabled = !inputMessage || isSubmitting;
     const brandColor = isDarkMode ? theme.colors.textWhite : theme.colors.brandingBlueGreen;
 
@@ -146,6 +211,7 @@ const ViewThought = ({
         getThoughtDetails(thought.id, {
             withUser: true,
             withReplies: true,
+            withParent: true,
         }).then((response) => {
             setFetchedThought(response?.thought || {});
             setReplies(
@@ -180,6 +246,16 @@ const ViewThought = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    // The parent is only known once the details fetch resolves, so the header title is corrected
+    // afterwards — "Reply" is the first signal that this post is part of a bigger thread.
+    useEffect(() => {
+        if (parentThought?.id) {
+            navigation.setOptions({
+                title: translate('pages.viewThought.headerTitleReply'),
+            });
+        }
+    }, [parentThought?.id, navigation, translate]);
+
     // Handlers
     const handleGoBack = useCallback(() => {
         // Nested replies are pushed onto the stack, so unwinding one level is a plain pop.
@@ -187,8 +263,10 @@ const ViewThought = ({
             navigation.goBack();
         } else if (fetchedThought?.parentId) {
             // Reached without a parent screen below (eg. a push notification deep link into a
-            // reply), so walk up to the parent thought explicitly.
-            navToViewContent({
+            // reply), so walk up to the parent thought explicitly. The fetched parent is handed
+            // over whole when we have it, so that screen renders the post immediately instead of
+            // an empty card until its own details request resolves.
+            navToViewContent(parentThought?.id ? parentThought : {
                 id: fetchedThought.parentId,
             }, user, navigation.replace);
         } else if (previousView && (previousView === 'Areas' || previousView === 'Notifications')) {
@@ -202,7 +280,25 @@ const ViewThought = ({
                 shouldShowPreview: false,
             });
         }
-    }, [fetchedThought, previousView, user, navigation]);
+    }, [fetchedThought, parentThought, previousView, user, navigation]);
+
+    const handleGoToParent = useCallback(() => {
+        if (!parentThought?.id) {
+            return;
+        }
+
+        // When this screen was pushed from the parent's own thread view, the parent is the screen
+        // directly below — popping to it keeps the stack from growing on every up-and-down walk.
+        if (previousView === 'ViewThought' && navigation.canGoBack()) {
+            navigation.goBack();
+            return;
+        }
+
+        // Otherwise (a deep link, a notification) there is no parent below to return to, so it is
+        // pushed. Unlike the back button's `replace`, this leaves the reply on the stack because
+        // the user asked to look up, not to leave.
+        navToViewContent(parentThought, user, navigation.push, 'ViewThought');
+    }, [parentThought, previousView, user, navigation]);
 
     const handleGoToViewUser = useCallback((userId) => {
         navigation.navigate('ViewUser', {
@@ -381,6 +477,19 @@ const ViewThought = ({
                     keyboardShouldPersistTaps="handled"
                 >
                     <View style={[themeAccentLayout.styles.container, themeThought.styles.inspectThoughtContainer, localStyles.contentContainer]}>
+                        {/* Thread context: only rendered when this post is a reply */}
+                        {
+                            !!parentThought?.id &&
+                                <ParentThoughtBanner
+                                    isDarkMode={isDarkMode}
+                                    onPress={handleGoToParent}
+                                    parentThought={parentThought}
+                                    theme={theme}
+                                    themeViewContent={themeThought}
+                                    translate={translate}
+                                />
+                        }
+
                         {/* Main thought */}
                         <ThoughtDisplay
                             translate={translate}
@@ -484,7 +593,9 @@ const ViewThought = ({
                         textColor={brandColor}
                         style={localStyles.footerButton}
                     >
-                        {translate('forms.editThought.buttons.back')}
+                        {parentThought?.id
+                            ? translate('pages.viewThought.backToParent')
+                            : translate('forms.editThought.buttons.back')}
                     </PaperButton>
                     {isMyContent && (
                         <PaperButton

--- a/TherrMobile/main/styles/user-content/thoughts/viewing.ts
+++ b/TherrMobile/main/styles/user-content/thoughts/viewing.ts
@@ -219,6 +219,34 @@ const buildStyles = (themeName?: IMobileThemeName, isDarkMode = true) => {
             borderTopColor: isDarkMode ? therrTheme.colors.accentDivider : therrTheme.colors.tertiary,
             backgroundColor: therrTheme.colors.accent1,
         },
+        // "This post is a reply" banner, rendered above the post in the details view. Styled as a
+        // quoted block (left rule + muted text) so it reads as context rather than as the post.
+        parentThoughtContainer: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            marginBottom: 10,
+            marginHorizontal: 2,
+            paddingVertical: 8,
+            paddingHorizontal: 10,
+            borderRadius: 8,
+            borderLeftWidth: 3,
+            borderLeftColor: therrTheme.colors.brand,
+            backgroundColor: isDarkMode ? therrTheme.colors.accent1 : therrTheme.colorVariations.backgroundNeutral,
+        },
+        parentThoughtTextContainer: {
+            flex: 1,
+            paddingHorizontal: 8,
+        },
+        parentThoughtLabel: {
+            fontSize: 12,
+            fontWeight: '600',
+            paddingBottom: 2,
+            color: therrTheme.colors.brand,
+        },
+        parentThoughtMessage: {
+            fontSize: 14,
+            color: isDarkMode ? therrTheme.colorVariations.accentTextWhiteFade : therrTheme.colors.tertiary,
+        },
         repliesDivider: {
             width: '100%',
             marginVertical: 12,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -50,6 +50,7 @@
 - **Auto-expanded thread previews (mobile & web)** — engaging thought threads show their top reply inline with a "View all N replies" link (Twitter-style); each post card also carries a reply-count control. Auto-expand criteria are shared: 2+ replies always expand, single-reply threads need a like signal on the parent or the reply
 - **Nested reply counts (mobile & web)** — in the thought details view only, each reply renders a reply icon with its own nested reply count; tapping it opens that reply's details view so threads can be walked one level at a time
 - **Inline reply likes (mobile)** — replies in the thought details view carry their own like control with an optimistic toggle (reverted if the request fails), so a reply can be liked without opening it. `getThoughtDetails` returns each reply's like count and the requesting user's reaction
+- **Parent thread context (mobile & web)** — a thought that is itself a reply opens with a quoted "Replying to @user" banner above it, linking up to the post it answers, plus a "Back to Thread" action and a breadcrumb/header that reads "Reply". `getThoughtDetails` takes `withParent` and returns `thought.parent` (author + message), and activates the parent so walking up from a deep-linked reply is never access-denied
 - **Content categories** — 20+ categories (food, music, nature, art, gaming, etc.)
 - **Media uploads** — image upload with CDN (ImageKit), YouTube video embedding
 

--- a/therr-api-gateway/src/services/users/validation/thoughts.ts
+++ b/therr-api-gateway/src/services/users/validation/thoughts.ts
@@ -10,6 +10,7 @@ export const getThoughtDetailsValidation = [
     param('thoughtId').exists(),
     body('withUser').isBoolean().optional(),
     body('withReplies').isBoolean().optional(),
+    body('withParent').isBoolean().optional(),
 ];
 
 export const createThoughtValidation = [

--- a/therr-client-web/src/locales/en-us/dictionary.json
+++ b/therr-client-web/src/locales/en-us/dictionary.json
@@ -490,7 +490,13 @@
       "loginToReply": "Log in to reply",
       "loginToView": "Log in to view this post and join the conversation",
       "backToThoughts": "Back to Thoughts",
-      "viewReplies": "View {count} replies"
+      "viewReplies": "View {count} replies",
+      "headerTitleReply": "Reply",
+      "parentThread": "Thread",
+      "partOfThread": "Part of a thread",
+      "replyingTo": "Replying to {userName}",
+      "viewParentThought": "View the post this replies to",
+      "backToParent": "Back to Thread"
     },
     "explorePeople": {
       "pageTitle": "Search People",

--- a/therr-client-web/src/locales/es/dictionary.json
+++ b/therr-client-web/src/locales/es/dictionary.json
@@ -490,7 +490,13 @@
       "loginToReply": "Inicia sesión para responder",
       "loginToView": "Inicia sesión para ver esta publicación y unirte a la conversación",
       "backToThoughts": "Volver a Pensamientos",
-      "viewReplies": "Ver {count} respuestas"
+      "viewReplies": "Ver {count} respuestas",
+      "headerTitleReply": "Respuesta",
+      "parentThread": "Conversación",
+      "partOfThread": "Parte de una conversación",
+      "replyingTo": "Respondiendo a {userName}",
+      "viewParentThought": "Ver la publicación a la que responde",
+      "backToParent": "Volver a la conversación"
     },
     "explorePeople": {
       "pageTitle": "Buscar personas",

--- a/therr-client-web/src/locales/fr-ca/dictionary.json
+++ b/therr-client-web/src/locales/fr-ca/dictionary.json
@@ -497,7 +497,13 @@
       "loginToReply": "Connectez-vous pour répondre",
       "loginToView": "Connectez-vous pour voir cette publication et rejoindre la conversation",
       "backToThoughts": "Retour aux pensées",
-      "viewReplies": "Voir {count} réponses"
+      "viewReplies": "Voir {count} réponses",
+      "headerTitleReply": "Réponse",
+      "parentThread": "Fil",
+      "partOfThread": "Fait partie d'un fil",
+      "replyingTo": "En réponse à {userName}",
+      "viewParentThought": "Voir la publication à laquelle ceci répond",
+      "backToParent": "Retour au fil"
     },
     "chatForum": {
       "pageTitle": "Clavardage hébergé",

--- a/therr-client-web/src/routes/ViewThought.tsx
+++ b/therr-client-web/src/routes/ViewThought.tsx
@@ -75,6 +75,7 @@ const ViewThought: React.FC = () => {
         const detailsPromise = dispatch(UsersActions.getThoughtDetails(tId, {
             withUser: true,
             withReplies: true,
+            withParent: true,
         }) as any);
         const reactionPromise = cachedThought?.reaction
             ? Promise.resolve(cachedThought.reaction)
@@ -192,10 +193,24 @@ const ViewThought: React.FC = () => {
         navigate(`/thoughts/${replyId}`);
     }, [navigate]);
 
+    // Present only when the post being viewed is a reply
+    const parentThought = thought?.parent;
+
     const breadcrumbs = [
         <Anchor component={Link} to="/" key="home" size="sm">{translate('pages.navigation.home')}</Anchor>,
         <Anchor component={Link} to="/posts/thoughts" key="thoughts" size="sm">{translate('pages.navigation.thoughts')}</Anchor>,
-        <Text size="sm" key="thought">{translate('pages.viewThought.headerTitle')}</Text>,
+        ...(parentThought?.id
+            ? [
+                <Anchor component={Link} to={`/thoughts/${parentThought.id}`} key="parent" size="sm">
+                    {translate('pages.viewThought.parentThread')}
+                </Anchor>,
+            ]
+            : []),
+        <Text size="sm" key="thought">
+            {parentThought?.id
+                ? translate('pages.viewThought.headerTitleReply')
+                : translate('pages.viewThought.headerTitle')}
+        </Text>,
     ];
 
     if (isLoading) {
@@ -238,6 +253,34 @@ const ViewThought: React.FC = () => {
         <Container id="page_view_thought" size="sm" py="xl">
             <Stack gap="lg">
                 <Breadcrumbs>{breadcrumbs}</Breadcrumbs>
+
+                {/*
+                    Thread context. Without it a reply renders exactly like a top-level thought,
+                    so the post it answers — and the rest of the conversation — is invisible.
+                */}
+                {parentThought?.id && (
+                    <Anchor
+                        component={Link}
+                        to={`/thoughts/${parentThought.id}`}
+                        className="view-thought-parent"
+                        underline="never"
+                        aria-label={translate('pages.viewThought.viewParentThought')}
+                    >
+                        <Group gap="xs" align="center" mb={4} wrap="nowrap">
+                            <InlineSvg name="forum" className="discovered-tile-icon" />
+                            <Text size="xs" fw={700}>
+                                {parentThought.fromUserName
+                                    ? translate('pages.viewThought.replyingTo', { userName: parentThought.fromUserName })
+                                    : translate('pages.viewThought.partOfThread')}
+                            </Text>
+                        </Group>
+                        {parentThought.message && (
+                            <Text size="sm" c="dimmed" lineClamp={2}>
+                                {parentThought.message}
+                            </Text>
+                        )}
+                    </Anchor>
+                )}
 
                 {/* Main thought */}
                 <div className="view-thought-main">
@@ -429,14 +472,25 @@ const ViewThought: React.FC = () => {
                     </Text>
                 )}
 
-                {/* Back button */}
-                <Button
-                    variant="outline"
-                    onClick={() => navigate('/posts/thoughts')}
-                    size="sm"
-                >
-                    {translate('pages.viewThought.backToThoughts')}
-                </Button>
+                {/* Back buttons */}
+                <Group gap="sm">
+                    {parentThought?.id && (
+                        <Button
+                            variant="outline"
+                            onClick={() => navigate(`/thoughts/${parentThought.id}`)}
+                            size="sm"
+                        >
+                            {translate('pages.viewThought.backToParent')}
+                        </Button>
+                    )}
+                    <Button
+                        variant={parentThought?.id ? 'subtle' : 'outline'}
+                        onClick={() => navigate('/posts/thoughts')}
+                        size="sm"
+                    >
+                        {translate('pages.viewThought.backToThoughts')}
+                    </Button>
+                </Group>
             </Stack>
         </Container>
     );

--- a/therr-client-web/src/routes/__tests__/ViewThought.test.tsx
+++ b/therr-client-web/src/routes/__tests__/ViewThought.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-disable import/first */
+
+const mockReduxState: any = {
+    user: {
+        isAuthenticated: true,
+        details: { id: 'viewer-1', userName: 'viewer' },
+        settings: { locale: 'en-us' },
+    },
+    content: { activeThoughts: [] },
+};
+
+jest.mock('react-redux', () => ({
+    // The component dispatches thunks and reads the response as a promise, so an identity
+    // dispatch is enough — the actions themselves are mocked below.
+    useDispatch: () => (action: any) => action,
+    useSelector: (selector: any) => selector(mockReduxState),
+}));
+
+jest.mock('therr-react/redux/actions', () => ({
+    ContentActions: {
+        createOrUpdateThoughtReaction: jest.fn(),
+    },
+}));
+
+jest.mock('therr-react/services', () => ({
+    ReactionsService: {
+        getThoughtReactions: jest.fn().mockResolvedValue({ data: [] }),
+    },
+}));
+
+jest.mock('therr-react/components', () => ({
+    InlineSvg: () => null,
+}));
+
+const mockGetThoughtDetails = jest.fn();
+
+jest.mock('../../redux/actions/UsersActions', () => ({
+    __esModule: true,
+    default: {
+        getThoughtDetails: (...args: any[]) => mockGetThoughtDetails(...args),
+        createThought: jest.fn(),
+    },
+}));
+
+import * as React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+import { act } from 'react-test-renderer';
+import { MantineProvider } from '@mantine/core';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import ViewThought from '../ViewThought';
+
+const PARENT_ID = 'thought-parent-1';
+
+const rootThought = {
+    id: 'thought-1',
+    fromUserId: 'author-1',
+    fromUserName: 'author',
+    message: 'the original thought',
+    createdAt: new Date().toISOString(),
+    replies: [],
+};
+
+const replyThought = {
+    id: 'thought-2',
+    parentId: PARENT_ID,
+    fromUserId: 'author-2',
+    fromUserName: 'replier',
+    message: 'a reply to the original',
+    createdAt: new Date().toISOString(),
+    replies: [],
+    parent: {
+        id: PARENT_ID,
+        fromUserId: 'author-1',
+        fromUserName: 'author',
+        message: 'the original thought',
+    },
+};
+
+const mountViewThought = async (thought: any) => {
+    mockGetThoughtDetails.mockResolvedValue({ thought });
+
+    let wrapper: ReactWrapper = null as any;
+
+    await act(async () => {
+        wrapper = mount(
+            <MantineProvider>
+                <MemoryRouter initialEntries={[`/thoughts/${thought.id}`]}>
+                    <Routes>
+                        <Route path="/thoughts/:thoughtId" element={<ViewThought />} />
+                    </Routes>
+                </MemoryRouter>
+            </MantineProvider>,
+        );
+    });
+    wrapper.update();
+
+    return wrapper;
+};
+
+describe('ViewThought thread context', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('requests the parent thought alongside the details', async () => {
+        await mountViewThought(rootThought);
+
+        expect(mockGetThoughtDetails).toHaveBeenCalledWith(
+            rootThought.id,
+            expect.objectContaining({ withParent: true }),
+        );
+    });
+
+    it('names the parent author and links up to the parent when the post is a reply', async () => {
+        const wrapper = await mountViewThought(replyThought);
+
+        expect(wrapper.text()).toContain('Replying to author');
+        expect(wrapper.find(`a[href="/thoughts/${PARENT_ID}"]`).length).toBeGreaterThan(0);
+    });
+
+    it('quotes the parent message so the reply is readable in context', async () => {
+        const wrapper = await mountViewThought(replyThought);
+
+        expect(wrapper.text()).toContain('the original thought');
+    });
+
+    it('offers a way back to the thread instead of only back to the feed', async () => {
+        const wrapper = await mountViewThought(replyThought);
+
+        expect(wrapper.text()).toContain('Back to Thread');
+    });
+
+    it('shows no thread context on a top-level thought', async () => {
+        const wrapper = await mountViewThought(rootThought);
+
+        expect(wrapper.text()).not.toContain('Replying to');
+        expect(wrapper.text()).not.toContain('Back to Thread');
+    });
+
+    it('falls back to generic wording when the parent author is unknown', async () => {
+        const wrapper = await mountViewThought({
+            ...replyThought,
+            parent: { id: PARENT_ID, message: 'the original thought' },
+        });
+
+        expect(wrapper.text()).toContain('Part of a thread');
+        expect(wrapper.find(`a[href="/thoughts/${PARENT_ID}"]`).length).toBeGreaterThan(0);
+    });
+});

--- a/therr-client-web/src/styles/pages/explore.scss
+++ b/therr-client-web/src/styles/pages/explore.scss
@@ -269,6 +269,35 @@
   }
 }
 
+// "Replying to ..." banner above a reply. Styled as a quoted block (left rule, muted text) so it
+// reads as context for the post rather than as the post itself.
+.view-thought-parent {
+  display: block;
+  padding: 10px 14px;
+  border-left: 3px solid var(--mantine-primary-color-filled, #1c7ed6);
+  border-radius: 0 8px 8px 0;
+  background: rgba(0, 0, 0, 0.03);
+  color: inherit;
+  margin-bottom: -8px;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.06);
+  }
+
+  .discovered-tile-icon {
+    height: 16px;
+    width: 16px;
+  }
+
+  [data-mantine-color-scheme="dark"] & {
+    background: rgba(255, 255, 255, 0.04);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+  }
+}
+
 .view-thought-reply-input {
   padding: 16px;
   border: 1px solid rgba(0, 0, 0, 0.1);

--- a/therr-public-library/therr-react/src/services/UsersService.ts
+++ b/therr-public-library/therr-react/src/services/UsersService.ts
@@ -101,6 +101,11 @@ interface ICreateThoughtBody {
 interface IGetThoughtDetailsArgs {
     withUser?: boolean;
     withReplies?: boolean;
+    /**
+     * Attaches `thought.parent` (author + message snippet) when the thought is a reply, so the
+     * details view can show it belongs to a thread and link back up to it.
+     */
+    withParent?: boolean;
 }
 
 interface IDeleteThoughtsBody {

--- a/therr-services/users-service/src/handlers/thoughts.ts
+++ b/therr-services/users-service/src/handlers/thoughts.ts
@@ -250,15 +250,18 @@ const getThoughtDetails = (req, res) => {
     const {
         withUser,
         withReplies,
+        withParent,
     } = req.body;
 
     const shouldFetchUser = !!withUser;
     const shouldFetchReplies = !!withReplies;
+    const shouldFetchParent = !!withParent;
 
     return Promise.all([
         Store.thoughts.getById(brand, thoughtId, {}, {
             withUser: shouldFetchUser,
             withReplies: shouldFetchReplies,
+            withParent: shouldFetchParent,
             shouldHideMatureContent: true, // TODO: Check the user settings to determine if mature content should be hidden
         }),
         Store.userMetrics.countWhere('thoughtId', thoughtId),
@@ -343,8 +346,11 @@ const getThoughtDetails = (req, res) => {
 
                 const replyIds = (thought.replies || []).map((reply) => reply.id).filter((id) => !!id);
                 // Activating this thought too (when it is itself a reply) keeps a reply reachable
-                // on its own after it was first opened via the parent's access.
-                const idsToActivate = thought.parentId ? [thought.id, ...replyIds] : replyIds;
+                // on its own after it was first opened via the parent's access. The parent is
+                // activated alongside it because the details view now offers a link up to it —
+                // without this, walking up from a reply reached by deep link 400s on a
+                // non-public parent the reader is plainly allowed to see.
+                const idsToActivate = thought.parentId ? [thought.id, thought.parentId, ...replyIds] : replyIds;
 
                 // Activate child thoughts otherwise
                 if (idsToActivate.length) {

--- a/therr-services/users-service/src/store/ThoughtsStore.ts
+++ b/therr-services/users-service/src/store/ThoughtsStore.ts
@@ -374,6 +374,55 @@ export default class ThoughtsStore {
                 });
             }
 
+            if (options.withParent) {
+                // A reply has no visible thread context of its own, so the details view renders a
+                // banner linking up to the parent — that needs the parent's author and a snippet
+                // of its message. Deliberately its own bounded query rather than a second
+                // self-join: joined onto the replies join it would multiply (parent rows x reply
+                // rows) and formatSQLJoinAsJSON would have to de-dupe the product.
+                const parentIds: string[] = [...new Set<string>(thoughts.map((thought) => thought.parentId).filter((id) => !!id))];
+
+                if (parentIds.length) {
+                    let parentQuery = knexBuilder
+                        .select([
+                            'id',
+                            'parentId',
+                            'fromUserId',
+                            'message',
+                            'isPublic',
+                            'isMatureContent',
+                            'createdAt',
+                        ])
+                        .from(THOUGHTS_TABLE_NAME)
+                        .whereIn('id', parentIds);
+
+                    // Mirrors the reply join's restriction: a habits reader must never be handed a
+                    // therr-brand parent, since the banner links to a thought they cannot open.
+                    if (readable !== 'all') {
+                        parentQuery = parentQuery.whereIn(`${THOUGHTS_TABLE_NAME}.brandVariation`, readable);
+                    }
+
+                    if (options?.shouldHideMatureContent) {
+                        parentQuery = parentQuery.where(`${THOUGHTS_TABLE_NAME}.isMatureContent`, false);
+                    }
+
+                    const parentRows = await this.db.read.query(parentQuery.toString()).then(({ rows: pRows }) => pRows);
+                    const parentsMap = parentRows.reduce((acc, parent) => {
+                        acc[parent.id] = parent;
+                        return acc;
+                    }, {});
+
+                    thoughts.forEach((thought) => {
+                        const modifiedThought = thought;
+                        // Left undefined (not null) when the parent is filtered out or deleted, so
+                        // clients fall back to "this is a reply" without a broken link target.
+                        if (modifiedThought.parentId && parentsMap[modifiedThought.parentId]) {
+                            modifiedThought.parent = parentsMap[modifiedThought.parentId];
+                        }
+                    });
+                }
+            }
+
             if (options.withUser) {
                 const userIds: string[] = [];
                 const thoughtDetailsPromises: Promise<any>[] = [];
@@ -385,6 +434,10 @@ export default class ThoughtsStore {
                         thought.replies.forEach((reply) => {
                             userIds.push(reply.fromUserId);
                         });
+                    }
+
+                    if (thought.parent) {
+                        userIds.push(thought.parent.fromUserId);
                     }
                 });
                 // TODO: Try fetching from redis/cache first, before fetching remaining media from DB
@@ -427,6 +480,23 @@ export default class ThoughtsStore {
 
                                 return modifiedReply;
                             });
+                        }
+                    }
+
+                    // Parent author, hydrated outside the `matchingUser` branch above: the banner
+                    // names the *parent's* author, so it must not go unnamed just because the
+                    // reply's own author row is missing.
+                    if (modifiedThought.parent) {
+                        const matchingParentUser = usersMap[modifiedThought.parent.fromUserId];
+                        if (matchingParentUser) {
+                            modifiedThought.parent = {
+                                ...modifiedThought.parent,
+                                fromUserName: matchingParentUser.userName,
+                                fromUserFirstName: matchingParentUser.firstName,
+                                fromUserLastName: matchingParentUser.lastName,
+                                fromUserMedia: matchingParentUser.media,
+                                fromUserIsSuperUser: matchingParentUser.isSuperUser,
+                            };
                         }
                     }
 

--- a/therr-services/users-service/tests/unit/ThoughtsStore.test.ts
+++ b/therr-services/users-service/tests/unit/ThoughtsStore.test.ts
@@ -462,6 +462,107 @@ describe('ThoughtsStore brand filtering', () => {
         });
     });
 
+    describe('getById (parent thread context)', () => {
+        const buildParentAwareStub = (parentRow?: any) => {
+            const { connection, readStub } = buildMockConnection();
+            readStub.onFirstCall().callsFake(() => Promise.resolve({
+                rows: [{
+                    id: 'reply-1',
+                    parentId: 'thought-1',
+                    fromUserId: '22',
+                    message: 'a reply',
+                }],
+            }));
+            readStub.onSecondCall().callsFake(() => Promise.resolve({
+                rows: parentRow ? [parentRow] : [],
+            }));
+
+            return { connection, readStub };
+        };
+
+        it('does not query for a parent when withParent is not requested', async () => {
+            const { connection, readStub } = buildParentAwareStub({ id: 'thought-1' });
+            const store = new ThoughtsStore(connection, stubUsersStore);
+
+            const { thoughts } = await store.getById(BrandVariations.THERR, 'reply-1', {}, {});
+
+            expect(readStub.callCount).to.equal(1);
+            expect(thoughts[0].parent).to.equal(undefined);
+        });
+
+        it('attaches the parent thought when the thought is a reply', async () => {
+            const { connection, readStub } = buildParentAwareStub({
+                id: 'thought-1',
+                parentId: null,
+                fromUserId: '11',
+                message: 'the original thought',
+            });
+            const store = new ThoughtsStore(connection, stubUsersStore);
+
+            const { thoughts } = await store.getById(BrandVariations.THERR, 'reply-1', {}, { withParent: true });
+
+            expect(readStub.callCount).to.equal(2);
+            expect(readStub.args[1][0]).to.include('in (\'thought-1\')');
+            expect(thoughts[0].parent.id).to.equal('thought-1');
+            expect(thoughts[0].parent.message).to.equal('the original thought');
+        });
+
+        it('restricts the parent lookup to the caller brand', async () => {
+            const { connection, readStub } = buildParentAwareStub();
+            const store = new ThoughtsStore(connection, stubUsersStore);
+
+            await store.getById(BrandVariations.HABITS, 'reply-1', {}, { withParent: true });
+
+            // Mirrors the reply join: a habits reader must not be linked up to a therr parent.
+            expect(readStub.args[1][0]).to.include('"brandVariation" in (\'habits\')');
+        });
+
+        it('leaves parent undefined when the parent is filtered out or deleted', async () => {
+            const { connection } = buildParentAwareStub();
+            const store = new ThoughtsStore(connection, stubUsersStore);
+
+            const { thoughts } = await store.getById(BrandVariations.HABITS, 'reply-1', {}, { withParent: true });
+
+            expect(thoughts[0].parent).to.equal(undefined);
+        });
+
+        it('does not query for a parent on a root thought', async () => {
+            const { connection, readStub } = buildMockConnection();
+            readStub.callsFake(() => Promise.resolve({
+                rows: [{ id: 'thought-1', parentId: null }],
+            }));
+            const store = new ThoughtsStore(connection, stubUsersStore);
+
+            await store.getById(BrandVariations.THERR, 'thought-1', {}, { withParent: true });
+
+            expect(readStub.callCount).to.equal(1);
+        });
+
+        it('hydrates the parent author even when the reply author is missing', async () => {
+            const { connection } = buildParentAwareStub({
+                id: 'thought-1',
+                fromUserId: '11',
+                message: 'the original thought',
+            });
+            const usersStore: any = {
+                findUsers: () => Promise.resolve([{
+                    id: '11',
+                    userName: 'original-poster',
+                    media: { profilePicture: 'pic' },
+                }]),
+            };
+            const store = new ThoughtsStore(connection, usersStore);
+
+            const { thoughts } = await store.getById(BrandVariations.THERR, 'reply-1', {}, {
+                withUser: true,
+                withParent: true,
+            });
+
+            expect(thoughts[0].fromUserName).to.equal(undefined);
+            expect(thoughts[0].parent.fromUserName).to.equal('original-poster');
+        });
+    });
+
     describe('create', () => {
         it('stamps the row with the caller brand on insert (habits)', () => {
             const { connection, writeStub } = buildMockConnection();


### PR DESCRIPTION
A reply has no thread context of its own in the details response, so clients
render it exactly like a top-level thought — the post it answers, and the rest
of the conversation, are invisible.

`getThoughtDetails` now accepts `withParent` and returns `thought.parent`
(id, author, message snippet) when the thought is a reply. The lookup is its
own bounded query rather than a second self-join, which would multiply against
the replies join; it mirrors the reply join's brand restriction so a habits
reader is never linked up to a therr-brand parent, and honors
shouldHideMatureContent.

The parent is also activated alongside the thought and its replies. Without
that, walking up from a reply reached by deep link 400s on a non-public parent
the reader is plainly allowed to see.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QSwwjr2d2RRwKGNsdjawmw