### PR TITLE
Add LaunchKiwi badge to the Friends with Habits landing page

### DIFF
--- a/therr-client-web/src/__tests__/habitsLandingSeo.test.ts
+++ b/therr-client-web/src/__tests__/habitsLandingSeo.test.ts
@@ -78,6 +78,37 @@ describe('habits landing page SEO markup', () => {
         expect(template.match(/<h1[\s>]/g)).toHaveLength(1);
     });
 
+    it('allows every third-party image host it embeds through the CSP', () => {
+        // Helmet's CSP is only applied outside development, so an img-src omission
+        // renders fine locally and breaks the image in production silently.
+        const serverClient = fs.readFileSync(path.join(__dirname, '../server-client.tsx'), 'utf8');
+        const imgSrcBlock = serverClient.match(/imgSrc: \[([\s\S]*?)\],/);
+        if (!imgSrcBlock) {
+            throw new Error('No imgSrc directive found in the server-client.tsx CSP');
+        }
+
+        const allowedSources = (imgSrcBlock[1].match(/'([^']+)'/g) || []).map((entry) => entry.slice(1, -1));
+        const isAllowed = (host: string) => allowedSources.some((source) => {
+            const sourceHost = source.replace(/^https:\/\//, '');
+            return sourceHost.startsWith('*.')
+                ? host === sourceHost.slice(2) || host.endsWith(sourceHost.slice(1))
+                : host === sourceHost;
+        });
+
+        const externalImageHosts = new Set(
+            (template.match(/(?:src|srcset)="https:\/\/[^/"]+/g) || [])
+                .map((match) => match.replace(/^(?:src|srcset)="https:\/\//, '')),
+        );
+        expect(externalImageHosts.size).toBeGreaterThan(0);
+        externalImageHosts.forEach((host) => expect({ host, isAllowed: isAllowed(host) }).toEqual({ host, isAllowed: true }));
+    });
+
+    it('links the LaunchKiwi badge with a theme-aware source', () => {
+        expect(template).toContain('href="https://launchkiwi.com/p/friends-with-habits"');
+        expect(template).toContain('srcset="https://launchkiwi.com/badge-dark.svg" media="(prefers-color-scheme: dark)"');
+        expect(template).toContain('src="https://launchkiwi.com/badge-light.svg"');
+    });
+
     it('ships an absolute, correctly-sized Open Graph image', () => {
         // A summary_large_image card with no og:image renders as a blank link preview.
         expect(template).toContain('<meta property="og:image" content="https://habits.therr.com/assets/images/habits-og-image.png">');

--- a/therr-client-web/src/server-client.tsx
+++ b/therr-client-web/src/server-client.tsx
@@ -146,6 +146,8 @@ if (process.env.NODE_ENV !== 'development') {
                     'https://*.tile.openstreetmap.org',
                     'https://*.basemaps.cartocdn.com',
                     'https://unpkg.com',
+                    // LaunchKiwi badge on the Friends with Habits landing page
+                    'https://launchkiwi.com',
                 ],
                 workerSrc: ["'self'", 'blob:'],
             },

--- a/therr-client-web/src/views/habits/landing.hbs
+++ b/therr-client-web/src/views/habits/landing.hbs
@@ -312,6 +312,16 @@
             margin: 0;
             color: var(--habits-text-muted);
         }
+        section.featured {
+            padding: 2rem 0;
+            text-align: center;
+        }
+        section.featured a { display: inline-block; line-height: 0; }
+        section.featured img {
+            display: block;
+            max-width: 100%;
+            height: auto;
+        }
         footer.site-footer {
             padding: 2rem 0 3rem;
             border-top: 1px solid var(--habits-border);
@@ -653,6 +663,32 @@
                     <h3>Who makes Friends with Habits?</h3>
                     <p>Friends with Habits is built by Therr, Inc., the company behind the <a href="https://www.therr.app/" rel="noopener">Therr app</a> for local discovery and community. The two apps share one account system, so a single Therr login works for both.</p>
                 </div>
+            </div>
+        </section>
+
+        <!--
+            LaunchKiwi launch-directory badge. Two things this depends on:
+
+              1. launchkiwi.com must stay in the CSP img-src allowlist in
+                 server-client.tsx. Helmet's CSP only applies outside development,
+                 so a missing entry looks fine locally and renders a broken image
+                 in production with nothing on the page to say why.
+              2. The srcset swap is keyed on the visitor's OS theme, not the page's:
+                 this template has no dark palette, so a dark-mode visitor gets the
+                 dark badge on the light page. Pin the img to badge-light.svg and
+                 drop the <source> if that ever reads wrong.
+
+            width/height are kept on the img so the badge reserves its layout box
+            and does not shove the footer down as the SVG loads.
+        -->
+        <section class="featured">
+            <div class="container">
+                <a href="https://launchkiwi.com/p/friends-with-habits" target="_blank" rel="noopener">
+                    <picture>
+                        <source srcset="https://launchkiwi.com/badge-dark.svg" media="(prefers-color-scheme: dark)">
+                        <img src="https://launchkiwi.com/badge-light.svg" alt="Featured on LaunchKiwi" width="198" height="62">
+                    </picture>
+                </a>
             </div>
         </section>
     </main>


### PR DESCRIPTION
Adds the launch-directory badge below the FAQ on habits.therr.com, using a
<picture> element so the badge art follows the visitor's OS colour scheme:
badge-dark.svg under prefers-color-scheme: dark, badge-light.svg otherwise.

Also allowlists https://launchkiwi.com in the Helmet CSP img-src. Helmet only
runs outside development, so without this the badge renders locally and is
blocked in production with nothing on the page to indicate why.

Adds two guards to the landing-page test suite: one asserting the badge markup,
and one that cross-checks every external image host in the template against the
CSP img-src list, so the next embedded third-party image cannot silently ship
without its allowlist entry.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EJhPt7HLUHXnUzLfE8cSWY