### PR TITLE
fix(k8s): promote the DNS-01 issuer and server-snippet removal to main

### DIFF
--- a/k8s/prod/ingress-rewrite-service.yaml
+++ b/k8s/prod/ingress-rewrite-service.yaml
@@ -19,16 +19,26 @@ metadata:
     nginx.ingress.kubernetes.io/gzip-min-length: "1000"
     # nginx.ingress.kubernetes.io/proxy-read-timeout: “3600”
     # nginx.ingress.kubernetes.io/proxy-send-timeout: “3600”
-    nginx.ingress.kubernetes.io/server-snippet: |
-        gzip on;
-        gzip_types      text/plain text/css text/js application/xml application/javascript;
-        gzip_proxied    no-cache no-store private expired auth;
-        gzip_min_length 1000;
-        gzip_disable "MSIE [1-6]\.";
-        gzip_vary on;
-        gzip_proxied any;
-        gzip_comp_level 5;
-        gzip_buffers 16 128k;
+    #
+    # REMOVED: nginx.ingress.kubernetes.io/server-snippet (a gzip on; ... block).
+    #
+    # It had not done anything for a long time. ingress-nginx defaults
+    # `allow-snippet-annotations` to false as of chart 4.8 / controller 1.9
+    # (CVE-2021-25742 hardening), and this cluster never set it to true. On
+    # cluster-1 the annotation survived only because the validating webhook
+    # grandfathers Ingresses created before the chart upgrade -- the controller
+    # logs it as "annotation group ServerSnippet contains risky annotation" and
+    # drops it. Verified against the live config: cluster-1's generated
+    # nginx.conf contains `gzip off;` and none of the snippet's directives.
+    #
+    # Applying it to a NEW cluster is not silently ignored, it is a hard
+    # failure: the webhook denies the create with "Snippet directives are
+    # disabled by the Ingress administrator", which blocks the whole manifest.
+    #
+    # Deleting it therefore changes no observable behavior on cluster-1 and
+    # unblocks the apply on therr-prod-1. If gzip is actually wanted, the
+    # supported route is `use-gzip: "true"` in the controller ConfigMap
+    # (a Helm value), applied to both clusters deliberately -- not a snippet.
 spec:
   tls:
   - hosts:

--- a/k8s/prod/issuer.yaml
+++ b/k8s/prod/issuer.yaml
@@ -12,14 +12,39 @@ spec:
     email: "info@therr.com"
     privateKeySecretRef:
       name: letsencrypt-prod
+    # DNS-01, not HTTP-01.
+    #
+    # HTTP-01 proves domain control by serving a token over the ingress that
+    # public DNS already points at. That makes it impossible to issue a
+    # certificate for a cluster BEFORE cutting traffic to it -- the challenge
+    # would be routed to the currently-live cluster and fail. It is also
+    # unreliable behind Cloudflare's orange-cloud proxy.
+    #
+    # DNS-01 proves control by writing a TXT record in the therr.com zone via
+    # the Cloudflare API, so any cluster holding the API token can issue valid
+    # certificates regardless of where the A records currently point. This is
+    # what lets a green cluster hold real certs days before cutover.
+    #
+    # REQUIRED: secret `cloudflare-api-token` (key `api-token`) must exist in
+    # the `cert-manager` namespace of EVERY cluster this issuer is applied to.
+    # Note that issuer.yaml lives in k8s/prod/, and deploy.sh runs
+    # `kubectl apply -f k8s/prod` wholesale -- so this issuer lands on every
+    # cluster. A cluster missing the secret goes NotReady and silently stops
+    # renewing certificates; existing certs keep serving until they expire.
+    #
+    # Token scope: Zone -> DNS -> Edit, on the therr.com zone only.
+    #
+    # A single 'therr.com' dnsZone matches subdomains too -- cert-manager
+    # selects the most specific matching zone, so 'www.therr.com' and
+    # 'habits.therr.com' both resolve to this solver.
     solvers:
-    - http01:
-        ingress:
-          class: nginx
+    - dns01:
+        cloudflare:
+          apiTokenSecretRef:
+            name: cloudflare-api-token
+            key: api-token
       selector:
         dnsZones:
         - 'therr.com'
-        - '*.therr.com'
         # Whitelabel
         # - 'adsly.app'
-        # - '*.adsly.app'


### PR DESCRIPTION
Unblocks Stage 4 of the GKE blue/green migration (`therr-infra-terraform` → `docs/gke-migration/stage-4-cutover.md`).

## Why this exists

#2753 merged to `general`, but **`main` is the only branch that deploys**. So the DNS-01 issuer and the `server-snippet` removal currently live *only* in `therr-prod-1`'s cluster state — nothing in git that CI reads.

`_bin/cicd/deploy.sh` applies the non-Deployment manifests from `k8s/prod` wholesale:

```bash
kubectl apply "${NON_DEPLOYMENT_MANIFESTS[@]}"
```

That makes the current `main` actively dangerous in two ways:

1. **It reverts green's ClusterIssuer to HTTP-01.** HTTP-01 cannot validate for a cluster public DNS does not point at, so renewals begin failing silently — the existing certs keep serving until they expire.
2. **Once CircleCI targets `therr-prod-1`, the deploy fails outright.** Green's admission webhook rejects the `server-snippet` annotation (`Snippet directives are disabled by the Ingress administrator`). Blue only tolerates it because the webhook grandfathers Ingresses created before the chart 4.15.0 upgrade.

## Scope

Just the two manifests, **byte-identical to `general`**:

| File | Change |
|---|---|
| `k8s/prod/issuer.yaml` | HTTP-01 → DNS-01 via the Cloudflare API token |
| `k8s/prod/ingress-rewrite-service.yaml` | drop the dead gzip `server-snippet` |

The rest of `general` (the `scripts/import-spaces` work) is deliberately **not** included — it promotes through the normal `general → stage → main` path. Cherry-picking keeps this single-purpose so it can be reverted cleanly mid-cutover.

## Safety

- **No image rebuild.** Manifest-only, so `should_deploy_service` logs "Skipping (No Changes)" for every service. `VERSIONS.txt` still pins `LAST_PUBLISHED_GIT_SHA=85ba1d30…`, which is exactly what green is already running.
- **Prerequisite met.** Secret `cloudflare-api-token` (key `api-token`) is confirmed present in the `cert-manager` namespace of **both** `cluster-1` and `therr-prod-1`, so the issuer stays Ready wherever it lands.
- **No-op on green.** Green's live issuer already has this exact solver config (`dnsZones: ["therr.com"]`, `dns01.cloudflare`). This merge makes that state durable rather than changing it.

## Merge ordering

Merge **after** `GKE_CLUSTER` / `GKE_ZONE` are set in CircleCI, so the resulting deploy lands on green — validating the pipeline against `therr-prod-1` before any cutover downtime is taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
