### PR TITLE
fix(habits): redraw the splash logo at the size the native splash used

### DIFF
--- a/TherrMobile/__tests__/components/splashLogoEyes.test.ts
+++ b/TherrMobile/__tests__/components/splashLogoEyes.test.ts
@@ -14,6 +14,13 @@ import { it, describe, expect, jest } from '@jest/globals';
  * the only pure-white shapes in the upper half of the logo, which makes them findable
  * without decoding the design intent.
  *
+ * Both bitmaps the overlay can draw are measured: the bundled JS copy (iOS, and the fallback
+ * everywhere) and the Android drawable the native splash itself draws. The drawable is also
+ * held to the 288dp canvas Android renders a splash logo in, because the overlay sizes itself
+ * to that canvas — regenerate the drawables the way react-native-bootsplash's own generator
+ * would (a 100dp logo centered in the canvas) and the overlay would draw the logo at 2.9x the
+ * size the native splash did. That shows up here as eyes in the wrong place, not as a crash.
+ *
  * The component itself is only imported for its constants; reanimated is stubbed out so
  * that import costs nothing.
  */
@@ -32,10 +39,27 @@ jest.mock('react-native-reanimated', () => {
     };
 });
 
-import { SPLASH_LOGO_EYES } from '../../main/components/SplashLogoSpinner';
+import { ANDROID_SPLASH_CANVAS_SIZE, SPLASH_LOGO_EYES, splashLogoSize } from '../../main/components/SplashLogoSpinner';
 
-/** Rendered at 4x, the density where the eyes are large enough to measure precisely. */
-const LOGO_PNG = path.resolve(__dirname, '../../main/assets/bootsplash_logo@4x.png');
+/** What `assets/bootsplash/manifest.json` and `ios/Therr/BootSplash.storyboard` size the logo at. */
+const MANIFEST_LOGO_SIZE = 100;
+
+const asset = (relative: string) => path.resolve(__dirname, '../..', relative);
+
+/** The artwork the overlay draws, at the densities where the eyes are large enough to measure. */
+const LOGO_PNGS = {
+    'the bundled JS copy': asset('main/assets/bootsplash_logo@4x.png'),
+    'the Android splash drawable': asset('android/app/src/main/res/drawable-xxhdpi/bootsplash_logo.png'),
+};
+
+/** `drawable-<density>` folders, and the scale each one renders at. */
+const ANDROID_DENSITIES: Array<[string, number]> = [
+    ['mdpi', 1],
+    ['hdpi', 1.5],
+    ['xhdpi', 2],
+    ['xxhdpi', 3],
+    ['xxxhdpi', 4],
+];
 
 interface IBitmap {
     width: number;
@@ -125,18 +149,18 @@ const readPng = (file: Buffer): IBitmap => {
     return { width, height, pixels };
 };
 
-const bitmap = readPng(fs.readFileSync(LOGO_PNG));
-
-const pixelAt = (x: number, y: number): number[] => {
-    const at = (y * bitmap.width * 4) + (x * 4);
-    return [bitmap.pixels[at], bitmap.pixels[at + 1], bitmap.pixels[at + 2], bitmap.pixels[at + 3]];
-};
-
 const isOpaque = ([, , , alpha]: number[]) => alpha > 200;
 const isWhite = (pixel: number[]) => isOpaque(pixel) && pixel[0] > 230 && pixel[1] > 230 && pixel[2] > 230;
 
 /** The white of each eye, as a fraction-of-the-box center and diameter. */
-const measureEyeWhites = () => {
+const measureEyeWhites = (file: string) => {
+    const bitmap = readPng(fs.readFileSync(file));
+
+    const pixelAt = (x: number, y: number): number[] => {
+        const at = (y * bitmap.width * 4) + (x * 4);
+        return [bitmap.pixels[at], bitmap.pixels[at + 1], bitmap.pixels[at + 2], bitmap.pixels[at + 3]];
+    };
+
     const halves: { left: number[][]; right: number[][] } = { left: [], right: [] };
 
     // The wordmark below is the logo's other white-adjacent region, so stay above it.
@@ -150,7 +174,7 @@ const measureEyeWhites = () => {
 
     return Object.entries(halves).reduce((acc, [side, points]) => {
         if (!points.length) {
-            throw new Error(`Found no eye white in the ${side} half of ${path.basename(LOGO_PNG)} — has the logo been redrawn?`);
+            throw new Error(`Found no eye white in the ${side} half of ${path.basename(file)} — has the logo been redrawn?`);
         }
 
         const xs = points.map(([x]) => x);
@@ -206,13 +230,13 @@ const measureEyeWhites = () => {
     }>);
 };
 
-const measured = measureEyeWhites();
-
 const toChannels = (hex: string) => [1, 3, 5].map((at) => parseInt(hex.slice(at, at + 2), 16));
 
 const SIDES: Array<'left' | 'right'> = ['left', 'right'];
 
-describe('HABITS splash-logo eye geometry', () => {
+describe.each(Object.entries(LOGO_PNGS))('HABITS splash-logo eye geometry in %s', (_label, file) => {
+    const measured = measureEyeWhites(file);
+
     it.each(SIDES)('centers the %s eyelid on the eye in the artwork', (side) => {
         expect(SPLASH_LOGO_EYES[side].centerXRatio).toBeCloseTo(measured[side].centerXRatio, 2);
         expect(SPLASH_LOGO_EYES.centerYRatio).toBeCloseTo(measured[side].centerYRatio, 2);
@@ -229,5 +253,62 @@ describe('HABITS splash-logo eye geometry', () => {
         toChannels(SPLASH_LOGO_EYES[side].lidColor).forEach((channel, index) => {
             expect(Math.abs(channel - measured[side].socketColor[index])).toBeLessThanOrEqual(16);
         });
+    });
+});
+
+describe('HABITS splash-logo overlay size', () => {
+    it('redraws the logo at the size the native splash drew it, per platform', () => {
+        // The storyboard pins its image view to the manifest size...
+        expect(splashLogoSize('ios', 1)).toBe(MANIFEST_LOGO_SIZE);
+        // ...while Android renders the whole canvas these drawables fill. Sizing both at the
+        // manifest's 100dp is the bug this guards: the logo shrank 2.88x at the handoff.
+        expect(splashLogoSize('android', 1)).toBe(ANDROID_SPLASH_CANVAS_SIZE);
+    });
+
+    it('follows the native icon down on Samsung One UI 4, which halves it', () => {
+        expect(splashLogoSize('android', 0.5)).toBe(ANDROID_SPLASH_CANVAS_SIZE / 2);
+        expect(splashLogoSize('ios', 0.5)).toBe(MANIFEST_LOGO_SIZE / 2);
+    });
+});
+
+/**
+ * The overlay draws its logo box at `ANDROID_SPLASH_CANVAS_SIZE` on Android because that is the
+ * canvas the platform renders a splash logo in, and because these drawables are artwork filling
+ * that canvas rather than a smaller logo centered inside one. Both halves of that reasoning are
+ * load-bearing, so hold the committed drawables to both.
+ */
+describe('HABITS Android splash drawables', () => {
+    it.each(ANDROID_DENSITIES)('is a %s canvas of the size the overlay assumes', (density, scale) => {
+        const bitmap = readPng(fs.readFileSync(asset(`android/app/src/main/res/drawable-${density}/bootsplash_logo.png`)));
+
+        expect(bitmap.width).toBe(ANDROID_SPLASH_CANVAS_SIZE * scale);
+        expect(bitmap.height).toBe(bitmap.width);
+    });
+
+    it('fills that canvas with the artwork, rather than centering a smaller logo in it', () => {
+        const drawable = readPng(fs.readFileSync(LOGO_PNGS['the Android splash drawable']));
+        const bundled = readPng(fs.readFileSync(LOGO_PNGS['the bundled JS copy']));
+
+        const artworkWidthRatio = ({ width, height, pixels }: IBitmap) => {
+            let minX = width;
+            let maxX = -1;
+
+            for (let y = 0; y < height; y += 1) {
+                for (let x = 0; x < width; x += 1) {
+                    if (pixels[(y * width * 4) + (x * 4) + 3] > 10) {
+                        minX = Math.min(minX, x);
+                        maxX = Math.max(maxX, x);
+                    }
+                }
+            }
+
+            return (maxX - minX + 1) / width;
+        };
+
+        // Same framing in both bitmaps: the overlay swaps between them (and falls back from one to
+        // the other) without the logo shifting or resizing.
+        expect(artworkWidthRatio(drawable)).toBeCloseTo(artworkWidthRatio(bundled), 2);
+        // The generator's own output would put the artwork at ~1/3 of the canvas.
+        expect(artworkWidthRatio(drawable)).toBeGreaterThan(0.8);
     });
 });

--- a/TherrMobile/main/components/SplashLogoSpinner.tsx
+++ b/TherrMobile/main/components/SplashLogoSpinner.tsx
@@ -1,5 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+    ImageSourcePropType,
+    Platform,
+    StyleSheet,
+    TurboModuleRegistry,
+    View,
+} from 'react-native';
 import Animated, {
     Easing,
     runOnJS,
@@ -14,7 +20,6 @@ import { CURRENT_BRAND_VARIATION } from '../config/brandConfig';
 // Matches the HABITS native bootsplash background (white) so the JS overlay
 // hands off from the native splash with no visible color flash.
 const BOOTSPLASH_BACKGROUND = '#ffffff';
-const LOGO_SIZE = 100;
 const SPIN_DURATION_MS = 700;
 const FADE_OUT_DURATION_MS = 250;
 
@@ -31,15 +36,90 @@ const BLINK_GAP_MS = 120;
 // icon on its own. HABITS gets a blink of the chameleon's eyes instead.
 const SHOULD_BLINK_LOGO = CURRENT_BRAND_VARIATION === BrandVariations.HABITS;
 
+/** What `assets/bootsplash/manifest.json` and `ios/Therr/BootSplash.storyboard` size the logo at. */
+const MANIFEST_LOGO_SIZE = 100;
+
 /**
- * Where the chameleon's eyes sit inside `bootsplash_logo.png`, as fractions of the
- * (square) logo box — the image is drawn `contain` into a `LOGO_SIZE` square, so a
- * fraction of the source maps 1:1 onto a fraction of the rendered box.
+ * The canvas Android hands a splash logo, per Google's splash-screen dimensions — and the size
+ * react-native-bootsplash's generator composites its Android drawables onto.
+ *
+ * Exported for `__tests__/components/splashLogoEyes.test.ts`, which holds the committed
+ * drawables to it.
+ */
+export const ANDROID_SPLASH_CANVAS_SIZE = 288;
+
+/**
+ * The size the *native* splash drew the logo at. The overlay has to redraw it at exactly that
+ * size or the logo visibly jumps the moment the overlay takes over.
+ *
+ * iOS draws `BootSplash.storyboard`, whose image view is pinned to the manifest's 100dp.
+ *
+ * Android is the reason this is not simply the manifest size. The platform renders
+ * `windowSplashScreenAnimatedIcon` in a 288dp canvas (pre-12, the compat layer draws the same
+ * drawable centered at its intrinsic density size — 288dp again), and HABITS' per-density
+ * `bootsplash_logo` drawables are artwork filling that whole canvas rather than a 100dp logo
+ * centered inside one, which is what the generator would have produced. So on Android this
+ * brand's splash logo lands at 288dp — 2.88x the size the overlay used to redraw it at.
+ *
+ * Scoped to the brand rather than to Android, because it is a property of these hand-made HABITS
+ * assets: a brand whose drawables came out of the generator still draws at the manifest size.
+ */
+const DRAWS_ANDROID_SPLASH_CANVAS = SHOULD_BLINK_LOGO && Platform.OS === 'android';
+
+/**
+ * `logoSizeRatio` is Samsung One UI 4's half-size splash icon — see `getNativeLogoSizeRatio`.
+ *
+ * Exported (with the platform passed in rather than read) so
+ * `__tests__/components/splashLogoEyes.test.ts` can hold both platforms to the size their native
+ * splash actually draws, which is the whole point of this file's sizing.
+ */
+export const splashLogoSize = (platformOS: string, logoSizeRatio: number): number => (
+    (SHOULD_BLINK_LOGO && platformOS === 'android' ? ANDROID_SPLASH_CANVAS_SIZE : MANIFEST_LOGO_SIZE)
+    * logoSizeRatio
+);
+
+/**
+ * On Android, draw the very drawable the native splash drew, addressed by resource name. The
+ * bundled JS copy tops out at 400px — fine for a 100dp box, a 2.9x upscale in a 288dp one —
+ * whereas the drawable set carries the density the system already picked (864px at xxhdpi).
+ * Falls back to the JS copy if the resource cannot be resolved, which would otherwise leave the
+ * eyelids blinking over nothing.
+ */
+const BUNDLED_LOGO_SOURCE = require('../assets/bootsplash_logo.png');
+const NATIVE_LOGO_SOURCE: ImageSourcePropType = DRAWS_ANDROID_SPLASH_CANVAS
+    ? { uri: 'bootsplash_logo' }
+    : BUNDLED_LOGO_SOURCE;
+
+/**
+ * Samsung's One UI 4 draws the splash icon at half size. react-native-bootsplash reports that as
+ * `logoSizeRatio` and scales its own hide-animation replica by it, but only exposes it through a
+ * hook that would also take over hiding the splash — which `Layout` owns. So read the same
+ * constant off the same native module. `TurboModuleRegistry.get` returns null instead of throwing
+ * when the module is absent (Jest, web), and the ratio is optional, so both fall back to 1.
+ */
+const getNativeLogoSizeRatio = (): number => {
+    try {
+        const bootSplashModule = TurboModuleRegistry
+            .get('RNBootSplash') as unknown as { getConstants: () => { logoSizeRatio?: number } } | null;
+        const ratio = bootSplashModule?.getConstants().logoSizeRatio;
+
+        return typeof ratio === 'number' && ratio > 0 ? ratio : 1;
+    } catch {
+        return 1;
+    }
+};
+
+/**
+ * Where the chameleon's eyes sit inside `bootsplash_logo.png`, as fractions of the (square)
+ * logo box — the image is drawn `contain` into a square, so a fraction of the source maps 1:1
+ * onto a fraction of the rendered box whatever size that box is. Both bitmaps the overlay can
+ * draw (the bundled JS copy and the Android drawable) frame the artwork identically, so one set
+ * of fractions covers both.
  *
  * These were measured off the committed artwork rather than off `habits-logo.svg`, whose
  * coordinates do not carry over: the bootsplash logo is the chameleon composited above the
  * wordmark, so it sits higher and smaller in its box than the app icon does.
- * `__tests__/components/splashLogoEyes.test.ts` re-measures the PNG and fails if a
+ * `__tests__/components/splashLogoEyes.test.ts` re-measures both PNGs and fails if a
  * regenerated logo moves the eyes out from under these lids.
  *
  * `lidColor` is sampled from the eye socket that rings each eye, so a closed lid reads as
@@ -54,13 +134,41 @@ export const SPLASH_LOGO_EYES = {
     right: { centerXRatio: 0.6563, lidColor: '#746a8b' },
 };
 
-const EYE_DIAMETER = LOGO_SIZE * SPLASH_LOGO_EYES.diameterRatio;
-const EYE_RADIUS = EYE_DIAMETER / 2;
+/** Lash-line weight, as a fraction of the logo box: 1dp at a 100dp logo, and proportional above. */
+const LASH_WIDTH_RATIO = 0.01;
+/** The ink the logo draws its smile and nostrils with. */
+const LASH_COLOR = 'rgba(46, 33, 64, 0.55)';
 
-const eyelidLayout = (centerXRatio: number) => ({
-    left: (LOGO_SIZE * centerXRatio) - EYE_RADIUS,
-    top: (LOGO_SIZE * SPLASH_LOGO_EYES.centerYRatio) - EYE_RADIUS,
-});
+/**
+ * Everything is derived from the logo box rather than hard-coded in dp, because that box is
+ * 100dp on iOS and 288dp on Android — see `NATIVE_LOGO_SIZE`.
+ */
+const buildLayout = (logoSize: number) => {
+    const eyeDiameter = logoSize * SPLASH_LOGO_EYES.diameterRatio;
+    const eyeRadius = eyeDiameter / 2;
+
+    const eyelid = (eye: { centerXRatio: number; lidColor: string }) => ({
+        position: 'absolute' as const,
+        left: (logoSize * eye.centerXRatio) - eyeRadius,
+        top: (logoSize * SPLASH_LOGO_EYES.centerYRatio) - eyeRadius,
+        width: eyeDiameter,
+        height: eyeDiameter,
+        borderBottomLeftRadius: eyeRadius,
+        borderBottomRightRadius: eyeRadius,
+        // Lash line along the lid's edge. Without it a closed eye reads as a missing eye — and a
+        // hairline is too faint to register at a 12dp eye.
+        borderBottomWidth: Math.max(StyleSheet.hairlineWidth, logoSize * LASH_WIDTH_RATIO),
+        borderBottomColor: LASH_COLOR,
+        backgroundColor: eye.lidColor,
+    });
+
+    return {
+        logo: { width: logoSize, height: logoSize },
+        eyeRadius,
+        leftEyelid: eyelid(SPLASH_LOGO_EYES.left),
+        rightEyelid: eyelid(SPLASH_LOGO_EYES.right),
+    };
+};
 
 /**
  * The lid is a full-eye-sized box pinned to the top of the eye and scaled down to nothing
@@ -69,15 +177,14 @@ const eyelidLayout = (centerXRatio: number) => ({
  * middle. Kept on transforms (rather than an animated `height`) so the blink stays off the
  * layout path on the UI thread.
  */
-const eyelidAnimation = (closed: number) => {
+const eyelidAnimation = (closed: number, eyeRadius: number) => {
     'worklet';
 
     return {
-        // A hairline bottom border on a zero-height lid would still draw a line across an
-        // open eye.
+        // A bottom border on a zero-height lid would still draw a line across an open eye.
         opacity: closed > 0 ? 1 : 0,
         transform: [
-            { translateY: -EYE_RADIUS * (1 - closed) },
+            { translateY: -eyeRadius * (1 - closed) },
             { scaleY: closed },
         ],
     };
@@ -94,6 +201,10 @@ const SplashLogoSpinner = ({ start, onAnimationComplete }: ISplashLogoSpinnerPro
     const eyelid = useSharedValue(0);
     const opacity = useSharedValue(1);
     const [hidden, setHidden] = useState(false);
+    const [logoSource, setLogoSource] = useState(NATIVE_LOGO_SOURCE);
+    // Read once on mount, as react-native-bootsplash does, rather than at import time.
+    const [logoSize] = useState(() => splashLogoSize(Platform.OS, getNativeLogoSizeRatio()));
+    const layout = useMemo(() => buildLayout(logoSize), [logoSize]);
 
     useEffect(() => {
         if (!start) {
@@ -161,8 +272,8 @@ const SplashLogoSpinner = ({ start, onAnimationComplete }: ISplashLogoSpinnerPro
     }));
 
     // One animated style per view — reanimated does not support sharing a single one.
-    const leftEyelidStyle = useAnimatedStyle(() => eyelidAnimation(eyelid.value));
-    const rightEyelidStyle = useAnimatedStyle(() => eyelidAnimation(eyelid.value));
+    const leftEyelidStyle = useAnimatedStyle(() => eyelidAnimation(eyelid.value, layout.eyeRadius));
+    const rightEyelidStyle = useAnimatedStyle(() => eyelidAnimation(eyelid.value, layout.eyeRadius));
 
     if (hidden) {
         return null;
@@ -170,16 +281,20 @@ const SplashLogoSpinner = ({ start, onAnimationComplete }: ISplashLogoSpinnerPro
 
     return (
         <Animated.View style={[styles.overlay, overlayStyle]}>
-            <View style={styles.logoContainer}>
+            <View style={layout.logo}>
                 <Animated.Image
-                    source={require('../assets/bootsplash_logo.png')}
-                    style={[styles.logo, logoStyle]}
+                    source={logoSource}
+                    // Android fades a freshly decoded image in over 300ms by default, which is
+                    // one more thing for the eye to catch at the handoff.
+                    fadeDuration={0}
+                    onError={() => setLogoSource(BUNDLED_LOGO_SOURCE)}
+                    style={[layout.logo, logoStyle]}
                     resizeMode="contain"
                 />
                 {SHOULD_BLINK_LOGO && (
                     <>
-                        <Animated.View style={[styles.eyelid, styles.eyelidLeft, leftEyelidStyle]} />
-                        <Animated.View style={[styles.eyelid, styles.eyelidRight, rightEyelidStyle]} />
+                        <Animated.View style={[layout.leftEyelid, leftEyelidStyle]} />
+                        <Animated.View style={[layout.rightEyelid, rightEyelidStyle]} />
                     </>
                 )}
             </View>
@@ -195,34 +310,6 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         zIndex: 9999,
         elevation: 9999,
-    },
-    logoContainer: {
-        width: LOGO_SIZE,
-        height: LOGO_SIZE,
-    },
-    logo: {
-        width: LOGO_SIZE,
-        height: LOGO_SIZE,
-    },
-    eyelid: {
-        position: 'absolute',
-        width: EYE_DIAMETER,
-        height: EYE_DIAMETER,
-        borderBottomLeftRadius: EYE_RADIUS,
-        borderBottomRightRadius: EYE_RADIUS,
-        // Lash line along the lid's edge, in the ink the logo draws its smile and nostrils
-        // with. Without it a closed eye reads as a missing eye rather than a shut one — and
-        // a hairline is too faint to register at a 12dp eye.
-        borderBottomWidth: 1,
-        borderBottomColor: 'rgba(46, 33, 64, 0.55)',
-    },
-    eyelidLeft: {
-        ...eyelidLayout(SPLASH_LOGO_EYES.left.centerXRatio),
-        backgroundColor: SPLASH_LOGO_EYES.left.lidColor,
-    },
-    eyelidRight: {
-        ...eyelidLayout(SPLASH_LOGO_EYES.right.centerXRatio),
-        backgroundColor: SPLASH_LOGO_EYES.right.lidColor,
     },
 });
 

--- a/context/memory/2026-09-02.md
+++ b/context/memory/2026-09-02.md
@@ -64,3 +64,42 @@ Lint 0 errors. tsc 0 errors all packages; mobile baseline 100=100.
 
 **Open thread:** followup added to WORK_IN_PROGRESS.md to verify the proofs
 endpoint end-to-end through the deployed gateway — no unit test covers that hop.
+
+---
+
+## Session — splash overlay sizing follow-up (niche/HABITS-general)
+
+**Goal:** the merged blink PR looked discontinuous — the logo "zoomed out" the moment
+the JS overlay took over from the native splash.
+
+**Root cause:** the overlay redrew the logo at a hard-coded 100dp on both platforms.
+That is right on iOS (`BootSplash.storyboard` pins its image view to the manifest's
+100dp) but wrong on Android: `drawable-*/bootsplash_logo.png` is a 288dp canvas — the
+size the platform renders `windowSplashScreenAnimatedIcon` in — and HABITS' hand-made
+drawables are artwork *filling* that canvas rather than a 100dp logo centered in one
+(what react-native-bootsplash's generator emits). So the native splash draws this logo
+at 288dp and the overlay shrank it 2.88x.
+
+**Deliverables:**
+- `SplashLogoSpinner.tsx` sizes its box per platform (288dp Android / 100dp iOS), times
+  react-native-bootsplash's `logoSizeRatio` (Samsung One UI 4 halves the splash icon),
+  read off the `RNBootSplash` TurboModule via `TurboModuleRegistry.get`.
+- On Android it now draws the drawable itself (`{ uri: 'bootsplash_logo' }`) so the
+  bitmap is the density the system picked; the bundled JS copy tops out at 400px and
+  would have been a 2.9x upscale in a 288dp box. `onError` falls back to it anyway.
+- `fadeDuration={0}` — Android otherwise fades a freshly decoded image in over 300ms.
+- Test extended: both bitmaps measured, drawables held to the 288dp canvas, and the
+  per-platform size asserted directly.
+
+**Decisions:**
+- Fixed the overlay to match the native splash, NOT the assets to match the manifest.
+  Shrinking the Android drawable to a 100dp logo would also fix continuity, but it
+  changes what the shipped splash looks like, which is not what was asked.
+- Left standing: Android's splash logo is ~2.9x iOS's, and its artwork sits outside the
+  192dp circle Google documents as the visible area for an icon without a background.
+  No crop has been reported, so the mask does not appear to apply to a plain bitmap —
+  worth a look if the Android splash ever starts showing a clipped wordmark.
+
+**Verification:** lint clean, mobile tsc baseline 105=105, full mobile jest 103 suites /
+1756 tests green. Blink re-composited onto the Android drawable at xxhdpi to check the
+lids still land on the eyes. Still not run on a device.


### PR DESCRIPTION
## What

Follow-up to #2844. The blink was landing on a logo that shrank the instant the JS overlay took over from the native splash, so the handoff read as a zoom-out rather than one continuous splash.

## Why it happened

The overlay hard-coded a 100dp logo box on both platforms.

- **iOS was right.** `ios/Therr/BootSplash.storyboard` pins its image view to 100×100, matching `assets/bootsplash/manifest.json`.
- **Android was 2.88× off.** The platform renders `windowSplashScreenAnimatedIcon` in a **288dp** canvas (and pre-12, the compat layer draws the same drawable centered at its intrinsic density size — 288dp again). That is the canvas react-native-bootsplash's generator composites onto, and it normally centers a 100dp logo inside it. HABITS' hand-made `drawable-*/bootsplash_logo.png` instead carries artwork filling the whole canvas (92% of it, at every density), so the native splash draws this logo at ~288dp while the overlay redrew it at 100dp.

## The fix

- Size the logo box per platform — 288dp on Android, the manifest's 100dp on iOS — and multiply by the `logoSizeRatio` the `RNBootSplash` module reports. That ratio exists because Samsung's One UI 4 draws the splash icon at half size; react-native-bootsplash scales its own hide-animation replica by it, but only exposes it through a hook that would also take over hiding the splash, which `Layout` owns. It is read through `TurboModuleRegistry.get`, which returns null rather than throwing when the module is absent, so Jest and web fall back to 1.
- Every other dimension already derived from ratios of the box, so the eyelids, their radii and the lash line follow the new size on their own.
- On Android, draw the drawable the native splash drew, by resource name. The bundled JS copy tops out at 400px — fine in a 100dp box, a 2.9× upscale in a 288dp one — while the drawable set carries the density the system already picked (864px at xxhdpi). `onError` falls back to the bundled copy, which beats eyelids blinking over nothing.
- `fadeDuration={0}`: Android otherwise fades a freshly decoded image in over 300ms, which is one more thing for the eye to catch at the handoff.

## Tests

`splashLogoEyes.test.ts` grew three ways:

- The eye-geometry measurements now run against **both** bitmaps the overlay can draw — the bundled JS copy and the Android drawable — and confirm they frame the artwork identically, so the fallback swap does not move the logo.
- The drawables are held to the 288dp canvas at every density, and to being canvas-filling rather than a smaller centered logo. Regenerating them the generator's way would otherwise silently reintroduce the same 2.9× mismatch.
- The per-platform size is asserted directly, including the halved One UI 4 case.

Verified locally: eslint clean on both files; `npm run pr:tsc-baseline:mobile` at `current=105 baseline=105`; full mobile Jest suite green (103 suites, 1756 tests). The blink was re-composited onto the Android drawable at xxhdpi to confirm the lids still land on the eyes at the larger size. Still not run on a device or emulator.

## Worth knowing

Two things this PR deliberately leaves alone, both pre-existing:

- Android's splash logo is ~2.9× the size of iOS's. Normalizing that means regenerating the Android drawables (a 100dp logo centered in the 288dp canvas), which would shrink what ships today — a product change, not a continuity fix.
- That artwork extends past the 192dp circle Google documents as the visible area for a splash icon without a background. No cropping has been reported, so the mask does not appear to apply to a plain bitmap — but if the Android splash ever starts showing a clipped wordmark, this is why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128AiTDm8WwidSj5xhTtqkj

---
_Generated by [Claude Code](https://claude.ai/code/session_0128AiTDm8WwidSj5xhTtqkj)_