### PR TITLE
fix(map): keep action buttons in sync with the preview strip and drop far-away areas

### DIFF
--- a/TherrMobile/__tests__/utilities/feedRanking.test.ts
+++ b/TherrMobile/__tests__/utilities/feedRanking.test.ts
@@ -11,6 +11,7 @@ import {
     getPostRankingScore,
     getReplyCount,
     getTopReply,
+    orderAreaPreviewStrip,
     rankAreaPreviews,
     rankFeedPosts,
     shouldAutoExpandThread,
@@ -261,6 +262,81 @@ describe('feedRanking', () => {
 
         it('handles empty input', () => {
             expect(rankAreaPreviews([] as any, [] as any)).toEqual([]);
+        });
+    });
+
+    describe('orderAreaPreviewStrip', () => {
+        const PRESSED_RADIUS_METERS = 120;
+        const order = (areas: any[], options: any = {}) => orderAreaPreviewStrip(areas as any, {
+            pressedAreaRadiusMeters: PRESSED_RADIUS_METERS,
+            ...options,
+        }).map((a) => a.id);
+
+        const area = (id: string, distanceFromPress: number, extra: any = {}) => ({
+            id,
+            areaType: 'spaces',
+            createdAt: hoursAgo(2),
+            distanceFromPress,
+            distanceFromUser: distanceFromPress,
+            ...extra,
+        });
+
+        it('leads with the area the user actually pressed', () => {
+            const pressed = area('pressed', 30);
+            const closer = area('closer', 0.001);
+            expect(order([closer, pressed], { pressedAreaId: 'pressed' })).toEqual(['pressed', 'closer']);
+        });
+
+        it('treats an area within the pressed radius as the pressed area', () => {
+            const onTop = area('onTop', 50 * MILES_PER_METER);
+            const nearby = area('nearby', 2);
+            expect(order([onTop, nearby])).toEqual(['onTop', 'nearby']);
+        });
+
+        it('hoists a nearby featured area ahead of unfeatured content', () => {
+            const featured = area('featured', 3, { featuredIncentiveRewardKey: 'reward' });
+            const plain = area('plain', 1);
+            expect(order([plain, featured])).toEqual(['featured', 'plain']);
+        });
+
+        it('does not hoist a featured area the user could not plausibly reach', () => {
+            const farFeatured = area('farFeatured', 260, { featuredIncentiveRewardKey: 'reward' });
+            const plain = area('plain', 1);
+            expect(order([farFeatured, plain])).toEqual(['plain']);
+        });
+
+        it('does not hoist a featured area past the hoist radius but inside the strip', () => {
+            const midFeatured = area('midFeatured', 40, { featuredIncentiveRewardKey: 'reward' });
+            const plain = area('plain', 1);
+            // Already in rank order — the assertion is that midFeatured stays where ranking
+            // put it rather than jumping the queue the way a nearby featured area does.
+            expect(order([plain, midFeatured])).toEqual(['plain', 'midFeatured']);
+        });
+
+        it('drops areas beyond the strip radius even when they rank first', () => {
+            const stale = area('stale', 400);
+            const near = area('near', 2);
+            expect(order([stale, near])).toEqual(['near']);
+        });
+
+        it('keeps the pressed area even when it is beyond the strip radius', () => {
+            const pressed = area('pressed', 400);
+            expect(order([pressed], { pressedAreaId: 'pressed' })).toEqual(['pressed']);
+        });
+
+        it('skips the distance ceilings for an explicitly provided overlapping set', () => {
+            const farFeatured = area('farFeatured', 400, { featuredIncentiveRewardKey: 'reward' });
+            const near = area('near', 2);
+            expect(order([farFeatured, near], { hasExplicitAreas: true })).toEqual(['farFeatured', 'near']);
+        });
+
+        it('caps the number of cards handed to the strip', () => {
+            const many = Array.from({ length: 150 }, (_, i) => area(`a${i}`, 1));
+            expect(orderAreaPreviewStrip(many as any, { pressedAreaRadiusMeters: PRESSED_RADIUS_METERS })).toHaveLength(100);
+        });
+
+        it('handles empty input', () => {
+            expect(order([])).toEqual([]);
         });
     });
 

--- a/TherrMobile/main/routes/Map/TherrMapView.tsx
+++ b/TherrMobile/main/routes/Map/TherrMapView.tsx
@@ -40,7 +40,7 @@ import mapStyles from '../../styles/map';
 import mapCustomStyle from '../../styles/map/googleCustom';
 import MarkerIcon from './MarkerIcon';
 import { getUserContentUri, isMyContent } from '../../utilities/content';
-import { rankAreaPreviews } from '../../utilities/feedRanking';
+import { orderAreaPreviewStrip, rankAreaPreviews } from '../../utilities/feedRanking';
 import AreaDisplayCard from '../../components/UserContent/AreaDisplayCard';
 import AreaCreatePromptCard from '../../components/UserContent/AreaCreatePromptCard';
 import { isUserAuthenticated } from '../../utilities/authUtils';
@@ -237,6 +237,14 @@ class TherrMapView extends React.PureComponent<ITherrMapViewProps, ITherrMapView
         this.unsubscribeFocusListener = navigation.addListener('focus', () => {});
 
         this.unsubscribeBlurListener = navigation.addListener('blur', () => {
+            // The parent owns the map action buttons and drops them to their compact,
+            // lifted-clear-of-the-strip subset while the strip is open. Closing the strip
+            // here without telling it stranded that layout: navigating back to the map left
+            // two buttons floating above a strip that was no longer there, with no way to
+            // get the rest back short of opening and closing the strip again.
+            if (this.state.isPreviewBottomSheetVisible) {
+                this.props.onPreviewBottomSheetClose();
+            }
             this.setState({
                 isPreviewBottomSheetVisible: false,
                 areaInPreviewIndex: -1,
@@ -604,21 +612,18 @@ class TherrMapView extends React.PureComponent<ITherrMapViewProps, ITherrMapView
             // even when the strip is showing an explicitly-provided overlapping set.
             const sortedAreasWithDistance = rankAreaPreviews(areasWithDistance, filteredMoments);
 
-            const areasArray: any[] = [];
-            let pressedAreas: any[] = [];
-            let featuredAreas: any[] = [];
             const missingMedias: {
                 path: string;
                 type: string;
             }[] = [];
 
-            sortedAreasWithDistance.some((area: any, index: number) => {
-                // Prevent loading spaces from too far away to be relevant
-                // Stop after 100 miles
-                if (index >= 20 && area.distanceFromUser && area.distanceFromUser > 100) {
-                    return true;
-                }
+            modifiedAreasInPreview = orderAreaPreviewStrip(sortedAreasWithDistance, {
+                pressedAreaId,
+                pressedAreaRadiusMeters: MAX_DISTANCE_TO_NEARBY_SPACE,
+                hasExplicitAreas: !!overlappingAreas?.length,
+            });
 
+            modifiedAreasInPreview.forEach((area: any) => {
                 if (area.medias?.length) {
                     area.medias
                         .forEach((media) => {
@@ -629,24 +634,7 @@ class TherrMapView extends React.PureComponent<ITherrMapViewProps, ITherrMapView
                 }
 
                 area.distance = getReadableDistance(area.distanceFromUser);
-
-                if (pressedAreaId && area.id === pressedAreaId) {
-                    pressedAreas.push(area);
-                } else if (pressedAreas.length < 1 && (area.distanceFromPress * METERS_PER_MILE) < MAX_DISTANCE_TO_NEARBY_SPACE) {
-                    // Prioritize area over featured when approximate press/click or search specific area by name
-                    pressedAreas.push(area);
-                } else if (area.featuredIncentiveRewardKey && featuredAreas.length < 2) {
-                    // TODO: Prioritize top 2 with highest rewards nearby
-                    featuredAreas.push(area);
-                } else {
-                    areasArray.push(area);
-                }
-
-                // Prevent loading too many areas in preview
-                return index >= 99;
             });
-
-            modifiedAreasInPreview = pressedAreas.concat(featuredAreas).concat(areasArray);
             if (missingMedias.length) {
                 this.fetchPrivateMedia(missingMedias);
             }

--- a/TherrMobile/main/routes/Map/index.tsx
+++ b/TherrMobile/main/routes/Map/index.tsx
@@ -437,8 +437,12 @@ class Map extends React.PureComponent<IMapProps, IMapState> {
             const { map, location, route: inScopeRoute } = this.props;
             const restoredScrollIndex = inScopeRoute?.params?.previewScrollIndex || 0;
             this.expandBottomSheet(-1);
+            // TherrMapView tears the strip down on blur, so it is always closed by the time
+            // the map is focused again. Anything below that re-opens it sets this back to
+            // true once its search resolves.
             this.setState({
                 areButtonsVisible: true,
+                isPreviewStripOpen: false,
             });
             setSearchDropdownVisibility(false);
 

--- a/TherrMobile/main/utilities/feedRanking.ts
+++ b/TherrMobile/main/utilities/feedRanking.ts
@@ -359,6 +359,86 @@ export const rankAreaPreviews = (areas: IRankablePost[], moments: IRankablePost[
 };
 
 /**
+ * Beyond this radius an area is dropped from the preview strip outright. `filteredSpaces`
+ * is a redux cache that accumulates across searches and across locations, and a couple of
+ * miles out the proximity term has already decayed to ~0 — so without a hard ceiling a space
+ * left over from a previous city is ordered on recency and engagement alone and can lead the
+ * strip.
+ */
+const MAX_AREA_PREVIEW_DISTANCE_MILES = 100;
+
+/**
+ * Featured (reward-bearing) areas are hoisted ahead of closer content. That trade only pays
+ * off for a reward the user could plausibly go claim, so a featured area past this radius is
+ * ordered like any other area instead of jumping the queue.
+ */
+const MAX_FEATURED_HOIST_DISTANCE_MILES = 25;
+
+/** Hard cap on cards handed to the strip. */
+const MAX_AREA_PREVIEW_COUNT = 100;
+
+interface IAreaPreviewStripOptions {
+    /** The area the user actually tapped, if the press resolved to a marker. */
+    pressedAreaId?: string;
+    /** Radius (meters) within which an untapped area still counts as "the thing pressed". */
+    pressedAreaRadiusMeters: number;
+    /**
+     * Set when the caller passed an explicit set of overlapping areas (markers stacked at one
+     * point). That set is the answer to the press by construction, so the distance ceilings
+     * are skipped for it.
+     */
+    hasExplicitAreas?: boolean;
+}
+
+/**
+ * Buckets an already-ranked area list into the order the preview strip renders: the pressed
+ * area first, then up to two nearby featured areas, then everything else in rank order.
+ *
+ * Distances are measured from the pressed coordinate rather than from the user, because
+ * panning to another city and pressing there is a supported way to browse it — the ceilings
+ * are about "far from what you asked about", not "far from home".
+ */
+export const orderAreaPreviewStrip = (
+    rankedAreas: IRankablePost[],
+    { pressedAreaId, pressedAreaRadiusMeters, hasExplicitAreas }: IAreaPreviewStripOptions,
+): IRankablePost[] => {
+    const pressedAreas: IRankablePost[] = [];
+    const featuredAreas: IRankablePost[] = [];
+    const remainingAreas: IRankablePost[] = [];
+
+    (rankedAreas || []).some((area) => {
+        const isPressedArea = !!pressedAreaId && area.id === pressedAreaId;
+        const milesFromPress = area.distanceFromPress || 0;
+        const isWithinStrip = hasExplicitAreas
+            || isPressedArea
+            || milesFromPress <= MAX_AREA_PREVIEW_DISTANCE_MILES;
+
+        if (isWithinStrip) {
+            if (isPressedArea) {
+                pressedAreas.push(area);
+            } else if (!pressedAreaId
+                && pressedAreas.length < 1
+                && (milesFromPress * METERS_PER_MILE) < pressedAreaRadiusMeters) {
+                // Prioritize area over featured when the press did not resolve to a marker
+                // (an approximate tap, or a search by name) but landed on top of one anyway.
+                pressedAreas.push(area);
+            } else if (area.featuredIncentiveRewardKey
+                && featuredAreas.length < 2
+                && (hasExplicitAreas || milesFromPress <= MAX_FEATURED_HOIST_DISTANCE_MILES)) {
+                // TODO: Prioritize top 2 with highest rewards nearby
+                featuredAreas.push(area);
+            } else {
+                remainingAreas.push(area);
+            }
+        }
+
+        return pressedAreas.length + featuredAreas.length + remainingAreas.length >= MAX_AREA_PREVIEW_COUNT;
+    });
+
+    return pressedAreas.concat(featuredAreas).concat(remainingAreas);
+};
+
+/**
  * Auto-expand criteria: threads with real conversation (2+ replies) always expand;
  * single-reply threads only expand when there is a like signal on the parent or reply.
  */


### PR DESCRIPTION
Two bugs reported from the map screen on mobile.

## 1. Action buttons stranded in compact mode after navigating back

`MapActionButtons` has a compact mode: while the area preview strip is open it drops to two FABs (GPS recenter + the featured create action), translated up by `areaPreviewStripFootprint` to clear the strip.

`TherrMapView` tears the strip down on `blur` but never told the parent, so `Map`'s `isPreviewStripOpen` stayed `true` across the navigation. Returning to the map left `isCompact` on with no strip underneath — two buttons floating above the bottom nav, and no way to get the rest back short of opening and closing the strip again.

`ViewSpace`'s footer *Back* button re-opens the strip (`shouldShowPreview: true`), which masks it, but the Map tab, the header logo, and the OS back gesture all pop without that param.

- The blur handler now calls `onPreviewBottomSheetClose()` when it closes an open strip.
- `Map`'s focus listener also resets `isPreviewStripOpen`, so the invariant holds even if blur is missed.

## 2. Preview strip led by a space hundreds of miles away

In `togglePreviewBottomSheet`, featured (reward-bearing) areas were hoisted to the front of the strip with **no distance check at all**. The only distance guard was `if (index >= 20 && distanceFromUser > 100) return true` — it did not apply to the first 20 entries, and it stopped iteration rather than filtering.

`filteredSpaces` is a redux cache that accumulates across searches and across locations, and past a couple of miles the proximity term (`exp(-d / 800m)`) has decayed to ~0 — so a stale featured space from a previous location wins on recency and engagement alone and takes the lead card, with everything after it sensibly close.

The bucketing moves out of `TherrMapView` into `orderAreaPreviewStrip` in `feedRanking.ts`, where it is a pure function and testable:

- Distances measured from the **pressed coordinate** rather than from the user — panning to another city and pressing there is a supported way to browse it, so the ceilings are about "far from what you asked about", not "far from home".
- Areas beyond 100 miles of the press are dropped outright.
- A featured area is only hoisted when it is within 25 miles; past that it is ordered like any other area.
- An explicitly provided overlapping set (stacked markers) skips both ceilings, since that set is the answer to the press by construction.
- The pressed area now always leads, instead of possibly landing behind an unrelated area that happened to sit inside the 120 m press radius.

## Verification

- 10 new unit tests for `orderAreaPreviewStrip` in `TherrMobile/__tests__/utilities/feedRanking.test.ts`.
- Full mobile suite: 61 suites / 1379 tests passing.
- ESLint clean on the touched files (the two remaining warnings are pre-existing inline styles elsewhere in those files).

Based on `general` per CLAUDE.md — `general → stage → main` is the only path to production, and this is flagship-app behavior rather than niche branding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bnugf8vywNJdbD6pekTioE


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bnugf8vywNJdbD6pekTioE)_