### PR TITLE
Fix space-correction URL normalizer accepting non-http schemes and TLD-less hosts

### DIFF
--- a/therr-public-library/therr-js-utilities/src/normalize-correction-value.ts
+++ b/therr-public-library/therr-js-utilities/src/normalize-correction-value.ts
@@ -35,14 +35,28 @@ const stableStringify = (value: unknown): string => {
     return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
 };
 
+// Matches an explicit URL scheme. The negative lookahead keeps `example.com:8080`
+// classified as a bare host with a port rather than an `example.com:` scheme, and
+// dots are excluded from the scheme charset (legal per RFC 3986 but unused in
+// practice) so `example.com:abc` isn't read as a scheme either.
+const URL_SCHEME_REGEX = /^([a-zA-Z][a-zA-Z0-9+-]*):(?!\d)/;
+
+// The last hostname label has to look like a TLD. `URL` lowercases and punycodes
+// international hostnames before we see them, so `xn--` forms must pass too.
+const TLD_REGEX = /^([a-z]{2,}|xn--[a-z0-9-]+)$/;
+
 const normalizeWebsiteUrl = (raw: string): NormalizeResult<string> => {
     const trimmed = raw.trim();
     if (!trimmed) return { ok: false, error: 'EMPTY_URL' };
 
-    let withScheme = trimmed;
-    if (!/^https?:\/\//i.test(withScheme)) {
-        withScheme = `https://${withScheme}`;
+    // Only prepend a scheme when there is none. Testing for `https?://` alone
+    // meant any other scheme got one glued on the front, and `ftp://example.com`
+    // canonicalized to the nonsense `https://ftp//example.com`.
+    const schemeMatch = trimmed.match(URL_SCHEME_REGEX);
+    if (schemeMatch && !/^https?$/i.test(schemeMatch[1])) {
+        return { ok: false, error: 'INVALID_URL' };
     }
+    const withScheme = schemeMatch ? trimmed : `https://${trimmed}`;
 
     let url: URL;
     try {
@@ -53,8 +67,21 @@ const normalizeWebsiteUrl = (raw: string): NormalizeResult<string> => {
 
     if (!url.hostname) return { ok: false, error: 'INVALID_URL' };
 
-    let host = url.hostname.toLowerCase();
+    // Trailing dots are a legal FQDN form; drop them so `example.com.` buckets
+    // with `example.com` rather than failing the label checks below.
+    let host = url.hostname.toLowerCase().replace(/\.+$/, '');
+    // Unconditional, so `www.notaurl` and `notaurl` reach the TLD check below as
+    // the same host rather than one passing and the other failing.
     if (host.startsWith('www.')) host = host.slice(4);
+
+    // A hostname with no TLD is not a business website: `notaurl` used to sail
+    // through as `https://notaurl`. This also rejects bare IPs and IPv6 literals.
+    const labels = host.split('.');
+    if (labels.length < 2
+        || labels.some((label) => !label)
+        || !TLD_REGEX.test(labels[labels.length - 1])) {
+        return { ok: false, error: 'INVALID_URL' };
+    }
 
     // Drop default ports
     let port = url.port;

--- a/therr-public-library/therr-js-utilities/tests/normalize-correction-value.test.ts
+++ b/therr-public-library/therr-js-utilities/tests/normalize-correction-value.test.ts
@@ -1,6 +1,12 @@
 import { expect } from 'chai';
 import normalizeCorrectionValue from '../src/normalize-correction-value';
 
+// TS doesn't narrow this generic discriminated union through the `.ok` flag, so
+// reach for the failure field explicitly (same workaround as SuggestEditModal).
+const errorCodeOf = (result: ReturnType<typeof normalizeCorrectionValue>): string | null => (
+    result.ok ? null : (result as { error: string }).error
+);
+
 describe('normalizeCorrectionValue', () => {
     describe('phoneNumber', () => {
         it('returns E.164 for a US number without country code (defaults to US)', () => {
@@ -100,6 +106,64 @@ describe('normalizeCorrectionValue', () => {
             if (a.ok && b.ok) {
                 expect(a.normalized).to.equal(b.normalized);
             }
+        });
+
+        it('keeps a non-default port', () => {
+            const result = normalizeCorrectionValue('websiteUrl', 'http://example.com:8080/x');
+            expect(result.ok).to.equal(true);
+            if (result.ok) {
+                expect(result.normalized).to.equal('http://example.com:8080/x');
+            }
+        });
+
+        it('ignores a trailing FQDN dot', () => {
+            const a = normalizeCorrectionValue('websiteUrl', 'https://example.com.');
+            const b = normalizeCorrectionValue('websiteUrl', 'https://example.com');
+            expect(a.ok && b.ok).to.equal(true);
+            if (a.ok && b.ok) {
+                expect(a.normalized).to.equal(b.normalized);
+            }
+        });
+
+        it('punycodes an international hostname', () => {
+            const result = normalizeCorrectionValue('websiteUrl', 'https://café.fr');
+            expect(result.ok).to.equal(true);
+            if (result.ok) {
+                expect(result.normalized).to.equal('https://xn--caf-dma.fr');
+            }
+        });
+
+        it('rejects a non-http scheme instead of prefixing https onto it', () => {
+            // Regressions: `ftp://example.com` used to normalize to the nonsense
+            // `https://ftp//example.com`, and `mailto:hello@example.com` quietly
+            // became a claim that the business website is `https://example.com`.
+            // `javascript:` was already rejected (invalid port) and is pinned here
+            // so it stays that way. Disable is for the test data, not for code.
+            // eslint-disable-next-line no-script-url
+            ['ftp://example.com', 'mailto:hello@example.com', 'javascript:alert(1)'].forEach((value) => {
+                const result = normalizeCorrectionValue('websiteUrl', value);
+                expect(errorCodeOf(result), value).to.equal('INVALID_URL');
+            });
+        });
+
+        it('rejects a hostname with no TLD', () => {
+            // Regression: `notaurl` used to be accepted as `https://notaurl`.
+            ['notaurl', 'https://localhost', 'https://localhost:3000', 'www.notaurl'].forEach((value) => {
+                const result = normalizeCorrectionValue('websiteUrl', value);
+                expect(errorCodeOf(result), value).to.equal('INVALID_URL');
+            });
+        });
+
+        it('rejects bare IP addresses', () => {
+            ['https://192.168.1.1', 'https://[::1]'].forEach((value) => {
+                const result = normalizeCorrectionValue('websiteUrl', value);
+                expect(result.ok, value).to.equal(false);
+            });
+        });
+
+        it('rejects a host left as a bare TLD after www. is stripped', () => {
+            // `www.com` used to canonicalize to the meaningless `https://com`.
+            expect(errorCodeOf(normalizeCorrectionValue('websiteUrl', 'https://www.com'))).to.equal('INVALID_URL');
         });
 
         it('rejects empty string', () => {


### PR DESCRIPTION
Two bugs in `normalizeWebsiteUrl` (`therr-js-utilities/src/normalize-correction-value.ts`), found by cross-checking it against the mobile client-side normalizer added in #2761.

This is the authoritative normalizer for crowdsourced space corrections. The gateway's `submitCorrectionValidation` only checks "non-empty string", so this function is the sole gate on what a correction may contain. Its output is stored as `normalizedValue` and used for agreement bucketing — so either bad value could have accumulated agreement and been written onto a space as its website.

## Bug 1 — any non-http scheme got `https://` prepended

The scheme test was `/^https?:\/\//`, so a URL with a *different* scheme failed it and fell into the "no scheme, add one" branch:

| Input | Before | After |
|---|---|---|
| `ftp://example.com` | `https://ftp//example.com` | rejected |
| `mailto:hello@example.com` | `https://example.com` | rejected |

The `mailto:` case is the worse of the two — an email address silently became a claim about the business's website.

Now an explicit scheme is detected first, and anything other than http/https is rejected. The scheme pattern excludes dots and won't match a colon followed by digits, so `example.com:8080/x` is still read as a host with a port rather than an `example.com:` scheme.

`javascript:alert(1)` was already rejected (it parses as an invalid port); there's now a test pinning that so it stays true.

## Bug 2 — hostnames with no TLD were accepted

`new URL()` happily parses a single-label host, so:

| Input | Before | After |
|---|---|---|
| `notaurl` | `https://notaurl` | rejected |
| `www.com` | `https://com` | rejected |
| `https://localhost` | `https://localhost` | rejected |
| `https://192.168.1.1` | accepted | rejected |

The last hostname label now has to look like a TLD. `xn--` forms pass, since `URL` lowercases and punycodes international hostnames before this code sees them (`https://café.fr` → `https://xn--caf-dma.fr`, unchanged and now covered by a test).

Note this can't distinguish `notaurl` from a real domain once a dot is present — `www.notaurl` and `foo.bar` still pass. Ruling those out needs a public-suffix list, which felt like the wrong trade here. The `www.` strip is now unconditional again for that reason: an earlier guarded version let `www.notaurl` through while rejecting bare `notaurl`, so the same site bucketed two ways.

## Also

Trailing FQDN dots are stripped, so `example.com.` buckets with `example.com` instead of failing the new label checks.

## Compatibility

No new error codes — both paths return the existing `INVALID_URL`, so no dictionary changes are needed in `therr-client-web` or `TherrMobile`. The exported signature is unchanged.

Values already stored from these inputs are unaffected; they simply stop being reachable by new submissions, and any pending ones will never gain further agreement.

## Verification

- `therr-js-utilities` suite: 136 passing (11 new assertions across 6 new cases, covering both regressions).
- `pr:typecheck:js-utils`, `pr:typecheck:maps`, `pr:typecheck:web` all clean.
- ESLint clean on both changed files.
- Re-ran the client/server cross-check over ~46 inputs that originally surfaced these: both URL divergences are gone. The three that remain are documented and expected — the mobile client is stricter about letters in a phone field, can't verify country-code assignment without libphonenumber metadata, and has no punycode encoder for the IDN preview.

Not verified: no manual end-to-end submission against a running maps-service.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ad9S7b9Dmu2LNEoYnq2UAc)_