### PR TITLE
fix: readable cross-brand goal posts + honest pact-nudge outcomes (shared half)

### DIFF
--- a/TherrMobile/__tests__/utilities/crossBrandPostLabel.test.ts
+++ b/TherrMobile/__tests__/utilities/crossBrandPostLabel.test.ts
@@ -1,0 +1,97 @@
+import { BrandVariations } from 'therr-js-utilities/constants';
+import translator from '../../main/utilities/translator';
+import { formatCrossBrandMessage, getCrossBrandLabelKey } from '../../main/utilities/crossBrandPostLabel';
+
+/**
+ * Cross-brand post labelling.
+ *
+ * `BRAND_THOUGHTS_VISIBILITY` lets the Therr app read every brand's posts, so a Friends
+ * with Habits goal lands in the Therr feed as a bare sentence with nothing saying what it
+ * is. These lock in that such a post is labelled for the reader, in the READER's locale,
+ * and that a post from the reader's own app is left alone.
+ */
+describe('crossBrandPostLabel', () => {
+    const translate = (locale: string) => (key: string, params?: any) => translator(locale, key, params);
+
+    describe('getCrossBrandLabelKey', () => {
+        it('labels a habits post when the reader is on another brand', () => {
+            expect(getCrossBrandLabelKey(BrandVariations.HABITS, BrandVariations.THERR))
+                .toBe('components.thoughtDisplay.crossBrandLabels.habits');
+        });
+
+        it('does not label a post authored in the reader\'s own app', () => {
+            expect(getCrossBrandLabelKey(BrandVariations.HABITS, BrandVariations.HABITS)).toBeUndefined();
+            expect(getCrossBrandLabelKey(BrandVariations.THERR, BrandVariations.THERR)).toBeUndefined();
+        });
+
+        it('does not label a brand with no label defined, or a post with no brand', () => {
+            expect(getCrossBrandLabelKey(BrandVariations.TEEM, BrandVariations.THERR)).toBeUndefined();
+            expect(getCrossBrandLabelKey(undefined, BrandVariations.THERR)).toBeUndefined();
+            expect(getCrossBrandLabelKey(null, BrandVariations.THERR)).toBeUndefined();
+        });
+    });
+
+    describe('formatCrossBrandMessage', () => {
+        it('prefixes a habits goal read from the Therr app', () => {
+            expect(formatCrossBrandMessage({
+                message: 'Run 3x this week',
+                brandVariation: BrandVariations.HABITS,
+                translate: translate('en-us'),
+                currentBrand: BrandVariations.THERR,
+            })).toBe('Goals update: Run 3x this week');
+        });
+
+        it('uses the reader\'s locale, not the author\'s', () => {
+            const args = {
+                message: 'Run 3x this week',
+                brandVariation: BrandVariations.HABITS,
+                currentBrand: BrandVariations.THERR,
+            };
+
+            expect(formatCrossBrandMessage({ ...args, translate: translate('es') }))
+                .toBe('Actualización de objetivos: Run 3x this week');
+            expect(formatCrossBrandMessage({ ...args, translate: translate('fr-ca') }))
+                .toBe('Mise à jour des objectifs : Run 3x this week');
+        });
+
+        it('leaves a post from the reader\'s own app untouched', () => {
+            expect(formatCrossBrandMessage({
+                message: 'Run 3x this week',
+                brandVariation: BrandVariations.HABITS,
+                translate: translate('en-us'),
+                currentBrand: BrandVariations.HABITS,
+            })).toBe('Run 3x this week');
+        });
+
+        it('leaves replies untouched — they inherit their parent\'s context', () => {
+            expect(formatCrossBrandMessage({
+                message: 'Nice work!',
+                brandVariation: BrandVariations.HABITS,
+                parentId: 'parent-1',
+                translate: translate('en-us'),
+                currentBrand: BrandVariations.THERR,
+            })).toBe('Nice work!');
+        });
+
+        it('never returns undefined for an empty message', () => {
+            expect(formatCrossBrandMessage({
+                message: null,
+                brandVariation: BrandVariations.THERR,
+                translate: translate('en-us'),
+                currentBrand: BrandVariations.THERR,
+            })).toBe('');
+        });
+
+        // The translator interpolates with `String.replace(string, string)`, where `$&`,
+        // `` $` `` and `$1` are substitution patterns in the REPLACEMENT argument. Passing
+        // the post body through as a param would mangle any post containing them.
+        it('preserves `$` sequences in the post body verbatim', () => {
+            expect(formatCrossBrandMessage({
+                message: 'Save $5/day — no more $& excuses',
+                brandVariation: BrandVariations.HABITS,
+                translate: translate('en-us'),
+                currentBrand: BrandVariations.THERR,
+            })).toBe('Goals update: Save $5/day — no more $& excuses');
+        });
+    });
+});

--- a/TherrMobile/main/components/UserContent/ThoughtDisplay.tsx
+++ b/TherrMobile/main/components/UserContent/ThoughtDisplay.tsx
@@ -19,6 +19,7 @@ import TherrIcon from '../TherrIcon';
 import RichText from '../RichText';
 import handleMentionPress from '../../utilities/handleMentionPress';
 import formatDate from '../../utilities/formatDate';
+import { formatCrossBrandMessage } from '../../utilities/crossBrandPostLabel';
 import SuperUserStatusIcon from '../SuperUserStatusIcon';
 
 // const hapticFeedbackOptions = {
@@ -383,6 +384,14 @@ const ThoughtContent = ({
 }) => {
     const totalReplies = replyCount ?? thought.replyCount ?? thought.replies?.length;
     const onMentionPress = (username: string) => handleMentionPress(username, goToViewUser);
+    // A post written in another Therr-family app (a Friends with Habits goal, say) reads as
+    // a bare sentence here with nothing saying where it came from. See crossBrandPostLabel.
+    const message = formatCrossBrandMessage({
+        message: thought.message,
+        brandVariation: thought.brandVariation,
+        parentId: thought.parentId,
+        translate,
+    });
     const hasRepliableActions = !thought.isDraft && isRepliable;
     // The repliable action row already renders a reply icon/count and a like control, so this
     // only fills the gap for non-repliable content (replies within the thought details view).
@@ -393,7 +402,7 @@ const ThoughtContent = ({
             <View style={spacingStyles.flexOne}>
                 <RichText
                     style={themeViewContent.styles.thoughtMessage}
-                    text={thought.message}
+                    text={message}
                     linkStyle={theme.styles.link}
                     onMentionPress={onMentionPress}
                     numberOfLines={isExpanded ? undefined : 7}

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -401,7 +401,11 @@
       "viewAllReplies": "View all {count} replies",
       "viewReplies": "View {count} replies",
       "likeThought": "Like this post",
-      "unlikeThought": "Remove like from this post"
+      "unlikeThought": "Remove like from this post",
+      "crossBrandLabels": {
+        "format": "{label}: {message}",
+        "habits": "Goals update"
+      }
     },
     "userMenu": {
       "buttons": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -401,7 +401,11 @@
       "viewAllReplies": "Ver las {count} respuestas",
       "viewReplies": "Ver {count} respuestas",
       "likeThought": "Me gusta esta publicación",
-      "unlikeThought": "Quitar me gusta de esta publicación"
+      "unlikeThought": "Quitar me gusta de esta publicación",
+      "crossBrandLabels": {
+        "format": "{label}: {message}",
+        "habits": "Actualización de objetivos"
+      }
     },
     "userMenu": {
       "buttons": {

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -401,7 +401,11 @@
       "viewAllReplies": "Voir les {count} réponses",
       "viewReplies": "Voir {count} réponses",
       "likeThought": "Aimer cette publication",
-      "unlikeThought": "Retirer le « j'aime » de cette publication"
+      "unlikeThought": "Retirer le « j'aime » de cette publication",
+      "crossBrandLabels": {
+        "format": "{label} : {message}",
+        "habits": "Mise à jour des objectifs"
+      }
     },
     "userMenu": {
       "buttons": {

--- a/TherrMobile/main/utilities/crossBrandPostLabel.ts
+++ b/TherrMobile/main/utilities/crossBrandPostLabel.ts
@@ -1,0 +1,71 @@
+import { BrandVariations } from 'therr-js-utilities/constants';
+import { CURRENT_BRAND_VARIATION } from '../config/brandConfig';
+
+/**
+ * Posts are minted with the brand the author was using (`main.thoughts.brandVariation`),
+ * and `BRAND_THOUGHTS_VISIBILITY` lets Therr read every brand's posts. So a
+ * Friends with Habits goal — written as a bare sentence like "Run 3x this week" —
+ * lands in the Therr feed with nothing saying what it is, next to ordinary thoughts.
+ *
+ * This prefixes such a post with a short label naming what it is ("Goals update: ..."),
+ * and only when the reader's app is NOT the app it was written in: inside Friends
+ * with Habits every post is a goal, so labelling them all there is pure noise.
+ *
+ * The label is resolved through the READER's dictionary, not the author's, so a
+ * French reader sees French copy on an English author's goal. That is also why the
+ * prefix is applied at render time rather than baked into the stored message.
+ */
+const CROSS_BRAND_LABEL_KEYS: { [brand: string]: string } = {
+    [BrandVariations.HABITS]: 'components.thoughtDisplay.crossBrandLabels.habits',
+};
+
+export const getCrossBrandLabelKey = (
+    brandVariation?: string | null,
+    currentBrand: string = CURRENT_BRAND_VARIATION,
+): string | undefined => {
+    if (!brandVariation || brandVariation === currentBrand) {
+        return undefined;
+    }
+
+    return CROSS_BRAND_LABEL_KEYS[brandVariation];
+};
+
+interface IFormatCrossBrandMessageArgs {
+    message?: string | null;
+    brandVariation?: string | null;
+    /** Replies inherit their parent's context, so only top-level posts are labelled. */
+    parentId?: string | null;
+    translate: (key: string, params?: any) => string;
+    currentBrand?: string;
+}
+
+export const formatCrossBrandMessage = ({
+    message,
+    brandVariation,
+    parentId,
+    translate,
+    currentBrand = CURRENT_BRAND_VARIATION,
+}: IFormatCrossBrandMessageArgs): string => {
+    const text = message || '';
+
+    if (parentId) {
+        return text;
+    }
+
+    const labelKey = getCrossBrandLabelKey(brandVariation, currentBrand);
+
+    if (!labelKey) {
+        return text;
+    }
+
+    // The post body is spliced in with split/join rather than handed to the translator as a
+    // param. The translator substitutes with `String.replace(string, string)`, whose
+    // replacement argument gives `$&`, `` $` `` and `$1` special meaning — a post containing
+    // any of those would come out mangled. `{message}` stays in the dictionary value so a
+    // locale can still choose where the body sits relative to the label.
+    return translate('components.thoughtDisplay.crossBrandLabels.format', {
+        label: translate(labelKey),
+    }).split('{message}').join(text);
+};
+
+export default formatCrossBrandMessage;

--- a/therr-public-library/therr-react/src/types/redux/habits.ts
+++ b/therr-public-library/therr-react/src/types/redux/habits.ts
@@ -70,7 +70,14 @@ export interface IPactMember {
 export interface IPactNudgeResult {
     partnerId: string;
     nudged: boolean;
-    reason?: 'cooldown' | 'error';
+    /**
+     * Why the nudge did not reach this partner. Mirrors `NudgeFailureReason` in
+     * users-service `src/utilities/pactNudgeOutcome.ts`:
+     *   cooldown      — nudged in the last 7 days; retry after `nextNudgeAvailableAt`
+     *   undeliverable — no Habits install and no email or phone on file; retrying cannot help
+     *   error         — dispatch threw; retrying is worth offering
+     */
+    reason?: 'cooldown' | 'undeliverable' | 'error';
     nextNudgeAvailableAt?: string;
 }
 

--- a/therr-services/users-service/src/handlers/pacts.ts
+++ b/therr-services/users-service/src/handlers/pacts.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express';
 import {
+    ErrorCodes,
     MetricNames,
     PushNotifications,
 } from 'therr-js-utilities/constants';
@@ -10,6 +11,12 @@ import handleHttpError from '../utilities/handleHttpError';
 import translate from '../utilities/translator';
 import sendEmailAndOrPushNotification from '../utilities/sendEmailAndOrPushNotification';
 import { dispatchPactInvitation } from '../utilities/dispatchPactInvitation';
+import {
+    INudgeOutcome,
+    classifyDispatchResult,
+    flattenNudgeOutcomes,
+    getCooldownOutcome,
+} from '../utilities/pactNudgeOutcome';
 import recordFunnelMetric from '../utilities/recordFunnelMetric';
 import { checkHabitCapacity } from './helpers/habitCapacity';
 import { ensureCompletedUserConnection } from './helpers/inviteAcceptance';
@@ -970,24 +977,27 @@ const nudgePact: RequestHandler = async (req: any, res: any) => {
     if (!pact) {
         return handleHttpError({
             res,
-            message: `Pact not found with id ${id}`,
+            message: translate(locale, 'errorMessages.pacts.notFound'),
             statusCode: 404,
+            errorCode: ErrorCodes.NOT_FOUND,
         });
     }
 
     if (pact.creatorUserId !== userId) {
         return handleHttpError({
             res,
-            message: 'Only the pact creator can send a nudge',
+            message: translate(locale, 'errorMessages.pacts.nudgeCreatorOnly'),
             statusCode: 403,
+            errorCode: ErrorCodes.NOT_PERMITTED,
         });
     }
 
     if (pact.status !== 'pending') {
         return handleHttpError({
             res,
-            message: 'Nudge is only available for pending pacts',
+            message: translate(locale, 'errorMessages.pacts.nudgeNotPending'),
             statusCode: 400,
+            errorCode: ErrorCodes.BAD_REQUEST,
         });
     }
 
@@ -1000,30 +1010,26 @@ const nudgePact: RequestHandler = async (req: any, res: any) => {
     if (pendingPartners.length === 0) {
         return handleHttpError({
             res,
-            message: 'No pending partners to nudge',
+            message: translate(locale, 'errorMessages.pacts.nudgeNoPendingPartners'),
             statusCode: 400,
+            errorCode: ErrorCodes.BAD_REQUEST,
         });
     }
 
-    const NUDGE_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000; // 7 days between nudges to the same partner
     const habitGoal = await Store.habitGoals.getById(pact.habitGoalId);
     const habitName = habitGoal?.name || 'your habit';
 
-    const settledOutcomes = await Promise.allSettled(
+    const settledOutcomes = await Promise.allSettled<INudgeOutcome>(
         pendingPartners.map(async (partner: any) => {
-            if (partner.nudgedAt) {
-                const nudgedMs = new Date(partner.nudgedAt).getTime();
-                if (Date.now() - nudgedMs < NUDGE_COOLDOWN_MS) {
-                    return {
-                        partnerId: partner.userId,
-                        nudged: false,
-                        reason: 'cooldown',
-                        nextNudgeAvailableAt: new Date(nudgedMs + NUDGE_COOLDOWN_MS).toISOString(),
-                    };
-                }
+            const cooldownOutcome = getCooldownOutcome(partner.userId, partner.nudgedAt);
+            if (cooldownOutcome) {
+                return cooldownOutcome;
             }
 
-            // Re-dispatch invitation via the same channel as the original invite
+            // Re-dispatch invitation via the same channel as the original invite.
+            // A throw here used to be swallowed into `{ isOnBrand: true }`, which pushed the
+            // partner down the on-brand path and then marked them nudged — reporting success
+            // and burning the 7-day cooldown on a nudge that failed.
             const dispatchResult = await dispatchPactInvitation({
                 pactMemberId: partner.id,
                 partnerUserId: partner.userId,
@@ -1039,10 +1045,18 @@ const nudgePact: RequestHandler = async (req: any, res: any) => {
                     messages: ['Error dispatching pact nudge'],
                     traceArgs: { 'error.message': err?.message },
                 });
-                return { isOnBrand: true };
+                return null;
             });
 
-            if (dispatchResult.isOnBrand) {
+            const outcome = classifyDispatchResult(partner.userId, dispatchResult);
+
+            if (!outcome.nudged) {
+                // Nothing went out, so the cooldown must not start — otherwise a partner with no
+                // reachable channel locks the creator out for a week for no benefit.
+                return outcome;
+            }
+
+            if (dispatchResult?.isOnBrand) {
                 // Partner is on Habits — send brand-scoped push
                 sendEmailAndOrPushNotification(Store.users.findUser, req.headers, {
                     authorization,
@@ -1065,17 +1079,16 @@ const nudgePact: RequestHandler = async (req: any, res: any) => {
             }
 
             await Store.pactMembers.markNudged(id, partner.userId);
-            return { partnerId: partner.userId, nudged: true };
+            return outcome;
         }),
     );
 
     // Flatten settled results into a clean per-partner outcome list. A rejected
     // entry means the dispatch/markNudged chain threw for that partner.
-    const nudgeResults = settledOutcomes.map((outcome, idx) => (
-        outcome.status === 'fulfilled'
-            ? outcome.value
-            : { partnerId: pendingPartners[idx].userId, nudged: false, reason: 'error' }
-    ));
+    const nudgeResults = flattenNudgeOutcomes(
+        settledOutcomes,
+        pendingPartners.map((partner: any) => partner.userId),
+    );
 
     logSpan({
         level: 'info',

--- a/therr-services/users-service/src/locales/en-us/dictionary.json
+++ b/therr-services/users-service/src/locales/en-us/dictionary.json
@@ -14,7 +14,11 @@
             "duplicatePost": "Duplicate posts are not allowed"
         },
         "pacts": {
-            "habitGoalRequired": "A habit goal is required to create a pact"
+            "habitGoalRequired": "A habit goal is required to create a pact",
+      "notFound": "That pact no longer exists",
+      "nudgeCreatorOnly": "Only the person who created this pact can send a nudge",
+      "nudgeNotPending": "This pact has already started, so there is no one left to nudge",
+      "nudgeNoPendingPartners": "Everyone has already responded to this pact"
         },
         "habits": {
             "habitGoalRequired": "A habit goal is required",

--- a/therr-services/users-service/src/locales/es/dictionary.json
+++ b/therr-services/users-service/src/locales/es/dictionary.json
@@ -14,7 +14,11 @@
             "duplicatePost": "No se permiten publicaciones duplicadas"
         },
         "pacts": {
-            "habitGoalRequired": "Se requiere una meta de hábito para crear un pacto"
+            "habitGoalRequired": "Se requiere una meta de hábito para crear un pacto",
+      "notFound": "Ese pacto ya no existe",
+      "nudgeCreatorOnly": "Solo quien creó este pacto puede enviar un recordatorio",
+      "nudgeNotPending": "Este pacto ya comenzó, así que no queda nadie a quien recordar",
+      "nudgeNoPendingPartners": "Todos ya respondieron a este pacto"
         },
         "habits": {
             "habitGoalRequired": "Se requiere una meta de hábito",

--- a/therr-services/users-service/src/locales/fr-ca/dictionary.json
+++ b/therr-services/users-service/src/locales/fr-ca/dictionary.json
@@ -14,7 +14,11 @@
             "duplicatePost": "Les publications en double ne sont pas autorisées"
         },
         "pacts": {
-            "habitGoalRequired": "Un objectif d'habitude est requis pour créer un pacte"
+            "habitGoalRequired": "Un objectif d'habitude est requis pour créer un pacte",
+      "notFound": "Ce pacte n'existe plus",
+      "nudgeCreatorOnly": "Seule la personne qui a créé ce pacte peut envoyer un rappel",
+      "nudgeNotPending": "Ce pacte a déjà commencé, il ne reste donc personne à relancer",
+      "nudgeNoPendingPartners": "Tout le monde a déjà répondu à ce pacte"
         },
         "habits": {
             "habitGoalRequired": "Un objectif d'habitude est requis",

--- a/therr-services/users-service/src/utilities/dispatchPactInvitation.ts
+++ b/therr-services/users-service/src/utilities/dispatchPactInvitation.ts
@@ -56,6 +56,13 @@ export interface IDispatchPactInvitationResult {
     claimToken?: string;
     claimCode?: string;
     invitedVia?: 'email' | 'sms' | 'push';
+    /**
+     * Set only when nothing was dispatched. `isOnBrand: false` on its own is ambiguous — it is
+     * returned both for a successful off-brand invite and for a partner we cannot reach at all —
+     * so callers that report an outcome to the user must read this (or `invitedVia`) rather than
+     * treating every non-throwing call as a delivery. See `pactNudgeOutcome.classifyDispatchResult`.
+     */
+    undeliverableReason?: 'partnerNotFound' | 'noContactMethod';
 }
 
 /**
@@ -81,7 +88,7 @@ export const dispatchPactInvitation = async (
     );
     const partner: any = partnerRows?.[0];
     if (!partner) {
-        return { isOnBrand: false };
+        return { isOnBrand: false, undeliverableReason: 'partnerNotFound' };
     }
 
     if (isOnHabits(partner.brandVariations)) {
@@ -94,7 +101,7 @@ export const dispatchPactInvitation = async (
     const hasEmail = !!partner.email && !partner.isUnclaimed;
     const hasPhone = !!partner.phoneNumber;
     if (!hasEmail && !hasPhone) {
-        return { isOnBrand: false };
+        return { isOnBrand: false, undeliverableReason: 'noContactMethod' };
     }
 
     const invitedVia: 'email' | 'sms' = hasEmail ? 'email' : 'sms';

--- a/therr-services/users-service/src/utilities/pactNudgeOutcome.ts
+++ b/therr-services/users-service/src/utilities/pactNudgeOutcome.ts
@@ -1,0 +1,96 @@
+// Type-only so this module stays free of runtime imports: it is pure decision logic and is
+// unit-tested without standing up Stores, Twilio or SES.
+import type { IDispatchPactInvitationResult } from './dispatchPactInvitation';
+
+/** 7 days between nudges to the same partner. */
+export const NUDGE_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Why a nudge did not reach a partner. The client maps these to specific copy, which is the
+ * whole point of returning them: "Could not send the nudge" for every failure told the user
+ * nothing about whether to retry, wait, or fix the partner's contact details.
+ */
+export type NudgeFailureReason =
+    /** Nudged within the last NUDGE_COOLDOWN_MS. Retry after `nextNudgeAvailableAt`. */
+    | 'cooldown'
+    /** No way to reach them: no Habits install, and no email or phone on file. Retrying won't help. */
+    | 'undeliverable'
+    /** Dispatch threw. Transient as far as we can tell, so retrying is worth offering. */
+    | 'error';
+
+export interface INudgeOutcome {
+    partnerId: string;
+    nudged: boolean;
+    reason?: NudgeFailureReason;
+    nextNudgeAvailableAt?: string;
+}
+
+/**
+ * Whether a partner is past their cooldown. A partner never nudged is always eligible.
+ */
+export const getCooldownOutcome = (
+    partnerId: string,
+    nudgedAt: string | Date | null | undefined,
+    nowMs: number = Date.now(),
+): INudgeOutcome | null => {
+    if (!nudgedAt) {
+        return null;
+    }
+
+    const nudgedMs = new Date(nudgedAt).getTime();
+
+    // An unparseable timestamp must not read as "nudged at the epoch" or, worse, produce a
+    // NaN comparison that silently falls through to "eligible" with a NaN date attached.
+    if (Number.isNaN(nudgedMs) || nowMs - nudgedMs >= NUDGE_COOLDOWN_MS) {
+        return null;
+    }
+
+    return {
+        partnerId,
+        nudged: false,
+        reason: 'cooldown',
+        nextNudgeAvailableAt: new Date(nudgedMs + NUDGE_COOLDOWN_MS).toISOString(),
+    };
+};
+
+/**
+ * Turns a `dispatchPactInvitation` result into a per-partner outcome.
+ *
+ * `isOnBrand: false` covers three different situations inside that helper — the partner row
+ * was missing, the partner had neither email nor phone, or an invite really was sent off-brand
+ * — and only the last one delivered anything. Treating all three as success is what made the
+ * creator see "Nudge sent! Your partner will be reminded." for a partner who is unreachable,
+ * and burned their 7-day cooldown on a nudge that never left the building.
+ */
+export const classifyDispatchResult = (
+    partnerId: string,
+    result: IDispatchPactInvitationResult | null | undefined,
+): INudgeOutcome => {
+    if (!result) {
+        return { partnerId, nudged: false, reason: 'error' };
+    }
+
+    // On-brand partners are reminded by the brand-scoped push the caller sends next.
+    if (result.isOnBrand) {
+        return { partnerId, nudged: true };
+    }
+
+    if (result.invitedVia) {
+        return { partnerId, nudged: true };
+    }
+
+    return { partnerId, nudged: false, reason: 'undeliverable' };
+};
+
+/**
+ * Flattens settled per-partner promises. A rejection means the dispatch/markNudged chain threw
+ * for that partner, which is reported rather than dropping the partner from the response.
+ */
+export const flattenNudgeOutcomes = (
+    settled: PromiseSettledResult<INudgeOutcome>[],
+    partnerIds: string[],
+): INudgeOutcome[] => settled.map((outcome, idx) => (
+    outcome.status === 'fulfilled'
+        ? outcome.value
+        : { partnerId: partnerIds[idx], nudged: false, reason: 'error' as NudgeFailureReason }
+));

--- a/therr-services/users-service/tests/unit/handlers-pacts-nudge.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-pacts-nudge.test.ts
@@ -1,5 +1,10 @@
-/* eslint-disable quotes, max-len */
 import { expect } from 'chai';
+import {
+    NUDGE_COOLDOWN_MS,
+    classifyDispatchResult,
+    flattenNudgeOutcomes,
+    getCooldownOutcome,
+} from '../../src/utilities/pactNudgeOutcome';
 
 /**
  * Pacts handler — nudge eligibility + cooldown regression tests.
@@ -9,12 +14,12 @@ import { expect } from 'chai';
  * must be at least one still-pending partner, and each partner is rate-limited
  * by a 7-day cooldown keyed on their `nudgedAt`.
  *
- * These tests mirror the decision tree from `src/handlers/pacts.ts` in pure
- * form so we can exercise it without standing up Express, Stores, or push
- * notifications — matching the style of `handlers-pacts-bulk.test.ts`.
+ * The authorization tree below is mirrored from `src/handlers/pacts.ts` in pure form so we
+ * can exercise it without standing up Express, Stores, or push notifications — matching the
+ * style of `handlers-pacts-bulk.test.ts`. Everything past that gate (the cooldown gate, the
+ * dispatch classification and the result flattening) lives in `src/utilities/pactNudgeOutcome`
+ * and is imported here directly, so these assertions cover the code that actually runs.
  */
-
-const NUDGE_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000; // keep in sync with handler
 
 interface INudgeMember {
     role: 'creator' | 'partner';
@@ -49,44 +54,10 @@ const decideNudge = ({
     return { allowed: true };
 };
 
-// Mirrors the per-partner cooldown gate: a partner is skipped only when it was
-// nudged within the cooldown window. A null/undefined nudgedAt is always eligible.
-const isPartnerNudgeable = (partner: INudgeMember, nowMs: number): boolean => {
-    if (!partner.nudgedAt) {
-        return true;
-    }
-    const nudgedMs = new Date(partner.nudgedAt).getTime();
-    return nowMs - nudgedMs >= NUDGE_COOLDOWN_MS;
-};
-
-interface INudgeOutcome {
-    partnerId: string;
-    nudged: boolean;
-    reason?: 'cooldown' | 'error';
-    nextNudgeAvailableAt?: string;
-}
-
-// Mirrors the cooldown branch's outcome payload returned to the client.
-const cooldownOutcome = (partnerId: string, nudgedAtIso: string): INudgeOutcome => {
-    const nudgedMs = new Date(nudgedAtIso).getTime();
-    return {
-        partnerId,
-        nudged: false,
-        reason: 'cooldown',
-        nextNudgeAvailableAt: new Date(nudgedMs + NUDGE_COOLDOWN_MS).toISOString(),
-    };
-};
-
-// Mirrors how settled per-partner promises are flattened into the response:
-// a rejection becomes a generic error outcome rather than dropping the partner.
-const flattenOutcomes = (
-    settled: PromiseSettledResult<INudgeOutcome>[],
-    partnerIds: string[],
-): INudgeOutcome[] => settled.map((outcome, idx) => (
-    outcome.status === 'fulfilled'
-        ? outcome.value
-        : { partnerId: partnerIds[idx], nudged: false, reason: 'error' }
-));
+// The cooldown gate, expressed as the handler consumes it: an outcome means "skipped".
+const isPartnerNudgeable = (partner: INudgeMember, nowMs: number): boolean => (
+    getCooldownOutcome('partner-1', partner.nudgedAt, nowMs) === null
+);
 
 describe('Pacts handler — nudge authorization', () => {
     const creatorUserId = 'creator-1';
@@ -168,10 +139,52 @@ describe('Pacts handler — nudge cooldown gate', () => {
     it('reports nextNudgeAvailableAt exactly one cooldown after the last nudge', () => {
         const sixDaysAgoMs = nowMs - (6 * 24 * 60 * 60 * 1000);
         const sixDaysAgo = new Date(sixDaysAgoMs).toISOString();
-        const outcome = cooldownOutcome('partner-1', sixDaysAgo);
-        expect(outcome.nudged).to.be.eq(false);
-        expect(outcome.reason).to.equal('cooldown');
-        expect(outcome.nextNudgeAvailableAt).to.equal(new Date(sixDaysAgoMs + NUDGE_COOLDOWN_MS).toISOString());
+        const outcome = getCooldownOutcome('partner-1', sixDaysAgo, nowMs);
+        expect(outcome).to.not.be.eq(null);
+        expect(outcome?.nudged).to.be.eq(false);
+        expect(outcome?.reason).to.equal('cooldown');
+        expect(outcome?.nextNudgeAvailableAt).to.equal(new Date(sixDaysAgoMs + NUDGE_COOLDOWN_MS).toISOString());
+    });
+
+    // A NaN comparison is false, so an unparseable timestamp would otherwise fall through the
+    // cooldown check as "eligible" — but with `nextNudgeAvailableAt: "Invalid Date"` attached
+    // had it been built anyway. Treat it as eligible, with no outcome payload.
+    it('treats an unparseable nudgedAt as eligible rather than emitting an invalid date', () => {
+        expect(getCooldownOutcome('partner-1', 'not-a-date' as any, nowMs)).to.be.eq(null);
+    });
+});
+
+describe('Pacts handler — nudge dispatch classification', () => {
+    it('counts an on-brand partner as nudged (the brand push is sent next)', () => {
+        expect(classifyDispatchResult('p1', { isOnBrand: true }))
+            .to.deep.equal({ partnerId: 'p1', nudged: true });
+    });
+
+    it('counts an off-brand invite that actually went out as nudged', () => {
+        expect(classifyDispatchResult('p1', { isOnBrand: false, invitedVia: 'email' }))
+            .to.deep.equal({ partnerId: 'p1', nudged: true });
+    });
+
+    // The regression this exists for: `dispatchPactInvitation` returns a bare
+    // `{ isOnBrand: false }` both for a real off-brand send and for a partner it could not
+    // reach at all. Reading only `isOnBrand` reported "Nudge sent!" for the unreachable case
+    // and started the 7-day cooldown on a nudge that never left the building.
+    it('does NOT count an undeliverable partner as nudged', () => {
+        expect(classifyDispatchResult('p1', { isOnBrand: false, undeliverableReason: 'noContactMethod' }))
+            .to.deep.equal({ partnerId: 'p1', nudged: false, reason: 'undeliverable' });
+        expect(classifyDispatchResult('p1', { isOnBrand: false, undeliverableReason: 'partnerNotFound' }))
+            .to.deep.equal({ partnerId: 'p1', nudged: false, reason: 'undeliverable' });
+        expect(classifyDispatchResult('p1', { isOnBrand: false }))
+            .to.deep.equal({ partnerId: 'p1', nudged: false, reason: 'undeliverable' });
+    });
+
+    // A dispatch that threw is reported as null by the handler's catch. It used to be
+    // swallowed into `{ isOnBrand: true }`, which claimed success for a failed send.
+    it('reports a thrown dispatch as an error, not a success', () => {
+        expect(classifyDispatchResult('p1', null))
+            .to.deep.equal({ partnerId: 'p1', nudged: false, reason: 'error' });
+        expect(classifyDispatchResult('p1', undefined))
+            .to.deep.equal({ partnerId: 'p1', nudged: false, reason: 'error' });
     });
 });
 
@@ -182,7 +195,7 @@ describe('Pacts handler — nudge result flattening', () => {
             { status: 'fulfilled', value: { partnerId: 'p1', nudged: true } },
             { status: 'rejected', reason: new Error('boom') },
         ];
-        const results = flattenOutcomes(settled, partnerIds);
+        const results = flattenNudgeOutcomes(settled, partnerIds);
         expect(results).to.have.length(2);
         expect(results[0]).to.deep.equal({ partnerId: 'p1', nudged: true });
         expect(results[1]).to.deep.equal({ partnerId: 'p2', nudged: false, reason: 'error' });


### PR DESCRIPTION
Shared half of three Friends with Habits bug reports. The brand-scoped half is #2779 — **merge this one first**; that PR consumes the `undeliverable` outcome and the localized error bodies added here.

## 1. Habits goals read as bare sentences in the Therr feed

`BRAND_THOUGHTS_VISIBILITY` gives Therr `'all'`, so a Friends with Habits goal (`main.thoughts` with `brandVariation = 'habits'`) lands in the Therr feed as an unlabelled sentence — "Run 3x this week" — next to ordinary thoughts, with nothing saying what it is.

Posts authored in another Therr-family app are now prefixed with a label naming what they are: **"Goals update: Run 3x this week"**.

- Resolved through the **reader's** dictionary, not the author's, so a French reader sees French copy on an English author's goal. That is why it is applied at render time rather than baked into the stored message.
- A post from the reader's own app is left alone — inside Friends with Habits every post is a goal, so labelling them all there is noise. Replies are left alone too; they inherit their parent's context.
- Driven by a brand → key map, so another variant only needs a dictionary entry.
- The body is spliced in with `split`/`join` rather than passed to the translator as a param: the translator interpolates with `String.replace(string, string)`, where `$&`, `` $` `` and `$1` are substitution patterns in the *replacement* argument and would mangle any post containing them.

New: `TherrMobile/main/utilities/crossBrandPostLabel.ts` + 9 unit tests. Wired into `ThoughtDisplay`, which covers both the feed (`AreaCarousel`) and the thought details view.

**Not covered:** `therr-client-web`. It renders `thought.message` directly in Explore/ViewThought, but has no module-level current-brand equivalent (it is served per-brand by origin), so labelling there is a separate change. The reported surface was the mobile Therr feed.

## 2. Pact nudge reported success when nothing was sent

`dispatchPactInvitation` returns a bare `{ isOnBrand: false }` in three different situations — partner row missing, partner has neither email nor phone, and a genuine off-brand invite. Only the last delivered anything. `nudgePact` read only `isOnBrand`, so:

- an **unreachable partner counted as nudged** — the creator saw "Nudge sent! Your partner will be reminded." and `markNudged` burned their 7-day cooldown on a nudge that never left the building;
- a **throw** from `dispatchPactInvitation` was swallowed into `{ isOnBrand: true }`, pushing the partner down the on-brand path and reporting success for a failed send.

Changes:

- `dispatchPactInvitation` names the undeliverable cases (`partnerNotFound` / `noContactMethod`). Additive — existing callers are unaffected.
- New `users-service/src/utilities/pactNudgeOutcome.ts` holds the per-partner decision logic and classifies each dispatch as `cooldown` / `undeliverable` / `error`, so a client can say something specific.
- Partners whose nudge did not go out are **no longer marked nudged**, so the cooldown only starts on a real send.
- An unparseable `nudgedAt` no longer falls through the cooldown check on a NaN comparison.

## 3. Nudge pre-flight errors were hardcoded English with no error code

The four rejections (pact not found, not the creator, pact no longer pending, nobody left to nudge) were untranslated literals with no `errorCode`, so clients had nothing to surface and fell back to their own generic copy. They are now translated (`en-us`/`es`/`fr-ca`) and carry an `ErrorCode`.

`IPactNudgeResult.reason` in `therr-react` gains `'undeliverable'` to match.

## Verification

| Gate | Result |
|---|---|
| `pr:test:unit:users` | 833 passing |
| `pr:typecheck:users` | clean |
| `pr:typecheck:therr-react` | clean |
| `pr:test:unit:mobile` | 1277 passing (53 suites) |
| `pr:tsc-baseline:mobile` | current=101 baseline=101, no new errors |
| `locales:check` | 9/9 OK |
| `eslint` on changed files | clean |

Integration tests were not run — no Docker in this environment.

The nudge tests now import the extracted utility directly instead of mirroring the handler's logic, and cover the undeliverable and thrown-dispatch cases.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk44Fd9Ug3vFs4pAZwRQSM