### PR TITLE
fix(habits): keep the custom-habit input visible above the keyboard

### DIFF
--- a/TherrMobile/__tests__/routes/CreatePactInviteKeyboardAvoidance.test.tsx
+++ b/TherrMobile/__tests__/routes/CreatePactInviteKeyboardAvoidance.test.tsx
@@ -1,0 +1,130 @@
+import {
+    it, describe, expect, jest, beforeEach,
+} from '@jest/globals';
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
+import { KeyboardAwareScrollView, KeyboardStickyView } from 'react-native-keyboard-controller';
+
+/**
+ * Keyboard avoidance in the create-pact wizard.
+ *
+ * "Or create your own" is the escape hatch for anyone whose habit is not one of
+ * the templates, and it sits at the very bottom of step 1, directly above the
+ * action bar. The app runs edge-to-edge, so the Android window does not resize
+ * when the IME opens: a plain `ScrollView` plus a `position: absolute` footer
+ * left both the input and the Next button underneath the keyboard, and the user
+ * could not see what they were typing.
+ *
+ * The fix is structural rather than cosmetic, so these tests assert the
+ * structure: the wizard scrolls inside a `KeyboardAwareScrollView` that is told
+ * to keep the focused input clear of the footer, and the footer rides on top of
+ * the keyboard inside a `KeyboardStickyView`.
+ */
+
+jest.mock('react-native-toast-message', () => ({
+    __esModule: true,
+    default: { show: jest.fn() },
+}));
+
+jest.mock('../../main/utilities/permissionsOrchestrator', () => ({
+    __esModule: true,
+    default: { requestIfAppropriate: jest.fn() },
+}));
+
+// Imported after the mocks above deliberately — the screen pulls in a chain of
+// native modules at import time.
+import { CreatePactInvite } from '../../main/routes/Pacts/CreatePactInvite';
+
+const BOTTOM_INSET = 24;
+
+/** Collects every element in a rendered React tree, depth-first. */
+const flattenElements = (node: any, collected: any[] = []): any[] => {
+    if (Array.isArray(node)) {
+        node.forEach((child) => flattenElements(child, collected));
+        return collected;
+    }
+    if (!node || typeof node !== 'object') {
+        return collected;
+    }
+    collected.push(node);
+    flattenElements(node.props?.children, collected);
+    return collected;
+};
+
+/**
+ * Both the body and the footer read the safe-area inset through a render-prop
+ * consumer, so the tree stops at the consumer until its child is called.
+ */
+const resolveInsetConsumers = (node: any): any[] => flattenElements(node)
+    .filter((el: any) => el.type === SafeAreaInsetsContext.Consumer)
+    .map((el: any) => el.props.children({ top: 0, bottom: BOTTOM_INSET, left: 0, right: 0 }));
+
+const buildWizard = () => {
+    const props: any = {
+        user: { settings: {}, isAuthenticated: true, details: { id: 'me' } },
+        habits: { templates: [], habitGoals: [], pacts: [] },
+        userConnections: { connections: [] },
+        navigation: { navigate: jest.fn(), goBack: jest.fn(), setOptions: jest.fn() },
+        route: { params: {} },
+        getTemplates: jest.fn(),
+        createGoal: jest.fn(),
+        bulkInvitePact: jest.fn(),
+        startUserHabit: jest.fn(),
+        getUserHabitEligibility: jest.fn(),
+        searchUsers: jest.fn(),
+    };
+
+    const instance = new CreatePactInvite(props);
+    instance.setState = jest.fn() as any;
+
+    return instance;
+};
+
+describe('create-pact wizard keyboard avoidance', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('scrolls the wizard body in a keyboard-aware scroll view', () => {
+        const scrollViews = resolveInsetConsumers(buildWizard().render())
+            .filter((el: any) => el?.type === KeyboardAwareScrollView);
+
+        expect(scrollViews).toHaveLength(1);
+    });
+
+    it('keeps the focused input clear of the footer, not just of the keyboard', () => {
+        // A bottomOffset of 0 scrolls the input flush with the top of the
+        // keyboard, which on this screen means flush underneath the action bar.
+        const [scrollView] = resolveInsetConsumers(buildWizard().render())
+            .filter((el: any) => el?.type === KeyboardAwareScrollView);
+
+        expect(scrollView.props.bottomOffset).toBeGreaterThan(0);
+    });
+
+    it('leaves room to scroll past the footer', () => {
+        const [scrollView] = resolveInsetConsumers(buildWizard().render())
+            .filter((el: any) => el?.type === KeyboardAwareScrollView);
+        const { paddingBottom } = scrollView.props.contentContainerStyle;
+
+        expect(paddingBottom).toBeGreaterThan(scrollView.props.bottomOffset + BOTTOM_INSET);
+    });
+
+    it('sticks the action bar to the top of the keyboard', () => {
+        const [footer] = resolveInsetConsumers(buildWizard().renderFooter());
+        // The footer is its own function component so it can subscribe to
+        // keyboard state; call it to reach the sticky wrapper it renders.
+        const rendered = footer.type(footer.props);
+
+        expect(rendered.type).toBe(KeyboardStickyView);
+        expect(rendered.props.style).toMatchObject({ position: 'absolute', bottom: 0 });
+    });
+
+    it('reports the footer height so the scroll view can offset by it', () => {
+        const instance = buildWizard();
+        const [footer] = resolveInsetConsumers(instance.renderFooter());
+        const measured = footer.type(footer.props).props.children;
+
+        measured.props.onLayout({ nativeEvent: { layout: { height: 123 } } });
+
+        expect(instance.setState).toHaveBeenCalledWith({ footerHeight: 123 });
+    });
+});

--- a/TherrMobile/main/routes/Pacts/CreatePactInvite.tsx
+++ b/TherrMobile/main/routes/Pacts/CreatePactInvite.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import {
-    ScrollView,
     View,
     Text,
     Pressable,
     TextInput,
     ActivityIndicator,
     Share,
+    LayoutChangeEvent,
 } from 'react-native';
 import { SafeAreaView, SafeAreaInsetsContext } from 'react-native-safe-area-context';
+import { KeyboardAwareScrollView, KeyboardStickyView, useKeyboardState } from 'react-native-keyboard-controller';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -41,6 +42,9 @@ import { getSoloUnlockProgress } from '../../utilities/soloHabitUnlock';
 
 const MAX_PARTNERS = 5;
 const DEFAULT_PACT_DURATION_DAYS = 30;
+// Used to keep a focused input clear of the footer until the footer reports its
+// real height (one layout pass), so the very first focus is not left underneath it.
+const FOOTER_HEIGHT_FALLBACK = 96;
 
 interface IConnectionDetails {
     id: string;
@@ -80,6 +84,7 @@ interface ICreatePactInviteState {
     isSending: boolean;
     isLoadingTemplates: boolean;
     isStartingSolo: boolean;
+    footerHeight: number;
 }
 
 const mapStateToProps = (state: any) => ({
@@ -117,7 +122,53 @@ const partnerDisplayName = (
     return details.userName || fallback;
 };
 
-class CreatePactInvite extends React.Component<ICreatePactInviteProps, ICreatePactInviteState> {
+/**
+ * The wizard's action bar is bottom-anchored, so under edge-to-edge the Android
+ * keyboard covers it (and, on step 1, the custom-habit input sitting just above
+ * it). `KeyboardStickyView` translates the bar up with the keyboard instead.
+ * Once the bar is riding on top of the keyboard the gesture-bar inset no longer
+ * applies to it, so that padding is dropped while the keyboard is open —
+ * otherwise a band of empty surface sits between the buttons and the keys.
+ */
+const WizardFooter = ({
+    bottomInset,
+    backgroundColor,
+    shadowColor,
+    onLayout,
+    children,
+}: {
+    bottomInset: number;
+    backgroundColor: string;
+    shadowColor: string;
+    onLayout: (event: LayoutChangeEvent) => void;
+    children: React.ReactNode;
+}) => {
+    const isKeyboardVisible = useKeyboardState((state) => state.isVisible);
+
+    return (
+        <KeyboardStickyView style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}>
+            <View
+                onLayout={onLayout}
+                style={{
+                    flexDirection: 'row',
+                    paddingHorizontal: 16,
+                    paddingTop: 16,
+                    paddingBottom: 16 + (isKeyboardVisible ? 0 : bottomInset),
+                    backgroundColor,
+                    shadowColor,
+                    shadowOffset: { width: 0, height: -2 },
+                    shadowOpacity: 0.1,
+                    shadowRadius: 4,
+                    elevation: 4,
+                }}
+            >
+                {children}
+            </View>
+        </KeyboardStickyView>
+    );
+};
+
+export class CreatePactInvite extends React.Component<ICreatePactInviteProps, ICreatePactInviteState> {
     private translate: (key: string, params?: any) => string;
     private theme = buildStyles();
     private themeButtons = buildButtonStyles();
@@ -141,6 +192,7 @@ class CreatePactInvite extends React.Component<ICreatePactInviteProps, ICreatePa
             isSending: false,
             isLoadingTemplates: false,
             isStartingSolo: false,
+            footerHeight: FOOTER_HEIGHT_FALLBACK,
         };
 
         this.theme = buildStyles(props.user.settings?.mobileThemeName);
@@ -923,23 +975,11 @@ class CreatePactInvite extends React.Component<ICreatePactInviteProps, ICreatePa
                 {(insets) => {
                     const bottomInset = insets?.bottom ?? bottomSafeAreaInset;
                     return (
-                        <View
-                            style={{
-                                position: 'absolute',
-                                bottom: 0,
-                                left: 0,
-                                right: 0,
-                                flexDirection: 'row',
-                                paddingHorizontal: 16,
-                                paddingTop: 16,
-                                paddingBottom: 16 + bottomInset,
-                                backgroundColor: this.theme.colors.surface,
-                                shadowColor: this.theme.colors.textBlack,
-                                shadowOffset: { width: 0, height: -2 },
-                                shadowOpacity: 0.1,
-                                shadowRadius: 4,
-                                elevation: 4,
-                            }}
+                        <WizardFooter
+                            bottomInset={bottomInset}
+                            backgroundColor={this.theme.colors.surface}
+                            shadowColor={this.theme.colors.textBlack}
+                            onLayout={this.onFooterLayout}
                         >
                             <Pressable
                                 onPress={this.handleBack}
@@ -961,15 +1001,24 @@ class CreatePactInvite extends React.Component<ICreatePactInviteProps, ICreatePa
                                     disabled={isBusy}
                                 />
                             </View>
-                        </View>
+                        </WizardFooter>
                     );
                 }}
             </SafeAreaInsetsContext.Consumer>
         );
     };
 
+    onFooterLayout = (event: LayoutChangeEvent) => {
+        const { height } = event.nativeEvent.layout;
+
+        if (height > 0 && Math.round(height) !== Math.round(this.state.footerHeight)) {
+            this.setState({ footerHeight: height });
+        }
+    };
+
     render() {
         const { user } = this.props;
+        const { footerHeight } = this.state;
 
         return (
             <>
@@ -982,9 +1031,16 @@ class CreatePactInvite extends React.Component<ICreatePactInviteProps, ICreatePa
                         {(insets) => {
                             const bottomInset = insets?.bottom ?? bottomSafeAreaInset;
                             return (
-                                <ScrollView contentContainerStyle={{ paddingBottom: 120 + bottomInset }}>
+                                /* `bottomOffset` keeps the focused input (the custom-habit
+                                 * name on step 1, the people search on step 2) clear of the
+                                 * action bar that sticks to the top of the keyboard. */
+                                <KeyboardAwareScrollView
+                                    bottomOffset={footerHeight}
+                                    keyboardShouldPersistTaps="handled"
+                                    contentContainerStyle={{ paddingBottom: footerHeight + 24 + bottomInset }}
+                                >
                                     {this.renderStepContent()}
-                                </ScrollView>
+                                </KeyboardAwareScrollView>
                             );
                         }}
                     </SafeAreaInsetsContext.Consumer>


### PR DESCRIPTION
## The bug

On step 1 of the create-pact wizard ("Pick a habit"), tapping **Or create your own** opens the Android keyboard directly over the input — the user cannot see the habit name they are typing, and the Cancel/Next bar is buried too.

The screen scrolled in a plain `ScrollView` with a `position: absolute` action bar. The app runs edge-to-edge (`setDecorFitsSystemWindows(false)`), so the window does not resize when the IME opens, and `android:windowSoftInputMode="adjustResize"` alone does not save the layout. The custom-habit input is the last thing in the step-1 content, sitting right above the bar, so it is the first thing the keyboard covers.

## The fix

`TherrMobile/main/routes/Pacts/CreatePactInvite.tsx`:

- **Body scrolls in `KeyboardAwareScrollView`** (`react-native-keyboard-controller`, the pattern already used by Register, EditEvent, EditGroup and friends), with `bottomOffset` set to the *measured* footer height so a focused input is scrolled clear of the action bar rather than flush underneath it. Step 2's people-search input gets the same treatment for free.
- **The action bar rides the keyboard** via `KeyboardStickyView`. While the keyboard is open the gesture-bar inset no longer applies to the bar, so that padding is dropped — otherwise a band of empty surface sits between the buttons and the keys. The bar is now its own small function component (`WizardFooter`) so it can subscribe to keyboard state; `ViewThought` does the same thing for its reply bar.
- **`keyboardShouldPersistTaps="handled"`** so picking a template or scrolling with the keyboard open takes one tap instead of two.
- `contentContainerStyle` bottom padding now derives from the measured footer height instead of the hard-coded `120`.

The keyboard height reported on Android is the full IME inset here (the library treats an edge-to-edge app as having a translucent navigation bar), so the bar lands exactly on the top edge of the keyboard.

## Tests

New `TherrMobile/__tests__/routes/CreatePactInviteKeyboardAvoidance.test.tsx` walks the wizard's rendered tree and asserts the structure the fix depends on: the body is a `KeyboardAwareScrollView`, its `bottomOffset` is non-zero, the content leaves room to scroll past the footer, the footer renders inside a `KeyboardStickyView`, and the footer reports its height back for the offset. The unconnected class is now exported so the test can build it the way the dashboard tests build `HabitsDashboard`.

```
npm test -- __tests__/routes --testPathPattern "Pact"   # 33 suites, 717 tests passing
npx eslint <changed files>                              # 0 errors (pre-existing inline-style warnings only)
npm run pr:tsc-baseline:mobile                          # current=105 baseline=105, no new errors
```

Not yet verified on a device — worth a quick look on an Android phone with gesture navigation before merging.

## Branch

Mobile-only (`TherrMobile/**`), so it targets `niche/HABITS-general` per the branch rules. Nothing here touches shared or backend paths.

---
_Generated by [Claude Code](https://claude.ai/code/session_019sEFEg8qP2wpubtZ3hyoGu)_