### PR TITLE
feat(habits): blink the chameleon's eyes before hiding the splash

### DIFF
--- a/TherrMobile/__tests__/components/splashLogoEyes.test.ts
+++ b/TherrMobile/__tests__/components/splashLogoEyes.test.ts
@@ -1,0 +1,233 @@
+import fs from 'fs';
+import path from 'path';
+import zlib from 'zlib';
+import { it, describe, expect, jest } from '@jest/globals';
+
+/**
+ * `SplashLogoSpinner` blinks the HABITS chameleon by sweeping a lid over each eye, and it
+ * places those lids from hard-coded fractions of the logo box. Nothing in the app checks
+ * that the fractions still land on the artwork: regenerate `bootsplash_logo.png` (per
+ * `main/assets/habits-icons/README.md`) with the chameleon a few percent higher or smaller
+ * and the lids quietly blink somewhere on its forehead instead.
+ *
+ * So re-measure the committed artwork here and hold the constants to it. The eye whites are
+ * the only pure-white shapes in the upper half of the logo, which makes them findable
+ * without decoding the design intent.
+ *
+ * The component itself is only imported for its constants; reanimated is stubbed out so
+ * that import costs nothing.
+ */
+jest.mock('react-native-reanimated', () => {
+    const { View, Image } = require('react-native');
+
+    return {
+        __esModule: true,
+        default: { View, Image, createAnimatedComponent: (Component: any) => Component },
+        useSharedValue: (value: number) => ({ value }),
+        useAnimatedStyle: (factory: any) => factory(),
+        withTiming: (toValue: number) => toValue,
+        withSequence: (...animations: any[]) => animations[animations.length - 1],
+        runOnJS: (fn: any) => fn,
+        Easing: { in: () => undefined, out: () => undefined, inOut: () => undefined, quad: undefined },
+    };
+});
+
+import { SPLASH_LOGO_EYES } from '../../main/components/SplashLogoSpinner';
+
+/** Rendered at 4x, the density where the eyes are large enough to measure precisely. */
+const LOGO_PNG = path.resolve(__dirname, '../../main/assets/bootsplash_logo@4x.png');
+
+interface IBitmap {
+    width: number;
+    height: number;
+    /** RGBA, 4 bytes per pixel, row-major. */
+    pixels: Buffer;
+}
+
+/**
+ * Minimal PNG reader: enough of the spec for the one file this suite measures — 8-bit RGBA,
+ * non-interlaced. Deliberately dependency-free, like `__tests__/assets/therrIconFont.test.ts`;
+ * an image library in the mobile package just to guard an asset is not worth it.
+ */
+const readPng = (file: Buffer): IBitmap => {
+    const idat: Buffer[] = [];
+    let width = 0;
+    let height = 0;
+    let bitDepth = 0;
+    let colorType = 0;
+    let interlace = 0;
+
+    // 8-byte signature, then a run of length-prefixed, type-tagged, CRC-suffixed chunks.
+    let offset = 8;
+    while (offset < file.length) {
+        const length = file.readUInt32BE(offset);
+        const type = file.toString('ascii', offset + 4, offset + 8);
+        const data = file.subarray(offset + 8, offset + 8 + length);
+
+        if (type === 'IHDR') {
+            width = data.readUInt32BE(0);
+            height = data.readUInt32BE(4);
+            bitDepth = data.readUInt8(8);
+            colorType = data.readUInt8(9);
+            interlace = data.readUInt8(12);
+        } else if (type === 'IDAT') {
+            idat.push(Buffer.from(data));
+        } else if (type === 'IEND') {
+            break;
+        }
+
+        offset += length + 12;
+    }
+
+    if (bitDepth !== 8 || colorType !== 6 || interlace !== 0) {
+        throw new Error(`Expected an 8-bit non-interlaced RGBA PNG, got bitDepth=${bitDepth} colorType=${colorType} interlace=${interlace}`);
+    }
+
+    const bytesPerPixel = 4;
+    const stride = width * bytesPerPixel;
+    const raw = zlib.inflateSync(Buffer.concat(idat));
+    const pixels = Buffer.alloc(stride * height);
+
+    // Every scanline is prefixed with the filter it was encoded under, and is decoded
+    // against the already-decoded pixel to its left (a) and the one above it (b/c).
+    for (let y = 0; y < height; y += 1) {
+        const filter = raw[y * (stride + 1)];
+        const line = raw.subarray((y * (stride + 1)) + 1, (y + 1) * (stride + 1));
+
+        for (let x = 0; x < stride; x += 1) {
+            const a = x >= bytesPerPixel ? pixels[(y * stride) + x - bytesPerPixel] : 0;
+            const b = y > 0 ? pixels[((y - 1) * stride) + x] : 0;
+            const c = (x >= bytesPerPixel && y > 0) ? pixels[((y - 1) * stride) + x - bytesPerPixel] : 0;
+            let value = line[x];
+
+            if (filter === 1) {
+                value += a;
+            } else if (filter === 2) {
+                value += b;
+            } else if (filter === 3) {
+                value += Math.floor((a + b) / 2);
+            } else if (filter === 4) {
+                // Paeth: pick whichever neighbour the gradient a + b - c is closest to.
+                const p = a + b - c;
+                const pa = Math.abs(p - a);
+                const pb = Math.abs(p - b);
+                const pc = Math.abs(p - c);
+                value += (pa <= pb && pa <= pc) ? a : (pb <= pc ? b : c);
+            } else if (filter !== 0) {
+                throw new Error(`Unknown PNG scanline filter ${filter} on row ${y}`);
+            }
+
+            // Filters are defined modulo 256, and every operand above is an unsigned byte.
+            pixels[(y * stride) + x] = value % 256;
+        }
+    }
+
+    return { width, height, pixels };
+};
+
+const bitmap = readPng(fs.readFileSync(LOGO_PNG));
+
+const pixelAt = (x: number, y: number): number[] => {
+    const at = (y * bitmap.width * 4) + (x * 4);
+    return [bitmap.pixels[at], bitmap.pixels[at + 1], bitmap.pixels[at + 2], bitmap.pixels[at + 3]];
+};
+
+const isOpaque = ([, , , alpha]: number[]) => alpha > 200;
+const isWhite = (pixel: number[]) => isOpaque(pixel) && pixel[0] > 230 && pixel[1] > 230 && pixel[2] > 230;
+
+/** The white of each eye, as a fraction-of-the-box center and diameter. */
+const measureEyeWhites = () => {
+    const halves: { left: number[][]; right: number[][] } = { left: [], right: [] };
+
+    // The wordmark below is the logo's other white-adjacent region, so stay above it.
+    for (let y = 0; y < bitmap.height * 0.7; y += 1) {
+        for (let x = 0; x < bitmap.width; x += 1) {
+            if (isWhite(pixelAt(x, y))) {
+                halves[x < bitmap.width / 2 ? 'left' : 'right'].push([x, y]);
+            }
+        }
+    }
+
+    return Object.entries(halves).reduce((acc, [side, points]) => {
+        if (!points.length) {
+            throw new Error(`Found no eye white in the ${side} half of ${path.basename(LOGO_PNG)} — has the logo been redrawn?`);
+        }
+
+        const xs = points.map(([x]) => x);
+        const ys = points.map(([, y]) => y);
+        const minX = Math.min(...xs);
+        const maxX = Math.max(...xs);
+        const minY = Math.min(...ys);
+        const maxY = Math.max(...ys);
+
+        return {
+            ...acc,
+            [side]: {
+                centerXRatio: ((minX + maxX + 1) / 2) / bitmap.width,
+                centerYRatio: ((minY + maxY + 1) / 2) / bitmap.height,
+                diameterRatio: (maxX - minX + 1) / bitmap.width,
+                /** Height of the eye socket the lid may spill onto, measured up from the eye's center. */
+                socketRadiusRatio: (() => {
+                    const centerX = Math.round((minX + maxX) / 2);
+                    const centerY = Math.round((minY + maxY) / 2);
+                    let top = centerY;
+                    while (top > 0 && isOpaque(pixelAt(centerX, top - 1))) {
+                        top -= 1;
+                    }
+                    return (centerY - top) / bitmap.height;
+                })(),
+                /** Average color of the socket ringing the eye — what a closed lid has to match. */
+                socketColor: (() => {
+                    const centerX = (minX + maxX) / 2;
+                    const centerY = (minY + maxY) / 2;
+                    const radius = ((maxX - minX) / 2) * 1.35;
+                    const samples: number[][] = [];
+
+                    for (let angle = 0; angle < 360; angle += 15) {
+                        const radians = (angle * Math.PI) / 180;
+                        samples.push(pixelAt(
+                            Math.round(centerX + (radius * Math.cos(radians))),
+                            Math.round(centerY + (radius * Math.sin(radians))),
+                        ));
+                    }
+
+                    return [0, 1, 2].map((channel) => Math.round(
+                        samples.reduce((sum, sample) => sum + sample[channel], 0) / samples.length,
+                    ));
+                })(),
+            },
+        };
+    }, {} as Record<string, {
+        centerXRatio: number;
+        centerYRatio: number;
+        diameterRatio: number;
+        socketRadiusRatio: number;
+        socketColor: number[];
+    }>);
+};
+
+const measured = measureEyeWhites();
+
+const toChannels = (hex: string) => [1, 3, 5].map((at) => parseInt(hex.slice(at, at + 2), 16));
+
+const SIDES: Array<'left' | 'right'> = ['left', 'right'];
+
+describe('HABITS splash-logo eye geometry', () => {
+    it.each(SIDES)('centers the %s eyelid on the eye in the artwork', (side) => {
+        expect(SPLASH_LOGO_EYES[side].centerXRatio).toBeCloseTo(measured[side].centerXRatio, 2);
+        expect(SPLASH_LOGO_EYES.centerYRatio).toBeCloseTo(measured[side].centerYRatio, 2);
+    });
+
+    it.each(SIDES)('sizes the lid to cover the %s eye without leaving the socket', (side) => {
+        // Wide enough to hide the whole white of the eye, including its antialiased edge...
+        expect(SPLASH_LOGO_EYES.diameterRatio).toBeGreaterThanOrEqual(measured[side].diameterRatio);
+        // ...but not so wide that a corner of the lid overhangs the head onto the background.
+        expect(SPLASH_LOGO_EYES.diameterRatio / 2).toBeLessThanOrEqual(measured[side].socketRadiusRatio);
+    });
+
+    it.each(SIDES)('paints the %s lid in the color of the socket around it', (side) => {
+        toChannels(SPLASH_LOGO_EYES[side].lidColor).forEach((channel, index) => {
+            expect(Math.abs(channel - measured[side].socketColor[index])).toBeLessThanOrEqual(16);
+        });
+    });
+});

--- a/TherrMobile/main/components/SplashLogoSpinner.tsx
+++ b/TherrMobile/main/components/SplashLogoSpinner.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import Animated, {
     Easing,
     runOnJS,
     useAnimatedStyle,
     useSharedValue,
+    withSequence,
     withTiming,
 } from 'react-native-reanimated';
 import { BrandVariations } from 'therr-js-utilities/constants';
@@ -17,11 +18,70 @@ const LOGO_SIZE = 100;
 const SPIN_DURATION_MS = 700;
 const FADE_OUT_DURATION_MS = 250;
 
+// Two blinks, timed to fill roughly the same beat the other brands spend spinning.
+const BLINK_CLOSE_MS = 100;
+const BLINK_HOLD_MS = 60;
+const BLINK_OPEN_MS = 120;
+/** Eyes-open pause between the two blinks. */
+const BLINK_GAP_MS = 120;
+
 // Some brands (e.g. HABITS) use a combined splash logo that bundles the icon
 // and the wordmark into a single image. Spinning that image rotates the text
 // too, which reads poorly — so we only spin brands whose splash logo is an
-// icon on its own, and fade the rest out without rotating.
-const SHOULD_SPIN_LOGO = CURRENT_BRAND_VARIATION !== BrandVariations.HABITS;
+// icon on its own. HABITS gets a blink of the chameleon's eyes instead.
+const SHOULD_BLINK_LOGO = CURRENT_BRAND_VARIATION === BrandVariations.HABITS;
+
+/**
+ * Where the chameleon's eyes sit inside `bootsplash_logo.png`, as fractions of the
+ * (square) logo box — the image is drawn `contain` into a `LOGO_SIZE` square, so a
+ * fraction of the source maps 1:1 onto a fraction of the rendered box.
+ *
+ * These were measured off the committed artwork rather than off `habits-logo.svg`, whose
+ * coordinates do not carry over: the bootsplash logo is the chameleon composited above the
+ * wordmark, so it sits higher and smaller in its box than the app icon does.
+ * `__tests__/components/splashLogoEyes.test.ts` re-measures the PNG and fails if a
+ * regenerated logo moves the eyes out from under these lids.
+ *
+ * `lidColor` is sampled from the eye socket that rings each eye, so a closed lid reads as
+ * the chameleon's own skin — and so the lid's square top corners, which overhang the round
+ * sclera, are invisible against the socket they land on.
+ */
+export const SPLASH_LOGO_EYES = {
+    /** Diameter of the white of the eye. A hair wider than measured, to cover its antialiased edge. */
+    diameterRatio: 0.12,
+    centerYRatio: 0.3475,
+    left: { centerXRatio: 0.3438, lidColor: '#65507d' },
+    right: { centerXRatio: 0.6563, lidColor: '#746a8b' },
+};
+
+const EYE_DIAMETER = LOGO_SIZE * SPLASH_LOGO_EYES.diameterRatio;
+const EYE_RADIUS = EYE_DIAMETER / 2;
+
+const eyelidLayout = (centerXRatio: number) => ({
+    left: (LOGO_SIZE * centerXRatio) - EYE_RADIUS,
+    top: (LOGO_SIZE * SPLASH_LOGO_EYES.centerYRatio) - EYE_RADIUS,
+});
+
+/**
+ * The lid is a full-eye-sized box pinned to the top of the eye and scaled down to nothing
+ * while open. Scaling happens about the box's center, so the translate re-pins its top
+ * edge; the result is a lid sweeping down over the eye rather than one growing from its
+ * middle. Kept on transforms (rather than an animated `height`) so the blink stays off the
+ * layout path on the UI thread.
+ */
+const eyelidAnimation = (closed: number) => {
+    'worklet';
+
+    return {
+        // A hairline bottom border on a zero-height lid would still draw a line across an
+        // open eye.
+        opacity: closed > 0 ? 1 : 0,
+        transform: [
+            { translateY: -EYE_RADIUS * (1 - closed) },
+            { scaleY: closed },
+        ],
+    };
+};
 
 interface ISplashLogoSpinnerProps {
     start: boolean;
@@ -30,6 +90,8 @@ interface ISplashLogoSpinnerProps {
 
 const SplashLogoSpinner = ({ start, onAnimationComplete }: ISplashLogoSpinnerProps) => {
     const rotation = useSharedValue(0);
+    /** 0 = eyes open, 1 = eyes closed. */
+    const eyelid = useSharedValue(0);
     const opacity = useSharedValue(1);
     const [hidden, setHidden] = useState(false);
 
@@ -55,8 +117,27 @@ const SplashLogoSpinner = ({ start, onAnimationComplete }: ISplashLogoSpinnerPro
             );
         };
 
-        if (!SHOULD_SPIN_LOGO) {
-            fadeOut();
+        if (SHOULD_BLINK_LOGO) {
+            const closing = { duration: BLINK_CLOSE_MS, easing: Easing.in(Easing.quad) };
+            const opening = { duration: BLINK_OPEN_MS, easing: Easing.out(Easing.quad) };
+            // A timing to the value the lid already holds is how a sequence waits.
+            const holdClosed = { duration: BLINK_HOLD_MS };
+            const holdOpen = { duration: BLINK_GAP_MS };
+
+            eyelid.value = withSequence(
+                withTiming(1, closing),
+                withTiming(1, holdClosed),
+                withTiming(0, opening),
+                withTiming(0, holdOpen),
+                withTiming(1, closing),
+                withTiming(1, holdClosed),
+                withTiming(0, opening, (blinkFinished) => {
+                    if (blinkFinished) {
+                        runOnJS(fadeOut)();
+                    }
+                }),
+            );
+
             return;
         }
 
@@ -69,7 +150,7 @@ const SplashLogoSpinner = ({ start, onAnimationComplete }: ISplashLogoSpinnerPro
                 }
             },
         );
-    }, [start, rotation, opacity, onAnimationComplete]);
+    }, [start, rotation, eyelid, opacity, onAnimationComplete]);
 
     const overlayStyle = useAnimatedStyle(() => ({
         opacity: opacity.value,
@@ -79,17 +160,29 @@ const SplashLogoSpinner = ({ start, onAnimationComplete }: ISplashLogoSpinnerPro
         transform: [{ rotate: `${rotation.value}deg` }],
     }));
 
+    // One animated style per view — reanimated does not support sharing a single one.
+    const leftEyelidStyle = useAnimatedStyle(() => eyelidAnimation(eyelid.value));
+    const rightEyelidStyle = useAnimatedStyle(() => eyelidAnimation(eyelid.value));
+
     if (hidden) {
         return null;
     }
 
     return (
         <Animated.View style={[styles.overlay, overlayStyle]}>
-            <Animated.Image
-                source={require('../assets/bootsplash_logo.png')}
-                style={[styles.logo, logoStyle]}
-                resizeMode="contain"
-            />
+            <View style={styles.logoContainer}>
+                <Animated.Image
+                    source={require('../assets/bootsplash_logo.png')}
+                    style={[styles.logo, logoStyle]}
+                    resizeMode="contain"
+                />
+                {SHOULD_BLINK_LOGO && (
+                    <>
+                        <Animated.View style={[styles.eyelid, styles.eyelidLeft, leftEyelidStyle]} />
+                        <Animated.View style={[styles.eyelid, styles.eyelidRight, rightEyelidStyle]} />
+                    </>
+                )}
+            </View>
         </Animated.View>
     );
 };
@@ -103,9 +196,33 @@ const styles = StyleSheet.create({
         zIndex: 9999,
         elevation: 9999,
     },
+    logoContainer: {
+        width: LOGO_SIZE,
+        height: LOGO_SIZE,
+    },
     logo: {
         width: LOGO_SIZE,
         height: LOGO_SIZE,
+    },
+    eyelid: {
+        position: 'absolute',
+        width: EYE_DIAMETER,
+        height: EYE_DIAMETER,
+        borderBottomLeftRadius: EYE_RADIUS,
+        borderBottomRightRadius: EYE_RADIUS,
+        // Lash line along the lid's edge, in the ink the logo draws its smile and nostrils
+        // with. Without it a closed eye reads as a missing eye rather than a shut one — and
+        // a hairline is too faint to register at a 12dp eye.
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(46, 33, 64, 0.55)',
+    },
+    eyelidLeft: {
+        ...eyelidLayout(SPLASH_LOGO_EYES.left.centerXRatio),
+        backgroundColor: SPLASH_LOGO_EYES.left.lidColor,
+    },
+    eyelidRight: {
+        ...eyelidLayout(SPLASH_LOGO_EYES.right.centerXRatio),
+        backgroundColor: SPLASH_LOGO_EYES.right.lidColor,
     },
 });
 

--- a/context/memory/2026-09-02.md
+++ b/context/memory/2026-09-02.md
@@ -1,0 +1,31 @@
+# 2026-09-02
+
+## Goal
+Blink the chameleon's eyes on the Friends with Habits splash screen, the way the Therr
+logo spins just before the splash hides. PR targets `niche/HABITS-general`.
+
+## Deliverables
+- `TherrMobile/main/components/SplashLogoSpinner.tsx` — HABITS now blinks twice (~680ms,
+  the beat the other brands spend spinning) before the fade-out; other brands still spin.
+  Lids are views swept over each eye by a reanimated transform (scaleY + translateY, so
+  the blink stays off the layout path), positioned from fractions of the logo box.
+- New guard `__tests__/components/splashLogoEyes.test.ts` — dependency-free PNG decode
+  (zlib + scanline unfilter) re-measures `bootsplash_logo@4x.png` and fails if a
+  regenerated logo moves or resizes the eyes out from under the lids.
+
+## Decisions
+- Kept the baked PNG instead of re-rendering the chameleon as SVG, so the JS overlay still
+  matches the native bootsplash pixel for pixel.
+- Eye geometry measured off the artwork, not off `habits-logo.svg` — the bootsplash logo
+  composites the chameleon above the wordmark, so the SVG's coordinates don't carry over.
+- Lid color is sampled from the eye socket, which makes the lid's overhang past the round
+  sclera invisible — no clipping or `overflow: hidden` needed.
+- 1dp lash line on the lid edge: a closed eye read as a *missing* eye without it, and
+  `hairlineWidth` was too faint at a 12dp eye.
+
+## Open threads
+- Not verified on a device/emulator — the blink was checked by compositing lid frames onto
+  the real artwork, and by lint + the new geometry test.
+- A fresh clone needs `therr-js-utilities` and `therr-react` built before
+  `pr:tsc-baseline:mobile` or most of the mobile jest suites will fail with TS2307 /
+  "Could not locate module therr-react/services".


### PR DESCRIPTION
## What

Friends with Habits' splash logo now blinks the chameleon's eyes twice before fading out — the beat the Therr app spends spinning its logo.

The HABITS splash logo bundles the chameleon and the wordmark into one image, so it had opted out of the spin (rotating baked-in text reads poorly) and simply faded. It gets an animation of its own now, timed to fill roughly the same ~700ms.

## How

- Each lid is a view pinned to the top of an eye and swept down over it with a `scaleY` + `translateY` transform, so the blink stays off the layout path on the UI thread.
- The lid is painted in the color of the eye socket, sampled from the artwork. That makes its overhang past the round sclera invisible, so no clipping or `overflow: hidden` is needed.
- A 1dp lash line rides the lid's edge — without it a closed eye reads as a *missing* eye, and `hairlineWidth` was too faint at a 12dp eye.
- Timing: close 100ms → hold 60ms → open 120ms, a 120ms pause, then the same again, then the existing 250ms fade.

Lid placement comes from fractions of the logo box measured off `bootsplash_logo.png` itself — `habits-logo.svg`'s coordinates don't carry over, since the bootsplash logo composites the chameleon above the wordmark and so sits higher and smaller in its box.

## Tests

`TherrMobile/__tests__/components/splashLogoEyes.test.ts` re-measures the committed PNG and holds the constants to it, so a regenerated logo that moves or resizes the eyes fails rather than blinking somewhere on the chameleon's forehead. It decodes the image with `zlib` plus a scanline unfilter rather than adding an image dependency, following `__tests__/assets/therrIconFont.test.ts`.

Verified locally:

- `npx eslint` on both changed files — clean.
- `npm run pr:tsc-baseline:mobile` — `current=105 baseline=105`, no new errors.
- Full mobile Jest suite — 103 suites, 1742 tests, all passing.
- The blink itself was checked by compositing the lid frames onto the real artwork at several closure amounts; not yet run on a device or emulator.

## Branch

Niche-only: both files are under `TherrMobile/**`, and `SplashLogoSpinner.tsx` already carries HABITS-specific code on this branch (white bootsplash background, the no-spin gate). Nothing here belongs on `general`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128AiTDm8WwidSj5xhTtqkj

---
_Generated by [Claude Code](https://claude.ai/code/session_0128AiTDm8WwidSj5xhTtqkj)_