### PR TITLE
fix(habits): fetch active pacts on dashboard refresh

### DIFF
--- a/TherrMobile/__tests__/components/CollapsibleHeaderTabView.test.tsx
+++ b/TherrMobile/__tests__/components/CollapsibleHeaderTabView.test.tsx
@@ -80,6 +80,25 @@ describe('getSceneContentContainerStyle', () => {
         expect(withInset.minHeight).toBe(withoutInset.minHeight);
     });
 
+    it('should add the top inset below the overlay so a card list clears the tab bar shadow', () => {
+        const withInset = getSceneContentContainerStyle({
+            containerHeight: CONTAINER_HEIGHT,
+            headerHeight: HEADER_HEIGHT,
+            tabBarHeight: TAB_BAR_HEIGHT,
+            topInset: 12,
+        });
+        const withoutInset = getSceneContentContainerStyle({
+            containerHeight: CONTAINER_HEIGHT,
+            headerHeight: HEADER_HEIGHT,
+            tabBarHeight: TAB_BAR_HEIGHT,
+        });
+
+        expect(withInset.paddingTop).toBe(HEADER_HEIGHT + TAB_BAR_HEIGHT + 12);
+        // The inset is spacing, not scroll range — the header must still collapse the
+        // same amount whether or not a brand asks for the extra gap.
+        expect(withInset.minHeight).toBe(withoutInset.minHeight);
+    });
+
     it('should stay benign before anything has been measured', () => {
         const style = getSceneContentContainerStyle({
             containerHeight: 0,

--- a/TherrMobile/main/components/CollapsibleHeaderTabView/index.tsx
+++ b/TherrMobile/main/components/CollapsibleHeaderTabView/index.tsx
@@ -52,6 +52,8 @@ interface ICollapsibleHeaderTabViewProps {
     lazyPreloadDistance?: number;
     /** Extra bottom padding for every list (e.g. to clear a bottom button menu). */
     listBottomInset?: number;
+    /** Extra top padding for every list, below the overlay (e.g. to clear the tab bar's shadow). */
+    listTopInset?: number;
     navigationState: { index: number; routes: any[] };
     onIndexChange: (index: number) => void;
     onLayout?: (event: LayoutChangeEvent) => void;
@@ -65,23 +67,26 @@ interface ICollapsibleHeaderTabViewProps {
 /**
  * Content padding/min-height for a scene's list.
  *
- * `paddingTop` clears the overlay (header + tab bar). `minHeight` guarantees the
- * list can always scroll at least a full header's worth, so a tab holding one item
- * — or none — can never strand the header in a collapsed state with no way to
- * scroll back up and reopen it.
+ * `paddingTop` clears the overlay (header + tab bar), plus `topInset` for scenes whose
+ * first item needs breathing room below the tab bar rather than sitting flush against
+ * it. `minHeight` guarantees the list can always scroll at least a full header's worth,
+ * so a tab holding one item — or none — can never strand the header in a collapsed
+ * state with no way to scroll back up and reopen it.
  */
 export const getSceneContentContainerStyle = ({
     containerHeight,
     headerHeight,
     tabBarHeight,
     bottomInset = 0,
+    topInset = 0,
 }: {
     containerHeight: number;
     headerHeight: number;
     tabBarHeight: number;
     bottomInset?: number;
+    topInset?: number;
 }): ViewStyle => ({
-    paddingTop: headerHeight + tabBarHeight,
+    paddingTop: headerHeight + tabBarHeight + topInset,
     paddingBottom: bottomInset,
     minHeight: containerHeight + headerHeight,
 });
@@ -148,6 +153,7 @@ const CollapsibleHeaderTabView = ({
     lazy,
     lazyPreloadDistance,
     listBottomInset = 0,
+    listTopInset = 0,
     navigationState,
     onIndexChange,
     onLayout,
@@ -302,7 +308,8 @@ const CollapsibleHeaderTabView = ({
         headerHeight,
         tabBarHeight,
         bottomInset: listBottomInset,
-    }), [containerHeight, headerHeight, tabBarHeight, listBottomInset]);
+        topInset: listTopInset,
+    }), [containerHeight, headerHeight, tabBarHeight, listBottomInset, listTopInset]);
 
     const collapsiblePropsByKey = React.useMemo(() => {
         const propsByKey: { [key: string]: ICollapsibleSceneProps } = {};

--- a/TherrMobile/main/routes/ViewUser/index.tsx
+++ b/TherrMobile/main/routes/ViewUser/index.tsx
@@ -63,12 +63,19 @@ import TherrIcon from '../../components/TherrIcon';
 import getDirections from '../../utilities/getDirections';
 import { PEOPLE_CAROUSEL_TABS, PROFILE_CAROUSEL_TABS } from '../../constants';
 import { buttonMenuHeight } from '../../styles/navigation/buttonMenu';
+import { space } from '../../styles/layouts/spacing';
 import { CURRENT_BRAND_VARIATION } from '../../config/brandConfig';
 
 const IS_HABITS = CURRENT_BRAND_VARIATION === BrandVariations.HABITS;
 
 const { width: viewportWidth } = Dimensions.get('window');
 const HABITS_TAB_LIST_CONTENT_STYLE = { paddingBottom: 120, paddingTop: 8 };
+
+// HABITS renders every profile tab as a list of elevated cards, and the tab bar casts a
+// shadow of its own. Padded flush to the overlay, the first card's own shadow lands inside
+// the tab bar's, which reads as the card being tucked underneath it. Therr's lists are flat
+// rows with no shadow to collide, so they stay flush.
+const HABITS_TAB_LIST_TOP_INSET = IS_HABITS ? space.md : 0;
 
 // The profile FAB opens the composer that fills the first profile tab: Therr's Thoughts tab
 // (lightbulb) and, on HABITS, the Goals tab — so it carries a trophy rather than a lightbulb.
@@ -1098,6 +1105,7 @@ class ViewUser extends React.Component<
                                     lazyPreloadDistance={0}
                                     headerStyle={this.themeUser.styles.profileHeaderCollapsible}
                                     listBottomInset={buttonMenuHeight}
+                                    listTopInset={HABITS_TAB_LIST_TOP_INSET}
                                     navigationState={{
                                         index: activeTabIndex,
                                         routes: tabRoutes,


### PR DESCRIPTION
Without this, PactOnboardingGuard never released for users landing on the
dashboard directly, because activePacts was only ever populated as a side
effect of visiting ViewUser or PactsList first.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>