### PR TITLE
feat(habits): Friend Streak data + close the pact cycle (§ 2.6.2, § 2.6.3)

### DIFF
--- a/therr-api-gateway/src/services/users/router.ts
+++ b/therr-api-gateway/src/services/users/router.ts
@@ -720,6 +720,10 @@ usersServiceRouter.put('/habits/pacts/:id/complete', handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
     method: 'put',
 }));
+usersServiceRouter.put('/habits/pacts/:id/renew', handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'put',
+}));
 // The nudge route existed in the service, in PactsService and in the mobile
 // PactsList screen, but was never registered here — so every "nudge" a user
 // sent died at the gateway with nothing in the UI to say so.

--- a/therr-public-library/therr-react/src/redux/actions/Habits.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Habits.ts
@@ -148,6 +148,19 @@ const Habits = {
         return response.data;
     }),
 
+    // Dispatches CREATE_PACT rather than a type of its own: a renewal *is* a
+    // new pact on the same habit goal, and the reducer's job here — put the new
+    // pact into state — is identical. The pact being renewed is refetched with
+    // its new `expired` status on the next list read.
+    renewPact: (id: string, durationDays?: number) => (dispatch: any) => PactsService
+        .renew(id, durationDays).then((response) => {
+            dispatch({
+                type: HabitsActionTypes.CREATE_PACT,
+                data: response.data,
+            });
+            return response.data;
+        }),
+
     // Checkins
     getTodayCheckins: (habitGoalId?: string) => (dispatch: any) => HabitCheckinsService
         .getTodayCheckins(habitGoalId).then((response: any) => {

--- a/therr-public-library/therr-react/src/services/PactsService.ts
+++ b/therr-public-library/therr-react/src/services/PactsService.ts
@@ -88,6 +88,20 @@ class PactsService {
         url: `/users-service/habits/pacts/${id}/abandon`,
     });
 
+    /**
+     * Starts a new cycle on the same habit goal, re-inviting the members of the
+     * one that ended. Answers 201 with the new pact; 409 when the pact has not
+     * ended yet or the user already has a live pact for that habit.
+     *
+     * `durationDays` is optional — omitted, the new cycle inherits the length of
+     * the one being renewed.
+     */
+    renew = (id: string, durationDays?: number) => axios({
+        method: 'put',
+        url: `/users-service/habits/pacts/${id}/renew`,
+        data: durationDays ? { durationDays } : {},
+    });
+
     delete = (id: string) => axios({
         method: 'delete',
         url: `/users-service/habits/pacts/${id}`,

--- a/therr-public-library/therr-react/src/types/redux/habits.ts
+++ b/therr-public-library/therr-react/src/types/redux/habits.ts
@@ -58,6 +58,16 @@ export interface IPactMember {
     currentStreak: number;
     longestStreak: number;
     completionRate?: number;
+    /**
+     * Whether this member has completed today's check-in for the pact's habit
+     * goal, on the service's UTC habit day. Derived server-side alongside the
+     * other stats (users-service `utilities/pactMemberStats`).
+     *
+     * Optional because a client can be talking to a users-service that predates
+     * it; treat `undefined` as "unknown" and render nothing rather than
+     * implying the member missed a day.
+     */
+    checkedInToday?: boolean;
     // Joined fields
     userName?: string;
     firstName?: string;

--- a/therr-services/users-service/src/handlers/habitsDigest.ts
+++ b/therr-services/users-service/src/handlers/habitsDigest.ts
@@ -24,6 +24,10 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 interface IDigestCounters {
     pactsEvaluated: number;
+    // Pacts whose window had passed and that this run closed out. Additive to
+    // the shape therr-messaging-automator logs, so an older automator simply
+    // does not print it.
+    pactsExpired: number;
     // Retained under their original names because therr-messaging-automator logs
     // this exact shape (see its IHabitsDigestCounters). They now count rows
     // *queued*, not pushes sent — the worker decides what actually goes out.
@@ -62,6 +66,9 @@ interface IDigestCounters {
  *                    complete yesterday's check-in.
  *  - pactExpiring  → to all active members when the pact ends within 3 days.
  *
+ * It also sweeps pacts whose window has passed into `expired` before reading
+ * the active set — see the sweep below.
+ *
  * Designed to be triggered once per day by an internal cron (today, a Cloud
  * Scheduler job poking therr-messaging-automator). The route is deliberately
  * NOT registered in the API gateway, so it is unreachable from the public
@@ -91,6 +98,7 @@ const runDailyHabitsDigest: RequestHandler = async (req: any, res: any) => {
 
     const counters: IDigestCounters = {
         pactsEvaluated: 0,
+        pactsExpired: 0,
         streakAtRiskSent: 0,
         partnerMissedSent: 0,
         pactExpiringSent: 0,
@@ -156,6 +164,46 @@ const runDailyHabitsDigest: RequestHandler = async (req: any, res: any) => {
     ): Promise<boolean> => (await queuePushOutcome(toUserId, type, dedupeKey, extras)) === 'queued';
 
     try {
+        // Close out pacts whose window has passed, before anything reads the
+        // active set.
+        //
+        // `PactsStore.expire()`, `PactsStore.getExpiredPacts()` and
+        // `pactHelpers.shouldExpirePact` have all existed since the pact schema
+        // landed and nothing has ever called any of them, so a pact reached its
+        // endDate and simply stayed `active` forever: still drawing digest
+        // reads, still rendering as in-flight, still counting against the
+        // one-live-pact-per-habit rule that gates renewal.
+        //
+        // Sweeping first is what stops a pact being warned that it expires in
+        // zero days on the same run that ends it. A failure here is logged and
+        // the digest continues — an unswept pact is the behaviour every run
+        // before this one had.
+        const expiredPacts = await Store.pacts.getExpiredPacts().catch((err: any) => {
+            counters.errors += 1;
+            logSpan({
+                level: 'error',
+                messageOrigin: 'API_SERVER',
+                messages: [err?.message, 'Habits digest: failed to read expired pacts'],
+            });
+            return [] as any[];
+        });
+        // eslint-disable-next-line no-restricted-syntax
+        for (const expiring of expiredPacts) {
+            try {
+                // eslint-disable-next-line no-await-in-loop
+                await Store.pacts.expire(expiring.id);
+                counters.pactsExpired += 1;
+            } catch (err: any) {
+                counters.errors += 1;
+                logSpan({
+                    level: 'error',
+                    messageOrigin: 'API_SERVER',
+                    messages: [err?.message, 'Habits digest: failed to expire pact'],
+                    traceArgs: { pactId: expiring.id },
+                });
+            }
+        }
+
         const activePacts = await Store.pacts.get({ status: 'active' }, undefined, DIGEST_MAX_PACTS);
         const habitNameCache = new Map<string, string>();
         const userNameCache = new Map<string, string>();

--- a/therr-services/users-service/src/handlers/helpers/pactMemberStats.ts
+++ b/therr-services/users-service/src/handlers/helpers/pactMemberStats.ts
@@ -6,6 +6,7 @@ import {
     IPactMemberStats,
     ZERO_PACT_MEMBER_STATS,
 } from '../../utilities/pactMemberStats';
+import { getTodayDateString } from '../../utilities/streakHelpers';
 
 interface IStatsTarget {
     key: string;
@@ -25,7 +26,7 @@ const withStats = (member: any, stats: IPactMemberStats) => ({ ...member, ...sta
  * streaks. Every member comes back with numeric stats, so clients never have to
  * distinguish "no progress" from "never computed".
  *
- * Batched across the whole page: three queries total regardless of how many
+ * Batched across the whole page: four queries total regardless of how many
  * pacts or members are passed in.
  */
 export const attachPactMemberStats = async (pacts: any[]): Promise<any[]> => {
@@ -75,10 +76,15 @@ export const attachPactMemberStats = async (pacts: any[]): Promise<any[]> => {
         }));
     }
 
-    const [goals, streaks, completedCounts] = await Promise.all([
+    // The service's UTC habit day, matching what the check-in write path
+    // stores in `scheduledDate` — see getTodayDateString.
+    const today = getTodayDateString();
+
+    const [goals, streaks, completedCounts, completedToday] = await Promise.all([
         Store.habitGoals.getByIds([...goalIds]),
         Store.streaks.getByUserHabitPairs(pairs),
         Store.habitCheckins.getCompletedCountsForWindows(targets),
+        Store.habitCheckins.getCompletedOnDateForPairs(pairs, today),
     ]);
 
     const goalsById: Record<string, any> = goals.reduce((acc: any, goal: any) => {
@@ -116,6 +122,7 @@ export const attachPactMemberStats = async (pacts: any[]): Promise<any[]> => {
                 scheduledCount: scheduledByPactId[pact.id] || 0,
                 completedCheckins: completedCounts[statsKey(pact.id, member.userId)] || 0,
                 streak: streaksByPair[`${member.userId}:${pact.habitGoalId}`],
+                checkedInToday: completedToday.has(`${member.userId}:${pact.habitGoalId}`),
             }))),
         };
     });

--- a/therr-services/users-service/src/handlers/pacts.ts
+++ b/therr-services/users-service/src/handlers/pacts.ts
@@ -25,6 +25,8 @@ import {
     validatePactParams,
     isUserInPact,
     isCreator,
+    isPactRenewable,
+    selectRenewalInvitees,
 } from '../utilities/pactHelpers';
 import {
     awardPactPioneerCreatedAchievement,
@@ -966,6 +968,231 @@ const completePact: RequestHandler = async (req: any, res: any) => {
 };
 
 // DELETE
+// RENEW — the fixed-cycle restart (docs/WORK_IN_PROGRESS.md § 2.6.3).
+//
+// The gamification meta-analysis this is drawn from measured a Hedges' g of
+// 0.42 on physical activity that decayed to 0.15 at 12-24 week follow-up: the
+// effect is real and it fades, which is why the intervention has to be renewed
+// on a cycle rather than run open-ended. Pacts already have the cycle
+// (durationDays of 7/14/30/90); until now nothing closed it, so a pact reached
+// its endDate and the app had nothing further to say.
+//
+// A renewal is a *new pact on the same habit goal*, not a mutation of the old
+// one — the old pact keeps its own history, completion rates and dates. The
+// streak is untouched by design: `habits.streaks` is keyed on
+// (userId, habitGoalId), never on pactId, so it carries across the boundary on
+// its own. Resetting it here would take the article's strongest mechanic away
+// from the user on a day they did nothing wrong.
+//
+// Previously-active partners are re-invited as `pending`, not silently
+// re-enrolled. A pact is a mutual commitment for a fixed number of days, and
+// one member tapping "re-commit" must not sign the others up for another 30.
+// That keeps the new pact on exactly the same pending -> activate-on-first-
+// acceptance path every other pact follows.
+const renewPact: RequestHandler = async (req: any, res: any) => {
+    const {
+        locale,
+        userId,
+        userName,
+        authorization,
+        whiteLabelOrigin,
+        brandVariation,
+    } = parseHeaders(req.headers);
+    const { id } = req.params;
+    const { durationDays } = req.body || {};
+
+    const pact = await Store.pacts.getById(id);
+    if (!pact) {
+        return handleHttpError({
+            res,
+            message: translate(locale, 'errorMessages.pacts.notFound'),
+            statusCode: 404,
+            errorCode: ErrorCodes.NOT_FOUND,
+        });
+    }
+
+    const previousMembers = await Store.pactMembers.getByPactId(id);
+    const membership = previousMembers.find((member: any) => member.userId === userId);
+    const isParticipant = isUserInPact(userId, pact.creatorUserId, pact.partnerUserId) || !!membership;
+    if (!isParticipant) {
+        return handleHttpError({
+            res,
+            message: translate(locale, 'errorMessages.pacts.notParticipant'),
+            statusCode: 403,
+            errorCode: ErrorCodes.NOT_PERMITTED,
+        });
+    }
+
+    // Only a finished cycle can be renewed — see isPactRenewable for which
+    // statuses qualify and why `abandoned` is not one of them.
+    if (!isPactRenewable(pact)) {
+        return handleHttpError({
+            res,
+            message: translate(locale, 'errorMessages.pacts.notRenewable'),
+            statusCode: 409,
+            errorCode: ErrorCodes.BAD_REQUEST,
+        });
+    }
+
+    // One live cycle per habit at a time. Without this, tapping renew twice —
+    // or two members each renewing the same ended pact — produces two parallel
+    // pacts on one goal, which the check-in path would then credit twice over.
+    const livePacts = await Store.pacts.getActiveByUserAndHabitGoal(userId, pact.habitGoalId);
+    if (livePacts.length) {
+        return handleHttpError({
+            res,
+            message: translate(locale, 'errorMessages.pacts.alreadyRenewed'),
+            statusCode: 409,
+            errorCode: ErrorCodes.BAD_REQUEST,
+        });
+    }
+
+    const nextDurationDays = durationDays || pact.durationDays || 30;
+    const validation = validatePactParams({
+        durationDays: nextDurationDays,
+        consequenceType: pact.consequenceType,
+        consequenceDetails: pact.consequenceDetails,
+    });
+    if (!validation.valid) {
+        return handleHttpError({
+            res,
+            message: translate(locale, validation.errorKey || 'errorMessages.pacts.invalidParams', validation.errorParams),
+            statusCode: 400,
+            errorCode: ErrorCodes.BAD_REQUEST,
+        });
+    }
+
+    const habitGoal = await Store.habitGoals.getById(pact.habitGoalId);
+    if (!habitGoal) {
+        return handleHttpError({
+            res,
+            message: translate(locale, 'errorMessages.habits.habitGoalNotFound'),
+            statusCode: 404,
+            errorCode: ErrorCodes.NOT_FOUND,
+        });
+    }
+
+    // No free-tier capacity check. The cap counts *habits tracked*, and this
+    // habit is already one of them — it had a pact. `getOrCreate` below will
+    // not resurrect a row the user archived, so a renewal cannot smuggle an
+    // extra habit past the limit either.
+
+    const inviteeIds = selectRenewalInvitees(previousMembers, userId);
+
+    // Keep the 1:1 shape where the last cycle had one: several read paths still
+    // fall back to `partnerUserId` for pacts with no member rows. A group pact
+    // leaves it null, exactly as bulkInvitePact does.
+    const nextPartnerUserId = inviteeIds.length === 1 ? inviteeIds[0] : undefined;
+
+    return Store.pacts.create({
+        creatorUserId: userId,
+        partnerUserId: nextPartnerUserId,
+        habitGoalId: pact.habitGoalId,
+        pactType: pact.pactType,
+        durationDays: nextDurationDays,
+        consequenceType: pact.consequenceType,
+        consequenceDetails: pact.consequenceDetails,
+    })
+        .then(async (renewed) => {
+            await Store.pactMembers.create({
+                pactId: renewed.id,
+                userId,
+                role: 'creator',
+                status: 'active',
+            });
+
+            const partnerMembers = inviteeIds.length
+                ? await Store.pactMembers.createBulk(inviteeIds.map((partnerId) => ({
+                    pactId: renewed.id,
+                    userId: partnerId,
+                    role: 'partner' as const,
+                    status: 'pending',
+                })))
+                : [];
+
+            await Store.userHabits.getOrCreate(userId, pact.habitGoalId);
+
+            // Close out the pact being renewed if the sweep has not yet. Done
+            // after the new pact exists so a failure here cannot leave the user
+            // with neither an old cycle nor a new one.
+            if (pact.status === 'active') {
+                await Store.pacts.expire(pact.id).catch((err) => {
+                    logSpan({
+                        level: 'error',
+                        messageOrigin: 'API_SERVER',
+                        messages: ['Failed to expire the pact being renewed'],
+                        traceArgs: { 'error.message': err?.message, pactId: pact.id },
+                    });
+                });
+            }
+
+            // A pact with nobody left to invite has no acceptance coming, so it
+            // would sit `pending` forever. Every other pact activates on the
+            // first partner acceptance, and this one keeps that rule.
+            const activated = partnerMembers.length
+                ? renewed
+                : await Store.pacts.activate(renewed.id);
+
+            recordFunnelMetric(MetricNames.FUNNEL_PACT_CREATED, userId, {
+                brandVariation: brandVariation || '',
+                isRenewal: 'true',
+            });
+            if (partnerMembers.length) {
+                recordFunnelMetric(MetricNames.FUNNEL_PACT_INVITE_SENT, userId, {
+                    brandVariation: brandVariation || '',
+                    isRenewal: 'true',
+                }, String(partnerMembers.length));
+            }
+
+            partnerMembers.forEach((member: any) => {
+                const toUserId = member.userId;
+                dispatchPactInvitation({
+                    pactMemberId: member.id,
+                    partnerUserId: toUserId,
+                    fromUserName: userName,
+                    habitName: habitGoal.name,
+                    brandVariation,
+                    whiteLabelOrigin,
+                    locale,
+                }).catch((err) => {
+                    logSpan({
+                        level: 'error',
+                        messageOrigin: 'API_SERVER',
+                        messages: ['Error dispatching pact renewal invitation'],
+                        traceArgs: { 'error.message': err?.message, toUserId },
+                    });
+                    return { isOnBrand: true };
+                }).then((dispatchResult) => {
+                    if (!dispatchResult.isOnBrand) {
+                        return undefined;
+                    }
+                    return sendEmailAndOrPushNotification(Store.users.findUser, req.headers, {
+                        authorization,
+                        fromUser: { id: userId, userName },
+                        locale,
+                        toUserId,
+                        type: PushNotifications.Types.pactInvitation,
+                        whiteLabelOrigin,
+                        brandVariation,
+                    });
+                }).catch((err) => {
+                    logSpan({
+                        level: 'error',
+                        messageOrigin: 'API_SERVER',
+                        messages: ['Error sending pact renewal notification'],
+                        traceArgs: { 'error.message': err?.message, toUserId },
+                    });
+                });
+            });
+
+            Store.habitGoals.incrementUsageCount(pact.habitGoalId).catch((e) => e);
+
+            const members = await Store.pactMembers.getByPactId(renewed.id);
+            return res.status(201).send(await attachMemberStatsToPact({ ...activated, members }));
+        })
+        .catch((err) => handleHttpError({ err, res, message: 'SQL:PACTS_ROUTES:ERROR' }));
+};
+
 const deletePact: RequestHandler = async (req: any, res: any) => {
     const { locale, userId } = parseHeaders(req.headers);
     const { id } = req.params;
@@ -1148,5 +1375,6 @@ export {
     declinePact,
     abandonPact,
     completePact,
+    renewPact,
     deletePact,
 };

--- a/therr-services/users-service/src/locales/en-us/dictionary.json
+++ b/therr-services/users-service/src/locales/en-us/dictionary.json
@@ -32,6 +32,8 @@
             "inviteesTooMany": "You can invite up to {limit} partners at a time",
             "notAcceptingMembers": "This pact is full",
             "notActive": "This pact isn't active",
+            "alreadyRenewed": "You already have a live pact for this habit",
+            "notRenewable": "This pact is still running — you can renew it once it ends",
             "notFound": "That pact no longer exists",
             "notInvitedPartner": "This invitation was sent to someone else",
             "notParticipant": "You're not part of this pact",

--- a/therr-services/users-service/src/locales/es/dictionary.json
+++ b/therr-services/users-service/src/locales/es/dictionary.json
@@ -32,6 +32,8 @@
             "inviteesTooMany": "Puedes invitar hasta {limit} compañeros a la vez",
             "notAcceptingMembers": "Este pacto ya está completo",
             "notActive": "Este pacto no está activo",
+            "alreadyRenewed": "Ya tienes un pacto activo para este hábito",
+            "notRenewable": "Este pacto sigue en curso: podrás renovarlo cuando termine",
             "notFound": "Ese pacto ya no existe",
             "notInvitedPartner": "Esta invitación se envió a otra persona",
             "notParticipant": "No formas parte de este pacto",

--- a/therr-services/users-service/src/locales/fr-ca/dictionary.json
+++ b/therr-services/users-service/src/locales/fr-ca/dictionary.json
@@ -32,6 +32,8 @@
             "inviteesTooMany": "Tu peux inviter jusqu'à {limit} partenaires à la fois",
             "notAcceptingMembers": "Ce pacte est complet",
             "notActive": "Ce pacte n'est pas actif",
+            "alreadyRenewed": "Tu as déjà un pacte en cours pour cette habitude",
+            "notRenewable": "Ce pacte est encore en cours : tu pourras le renouveler quand il sera terminé",
             "notFound": "Ce pacte n'existe plus",
             "notInvitedPartner": "Cette invitation a été envoyée à quelqu'un d'autre",
             "notParticipant": "Tu ne fais pas partie de ce pacte",

--- a/therr-services/users-service/src/routes/pactsRouter.ts
+++ b/therr-services/users-service/src/routes/pactsRouter.ts
@@ -12,6 +12,7 @@ import {
     declinePact,
     abandonPact,
     completePact,
+    renewPact,
     deletePact,
 } from '../handlers/pacts';
 import runDailyHabitsDigest from '../handlers/habitsDigest';
@@ -40,6 +41,7 @@ router.put('/:id/accept', acceptPact);
 router.put('/:id/decline', declinePact);
 router.put('/:id/abandon', abandonPact);
 router.put('/:id/complete', completePact);
+router.put('/:id/renew', renewPact);
 
 // DELETE
 router.delete('/:id', deletePact);

--- a/therr-services/users-service/src/store/HabitCheckinsStore.ts
+++ b/therr-services/users-service/src/store/HabitCheckinsStore.ts
@@ -254,6 +254,53 @@ export default class HabitCheckinsStore {
         ));
     }
 
+    /**
+     * Which of these (user, habit goal) pairs have a completed check-in on
+     * `date`, in one query.
+     *
+     * This is what lets a pact card say who has and has not shown up today —
+     * the whole mechanism behind Duolingo's Friend Streak result (+22% daily
+     * completion from adding nothing but a second reader). A per-member query
+     * would make the pacts list O(members) round trips on a hot read path.
+     *
+     * `date` is a habit day as the service counts them (UTC, via
+     * `getTodayDateString`), matching what the check-in write path stores in
+     * `scheduledDate` — not the viewer's local calendar day.
+     *
+     * Returns a Set of `${userId}:${habitGoalId}`. Absence means "no completed
+     * check-in", which is the same thing the caller wants to render.
+     */
+    getCompletedOnDateForPairs(
+        pairs: { userId: string; habitGoalId: string }[],
+        date: string,
+    ): Promise<Set<string>> {
+        if (!pairs.length) {
+            return Promise.resolve(new Set<string>());
+        }
+
+        const values = pairs.map(() => '(?::uuid, ?::uuid)').join(', ');
+        const bindings = pairs.reduce(
+            (acc: string[], pair) => acc.concat([pair.userId, pair.habitGoalId]),
+            [],
+        ).concat([date]);
+
+        const queryString = knexBuilder.raw(
+            `WITH pairs("userId", "habitGoalId") AS (VALUES ${values})
+            SELECT DISTINCT p."userId" AS "userId", p."habitGoalId" AS "habitGoalId"
+            FROM pairs p
+            JOIN ${HABIT_CHECKINS_TABLE_NAME} c
+                ON c."userId" = p."userId"
+                AND c."habitGoalId" = p."habitGoalId"
+                AND c.status = 'completed'
+                AND c."scheduledDate" = ?::date`,
+            bindings,
+        ).toString();
+
+        return this.db.read.query(queryString).then((response) => new Set<string>(
+            response.rows.map((row: any) => `${row.userId}:${row.habitGoalId}`),
+        ));
+    }
+
     create(params: ICreateHabitCheckinParams) {
         const queryString = knexBuilder
             .insert({

--- a/therr-services/users-service/src/utilities/pactHelpers.ts
+++ b/therr-services/users-service/src/utilities/pactHelpers.ts
@@ -61,6 +61,49 @@ export const shouldExpirePact = (
 };
 
 /**
+ * Whether a pact's cycle is over and can therefore be renewed.
+ *
+ * An `active` pact that is merely past its endDate counts as finished: the
+ * digest's sweep will have marked it `expired`, but renewal must not depend on
+ * that job having run — a user who opens the app before the nightly digest
+ * would otherwise be told their finished pact is "still running".
+ *
+ * `abandoned` is deliberately absent. Someone who walked away from a pact
+ * should start a fresh one deliberately rather than re-run the one they quit,
+ * and `pending` never had a cycle to finish in the first place.
+ */
+export const isPactRenewable = (
+    pact: { status: PactStatus | string; endDate?: Date | string | null } | null | undefined,
+): boolean => {
+    if (!pact) {
+        return false;
+    }
+    if (pact.status === 'completed' || pact.status === 'expired') {
+        return true;
+    }
+    return pact.status === 'active' && shouldExpirePact(pact.status as PactStatus, pact.endDate ?? null);
+};
+
+/**
+ * Who carries over into the renewed cycle, given the previous cycle's members
+ * and whoever tapped renew.
+ *
+ * Only members who were actually *in* the last cycle come along — `left` and
+ * `removed` opted out, and a `pending` invitee never accepted, so re-inviting
+ * any of them would turn a renewal into a fresh round of asking people who
+ * already said no (or never answered). The renewer is excluded because they
+ * join the new pact as its creator.
+ */
+export const selectRenewalInvitees = (
+    members: { userId?: string; status?: string }[],
+    renewerUserId: string,
+): string[] => Array.from(new Set(members
+    .filter((member) => member?.userId
+        && member.userId !== renewerUserId
+        && (member.status === 'active' || member.status === 'completed'))
+    .map((member) => member.userId as string)));
+
+/**
  * Check if a pact invitation has expired (default: 7 days)
  */
 export const hasInvitationExpired = (

--- a/therr-services/users-service/src/utilities/pactMemberStats.ts
+++ b/therr-services/users-service/src/utilities/pactMemberStats.ts
@@ -36,6 +36,17 @@ export interface IPactMemberStats {
     currentStreak: number;
     longestStreak: number;
     completionRate: number;
+    /**
+     * Whether this member has a completed check-in for the pact's habit goal
+     * **today**, on the service's UTC habit day.
+     *
+     * A statement about the member's habit, not about the pact: it stays
+     * factual for a pact that has already ended, and the caller decides
+     * whether showing it makes sense there. Pacts with no measurable window
+     * (pending, or not yet started) report `false` along with every other
+     * zeroed stat — there is nothing to be late for yet.
+     */
+    checkedInToday: boolean;
 }
 
 export const ZERO_PACT_MEMBER_STATS: IPactMemberStats = {
@@ -44,6 +55,7 @@ export const ZERO_PACT_MEMBER_STATS: IPactMemberStats = {
     currentStreak: 0,
     longestStreak: 0,
     completionRate: 0,
+    checkedInToday: false,
 };
 
 /**
@@ -136,10 +148,12 @@ export const buildPactMemberStats = ({
     scheduledCount,
     completedCheckins,
     streak,
+    checkedInToday = false,
 }: {
     scheduledCount: number;
     completedCheckins: number;
     streak?: { currentStreak?: number | string; longestStreak?: number | string } | null;
+    checkedInToday?: boolean;
 }): IPactMemberStats => {
     const completed = Math.max(0, Math.round(Number(completedCheckins) || 0));
     // A user can log more check-ins than the cadence schedules (a 3x/week
@@ -155,5 +169,6 @@ export const buildPactMemberStats = ({
         currentStreak: Number(streak?.currentStreak) || 0,
         longestStreak: Number(streak?.longestStreak) || 0,
         completionRate,
+        checkedInToday,
     };
 };

--- a/therr-services/users-service/tests/unit/handlers-habits-digest.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-habits-digest.test.ts
@@ -79,6 +79,12 @@ const buildFakeQueue = () => {
 };
 
 const stubDigestReads = () => {
+    // The expiry sweep runs before the active-pact read. Nothing is past its
+    // endDate in this fixture, so the sweep is a no-op here — it has its own
+    // tests below.
+    sinon.stub(Store.pacts, 'getExpiredPacts').resolves([] as any);
+    sinon.stub(Store.pacts, 'expire').resolves({} as any);
+
     sinon.stub(Store.pacts, 'get').resolves([{
         id: PACT_ID,
         habitGoalId: HABIT_GOAL_ID,
@@ -235,6 +241,58 @@ describe('Habits digest — running it twice is a no-op', () => {
 
         // Same work decided on both times; only the disposition differs.
         expect(first.pactsEvaluated).to.equal(second.pactsEvaluated);
+    });
+
+    it('sweeps pacts whose window has passed into expired', async () => {
+        sinon.restore();
+        buildFakeQueue();
+        stubDigestReads();
+        (Store.pacts.getExpiredPacts as any).restore();
+        (Store.pacts.expire as any).restore();
+        sinon.stub(Store.pacts, 'getExpiredPacts').resolves([
+            { id: 'stale-1' }, { id: 'stale-2' },
+        ] as any);
+        const expire = sinon.stub(Store.pacts, 'expire').resolves({} as any);
+
+        const counters = await runDigest();
+
+        expect(counters.pactsExpired).to.equal(2);
+        expect(expire.callCount).to.equal(2);
+        expect(counters.errors).to.equal(0);
+    });
+
+    // The sweep runs before the active-pact read specifically so a pact cannot
+    // be warned that it expires in zero days on the same run that ends it.
+    it('sweeps before reading the active set', async () => {
+        sinon.restore();
+        buildFakeQueue();
+        stubDigestReads();
+        (Store.pacts.expire as any).restore();
+        const expire = sinon.stub(Store.pacts, 'expire').resolves({} as any);
+
+        await runDigest();
+
+        // `get` is the active-pact read; both are stubs on the same object, so
+        // sinon's call ordering is the real execution order.
+        expect((Store.pacts.getExpiredPacts as any).calledBefore(Store.pacts.get as any)).to.equal(true);
+        expect(expire.called).to.equal(false);
+    });
+
+    // A pact left un-swept is exactly the behaviour every run before this one
+    // had — worth a wasted read, never worth failing the digest over.
+    it('counts a failed sweep as an error and still runs the digest', async () => {
+        sinon.restore();
+        const failQueue = buildFakeQueue();
+        stubDigestReads();
+        (Store.pacts.getExpiredPacts as any).restore();
+        sinon.stub(Store.pacts, 'getExpiredPacts').rejects(new Error('read pool exhausted'));
+
+        const counters = await runDigest();
+
+        expect(counters.pactsExpired).to.equal(0);
+        expect(counters.errors).to.equal(1);
+        // The notifications still went out.
+        expect(failQueue.insertedCount()).to.equal(9);
     });
 
     it('reports a broken queue as errors, never as dedup', async () => {

--- a/therr-services/users-service/tests/unit/handlers-pacts-renew.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-pacts-renew.test.ts
@@ -1,0 +1,333 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Store from '../../src/store';
+import { renewPact } from '../../src/handlers/pacts';
+import { isPactRenewable, selectRenewalInvitees } from '../../src/utilities/pactHelpers';
+
+/**
+ * Pact renewal — the fixed-cycle restart (docs/WORK_IN_PROGRESS.md § 2.6.3).
+ *
+ * The RCT meta-analysis behind this work measured a Hedges' g of 0.42 that
+ * decayed to 0.15 at 12–24 week follow-up: gamified effects are real and they
+ * fade, so the intervention has to be renewed on a cycle. Pacts already had the
+ * cycle; nothing closed it.
+ *
+ * Three properties carry the whole feature, and each fails silently if broken:
+ *
+ *   1. The streak survives. `habits.streaks` is keyed (userId, habitGoalId) and
+ *      never on pactId, so a renewal that touched it would take the user's
+ *      strongest reason to keep going away on a day they did nothing wrong.
+ *   2. Exactly one live pact per habit. Two parallel pacts on one goal get the
+ *      check-in path crediting the same check-in twice.
+ *   3. Partners are re-invited, not re-enrolled. A pact is a mutual commitment
+ *      for a fixed number of days; one member tapping renew must not sign the
+ *      others up for another 30.
+ *
+ * The eligibility and carry-over rules are exercised directly through the pure
+ * helpers the handler uses, and the handler itself is driven against stubbed
+ * stores so the assertions cover the code that actually runs.
+ */
+
+const RENEWER = 'aaaaaaaa-0000-4000-8000-00000000000a';
+const PARTNER = 'bbbbbbbb-0000-4000-8000-00000000000b';
+const SECOND_PARTNER = 'cccccccc-0000-4000-8000-00000000000c';
+const PACT_ID = 'pact-1';
+const HABIT_GOAL_ID = 'habit-goal-1';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const yesterday = () => new Date(Date.now() - DAY_MS);
+const tomorrow = () => new Date(Date.now() + DAY_MS);
+
+describe('Pact renewal — eligibility', () => {
+    it('allows renewing a completed or expired pact', () => {
+        expect(isPactRenewable({ status: 'completed', endDate: yesterday() })).to.equal(true);
+        expect(isPactRenewable({ status: 'expired', endDate: yesterday() })).to.equal(true);
+    });
+
+    // The sweep runs nightly. A user who finishes a pact and opens the app the
+    // same evening must not be told their finished pact is "still running".
+    it('allows renewing an active pact whose window has already passed', () => {
+        expect(isPactRenewable({ status: 'active', endDate: yesterday() })).to.equal(true);
+    });
+
+    it('refuses to renew a pact that is still running', () => {
+        expect(isPactRenewable({ status: 'active', endDate: tomorrow() })).to.equal(false);
+    });
+
+    it('refuses to renew a pending or abandoned pact', () => {
+        expect(isPactRenewable({ status: 'pending', endDate: null })).to.equal(false);
+        expect(isPactRenewable({ status: 'abandoned', endDate: yesterday() })).to.equal(false);
+    });
+
+    it('refuses to renew nothing', () => {
+        expect(isPactRenewable(null)).to.equal(false);
+        expect(isPactRenewable(undefined)).to.equal(false);
+    });
+});
+
+describe('Pact renewal — who carries over', () => {
+    it('carries over the members who were actually in the last cycle', () => {
+        const invitees = selectRenewalInvitees([
+            { userId: RENEWER, status: 'active' },
+            { userId: PARTNER, status: 'active' },
+            { userId: SECOND_PARTNER, status: 'completed' },
+        ], RENEWER);
+        expect(invitees).to.deep.equal([PARTNER, SECOND_PARTNER]);
+    });
+
+    // Re-inviting these would turn a renewal into a fresh round of asking
+    // people who already said no, or who never answered the first time.
+    it('leaves behind members who left, were removed, or never accepted', () => {
+        const invitees = selectRenewalInvitees([
+            { userId: PARTNER, status: 'left' },
+            { userId: SECOND_PARTNER, status: 'removed' },
+            { userId: 'dddddddd-0000-4000-8000-00000000000d', status: 'pending' },
+        ], RENEWER);
+        expect(invitees).to.deep.equal([]);
+    });
+
+    it('never invites the renewer, who joins as the new creator', () => {
+        const invitees = selectRenewalInvitees([{ userId: RENEWER, status: 'active' }], RENEWER);
+        expect(invitees).to.deep.equal([]);
+    });
+
+    it('dedupes a user appearing twice in the member list', () => {
+        const invitees = selectRenewalInvitees([
+            { userId: PARTNER, status: 'active' },
+            { userId: PARTNER, status: 'completed' },
+        ], RENEWER);
+        expect(invitees).to.deep.equal([PARTNER]);
+    });
+});
+
+describe('Pact renewal — handler', () => {
+    let createdPact: any;
+    let createdMembers: any[];
+    let bulkMembers: any[];
+
+    const buildRes = () => {
+        const captured: { statusCode?: number; body?: any } = {};
+        return {
+            captured,
+            res: {
+                status: (statusCode: number) => {
+                    captured.statusCode = statusCode;
+                    return { send: (payload: any) => { captured.body = payload; return payload; } };
+                },
+            } as any,
+        };
+    };
+
+    const stubStores = ({
+        pact,
+        members,
+        livePacts = [],
+    }: { pact: any; members: any[]; livePacts?: any[] }) => {
+        sinon.stub(Store.pacts, 'getById').resolves(pact);
+        sinon.stub(Store.pactMembers, 'getByPactId')
+            .onFirstCall().resolves(members)
+            .onSecondCall()
+            .resolves(members);
+        sinon.stub(Store.pacts, 'getActiveByUserAndHabitGoal').resolves(livePacts as any);
+        sinon.stub(Store.habitGoals, 'getById').resolves({ id: HABIT_GOAL_ID, name: 'Morning run' } as any);
+        sinon.stub(Store.habitGoals, 'incrementUsageCount').resolves({} as any);
+        sinon.stub(Store.pacts, 'create').callsFake((params: any) => {
+            createdPact = { id: 'pact-2', status: 'pending', ...params };
+            return Promise.resolve(createdPact);
+        });
+        sinon.stub(Store.pacts, 'activate').callsFake(() => {
+            createdPact = { ...createdPact, status: 'active' };
+            return Promise.resolve(createdPact);
+        });
+        sinon.stub(Store.pacts, 'expire').resolves({} as any);
+        sinon.stub(Store.pactMembers, 'create').callsFake((params: any) => {
+            createdMembers.push(params);
+            return Promise.resolve({ id: `member-${createdMembers.length}`, ...params });
+        });
+        sinon.stub(Store.pactMembers, 'createBulk').callsFake((rows: any[]) => {
+            bulkMembers = rows;
+            return Promise.resolve(rows.map((row, i) => ({ id: `bulk-${i}`, ...row })));
+        });
+        sinon.stub(Store.userHabits, 'getOrCreate').resolves({} as any);
+        sinon.stub(Store.users, 'findUser').resolves([] as any);
+    };
+
+    const endedPact = (overrides: any = {}) => ({
+        id: PACT_ID,
+        creatorUserId: RENEWER,
+        partnerUserId: PARTNER,
+        habitGoalId: HABIT_GOAL_ID,
+        pactType: 'accountability',
+        status: 'expired',
+        durationDays: 30,
+        endDate: yesterday(),
+        consequenceType: null,
+        consequenceDetails: null,
+        ...overrides,
+    });
+
+    const run = async (pactId = PACT_ID, body: any = {}) => {
+        const { captured, res } = buildRes();
+        await renewPact({
+            headers: { 'x-userid': RENEWER, 'x-localecode': 'en-us', 'x-brand-variation': 'habits' },
+            params: { id: pactId },
+            body,
+        } as any, res, (() => undefined) as any);
+        return captured;
+    };
+
+    beforeEach(() => {
+        createdPact = undefined;
+        createdMembers = [];
+        bulkMembers = [];
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('creates a new pact on the same habit goal and never touches the streak', async () => {
+        // Every way the streak row could be moved or ended. The renewal must
+        // reach for none of them: the streak is keyed (userId, habitGoalId), so
+        // carrying across the cycle boundary is what happens when nothing acts.
+        const streakWrites = [
+            sinon.stub(Store.streaks, 'resetStreak').resolves({} as any),
+            sinon.stub(Store.streaks, 'update').resolves({} as any),
+            sinon.stub(Store.streaks, 'deactivate').resolves({} as any),
+        ];
+        stubStores({
+            pact: endedPact(),
+            members: [
+                { userId: RENEWER, status: 'active', role: 'creator' },
+                { userId: PARTNER, status: 'active', role: 'partner' },
+            ],
+        });
+
+        const { statusCode } = await run();
+
+        expect(statusCode).to.equal(201);
+        expect(createdPact.habitGoalId).to.equal(HABIT_GOAL_ID);
+        expect(createdPact.creatorUserId).to.equal(RENEWER);
+        // Inherits the length of the cycle being renewed.
+        expect(createdPact.durationDays).to.equal(30);
+        streakWrites.forEach((write) => expect(write.called).to.equal(false));
+    });
+
+    it('re-invites the previous partner as pending rather than re-enrolling them', async () => {
+        stubStores({
+            pact: endedPact(),
+            members: [
+                { userId: RENEWER, status: 'active', role: 'creator' },
+                { userId: PARTNER, status: 'active', role: 'partner' },
+            ],
+        });
+
+        await run();
+
+        expect(createdMembers).to.have.length(1);
+        expect(createdMembers[0]).to.include({ userId: RENEWER, role: 'creator', status: 'active' });
+        expect(bulkMembers).to.have.length(1);
+        expect(bulkMembers[0]).to.include({ userId: PARTNER, role: 'partner', status: 'pending' });
+        // Pending invites mean the pact activates on the first acceptance, the
+        // same path every other pact follows.
+        expect(createdPact.status).to.equal('pending');
+    });
+
+    it('activates immediately when nobody is left to accept', async () => {
+        stubStores({
+            pact: endedPact({ partnerUserId: null }),
+            members: [{ userId: RENEWER, status: 'active', role: 'creator' }],
+        });
+
+        await run();
+
+        expect(bulkMembers).to.have.length(0);
+        // Otherwise it would sit pending forever with no acceptance coming.
+        expect(createdPact.status).to.equal('active');
+    });
+
+    it('refuses when the user already has a live pact for that habit', async () => {
+        stubStores({
+            pact: endedPact(),
+            members: [{ userId: RENEWER, status: 'active', role: 'creator' }],
+            livePacts: [{ id: 'pact-live' }],
+        });
+
+        const { statusCode } = await run();
+
+        expect(statusCode).to.equal(409);
+        expect(createdPact).to.equal(undefined);
+    });
+
+    it('refuses to renew a pact that is still running', async () => {
+        stubStores({
+            pact: endedPact({ status: 'active', endDate: tomorrow() }),
+            members: [{ userId: RENEWER, status: 'active', role: 'creator' }],
+        });
+
+        const { statusCode } = await run();
+
+        expect(statusCode).to.equal(409);
+        expect(createdPact).to.equal(undefined);
+    });
+
+    it('refuses a renewal from someone who was never in the pact', async () => {
+        stubStores({
+            pact: endedPact({ creatorUserId: PARTNER, partnerUserId: SECOND_PARTNER }),
+            members: [
+                { userId: PARTNER, status: 'active', role: 'creator' },
+                { userId: SECOND_PARTNER, status: 'active', role: 'partner' },
+            ],
+        });
+
+        const { statusCode } = await run();
+
+        expect(statusCode).to.equal(403);
+        expect(createdPact).to.equal(undefined);
+    });
+
+    it('404s on a pact that does not exist', async () => {
+        sinon.stub(Store.pacts, 'getById').resolves(undefined as any);
+
+        const { statusCode } = await run('missing');
+
+        expect(statusCode).to.equal(404);
+    });
+
+    // The new pact exists before the old one is closed: a failure closing the
+    // old cycle must never leave the user with neither an old pact nor a new one.
+    it('closes out an active-but-past-due pact it renewed', async () => {
+        stubStores({
+            pact: endedPact({ status: 'active', endDate: yesterday() }),
+            members: [{ userId: RENEWER, status: 'active', role: 'creator' }],
+        });
+
+        await run();
+
+        expect((Store.pacts.expire as any).calledWith(PACT_ID)).to.equal(true);
+        expect(createdPact).to.not.equal(undefined);
+    });
+
+    it('takes a caller-supplied duration over the previous cycle length', async () => {
+        stubStores({
+            pact: endedPact({ durationDays: 30 }),
+            members: [{ userId: RENEWER, status: 'active', role: 'creator' }],
+        });
+
+        await run(PACT_ID, { durationDays: 90 });
+
+        expect(createdPact.durationDays).to.equal(90);
+    });
+
+    it('rejects a duration the pact rules do not allow', async () => {
+        stubStores({
+            pact: endedPact(),
+            members: [{ userId: RENEWER, status: 'active', role: 'creator' }],
+        });
+
+        const { statusCode } = await run(PACT_ID, { durationDays: 17 });
+
+        expect(statusCode).to.equal(400);
+        expect(createdPact).to.equal(undefined);
+    });
+});

--- a/therr-services/users-service/tests/unit/pactMemberStats.test.ts
+++ b/therr-services/users-service/tests/unit/pactMemberStats.test.ts
@@ -119,6 +119,7 @@ describe('pactMemberStats', () => {
                 currentStreak: 3,
                 longestStreak: 5,
                 completionRate: 70,
+                checkedInToday: false,
             });
         });
 
@@ -133,6 +134,19 @@ describe('pactMemberStats', () => {
             expect(stats.completionRate).to.equal(100);
         });
 
+        // The pact card renders this to show who has and has not shown up
+        // today. It defaults to false so a caller that has not resolved it —
+        // the zeroed pending-pact path — cannot accidentally imply a member
+        // checked in.
+        it('defaults checkedInToday to false and carries it through when given', () => {
+            expect(buildPactMemberStats({ scheduledCount: 1, completedCheckins: 1 }).checkedInToday).to.equal(false);
+            expect(buildPactMemberStats({
+                scheduledCount: 1,
+                completedCheckins: 1,
+                checkedInToday: true,
+            }).checkedInToday).to.equal(true);
+        });
+
         it('zeroes out cleanly when nothing is scheduled yet', () => {
             const stats = buildPactMemberStats({ scheduledCount: 0, completedCheckins: 0 });
             expect(stats).to.deep.equal({
@@ -141,6 +155,7 @@ describe('pactMemberStats', () => {
                 currentStreak: 0,
                 longestStreak: 0,
                 completionRate: 0,
+                checkedInToday: false,
             });
         });
 


### PR DESCRIPTION
Backend and shared-library half of [`docs/WORK_IN_PROGRESS.md`](https://github.com/rili-live/therr-app/blob/general/docs/WORK_IN_PROGRESS.md) § 2.6.2 and § 2.6.3. Two independent commits; either can be dropped without touching the other.

The mobile half of § 2.6.2 is [rili-live/therr-app#2811](https://github.com/rili-live/therr-app/pull/2811) against `niche/HABITS-general`.

---

## § 2.6.2 — `checkedInToday` on pact member stats

Duolingo's Friend Streak — a streak shared with up to five people, no leaderboard, no messaging, no new content — makes learners **22% more likely** to complete their daily lesson. It adds nothing but a second reader, which only works if a partner's absence is *noticeable*.

Pacts are already the right shape (`MAX_BULK_INVITEES = 5`) and `attachPactMemberStats` already derives each member's `currentStreak`, but nothing said who had actually shown up **today**.

- New `HabitCheckinsStore.getCompletedOnDateForPairs` — one batched query over the pairs the helper already collects, so the pacts list stays at a fixed query count regardless of how many pacts or members are on the page (three queries → four).
- `checkedInToday` added to `IPactMemberStats`, `ZERO_PACT_MEMBER_STATS` and `buildPactMemberStats`.
- Resolved on the service's **UTC habit day** — the same day the check-in write path stores in `scheduledDate`, not the viewer's local calendar day.

It is a statement about the member's *habit*, not about the pact, so it stays factual for a pact that has already ended and the caller decides where showing it makes sense. On the `therr-react` type it is **optional**: a client may be talking to a users-service that predates this, and "unknown" has to render as nothing rather than as a missed day.

## § 2.6.3 — expiry sweep and renewal

The RCT meta-analysis behind this work measured a Hedges' g of **0.42** on physical activity that decayed to **0.15** at 12–24 week follow-up. Gamified effects are real and they fade, which is why the intervention has to be renewed on a cycle rather than run open-ended. Pacts already have the cycle (`durationDays` of 7/14/30/90) — nothing closed it.

**1. Expiry sweep in the daily digest.** `PactsStore.expire()`, `PactsStore.getExpiredPacts()` and `pactHelpers.shouldExpirePact` have all existed since the pact schema landed and **nothing has ever called any of them**, so a pact reached its `endDate` and stayed `active` forever — still drawing digest reads, still rendering as in-flight, still counting against the one-live-pact-per-habit rule that now gates renewal.

The sweep runs *before* the active-pact read, so a pact cannot be warned that it expires in zero days on the same run that ends it. A sweep failure is counted and logged rather than failing the digest — an un-swept pact is exactly what every run before this one did. New `pactsExpired` counter is additive to the shape `therr-messaging-automator` logs, so an older automator simply does not print it.

**2. `PUT /habits/pacts/:id/renew`** — a new cycle on the same habit goal, registered in the service router and the gateway, with `PactsService.renew` / `HabitActions.renewPact` in `therr-react`.

Three properties carry the feature, each of which fails silently if broken:

| Property | Why it matters | How it's held |
|---|---|---|
| **The streak survives** | `habits.streaks` is keyed `(userId, habitGoalId)`, never on `pactId`. A renewal that reset it would take the strongest mechanic away from the user on a day they did nothing wrong. | Nothing in the renew path touches a streak; the test stubs `resetStreak`, `update` and `deactivate` and asserts none is called. |
| **One live pact per habit** | Two parallel pacts on one goal get the check-in path crediting the same check-in twice. | 409 while a live pact exists. |
| **Partners are re-invited, not re-enrolled** | A pact is a mutual commitment for a fixed number of days; one member tapping re-commit must not sign the others up for another 30. | New pact follows the same `pending` → activate-on-first-acceptance path as every other pact, and activates immediately only when nobody is left to accept. |

Other decisions worth a reviewer's eye:

- Only a **finished** cycle can be renewed. An `active` pact past its `endDate` counts as finished, so renewal never depends on the nightly sweep having run. `abandoned` is excluded — someone who walked away should start fresh deliberately.
- Members who `left`, were `removed`, or never accepted are **not** carried over; re-inviting them would turn a renewal into a fresh round of asking people who already said no.
- **No free-tier capacity check.** The cap counts habits *tracked*, and this habit is already one of them. `getOrCreate` will not resurrect an archived row, so a renewal cannot smuggle an extra habit past the limit either.
- Eligibility and carry-over are pure helpers (`isPactRenewable`, `selectRenewalInvitees`) so the handler and its tests share one definition rather than mirroring it.

## Verification

| Gate | Result |
|---|---|
| users-service unit tests | **918 passing**, 0 failing (was 890 + 28 new/updated) |
| `pr:typecheck:users` | clean |
| `pr:typecheck:gateway` | clean |
| `pr:typecheck:therr-react` | clean |
| `eslint` on all changed files | 0 errors (2 pre-existing `import/no-extraneous-dependencies` warnings in the gateway router, present on `general` before this change) |
| `locales:check` | OK, all 3 locales in parity |

New tests: `handlers-pacts-renew.test.ts` (19 cases — eligibility, carry-over, and the handler driven against stubbed stores), plus three digest-sweep cases and one `checkedInToday` case in the existing suites.

Two existing tests were updated rather than worked around: `pactMemberStats.test.ts`'s deep-equals gained the new field, and the digest suite now stubs the two store reads the sweep added.

Integration tests were not run — they need the Docker Compose infrastructure, which is not available in this environment.

## Deploy note

The sweep will close out **every** pact currently sitting past its `endDate` on its first run after deploy — potentially a large batch, since nothing has ever swept. They are already over; this only makes the status honest. `pactsExpired` in the digest response reports the size of that first wave.