### PR TITLE
fix(habits): show a re-commit as a continuation, not a second pact

### DIFF
--- a/TherrMobile/__tests__/components/PactCardRenewalLineage.test.tsx
+++ b/TherrMobile/__tests__/components/PactCardRenewalLineage.test.tsx
@@ -1,0 +1,177 @@
+import { it, describe, expect, jest } from '@jest/globals';
+import React from 'react';
+import { Text } from 'react-native';
+import renderer, { act } from 'react-test-renderer';
+
+jest.mock('react-native-vector-icons/FontAwesome5', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+// Imported after the mock, as PactStatusText.test.ts does: the card pulls in
+// react-native-vector-icons at module scope, which has no native module under Jest.
+import PactCard from '../../main/components/Habits/PactCard';
+
+/**
+ * Renewal lineage on the pact card.
+ *
+ * "Re-commit for 30 days" creates a *new* pact on the same habit goal rather than
+ * extending the old row, and the finished cycle keeps its own dates, completion rates
+ * and history. That is the right storage model, but it used to reach the user as two
+ * pacts where they had one habit — and each further tap of the still-live CTA added
+ * another, because nothing about the finished cycle changed when it was continued.
+ *
+ * Three things have to hold on the card for a renewal to read as a continuation:
+ *
+ *   1. A continued cycle stops offering to be continued again.
+ *   2. A cycle that continues an earlier one says so, and can reach it — the list
+ *      leaves superseded cycles out, so the link is the only route to the history.
+ *   3. Following that link opens the pact it names, not the card it sits on.
+ */
+
+const themeHabits: any = {
+    colors: {
+        alertSuccess: '#0a0',
+        alertWarning: '#fa0',
+        onSurfaceMuted: '#888',
+        onBrand: '#fff',
+        textGray: '#666',
+    },
+    // Every style the card reads, as an identity map: these assertions are about
+    // structure and handlers, and a real StyleSheet would only add a native dependency.
+    styles: new Proxy({}, { get: (_target, key) => ({ styleKey: key }) }),
+};
+
+const translate = (key: string, params?: any) => (params
+    ? `${key}:${JSON.stringify(params)}`
+    : key);
+
+const basePact: any = {
+    id: 'pact-2',
+    creatorUserId: 'me',
+    habitGoalId: 'goal-1',
+    habitGoalName: 'Morning run',
+    pactType: 'accountability',
+    status: 'active',
+    durationDays: 30,
+    members: [],
+};
+
+const render = (pact: any, props: any = {}) => {
+    let tree: renderer.ReactTestRenderer | undefined;
+    act(() => {
+        tree = renderer.create(
+            <PactCard
+                pact={pact}
+                currentUserId="me"
+                themeHabits={themeHabits}
+                translate={translate}
+                {...props}
+            />,
+        );
+    });
+    return tree as renderer.ReactTestRenderer;
+};
+
+const textContents = (tree: renderer.ReactTestRenderer): string[] => tree.root
+    .findAllByType(Text)
+    .map((node) => node.props.children)
+    .filter((child): child is string => typeof child === 'string');
+
+/**
+ * The tappable lineage rows, found by props rather than by component type.
+ *
+ * `Pressable` renders a host View that carries the same `accessibilityLabel`, and
+ * TherrMobile's Babel `resolvePath` sends `react-native` imports through
+ * `resolver/react-native/`, so an identity check against the imported symbol does not
+ * hold either. `onPress` is on the composite alone, which makes it the reliable
+ * discriminator.
+ */
+const lineageLinks = (tree: renderer.ReactTestRenderer) => tree.root.findAll((node) => (
+    typeof node.props?.accessibilityLabel === 'string'
+    && node.props.accessibilityLabel.startsWith('pages.pacts.renew.')
+    && typeof node.props?.onPress === 'function'
+));
+
+describe('PactCard renewal lineage', () => {
+    it('hides the re-commit CTA on a cycle that has already been continued', () => {
+        const onRenew = jest.fn();
+        const tree = render({
+            ...basePact,
+            status: 'expired',
+            endDate: '2020-01-01T00:00:00.000Z',
+            supersededByPactId: 'pact-3',
+        }, { onRenew });
+
+        expect(textContents(tree)).not.toContain('pages.pacts.renew.prompt');
+    });
+
+    it('still offers the CTA on a finished cycle nothing has continued', () => {
+        const tree = render({
+            ...basePact,
+            status: 'expired',
+            endDate: '2020-01-01T00:00:00.000Z',
+        }, { onRenew: jest.fn() });
+
+        expect(textContents(tree)).toContain('pages.pacts.renew.prompt');
+    });
+
+    it('links back to the cycle a renewal continues', () => {
+        const onViewSourcePact = jest.fn();
+        const tree = render(
+            { ...basePact, renewedFromPactId: 'pact-1', renewalCycleNumber: 2 },
+            { onViewSourcePact },
+        );
+
+        const [link] = lineageLinks(tree);
+        expect(link?.props.accessibilityLabel).toBe('pages.pacts.renew.extendedFrom');
+
+        // stopPropagation matters as much as the handler: the whole card is a Pressable
+        // that opens this pact, so a tap that bubbled would open the successor the user
+        // is already looking at instead of the history they asked for.
+        const stopPropagation = jest.fn();
+        act(() => {
+            link.props.onPress({ stopPropagation });
+        });
+        expect(onViewSourcePact).toHaveBeenCalledWith('pact-1');
+        expect(stopPropagation).toHaveBeenCalled();
+    });
+
+    it('links forward from a superseded cycle to the one that replaced it', () => {
+        const onViewSuccessorPact = jest.fn();
+        const onViewSourcePact = jest.fn();
+        const tree = render({
+            ...basePact,
+            status: 'expired',
+            renewedFromPactId: 'pact-1',
+            supersededByPactId: 'pact-3',
+        }, { onViewSuccessorPact, onViewSourcePact });
+
+        // A middle cycle has a link in both directions and the card draws one. Forward
+        // wins: it answers "so where is my habit now".
+        const links = lineageLinks(tree);
+        expect(links).toHaveLength(1);
+
+        act(() => {
+            links[0].props.onPress({ stopPropagation: jest.fn() });
+        });
+        expect(onViewSuccessorPact).toHaveBeenCalledWith('pact-3');
+        expect(onViewSourcePact).not.toHaveBeenCalled();
+    });
+
+    it('states the relationship without a handler rather than drawing a dead link', () => {
+        const tree = render({ ...basePact, renewedFromPactId: 'pact-1' });
+
+        expect(textContents(tree)).toContain('pages.pacts.renew.extendedFrom');
+        expect(lineageLinks(tree)).toHaveLength(0);
+    });
+
+    it('badges the cycle count from the second cycle on, never the first', () => {
+        expect(textContents(render({ ...basePact, renewalCycleNumber: 3 })))
+            .toContain('pages.pacts.renew.cycleLabel:{"number":3}');
+        expect(textContents(render({ ...basePact, renewalCycleNumber: 1 })).join(' '))
+            .not.toContain('cycleLabel');
+        // Legacy rows predate the column and are first cycles as far as anything knows.
+        expect(textContents(render(basePact)).join(' ')).not.toContain('cycleLabel');
+    });
+});

--- a/TherrMobile/__tests__/routes/PactRenewability.test.ts
+++ b/TherrMobile/__tests__/routes/PactRenewability.test.ts
@@ -1,5 +1,5 @@
 import { it, describe, expect, beforeAll, afterAll } from '@jest/globals';
-import { isPactRenewable } from '../../main/routes/Habits/pactState';
+import { isPactRenewable, isPactSuperseded } from '../../main/routes/Habits/pactState';
 
 /**
  * Pact renewal CTA gating.
@@ -68,5 +68,42 @@ describe('isPactRenewable', () => {
         expect(isPactRenewable(undefined)).toBe(false);
         expect(isPactRenewable({} as any)).toBe(false);
         expect(isPactRenewable(pact('active', 'not-a-date'))).toBe(false);
+    });
+
+    /**
+     * The reported bug: each tap of "re-commit" added what looked like a duplicate pact.
+     *
+     * The CTA stayed live on a cycle that had already been continued, because
+     * renewability was purely a question about *this* pact's dates and status — and a
+     * renewal with partners is created `pending`, so nothing about the finished cycle
+     * changed to switch its button off. Every tap therefore started another parallel
+     * cycle. The server is idempotent about it now, but the button should not be there
+     * to press in the first place.
+     */
+    it('does not offer to re-commit a cycle that has already been continued', () => {
+        expect(isPactRenewable({
+            ...pact('expired', '2026-08-25T00:00:00.000Z'),
+            supersededByPactId: 'pact-2',
+        })).toBe(false);
+    });
+
+    // An `abandoned` successor — which is what declining a 1:1 renewal produces — is not
+    // reported in `supersededByPactId`, so the finished cycle stays re-committable. That
+    // is the difference between a partner saying no and the habit being over.
+    it('still offers a cycle whose only renewal was declined', () => {
+        expect(isPactRenewable({
+            ...pact('expired', '2026-08-25T00:00:00.000Z'),
+            supersededByPactId: null,
+        })).toBe(true);
+    });
+});
+
+describe('isPactSuperseded', () => {
+    it('is true only when a successor is actually named', () => {
+        expect(isPactSuperseded({ supersededByPactId: 'pact-2' })).toBe(true);
+        expect(isPactSuperseded({ supersededByPactId: null })).toBe(false);
+        expect(isPactSuperseded({})).toBe(false);
+        expect(isPactSuperseded(null)).toBe(false);
+        expect(isPactSuperseded(undefined)).toBe(false);
     });
 });

--- a/TherrMobile/main/components/Habits/PactCard.tsx
+++ b/TherrMobile/main/components/Habits/PactCard.tsx
@@ -4,7 +4,7 @@ import FontAwesome5Icon from 'react-native-vector-icons/FontAwesome5';
 import { IPact, IPactMember } from 'therr-react/types';
 import { ITherrThemeColors } from '../../styles/themes';
 import { getCheckedInToday } from './PactMemberRow';
-import { isPactRenewable } from '../../routes/Habits/pactState';
+import { isPactRenewable, isPactSuperseded } from '../../routes/Habits/pactState';
 
 interface IPactCardProps {
     pact: IPact;
@@ -21,6 +21,13 @@ interface IPactCardProps {
     // the card stays read-only there.
     onRenew?: () => void;
     isRenewPending?: boolean;
+    // Renewal lineage. A re-commit creates a *new* pact on the same habit goal, so
+    // without a way across the boundary the finished cycle is either invisible (it is
+    // left out of the list) or, when it is on screen, indistinguishable from a
+    // separate pact. Supplying these renders the link in whichever direction the
+    // pact has one; omit them and the card just states the relationship.
+    onViewSourcePact?: (sourcePactId: string) => void;
+    onViewSuccessorPact?: (successorPactId: string) => void;
     themeHabits: {
         colors: ITherrThemeColors;
         styles: any;
@@ -70,6 +77,8 @@ const PactCard: React.FC<IPactCardProps> = ({
     isRespondPending,
     onRenew,
     isRenewPending,
+    onViewSourcePact,
+    onViewSuccessorPact,
     themeHabits,
     translate,
 }) => {
@@ -77,6 +86,7 @@ const PactCard: React.FC<IPactCardProps> = ({
     const partnerMember = pact.members?.find((m) => m.userId !== currentUserId);
     const showInviteActions = !!onAccept && !!onDecline;
     const showRenewAction = !!onRenew && !showInviteActions && isPactRenewable(pact);
+    const cycleNumber = pact.renewalCycleNumber || 1;
 
     // Badge surface, dot and label color move together — a tonal badge is only
     // legible when its foreground matches the tint it sits on.
@@ -103,6 +113,73 @@ const PactCard: React.FC<IPactCardProps> = ({
     };
 
     const statusStyles = getStatusBadgeStyles();
+
+    /**
+     * The link across a renewal boundary, in whichever direction this pact has one.
+     *
+     * Only one is ever drawn. A pact that has been continued is history, and the useful
+     * move from it is forward to the cycle that replaced it; a pact that continues an
+     * earlier one is current, and the useful move is back to what it was built on. A
+     * middle cycle in a long chain has both, and forward wins — it is the one that
+     * answers "so where is my habit now".
+     */
+    const renderLineageLink = () => {
+        const isSuperseded = isPactSuperseded(pact);
+        const targetPactId = isSuperseded ? pact.supersededByPactId : pact.renewedFromPactId;
+        if (!targetPactId) {
+            return null;
+        }
+
+        const onPressTarget = isSuperseded ? onViewSuccessorPact : onViewSourcePact;
+        const label = translate(isSuperseded
+            ? 'pages.pacts.renew.continuedAs'
+            : 'pages.pacts.renew.extendedFrom');
+
+        // Without a handler the relationship is still worth stating — it is why this
+        // pact's numbers start where they do — so the row renders as plain text rather
+        // than a dead button.
+        if (!onPressTarget) {
+            return (
+                <View style={themeHabits.styles.pactCardLineageRow}>
+                    <FontAwesome5Icon
+                        name="history"
+                        size={10}
+                        color={themeHabits.colors.onSurfaceMuted}
+                    />
+                    <Text style={themeHabits.styles.pactCardLineageText}>{label}</Text>
+                </View>
+            );
+        }
+
+        return (
+            <Pressable
+                accessibilityRole="link"
+                accessibilityLabel={label}
+                // Stops the tap reaching the card's own onPress, which would open this
+                // pact instead of the one the link names.
+                onPress={(event) => {
+                    event.stopPropagation();
+                    onPressTarget(targetPactId);
+                }}
+                style={({ pressed }) => [
+                    themeHabits.styles.pactCardLineageRow,
+                    pressed && themeHabits.styles.pactCardLineageRowPressed,
+                ]}
+            >
+                <FontAwesome5Icon
+                    name="history"
+                    size={10}
+                    color={themeHabits.colors.onSurfaceMuted}
+                />
+                <Text style={themeHabits.styles.pactCardLineageText}>{label}</Text>
+                <FontAwesome5Icon
+                    name="chevron-right"
+                    size={9}
+                    color={themeHabits.colors.onSurfaceMuted}
+                />
+            </Pressable>
+        );
+    };
 
     const renderMemberComparison = (member: IPactMember | undefined, label: string) => {
         // `undefined` means the server has not told us — see getCheckedInToday.
@@ -175,8 +252,15 @@ const PactCard: React.FC<IPactCardProps> = ({
                             type: translate(`pages.pacts.pactType.${pact.pactType}`),
                         })}
                     </Text>
+                    {cycleNumber > 1 && (
+                        <Text style={themeHabits.styles.pactCardCycleBadge}>
+                            {translate('pages.pacts.renew.cycleLabel', { number: cycleNumber })}
+                        </Text>
+                    )}
                 </View>
             </View>
+
+            {renderLineageLink()}
 
             {partnerMember && (
                 <View style={themeHabits.styles.pactPartnerRow}>

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -2271,7 +2271,10 @@
                 "cta": "Re-commit for {days} more days",
                 "successTitle": "You're re-committed",
                 "successMessage": "{days} more days, same crew. Your streak keeps going.",
-                "error": "Could not renew this pact. Please try again."
+                "error": "Could not renew this pact. Please try again.",
+                "cycleLabel": "Cycle {number}",
+                "extendedFrom": "Extended from previous pact",
+                "continuedAs": "Continued in a newer pact"
             }
         },
         "pushOptIn": {

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -2271,7 +2271,10 @@
                 "cta": "Comprometerse {days} días más",
                 "successTitle": "Te has vuelto a comprometer",
                 "successMessage": "{days} días más, el mismo equipo. Tu racha continúa.",
-                "error": "No se pudo renovar el pacto. Inténtalo de nuevo."
+                "error": "No se pudo renovar el pacto. Inténtalo de nuevo.",
+                "cycleLabel": "Ciclo {number}",
+                "extendedFrom": "Continuación del pacto anterior",
+                "continuedAs": "Continuado en un pacto más reciente"
             }
         },
         "pushOptIn": {

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -2271,7 +2271,10 @@
                 "cta": "Se réengager pour {days} jours de plus",
                 "successTitle": "Vous êtes réengagé",
                 "successMessage": "{days} jours de plus, la même équipe. Votre série continue.",
-                "error": "Impossible de renouveler le pacte. Veuillez réessayer."
+                "error": "Impossible de renouveler le pacte. Veuillez réessayer.",
+                "cycleLabel": "Cycle {number}",
+                "extendedFrom": "Prolongement du pacte précédent",
+                "continuedAs": "Poursuivi dans un pacte plus récent"
             }
         },
         "pushOptIn": {

--- a/TherrMobile/main/routes/Habits/Dashboard.tsx
+++ b/TherrMobile/main/routes/Habits/Dashboard.tsx
@@ -30,7 +30,7 @@ import { getFreezeConsumed, getStreakSavedByFreeze } from '../../utilities/strea
 import PactOnboardingGuard from '../../components/Habits/PactOnboardingGuard';
 import { signImageUrl } from '../../utilities/content';
 import { DURATION, showToast } from '../../utilities/toasts';
-import { IHabitWithPactState, splitHabitsByPactState } from './pactState';
+import { IHabitWithPactState, isPactSuperseded, splitHabitsByPactState } from './pactState';
 import { getNudgeErrorMessage, getNudgeOutcomeToast } from '../Pacts/nudgeOutcome';
 import { getSoloUnlockProgress } from '../../utilities/soloHabitUnlock';
 import getConfig from '../../utilities/getConfig';
@@ -451,6 +451,20 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
         navigation.navigate('PactDetail', { pactId: pact.id });
     };
 
+    /**
+     * Opens the other side of a renewal boundary — the cycle a pact continues, or the
+     * cycle that continues it.
+     *
+     * Takes an id rather than a pact because the target is frequently not in this
+     * screen's list: the list read leaves superseded cycles out, which is the point.
+     * `PactDetail` fetches by id, so the link works whether or not the pact is loaded
+     * here.
+     */
+    handleViewLineagePact = (pactId: string) => {
+        const { navigation } = this.props;
+        navigation.navigate('PactDetail', { pactId });
+    };
+
     // The invite wizard is the single creation flow: it creates the habit goal
     // (from a template or a custom name) and sends the pact invites together.
     // Shared by the floating action, the empty states, and the Sent-tab card's
@@ -722,7 +736,13 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
                 return this.getOutgoingInvites();
             case 'all':
             default:
-                return habits.pacts || [];
+                // Superseded cycles are already left out of the list read. They are
+                // filtered again here because `getPactDetails` upserts whatever it
+                // fetches into this same list — so opening an old cycle through a
+                // successor's "extended from" link would otherwise put it back on the
+                // dashboard, next to the cycle that replaced it, which is the exact
+                // duplicate this work removes.
+                return (habits.pacts || []).filter((pact) => !isPactSuperseded(pact));
         }
     };
 
@@ -950,6 +970,8 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
                 isRespondPending={respondingPactId === item.id}
                 onRenew={() => this.handleRenewPact(item)}
                 isRenewPending={renewingPactId === item.id}
+                onViewSourcePact={this.handleViewLineagePact}
+                onViewSuccessorPact={this.handleViewLineagePact}
                 themeHabits={this.themeHabits}
                 translate={this.translate}
             />

--- a/TherrMobile/main/routes/Habits/pactState.ts
+++ b/TherrMobile/main/routes/Habits/pactState.ts
@@ -141,6 +141,22 @@ export const splitHabitsByPactState = (
 );
 
 /**
+ * Has this cycle already been continued by a re-commit?
+ *
+ * `supersededByPactId` is derived server-side and names the newest cycle that
+ * continues this pact — absent when the only renewal was declined or abandoned,
+ * which is what makes such a pact re-committable again.
+ *
+ * The list read leaves superseded cycles out, so most screens never see one.
+ * The exception is the pact reached deliberately, through a successor's
+ * "extended from" link: there the pact is history, and it must read as history
+ * rather than offering to start a cycle that already exists.
+ */
+export const isPactSuperseded = (
+    pact: { supersededByPactId?: string | null } | null | undefined,
+): boolean => !!pact?.supersededByPactId;
+
+/**
  * Whether a pact's cycle is over and can therefore be renewed.
  *
  * Mirrors `isPactRenewable` in users-service (`src/utilities/pactHelpers.ts`),
@@ -158,11 +174,23 @@ export const splitHabitsByPactState = (
  * `abandoned` and `pending` are deliberately absent: someone who walked away
  * should start fresh deliberately, and a pending pact never had a cycle to
  * finish.
+ *
+ * The supersession arm has no counterpart in the server helper, because the
+ * server answers the same question in two steps — `isPactRenewable`, then a
+ * separate successor lookup. Here it has to be one answer, since every CTA on
+ * both screens is drawn from this predicate: a cycle that has already been
+ * continued must not offer to continue it a second time. That combination —
+ * the CTA staying live on a pact that had already been renewed — is how one tap
+ * per duplicate pact used to reach the server at all.
  */
 export const isPactRenewable = (
-    pact: { status?: string; endDate?: Date | string | null } | null | undefined,
+    pact: {
+        status?: string;
+        endDate?: Date | string | null;
+        supersededByPactId?: string | null;
+    } | null | undefined,
 ): boolean => {
-    if (!pact) {
+    if (!pact || isPactSuperseded(pact)) {
         return false;
     }
     if (pact.status === 'completed' || pact.status === 'expired') {

--- a/TherrMobile/main/routes/Pacts/PactDetail.tsx
+++ b/TherrMobile/main/routes/Pacts/PactDetail.tsx
@@ -148,6 +148,19 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
         this.props.navigation.navigate('HabitDetail', { habitGoalId });
     };
 
+    /**
+     * Moves this screen onto another pact rather than pushing a second copy of itself.
+     *
+     * `setParams` + refetch is what `handleRenew` already does for the pact it creates,
+     * and following a renewal chain has the same shape: it is one habit's history, and
+     * stacking a screen per cycle would leave the back button walking the chain in
+     * reverse instead of returning to the list the user came from.
+     */
+    goToPactDetail = (pactId: string) => {
+        this.props.navigation.setParams({ pactId });
+        this.handleRefresh();
+    };
+
     goToUserProfile = (userId: string) => {
         this.props.navigation.navigate('ViewUser', {
             userInView: { id: userId },
@@ -368,6 +381,37 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
         </Pressable>
     );
 
+    /**
+     * A link to the cycle on the other side of a renewal boundary.
+     *
+     * Both directions are offered here, unlike on the card, which draws one. This is
+     * the screen someone is on when they are asking what happened to a habit, and a
+     * cycle in the middle of a chain has an answer in each direction: what it was built
+     * on, and where it went next. The forward link is the one that matters most — the
+     * list leaves superseded cycles out, so without it a user who followed an "extended
+     * from" link back would have no way to the current cycle but the back button.
+     */
+    renderLineageLink = (targetPactId: string, labelKey: string) => (
+        <Pressable
+            accessibilityRole="link"
+            accessibilityLabel={this.translate(labelKey)}
+            onPress={() => this.goToPactDetail(targetPactId)}
+            style={({ pressed }) => [
+                this.themeHabits.styles.pactLinkRow,
+                pressed && this.themeHabits.styles.pactPressedSurface,
+            ]}
+        >
+            <Text style={this.themeHabits.styles.pactLinkText}>
+                {this.translate(labelKey)}
+            </Text>
+            <MaterialIcon
+                name="chevron-right"
+                size={24}
+                color={this.themeHabits.colors.primary3}
+            />
+        </Pressable>
+    );
+
     renderMembersCard = (pact: IPact, currentUserId: string) => {
         const otherMembers = (pact.members || []).filter((m) => m.userId !== currentUserId);
 
@@ -514,6 +558,13 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
                                             type: this.translate(`pages.pacts.pactType.${pact.pactType}`),
                                         })}
                                     </Text>
+                                    {(pact.renewalCycleNumber || 1) > 1 && (
+                                        <Text style={this.themeHabits.styles.pactCardCycleBadge}>
+                                            {this.translate('pages.pacts.renew.cycleLabel', {
+                                                number: pact.renewalCycleNumber,
+                                            })}
+                                        </Text>
+                                    )}
                                 </View>
                             </View>
 
@@ -529,6 +580,15 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
                             </View>
 
                             {linkableHabitGoalId && this.renderHabitLink(linkableHabitGoalId)}
+
+                            {!!pact.supersededByPactId && this.renderLineageLink(
+                                pact.supersededByPactId,
+                                'pages.pacts.renew.continuedAs',
+                            )}
+                            {!!pact.renewedFromPactId && this.renderLineageLink(
+                                pact.renewedFromPactId,
+                                'pages.pacts.renew.extendedFrom',
+                            )}
                         </View>
 
                         {this.renderMembersCard(pact, currentUserId)}

--- a/TherrMobile/main/styles/habits/index.ts
+++ b/TherrMobile/main/styles/habits/index.ts
@@ -426,6 +426,43 @@ const buildStyles = (themeName?: IMobileThemeName) => {
         pactCardStatusTextNeutral: {
             color: therrTheme.colors.onSurfaceMuted,
         },
+        // Pact Card / detail — renewal lineage.
+        //
+        // A re-commit creates a new pact on the same habit goal, and the list shows only
+        // the newest cycle. These render the edge across that boundary: which cycle a pact
+        // continues, and (on a pact reached through that link) which newer cycle continues
+        // it. Deliberately quiet — a chip, not a button. The row is a fact about the pact
+        // first and a way to navigate second, and it sits above the partner row so it is
+        // read as part of the pact's identity rather than as one of its actions.
+        pactCardLineageRow: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            alignSelf: 'flex-start',
+            marginTop: space.sm,
+            paddingVertical: 4,
+            paddingHorizontal: space.sm,
+            borderRadius: radius.sm,
+            backgroundColor: therrTheme.colors.backgroundNeutral,
+        },
+        pactCardLineageRowPressed: {
+            opacity: 0.6,
+        },
+        pactCardLineageText: {
+            fontFamily: therrFontFamily,
+            fontSize: fontSizes.xs,
+            color: therrTheme.colors.onSurfaceMuted,
+            marginHorizontal: 6,
+        },
+        // The cycle count, shown from the second cycle on. A first cycle badged
+        // "cycle 1" is noise; "cycle 3" is the answer to "why have I seen this habit
+        // before", which is the question a renewal list raises.
+        pactCardCycleBadge: {
+            fontFamily: therrFontFamily,
+            fontSize: fontSizes.xs,
+            fontWeight: fontWeights.semibold,
+            color: therrTheme.colors.onSurfaceMuted,
+            marginTop: 2,
+        },
         // Pact Card — pending invite response actions
         pactCardInvitePrompt: {
             fontFamily: therrFontFamily,


### PR DESCRIPTION
The mobile half of the re-commit UX fix. The `general` half — renewal lineage, the list read that leaves superseded cycles out, and the idempotent renew endpoint — merged in #2853.

## The problem

Tapping **"Re-commit for 30 days"** looked like it added a duplicate pact, and tapping it again added another.

It was really creating pacts. A renewal has always been a *new* `habits.pacts` row on the same habit goal — the finished cycle keeps its own dates, completion rates and history, and the streak survives because `habits.streaks` is keyed `(userId, habitGoalId)` and never on `pactId`. That storage model is right and has not changed. Two things around it were wrong:

1. Nothing recorded that the new pact was a renewal *of* the old one, so the list could not tell "two pacts on one habit" from "one habit, second cycle" — and rendered both.
2. The re-commit CTA stayed live on a cycle that had already been continued, so every further tap started another parallel cycle. One tap per apparent duplicate, with no error anywhere.

#2853 fixed the data and the endpoint. This makes the app read the new shape.

## Changes

**`isPactRenewable` refuses a pact carrying `supersededByPactId`** (`routes/Habits/pactState.ts`). That one predicate draws every re-commit CTA on both the card and the detail screen, and it is why defect 2 could reach the server at all: renewability was purely a question about *this* pact's own dates and status, and a renewal with partners is created `pending`, so nothing about the finished cycle changed when it was continued.

An `abandoned` successor is deliberately *not* reported in `supersededByPactId`, so a declined 1:1 renewal leaves the finished cycle re-committable — the difference between a partner saying no and the habit being over.

**`PactCard` gains the link across the renewal boundary** — "Extended from previous pact" on a cycle that continues an earlier one, "Continued in a newer pact" on one that has been continued. One direction per card; forward wins on a middle cycle, since it answers "so where is my habit now". The tap calls `stopPropagation`, because the whole card is a `Pressable` that opens *this* pact — a bubbled tap would open the successor the user is already looking at. Without a handler the row still states the relationship rather than drawing a dead link, which is what a read-only context needs.

**`PactDetail` offers both directions**, because that is the screen someone is on when they are asking what happened to a habit. It moves itself onto the target with `setParams` + refetch rather than pushing a copy of itself — matching what `handleRenew` already does. Stacking a screen per cycle would leave the back button walking the chain in reverse instead of returning to the list.

**The dashboard's "All" segment filters superseded cycles locally as well as server-side.** Not belt-and-braces: `getPactDetails` upserts whatever it fetches into that same `pacts` list, so following an "extended from" link would otherwise put the old cycle straight back on the dashboard beside the one that replaced it — the exact duplicate this work removes.

**Cycle count is badged from the second cycle on.** "Cycle 1" is noise; "cycle 3" is the answer to "why have I seen this habit before", which is the question a renewal history raises.

## Merge order — CI will be red until `general` is merged down

This branch is mobile-only (10 files, no `therr-services/**` or `therr-public-library/**`), and `niche/HABITS-general` does not yet carry #2853. Verified by rebuilding `therr-react` from this branch's own source and running the gate:

```
Mobile tsc errors: current=116 baseline=105
❌ 11 TypeScript error(s) not present in the baseline:
   Property 'renewedFromPactId' does not exist on type 'IPact'.
   Property 'renewalCycleNumber' does not exist on type 'IPact'.
   Property 'supersededByPactId' does not exist on type 'IPact'.
   ...
```

With those fields present the same gate reads `current=105 baseline=105 ✅`. So `general` needs merging down into `niche/HABITS-general` before this lands — the routine step 2, not something this PR should own.

> ⚠️ That merge-down is the un-branding hazard, and it is live here. `general` is now at `applicationId "app.therrmobile"`, `versionCode 458`, `versionName "3.17.5"`; this branch is at `com.therr.habits`, `34`, `1.4.0`. Taking general's side would make the Habits app unreleasable on Play. Run `/split-branch-prs verify-brand` after merging and fix forward.

Deliberately left out of this PR for the same reason — merging `general` in here would drag that version bump onto the niche branch inside a feature change.

## Verification

- `TherrMobile` — 106 suites / 1774 tests passing, including new coverage for both defects
- `npm run pr:tsc-baseline:mobile` — 105 = 105, no new errors (with #2853 present)
- `npm run locales:check` — green; `renew.cycleLabel` / `extendedFrom` / `continuedAs` added to `en-us`, `es`, `fr-ca`
- ESLint clean on every changed file
- Brand identity checked after touching this branch: `CURRENT_BRAND_VARIATION` still `BrandVariations.HABITS`, and no diff in `brandConfig.ts`, `app.json`, `eas.json`, `strings.xml`, `colors.xml`, `ic_launcher_background.xml`, `values-v31/styles.xml`, icons, splash, or the three gradle brand values

New tests:
- `__tests__/components/PactCardRenewalLineage.test.tsx` — CTA hidden on a continued cycle, still offered on one nothing continued, both link directions, `stopPropagation`, no dead link without a handler, cycle badge from 2 on
- `__tests__/routes/PactRenewability.test.ts` — supersession arm of `isPactRenewable`, plus `isPactSuperseded`

## Not included

Pre-existing duplicate rows in production carry no lineage, so nothing can link or hide them — an affected user keeps seeing their duplicates until they are cleaned up. Identifying SQL and the approach are recorded in `docs/WORK_IN_PROGRESS.md` § Manual Operational Follow-ups (landed in #2853), rather than guessed at in a migration: which of several same-second pacts a user meant to keep is a judgement about their data.

I also did not restructure the "All" tab into a grouped-by-habit history view, which would additionally mask those legacy rows. That is a larger design change worth deciding on separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBuVVwMjG2E8cA1T3XP8G8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBuVVwMjG2E8cA1T3XP8G8)_