### PR TITLE
fix(maps-service): authorize private media URL resolution

### DIFF
--- a/TherrMobile/main/components/UserContent/ThoughtDisplay.tsx
+++ b/TherrMobile/main/components/UserContent/ThoughtDisplay.tsx
@@ -11,11 +11,12 @@ import { Button } from '../BaseButton';
 import { Image } from '../BaseImage';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import { canRepostThought } from 'therr-js-utilities/content';
+import { Content } from 'therr-js-utilities/constants';
 import { IUserState } from 'therr-react/types';
 import HashtagsContainer from './HashtagsContainer';
 import { ITherrThemeColors } from '../../styles/themes';
 import spacingStyles from '../../styles/layouts/spacing';
-import { getUserImageUri } from '../../utilities/content';
+import { getUserContentUri, getUserImageUri } from '../../utilities/content';
 import TherrIcon from '../TherrIcon';
 import RichText from '../RichText';
 import handleMentionPress from '../../utilities/handleMentionPress';
@@ -488,6 +489,20 @@ const ThoughtContent = ({
         parentId: thought.parentId,
         translate,
     });
+    /**
+     * Attached image, if the post has one.
+     *
+     * `media` is normalized to an array by `ThoughtsStore` on every read path; the
+     * `medias` fallback covers a row shaped straight from the column (the journal feed
+     * selects it directly). Only the first image renders — the composer attaches one.
+     *
+     * Resolved against the public ImageKit endpoint, the same way `AreaDisplay` renders
+     * moment and event media. Private-bucket thought media needs the extra signed-URL
+     * round trip the nearby feed makes and is not rendered here yet.
+     */
+    const thoughtMedia = (thought.media || thought.medias || [])
+        .find((m) => m?.path && m?.type === Content.mediaTypes.USER_IMAGE_PUBLIC);
+    const thoughtMediaUri = thoughtMedia ? getUserContentUri(thoughtMedia) : undefined;
     const hasRepliableActions = !thought.isDraft && isRepliable;
     const totalReposts = thought.repostCount ?? 0;
     // Shared with the server's own gate (handlers/thoughts createThought) so the control is
@@ -508,6 +523,14 @@ const ThoughtContent = ({
                     onMentionPress={onMentionPress}
                     numberOfLines={isExpanded ? undefined : 7}
                 />
+                {
+                    !!thoughtMediaUri &&
+                        <Image
+                            source={{ uri: thoughtMediaUri }}
+                            style={themeViewContent.styles.thoughtMediaImage}
+                            resizeMode="cover"
+                        />
+                }
                 {
                     !!thought.isRepost &&
                         <RepostEmbed

--- a/TherrMobile/main/routes/EditThought/index.tsx
+++ b/TherrMobile/main/routes/EditThought/index.tsx
@@ -185,6 +185,10 @@ export class EditThought extends React.Component<IEditThoughtProps, IEditThought
             createArgs.media = [{}];
             createArgs.media[0].type = isPublic ? Content.mediaTypes.USER_IMAGE_PUBLIC : Content.mediaTypes.USER_IMAGE_PRIVATE;
             createArgs.media[0].path = response?.data?.path;
+            // The column is `medias` (jsonb), matching moments/spaces/events. `media` is kept
+            // alongside it for the same reason EditMoment keeps both: already-installed apps
+            // send only `media`, and the store accepts either.
+            createArgs.medias = createArgs.media;
 
             const localFileCroppedPath = `${imageDetails?.path}`;
 

--- a/TherrMobile/main/styles/user-content/thoughts/viewing.ts
+++ b/TherrMobile/main/styles/user-content/thoughts/viewing.ts
@@ -250,6 +250,17 @@ const buildStyles = (themeName?: IMobileThemeName, isDarkMode = true) => {
             paddingRight: 14,
             paddingBottom: 4,
         },
+        // Attached image on a thought. `aspectRatio` rather than a fixed height so a
+        // portrait photo is not letterboxed; `resizeMode="cover"` at the call site keeps
+        // it filling the frame either way.
+        thoughtMediaImage: {
+            width: '100%',
+            aspectRatio: 4 / 3,
+            borderRadius: 8,
+            marginTop: 4,
+            marginBottom: 8,
+            backgroundColor: isDarkMode ? therrTheme.colors.accent1 : therrTheme.colorVariations.backgroundNeutral,
+        },
         thoughtDistance: {
             color: isDarkMode ? therrTheme.colors.textGray : therrTheme.colors.tertiary,
             width: '100%',

--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -455,6 +455,34 @@ are the steps code cannot do. Strategy, thresholds and the decision log live in
 > `[ ] (YYYY-MM-DD, /<skill-name>) <action> — <why>`
 
 <!-- skill-followups:start -->
+- [ ] (2026-09-05, /work-plan) **Run the two new migrations after this reaches `main`.**
+  maps-service `20260905000000_main.medias_gin_indexes` and users-service
+  `20260905000001_main.thoughts.medias` — automated by `_bin/cicd/run-migrations.sh` on `main`
+  deploys, so this is a verification step unless `RUN_MIGRATIONS_ON_DEPLOY=false` is set.
+  The GIN indexes are the one worth watching: `createMediaUrls` now runs a `medias @> …`
+  containment probe for any private path the caller does not own, and without the indexes
+  that is a sequential scan on `main.moments` on every nearby-feed render carrying another
+  user's private image. Build them before or with the maps-service rollout, not after.
+- [ ] (2026-09-05, /work-plan) **Watch for private media disappearing from the nearby feed
+  and map after the maps-service deploy.** `POST /media/signed-urls` now omits paths the
+  caller neither owns nor can justify with a moment/space/event, where it previously
+  resolved anything. The intended blast radius is zero — every path a client holds came
+  from a content row — but a resolution path nobody remembered would show up as a missing
+  image with **no error on either side**, the same silent shape as the bug being fixed.
+  Check `NearbyWrapper` / `TherrMapView` render private area images, and `MyDrafts` renders
+  a user's own.
+- [ ] (2026-09-05, /work-plan) **Confirm proof moderation is actually writing.** Nothing
+  fails if it does not — the check is fire-and-forget by design. After a check-in with a
+  photo, `habits.proofs` rows should leave `verificationStatus = 'pending'` for
+  `'auto_verified'` (or `'flagged'`) within seconds. A population stuck at `pending` means
+  `SIGHTENGINE_API_KEY` / `SIGHTENGINE_API_SECRET` are unset on users-service — the moments
+  path has them, but this is the first users-service caller of `checkIsMediaSafeForWork`
+  outside the profile-picture path.
+- [ ] (2026-09-05, /work-plan) **Thought images start appearing for posts made from the
+  already-installed app.** `ThoughtsStore.create` accepts the legacy `media` field, so
+  installs that predate the `EditThought` change stop losing photos as soon as users-service
+  rolls — no app release required. Historical posts stay imageless: their uploads are
+  orphaned objects with no row pointing at them (see § 2.6.7 "Still open").
 - [ ] (2026-09-01, /work-plan) **Ship the `niche/HABITS-general` half of `pactEnded` before
   this reaches production traffic.** Two things are missing there and neither errors: the
   `${notificationActionPrefix}.PACT_ENDED` `<intent-filter>` in
@@ -2034,22 +2062,54 @@ Two decisions worth not re-deriving:
   belongs gets a broken image and no error anywhere. See
   `utilities/checkinProofs.ts`.
 
-Still open, and the reason this is a section rather than a closed line:
+Closed 2026-09-05 (/work-plan), both items.
 
-- [ ] **`POST /maps-service/media/signed-urls` does no authorization.**
-  `createMediaUrls` carries an explicit `// TODO: Check that the user has access
-  to this media` and honours it for nobody: it resolves any path the caller
-  names, and private media resolves to a *deterministic* `IMAGE_KIT_URL_PRIVATE`
-  URL rather than a signed one — so knowing a path is the whole access story.
-  The new endpoint does not widen this (it only ever hands a user their own
-  paths), but proofs are the first private media whose paths follow a guessable
-  shape: `<userId>/content/habits_proof_<habitGoalId>_<epochMs>.jpeg`. Fix the
-  endpoint, not the filename. Scope: `general`, maps-service.
-- [ ] **Proof images are never moderated.** `verificationStatus`,
-  `isSafeForWork` and `moderationFlags` on `habits.proofs` are all still at
-  their insert defaults — nothing writes them. The moments upload path runs
-  Sightengine; the proof path does not. Harmless while proofs are owner-only,
-  **blocking** for 2.6.8, which makes them public.
+**`POST /maps-service/media/signed-urls` now authorizes.** It resolved any path any
+caller named, and private media resolves to a *deterministic* `IMAGE_KIT_URL_PRIVATE`
+URL rather than a signed one — so handing back a URL for a path was equivalent to handing
+back the image, permanently. Three tiers now, in cost order: public-bucket media resolves
+unconditionally (withholding it protects nothing); private media under the caller's own
+`<userId>/` prefix resolves with no database round trip; anything else must be referenced
+by a moment, space or event (`ContentMediaStore.getReferencedPaths`).
+
+That third tier is what keeps the fix non-breaking, and it is not obvious: the nearby feed
+and map legitimately hand a client *other users'* `USER_IMAGE_PRIVATE` paths — they arrive
+inside the area rows, and `NearbyWrapper` collects them into `missingMedias` — so an
+owner-only rule would have blanked those images. It is also what closes the habits case:
+`habits.proofs` paths live in users-service and are referenced by none of those three
+tables, so a proof path is now resolvable only by its owner.
+
+Two things worth not re-deriving:
+
+- **Unresolvable paths are omitted from the response, not rejected.** Clients batch a
+  screenful into one call and already handle a path coming back absent; a 403 for the
+  batch would blank every image in it, including the ones the caller is entitled to. Same
+  choice the reactions write allow-list makes.
+- **The residual gap is deliberate.** "Referenced by content" is weaker than a real
+  visibility check — a caller who knows a path *and* it belongs to a real moment still
+  resolves it. Closing that needs per-content visibility (proximity, connections), which
+  is a much larger change; this refuses the case that had no referent at all.
+- `20260905000000_main.medias_gin_indexes` adds `jsonb_path_ops` GIN indexes on the three
+  `medias` columns. Without them the containment probe is a sequential scan on every
+  nearby-feed render carrying another user's private image.
+
+**Proof images are now moderated.** `utilities/moderateProofs` runs the same
+`checkIsMediaSafeForWork` the moments upload path runs and writes `isSafeForWork` /
+`verificationStatus` / `moderationFlags` via `ProofsStore.setModerationResult`.
+
+Deliberately **not awaited** by the check-in handler and unable to fail it: the check-in
+commits on the first tap (§ 2.6.1), and proofs are owner-only (`canReadProofs`), so an
+unmoderated proof is visible to exactly one person — the uploader. The result matters at
+the moment a proof is *shared*, which is why this is a prerequisite for 2.6.8 rather than
+a gate on check-in.
+
+One asymmetry is load-bearing: `checkIsMediaSafeForWork` fails **closed**, returning false
+when signing or Sightengine throws. That is right for a share gate and wrong for a
+permanent record, so a thrown error is recorded as `pending` — still unverified, still not
+shareable — rather than as `rejected`, which would accuse a user of posting something
+unsafe because a vendor had an outage. Anything that exposes a proof beyond its owner must
+therefore read `verificationStatus === 'auto_verified'`, never `isSafeForWork` alone: rows
+sit briefly at their insert defaults (`pending` / `isSafeForWork: true`).
 
 #### 2.6.7 Thoughts silently drop uploaded images (#2840)
 
@@ -2068,15 +2128,41 @@ The Journal's own comment on `handleCreateGoal` documents the behaviour we do
 not have — "it gets the thought form's public/private toggle, category, hashtags
 and image". Every goal posted with a photo since that shipped has lost the photo.
 
-- [ ] Add a `medias jsonb` column (`[{path, type}]`), matching the
-      moments/spaces convention — **not** the legacy comma-separated `mediaIds`,
-      which areas already migrated away from. Clients then get display for free
-      via the existing `getUserContentUri(media)`.
-- [ ] Add `medias` to the `ThoughtsStore.create` allow-list and hydrate it on
-      the read paths (`getById`, `find`, `getForJournal`), replacing the
-      placeholder `media: {}`.
-- [ ] Render it in `ThoughtDisplay` (mobile) and `ViewThought` / `ThoughtCard`
-      (web). `AreaDisplay` is the working reference.
+Closed 2026-09-05 (/work-plan), the code half.
+
+`20260905000001_main.thoughts.medias` adds `medias jsonb` (`[{path, type, altText}]`),
+matching the moments/spaces/events convention rather than reviving the comma-separated
+`mediaIds`. `mediaIds` is deliberately **left in place**: therr-ai-automator writes
+`main.thoughts` directly, so dropping a column in the same change that adds one risks
+breaking a Cloud Function at its next firing rather than at deploy. Removing it is a later
+contract migration.
+
+`ThoughtsStore.create` now persists it, and `withMedia` hydrates `media` on every read
+path — `getById`, `find` (including their reply rows and their empty branches) and
+`getForJournal`. The old `media: {}` placeholder is gone: it was an *object* on a key
+clients map over, so it would have thrown rather than rendered empty.
+
+Two decisions worth not re-deriving:
+
+- **`create` accepts `media` as well as `medias`.** The deployed mobile composer sends only
+  `media` (`EditThought.signAndUploadImage`) and cannot be force-updated — the same reason
+  `EditMoment` still carries its `createArgs.medias = createArgs.media` line, which
+  `EditThought` was simply missing. Honoring both is what makes already-installed apps stop
+  losing photos on the day this deploys rather than on the day the next release lands.
+- **Only `path`, `type` and `altText` are carried through.** `type` selects the bucket, and
+  maps-service `getBucket` falls through to the **public** bucket for a value it does not
+  recognize — an unfiltered spread is how a private image ends up resolved publicly.
+
+Rendering is in place on `ThoughtDisplay` (mobile) and `ViewThought` / `ThoughtCard` (web,
+via `utilities/getThoughtMediaUri`).
+
+Still open:
+
+- [ ] **Private-bucket thought media does not render.** All three surfaces resolve against
+      the public ImageKit endpoint, the way `AreaDisplay` renders moment and event media. A
+      thought posted with `isPublic: false` gets `USER_IMAGE_PRIVATE` and needs the extra
+      `POST /maps-service/media/signed-urls` round trip the nearby feed makes; until then
+      the image is skipped rather than rendered broken.
 - [ ] Decide what happens to already-orphaned uploads. They are unreferenced
       objects in both buckets with no row pointing at them; a bucket-side
       lifecycle rule is probably cheaper than a reconciliation script.
@@ -2457,8 +2543,6 @@ English-formatted timestamps.
 - `therr-services/maps-service/src/handlers/spaces.ts:347` — Check user is
   part of organization and has access to view (currently any auth'd user can
   view any org space)
-- `therr-services/maps-service/src/handlers/createMediaUrls.ts:8, 11` — More
-  security on media access (verify requesting user has permission)
 - `therr-services/maps-service/src/store/EventsStore.ts:37` — Same
 - `therr-services/maps-service/src/store/MomentsStore.ts:33` — Same
 - `therr-services/maps-service/src/store/SpacesStore.ts:57` — Same

--- a/therr-client-web/src/components/business-profile/ThoughtCard.tsx
+++ b/therr-client-web/src/components/business-profile/ThoughtCard.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import {
-    Paper, Text, Group, Badge, Stack, Anchor,
+    Paper, Text, Group, Badge, Stack, Anchor, Image,
 } from '@mantine/core';
 import { formatDate } from '../../utilities/formatDate';
 import EmbeddedThought from '../EmbeddedThought';
 import useTranslation from '../../hooks/useTranslation';
+import getThoughtMediaUri from '../../utilities/getThoughtMediaUri';
 
 interface IThoughtCardProps {
     locale: string;
@@ -17,6 +18,7 @@ const ThoughtCard: React.FC<IThoughtCardProps> = ({ locale, thought, onThoughtCl
     const { t: translate } = useTranslation();
     const hashTags = thought.hashTags ? thought.hashTags.split(',').filter(Boolean) : [];
     const thoughtUrl = `/thoughts/${thought.id}`;
+    const mediaUri = getThoughtMediaUri(thought, 400, 400);
 
     const handleClick = (e: React.MouseEvent) => {
         if (onThoughtClick) {
@@ -58,6 +60,16 @@ const ThoughtCard: React.FC<IThoughtCardProps> = ({ locale, thought, onThoughtCl
                     <Text size="sm" style={{ whiteSpace: 'pre-wrap' }} lineClamp={4}>
                         {thought.message}
                     </Text>
+                    {mediaUri && (
+                        <Image
+                            src={mediaUri}
+                            alt=""
+                            radius="sm"
+                            h={180}
+                            fit="cover"
+                            loading="lazy"
+                        />
+                    )}
                     {/*
                         A plain repost has an empty message, so without the embed this card would
                         render as a blank tile on the author's profile. Non-interactive because the

--- a/therr-client-web/src/routes/ViewThought.tsx
+++ b/therr-client-web/src/routes/ViewThought.tsx
@@ -15,6 +15,7 @@ import {
     Container,
     Divider,
     Group,
+    Image,
     Skeleton,
     Stack,
     Text,
@@ -29,6 +30,7 @@ import EmbeddedThought from '../components/EmbeddedThought';
 import RepostModal from '../components/RepostModal';
 import { formatTimeAgo } from '../utilities/formatDate';
 import getRepostErrorKey from '../utilities/repostErrors';
+import getThoughtMediaUri from '../utilities/getThoughtMediaUri';
 
 const ViewThought: React.FC = () => {
     const { t: translate, locale } = useTranslation();
@@ -354,6 +356,16 @@ const ViewThought: React.FC = () => {
                     <Text size="md" mb="sm" className="thought-card-message">
                         {thought.message}
                     </Text>
+
+                    {getThoughtMediaUri(thought) && (
+                        <Image
+                            src={getThoughtMediaUri(thought)}
+                            alt=""
+                            radius="md"
+                            mb="sm"
+                            fit="contain"
+                        />
+                    )}
 
                     {thought.isRepost && <EmbeddedThought repostOf={thought.repostOf} />}
 

--- a/therr-client-web/src/routes/__tests__/ViewThought.test.tsx
+++ b/therr-client-web/src/routes/__tests__/ViewThought.test.tsx
@@ -12,6 +12,15 @@ const mockReduxState: any = {
     content: { activeThoughts: [] },
 };
 
+// `getUserContentUri` reads `globalConfig[process.env.NODE_ENV]` at module load, and
+// global-config.js declares no `test` env — so importing it at all throws here. Mocked
+// the same way ListSpaces and ViewSpace mock it. ViewThought reaches it transitively
+// through `getThoughtMediaUri`, which renders a thought's attached image.
+jest.mock('../../utilities/getUserContentUri', () => ({
+    __esModule: true,
+    default: () => 'https://example.com/image.jpg',
+}));
+
 jest.mock('react-redux', () => ({
     // The component dispatches thunks and reads the response as a promise, so an identity
     // dispatch is enough — the actions themselves are mocked below.

--- a/therr-client-web/src/utilities/getThoughtMediaUri.ts
+++ b/therr-client-web/src/utilities/getThoughtMediaUri.ts
@@ -1,0 +1,28 @@
+import { Content } from 'therr-js-utilities/constants';
+import getUserContentUri from './getUserContentUri';
+
+/**
+ * The display URL for a thought's attached image, if it has a renderable one.
+ *
+ * Reads `media` (normalized to an array by `ThoughtsStore` on every read path) and falls
+ * back to the raw `medias` column shape. Only the first image is used — the composer
+ * attaches one.
+ *
+ * Public-bucket media only. Private thought media resolves through
+ * `POST /maps-service/media/signed-urls`, an extra round trip no web thought surface
+ * makes today; rendering it against the public endpoint would produce a broken image
+ * rather than an error.
+ */
+const getThoughtMediaUri = (thought: any, height?: number, width?: number): string | null => {
+    const medias = thought?.media || thought?.medias;
+
+    if (!Array.isArray(medias)) {
+        return null;
+    }
+
+    const media = medias.find((m) => m?.path && m?.type === Content.mediaTypes.USER_IMAGE_PUBLIC);
+
+    return media ? getUserContentUri(media, height, width) : null;
+};
+
+export default getThoughtMediaUri;

--- a/therr-services/maps-service/src/handlers/createMediaUrls.ts
+++ b/therr-services/maps-service/src/handlers/createMediaUrls.ts
@@ -3,12 +3,75 @@ import Store from '../store';
 import handleHttpError from '../utilities/handleHttpError';
 import getBucket from '../utilities/getBucket';
 import { storage } from '../api/aws';
+import { IRequestedMedia, partitionByOwnership } from '../utilities/mediaAccess';
+
+/**
+ * Resolve display URLs for media the caller names.
+ *
+ * Authorization matters more here than the signing does. Private-bucket media
+ * resolves to a **deterministic** `IMAGE_KIT_URL_PRIVATE` URL rather than a signed
+ * one, so handing back a URL for a path is equivalent to handing back the image
+ * itself, permanently. Until now the handler resolved any path any caller named.
+ *
+ * Three tiers, in cost order:
+ *
+ * 1. Public-bucket media resolves unconditionally — the bucket is public, so
+ *    withholding a URL protects nothing and only breaks rendering.
+ * 2. Private media under the caller's own `<userId>/` prefix resolves with no
+ *    database round trip. This is the common case (drafts, a user's own proofs).
+ * 3. Anything else must be justified by a moment, space or event that references
+ *    the path — which is how the nearby feed and map legitimately render another
+ *    user's private area image.
+ *
+ * Unresolvable paths are **omitted from the response rather than rejected**, the
+ * same choice the reactions write allow-list makes. Clients batch a screenful of
+ * paths into one call and already handle a path coming back absent
+ * (`!content?.media[media.path]` in `NearbyWrapper`); a 403 for the batch would
+ * blank every image in it, including the ones the caller is entitled to.
+ */
+const resolveUrl = (media: IRequestedMedia, imageExpireTime: number): Promise<Record<string, string>> | null => {
+    const bucket = getBucket(media.type);
+
+    if (!bucket) {
+        console.log('createMediaUrls.ts: bucket is undefined');
+        return null;
+    }
+
+    if (bucket === getBucket(Content.mediaTypes.USER_IMAGE_PUBLIC)) {
+        return Promise.resolve({
+            [media.path]: `${process.env.IMAGE_KIT_URL}${media.path}`,
+        });
+    }
+
+    if (bucket === getBucket(Content.mediaTypes.USER_IMAGE_PRIVATE)) {
+        return Promise.resolve({
+            [media.path]: `${process.env.IMAGE_KIT_URL_PRIVATE}${media.path}`,
+        });
+    }
+
+    return storage
+        .bucket(bucket)
+        .file(media.path)
+        .getSignedUrl({
+            version: 'v4',
+            action: 'read',
+            expires: imageExpireTime,
+            // TODO: Test is cache-control headers work here
+            extensionHeaders: {
+                'Cache-Control': 'public, max-age=43200', // 1 day
+            },
+        })
+        .then((urls) => ({
+            [media.path]: urls[0],
+        }))
+        .catch((err) => {
+            console.log(err);
+            return {};
+        });
+};
 
 // POST
-// TODO: This needs more security logic to ensure the requesting user has permissions to view
-// non-public images
 const createMediaUrls = (req, res) => {
-    // TODO: Check that the user has access to this media
     const userId = req.headers['x-userid'];
     const { mediaIds, ttl, medias } = req.body;
     const imageExpireTime = ttl || (Date.now() + 60 * 60 * 1000); // 60 minutes
@@ -16,57 +79,33 @@ const createMediaUrls = (req, res) => {
 
     // TODO: This provides temporary backwards compatibility
     // We can remove mediaIds after full refactor of frontend
-    const fetchPrivateMediaPromise = medias?.length
+    const fetchPrivateMediaPromise: Promise<IRequestedMedia[]> = medias?.length
         ? Promise.resolve(medias)
         : Store.media.get(sanitizedIds);
 
     return fetchPrivateMediaPromise.then((media) => {
-        const urlPromises: Promise<any>[] = [];
-        media.forEach((m) => {
-            const bucket = getBucket(m.type);
-            if (bucket) {
-                let promise;
-                if (bucket === getBucket(Content.mediaTypes.USER_IMAGE_PUBLIC)) {
-                    promise = Promise.resolve({
-                        [m.path]: `${process.env.IMAGE_KIT_URL}${m.path}`,
-                    });
-                } else if (bucket === getBucket(Content.mediaTypes.USER_IMAGE_PRIVATE)) {
-                    // NOTE: Private media should require authorization
-                    promise = Promise.resolve({
-                        [m.path]: `${process.env.IMAGE_KIT_URL_PRIVATE}${m.path}`,
-                    });
-                } else {
-                    promise = storage
-                        .bucket(bucket)
-                        .file(m.path)
-                        .getSignedUrl({
-                            version: 'v4',
-                            action: 'read',
-                            expires: imageExpireTime,
-                            // TODO: Test is cache-control headers work here
-                            extensionHeaders: {
-                                'Cache-Control': 'public, max-age=43200', // 1 day
-                            },
-                        })
-                        .then((urls) => ({
-                            [m.path]: urls[0],
-                        }))
-                        .catch((err) => {
-                            console.log(err);
-                            return {};
-                        });
-                }
-                // TODO: Consider alternatives to cache these urls (per user) and their expire time
+        const { allowed, needsReferenceCheck } = partitionByOwnership(media, userId);
 
-                urlPromises.push(promise);
-            } else {
-                console.log('MomentsStore.ts: bucket is undefined');
-            }
+        const authorizedPromise: Promise<IRequestedMedia[]> = needsReferenceCheck.length
+            ? Store.contentMedia
+                .getReferencedPaths(needsReferenceCheck.map((m) => m.path))
+                .then((referenced) => {
+                    const referencedSet = new Set(referenced);
+
+                    return allowed.concat(needsReferenceCheck.filter((m) => referencedSet.has(m.path)));
+                })
+            : Promise.resolve(allowed);
+
+        return authorizedPromise.then((authorized) => {
+            const urlPromises = authorized
+                .map((m) => resolveUrl(m, imageExpireTime))
+                .filter((promise): promise is Promise<Record<string, string>> => !!promise);
+
+            // TODO: Consider alternatives to cache these urls (per user) and their expire time
+            return Promise.all(urlPromises).then((mediaUrls) => res.status(201).send({
+                media: mediaUrls.reduce((prev: any, curr: any) => ({ ...curr, ...prev }), {}),
+            }));
         });
-
-        return Promise.all(urlPromises).then((mediaUrls) => res.status(201).send({
-            media: mediaUrls.reduce((prev: any, curr: any) => ({ ...curr, ...prev }), {}),
-        }));
     }).catch((err) => handleHttpError({ err, res, message: 'SQL:MEDIA_ROUTES:ERROR' }));
 };
 

--- a/therr-services/maps-service/src/store/ContentMediaStore.ts
+++ b/therr-services/maps-service/src/store/ContentMediaStore.ts
@@ -1,0 +1,65 @@
+import { IConnection } from './connection';
+import { MOMENTS_TABLE_NAME } from './MomentsStore';
+import { SPACES_TABLE_NAME } from './SpacesStore';
+import { EVENTS_TABLE_NAME } from './EventsStore';
+
+/**
+ * Bounded so a caller cannot turn one request into an unbounded OR chain.
+ * Well past any real batch — the nearby feed resolves a screenful at a time.
+ */
+export const MAX_REFERENCE_CHECK_PATHS = 100;
+
+const REFERENCING_TABLES = [MOMENTS_TABLE_NAME, SPACES_TABLE_NAME, EVENTS_TABLE_NAME];
+
+/**
+ * Answers one question: is this media path carried by a piece of maps-service content?
+ *
+ * Separate from `MediaStore` on purpose — moments, spaces and events all import
+ * `MediaStore`, so reaching back to their table names from inside it would make a
+ * require cycle out of what is only a read.
+ */
+export default class ContentMediaStore {
+    db: IConnection;
+
+    constructor(dbConnection) {
+        this.db = dbConnection;
+    }
+
+    /**
+     * Which of these paths does a moment, space or event actually reference?
+     *
+     * This is the authorization fallback in `createMediaUrls` for private media the
+     * requester does not own. The nearby feed and the map legitimately hand a client
+     * another user's `USER_IMAGE_PRIVATE` paths — they arrive inside the area rows
+     * themselves — so an owner-only rule would stop those images rendering. A path
+     * that no content row references was never published by this service to anybody,
+     * which is the case worth refusing: `habits.proofs` paths live in users-service
+     * and appear in none of these three tables.
+     *
+     * Written as an OR of `@>` containment predicates rather than as a lateral
+     * extraction in the WHERE clause, because containment is the form the GIN indexes
+     * in `20260905000000_main.medias_gin_indexes` can answer. The lateral join is
+     * only there to report *which* candidates matched.
+     */
+    getReferencedPaths(paths: string[]): Promise<string[]> {
+        const candidates = [...new Set(paths.filter((p) => !!p))].slice(0, MAX_REFERENCE_CHECK_PATHS);
+
+        if (!candidates.length) {
+            return Promise.resolve([]);
+        }
+
+        const params = candidates.map((p) => JSON.stringify([{ path: p }]));
+        const containment = candidates.map((_, index) => `c.medias @> $${index + 1}::jsonb`).join(' OR ');
+        const extraction = candidates.map((_, index) => `$${index + 1}::jsonb->0->>'path'`).join(', ');
+
+        const queries = REFERENCING_TABLES.map((tableName) => this.db.read.query(
+            `SELECT DISTINCT elem->>'path' AS path
+               FROM ${tableName} c, LATERAL jsonb_array_elements(c.medias) elem
+              WHERE (${containment})
+                AND elem->>'path' IN (${extraction})`,
+            params,
+        ).then((response) => response.rows.map((row) => row.path)));
+
+        return Promise.all(queries).then((results) => [...new Set(results.flat())]);
+    }
+}

--- a/therr-services/maps-service/src/store/index.ts
+++ b/therr-services/maps-service/src/store/index.ts
@@ -1,5 +1,6 @@
 import connection, { IConnection } from './connection';
 import CityWikiCacheStore from './CityWikiCacheStore';
+import ContentMediaStore from './ContentMediaStore';
 import EventsStore from './EventsStore';
 import ExternalMediaIntegrationsStore from './ExternalMediaIntegrationsStore';
 import MediaStore from './MediaStore';
@@ -16,6 +17,8 @@ class Store {
     db: IConnection;
 
     cityWikiCache: CityWikiCacheStore;
+
+    contentMedia: ContentMediaStore;
 
     events: EventsStore;
 
@@ -43,6 +46,8 @@ class Store {
         this.db = dbConnection;
 
         this.cityWikiCache = new CityWikiCacheStore(this.db);
+
+        this.contentMedia = new ContentMediaStore(this.db);
 
         this.externalMediaIntegrations = new ExternalMediaIntegrationsStore(this.db);
 

--- a/therr-services/maps-service/src/store/migrations/20260905000000_main.medias_gin_indexes.js
+++ b/therr-services/maps-service/src/store/migrations/20260905000000_main.medias_gin_indexes.js
@@ -1,0 +1,25 @@
+// Supports the authorization check in `createMediaUrls` / `ContentMediaStore.getReferencedPaths`.
+//
+// That handler now refuses to resolve a private media path the caller neither owns nor
+// can justify with a piece of content, and "can justify" is a `medias @> '[{"path": …}]'`
+// containment probe against these three tables. Without an index that probe is a
+// sequential scan on every nearby-feed render that includes another user's private
+// image, which is the common case the check has to stay cheap for.
+//
+// `jsonb_path_ops` rather than the default `jsonb_ops`: it indexes only containment,
+// which is the sole operator used here, and produces a substantially smaller index.
+
+exports.up = (knex) => knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_moments_medias_gin
+    ON main."moments" USING GIN ("medias" jsonb_path_ops)
+`).then(() => knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_spaces_medias_gin
+    ON main."spaces" USING GIN ("medias" jsonb_path_ops)
+`)).then(() => knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_events_medias_gin
+    ON main."events" USING GIN ("medias" jsonb_path_ops)
+`));
+
+exports.down = (knex) => knex.raw('DROP INDEX IF EXISTS main.idx_moments_medias_gin')
+    .then(() => knex.raw('DROP INDEX IF EXISTS main.idx_spaces_medias_gin'))
+    .then(() => knex.raw('DROP INDEX IF EXISTS main.idx_events_medias_gin'));

--- a/therr-services/maps-service/src/utilities/mediaAccess.ts
+++ b/therr-services/maps-service/src/utilities/mediaAccess.ts
@@ -1,0 +1,71 @@
+import { Content } from 'therr-js-utilities/constants';
+import getBucket from './getBucket';
+
+export interface IRequestedMedia {
+    path: string;
+    type: string;
+}
+
+/**
+ * Does this path live in the private bucket?
+ *
+ * Keyed off `getBucket` rather than off the type string directly, because
+ * `getBucket` falls through to the **public** bucket for anything it does not
+ * recognize. Asking it the question keeps this in step with that fall-through:
+ * an unrecognized type resolves publicly, so it is not private media and does
+ * not need the ownership/reference check below.
+ */
+export const isPrivateMedia = (media: IRequestedMedia): boolean => {
+    const bucket = getBucket(media.type);
+
+    return !!bucket && bucket === getBucket(Content.mediaTypes.USER_IMAGE_PRIVATE);
+};
+
+/**
+ * Every upload path is written under the uploader's own id — see the
+ * `signImageUrl` handler, which prefixes `<userId>/` before the caller's
+ * requested filename. So the first segment identifies the owner without a
+ * lookup, which is what keeps the common case (a user resolving their own
+ * drafts) free of a database round trip.
+ *
+ * Compared as whole segments: a plain `startsWith` would let user `abc` claim
+ * `abcdef/content/...`.
+ */
+export const isOwnedBy = (path: string, userId: string | undefined): boolean => {
+    if (!path || !userId) {
+        return false;
+    }
+
+    const [owner, ...rest] = path.split('/');
+
+    return rest.length > 0 && owner === String(userId);
+};
+
+/**
+ * Split a requested batch into what may be resolved without asking the database,
+ * and what still has to be justified by a piece of maps-service content.
+ *
+ * Public-bucket media is unconditional — the bucket is public, so withholding a
+ * URL protects nothing and would only break rendering.
+ */
+export const partitionByOwnership = (
+    medias: IRequestedMedia[],
+    userId: string | undefined,
+): { allowed: IRequestedMedia[]; needsReferenceCheck: IRequestedMedia[] } => {
+    const allowed: IRequestedMedia[] = [];
+    const needsReferenceCheck: IRequestedMedia[] = [];
+
+    medias.forEach((media) => {
+        if (!media?.path) {
+            return;
+        }
+
+        if (!isPrivateMedia(media) || isOwnedBy(media.path, userId)) {
+            allowed.push(media);
+        } else {
+            needsReferenceCheck.push(media);
+        }
+    });
+
+    return { allowed, needsReferenceCheck };
+};

--- a/therr-services/maps-service/tests/unit/mediaAccess.test.ts
+++ b/therr-services/maps-service/tests/unit/mediaAccess.test.ts
@@ -1,0 +1,109 @@
+import { expect } from 'chai';
+import { Content } from 'therr-js-utilities/constants';
+import { isOwnedBy, isPrivateMedia, partitionByOwnership } from '../../src/utilities/mediaAccess';
+
+// `getBucket` reads these at call time, and the private/public distinction is the
+// whole point of the partition — with both unset they collapse to `undefined` and
+// every media would read as public.
+const PUBLIC_BUCKET = 'test-public-user-data';
+const PRIVATE_BUCKET = 'test-private-user-data';
+
+describe('mediaAccess', () => {
+    let originalPublic: string | undefined;
+    let originalPrivate: string | undefined;
+
+    before(() => {
+        originalPublic = process.env.BUCKET_PUBLIC_USER_DATA;
+        originalPrivate = process.env.BUCKET_PRIVATE_USER_DATA;
+        process.env.BUCKET_PUBLIC_USER_DATA = PUBLIC_BUCKET;
+        process.env.BUCKET_PRIVATE_USER_DATA = PRIVATE_BUCKET;
+    });
+
+    after(() => {
+        process.env.BUCKET_PUBLIC_USER_DATA = originalPublic;
+        process.env.BUCKET_PRIVATE_USER_DATA = originalPrivate;
+    });
+
+    describe('isOwnedBy', () => {
+        it('accepts a path under the user\'s own prefix', () => {
+            expect(isOwnedBy('user-1/content/photo_abc.jpeg', 'user-1')).to.equal(true);
+        });
+
+        it('rejects another user\'s path', () => {
+            expect(isOwnedBy('user-2/content/photo_abc.jpeg', 'user-1')).to.equal(false);
+        });
+
+        // A plain startsWith would let `user-1` claim every path belonging to `user-10`.
+        it('compares whole segments, not a string prefix', () => {
+            expect(isOwnedBy('user-10/content/photo_abc.jpeg', 'user-1')).to.equal(false);
+        });
+
+        it('rejects a bare prefix with no file after it', () => {
+            expect(isOwnedBy('user-1', 'user-1')).to.equal(false);
+        });
+
+        it('rejects an unauthenticated caller', () => {
+            expect(isOwnedBy('user-1/content/photo_abc.jpeg', undefined)).to.equal(false);
+        });
+    });
+
+    describe('isPrivateMedia', () => {
+        it('recognizes private media', () => {
+            expect(isPrivateMedia({ path: 'p', type: Content.mediaTypes.USER_IMAGE_PRIVATE })).to.equal(true);
+        });
+
+        it('recognizes public media', () => {
+            expect(isPrivateMedia({ path: 'p', type: Content.mediaTypes.USER_IMAGE_PUBLIC })).to.equal(false);
+        });
+
+        // getBucket falls through to the public bucket for anything it does not know,
+        // so an unrecognized type is not private and must not be gated as though it were.
+        it('treats an unrecognized type as public, matching getBucket\'s fall-through', () => {
+            expect(isPrivateMedia({ path: 'p', type: 'not-a-real-type' })).to.equal(false);
+        });
+    });
+
+    describe('partitionByOwnership', () => {
+        const publicMedia = { path: 'user-2/content/pub.jpeg', type: Content.mediaTypes.USER_IMAGE_PUBLIC };
+        const ownPrivate = { path: 'user-1/content/mine.jpeg', type: Content.mediaTypes.USER_IMAGE_PRIVATE };
+        const othersPrivate = { path: 'user-2/content/theirs.jpeg', type: Content.mediaTypes.USER_IMAGE_PRIVATE };
+
+        it('allows public media regardless of owner, with no reference check', () => {
+            const { allowed, needsReferenceCheck } = partitionByOwnership([publicMedia], 'user-1');
+
+            expect(allowed).to.deep.equal([publicMedia]);
+            expect(needsReferenceCheck).to.have.lengthOf(0);
+        });
+
+        it('allows the caller\'s own private media with no reference check', () => {
+            const { allowed, needsReferenceCheck } = partitionByOwnership([ownPrivate], 'user-1');
+
+            expect(allowed).to.deep.equal([ownPrivate]);
+            expect(needsReferenceCheck).to.have.lengthOf(0);
+        });
+
+        // This is the habit-proof case: a proof path is private, belongs to someone
+        // else, and is referenced by no maps-service content, so the reference check
+        // is what ends up refusing it.
+        it('defers another user\'s private media to the reference check', () => {
+            const { allowed, needsReferenceCheck } = partitionByOwnership([othersPrivate], 'user-1');
+
+            expect(allowed).to.have.lengthOf(0);
+            expect(needsReferenceCheck).to.deep.equal([othersPrivate]);
+        });
+
+        it('defers everything private for an unauthenticated caller', () => {
+            const { allowed, needsReferenceCheck } = partitionByOwnership([ownPrivate, publicMedia], undefined);
+
+            expect(allowed).to.deep.equal([publicMedia]);
+            expect(needsReferenceCheck).to.deep.equal([ownPrivate]);
+        });
+
+        it('drops entries with no path', () => {
+            const { allowed, needsReferenceCheck } = partitionByOwnership([{ path: '', type: 'x' } as any], 'user-1');
+
+            expect(allowed).to.have.lengthOf(0);
+            expect(needsReferenceCheck).to.have.lengthOf(0);
+        });
+    });
+});

--- a/therr-services/users-service/src/handlers/habitCheckins.ts
+++ b/therr-services/users-service/src/handlers/habitCheckins.ts
@@ -21,6 +21,7 @@ import {
 } from '../utilities/streakHelpers';
 import { isUserInPact } from '../utilities/pactHelpers';
 import { canReadProofs, serializeProofs } from '../utilities/checkinProofs';
+import moderateProofs from '../utilities/moderateProofs';
 import recordFunnelMetric from '../utilities/recordFunnelMetric';
 import { resolvePactPartnerIds } from './helpers/pactPartners';
 import {
@@ -149,7 +150,7 @@ const createCheckin: RequestHandler = async (req: any, res: any) => {
             // Persist any attached proofs
             if (hasProof) {
                 await Store.proofs.deleteByCheckinId(checkin.id);
-                await Store.proofs.createMany(
+                const createdProofs = await Store.proofs.createMany(
                     proofMedias
                         .filter((m: any) => m && m.path)
                         .map((m: any) => ({
@@ -164,6 +165,19 @@ const createCheckin: RequestHandler = async (req: any, res: any) => {
                             durationSeconds: m.durationSeconds,
                         })),
                 );
+
+                // Fire-and-forget: the check-in commits on the first tap and must not
+                // wait on a third-party content check, nor fail when it is down. See
+                // `utilities/moderateProofs` for why this is not awaited.
+                moderateProofs(createdProofs).catch((err) => logSpan({
+                    level: 'error',
+                    messageOrigin: 'API_SERVER',
+                    messages: ['proof moderation dispatch failed'],
+                    traceArgs: {
+                        'error.message': err?.message,
+                        'checkin.id': checkin.id,
+                    },
+                }));
             }
 
             // Freeze accounting for this request. Reported back on the 201 so

--- a/therr-services/users-service/src/store/ProofsStore.ts
+++ b/therr-services/users-service/src/store/ProofsStore.ts
@@ -51,6 +51,37 @@ export default class ProofsStore {
         return this.db.write.query(queryString).then((response) => response.rows);
     }
 
+    /**
+     * Record what the content check decided about one proof.
+     *
+     * Separate from `createMany` because the check is asynchronous and must not
+     * hold up the check-in — see `utilities/moderateProofs`. Rows therefore live
+     * briefly at their insert defaults (`pending` / `isSafeForWork: true`), which
+     * is why nothing that exposes a proof beyond its owner may read
+     * `isSafeForWork` alone: `verificationStatus === 'auto_verified'` is the
+     * signal that a check actually ran.
+     */
+    setModerationResult(proofId: string, params: {
+        isSafeForWork: boolean;
+        verificationStatus: string;
+        moderationFlags?: Record<string, unknown>;
+    }) {
+        const queryString = knexBuilder
+            .where({ id: proofId })
+            .update({
+                isSafeForWork: params.isSafeForWork,
+                verificationStatus: params.verificationStatus,
+                moderationFlags: params.moderationFlags ? JSON.stringify(params.moderationFlags) : null,
+                verifiedAt: new Date(),
+                updatedAt: new Date(),
+            })
+            .into(PROOFS_TABLE_NAME)
+            .returning('*')
+            .toString();
+
+        return this.db.write.query(queryString).then((response) => response.rows[0]);
+    }
+
     deleteByCheckinId(checkinId: string) {
         const queryString = knexBuilder
             .where({ checkinId })

--- a/therr-services/users-service/src/store/ThoughtsStore.ts
+++ b/therr-services/users-service/src/store/ThoughtsStore.ts
@@ -100,6 +100,24 @@ const REPOST_ORIGINAL_COLUMNS = [
     'createdAt',
 ];
 
+/**
+ * Present a thought's stored `medias` under the `media` key clients already read.
+ *
+ * Every content type here exposes attached media as `media` (`AreaDisplay` and
+ * `getUserContentUri` both key off it), while the column is `medias` — the same split
+ * `MomentsStore` bridges on its own read path. Doing it here means the display side
+ * needs no thought-specific branch.
+ *
+ * Always an array: the read paths previously returned a hard-coded `media: {}`, and a
+ * client that tries to map over an object gets a runtime error rather than an empty list.
+ */
+const withMedia = (thought: any) => {
+    const modified = thought;
+    modified.media = Array.isArray(modified.medias) ? modified.medias : [];
+
+    return modified;
+};
+
 export interface ICreateThoughtParams {
     parentId?: string;
     areaType?: string;
@@ -114,7 +132,13 @@ export interface ICreateThoughtParams {
     message: string;
     notificationMsg?: string;
     mediaIds?: string;
-    media?: any;
+    /**
+     * `media` is what the deployed mobile composer sends; `medias` is the column.
+     * `create` accepts either and normalizes — see the assignment there for why the
+     * older field name has to keep working.
+     */
+    media?: { path: string; type: string; altText?: string }[];
+    medias?: { path: string; type: string; altText?: string }[];
     mentionsIds?: string;
     hashTags?: string;
     maxViews?: number;
@@ -160,6 +184,7 @@ export interface IThoughtJournalRow {
     category: string | null;
     isPublic: boolean;
     hashTags: string | null;
+    medias: { path: string; type: string }[] | null;
 }
 
 export default class ThoughtsStore {
@@ -662,6 +687,10 @@ export default class ThoughtsStore {
                 `${THOUGHTS_TABLE_NAME}.category`,
                 `${THOUGHTS_TABLE_NAME}.isPublic`,
                 `${THOUGHTS_TABLE_NAME}.hashTags`,
+                // The journal's "Share a goal" flow posts an image with the thought, so an
+                // entry that has one has to be able to render it — that was the behaviour
+                // `handleCreateGoal`'s own comment already described.
+                `${THOUGHTS_TABLE_NAME}.medias`,
                 // Aliased in object form, not as "col AS alias" in a string —
                 // knex only splits string aliases on a lowercase " as ".
                 { occurredAt: `${THOUGHTS_TABLE_NAME}.createdAt` },
@@ -763,6 +792,7 @@ export default class ThoughtsStore {
                     'replies.isRepost as replies[].isRepost',
                     'replies.message as replies[].message',
                     'replies.mediaIds as replies[].mediaIds',
+                    'replies.medias as replies[].medias',
                     'replies.mentionsIds as replies[].mentionsIds',
                     'replies.hashTags as replies[].hashTags',
                     'replies.maxViews as replies[].maxViews',
@@ -888,7 +918,7 @@ export default class ThoughtsStore {
                 }, {});
 
                 const mappedThoughts = thoughts.map((thought) => {
-                    const modifiedThought = thought;
+                    const modifiedThought = withMedia(thought);
 
                     // USER
                     const matchingUser = usersMap[modifiedThought.fromUserId];
@@ -903,7 +933,7 @@ export default class ThoughtsStore {
                         // Replies
                         if (options.withReplies) {
                             modifiedThought.replies = modifiedThought.replies.map((reply) => {
-                                const modifiedReply = reply;
+                                const modifiedReply = withMedia(reply);
                                 const matchingReplyUser = usersMap[modifiedReply.fromUserId];
                                 if (matchingReplyUser) {
                                     modifiedReply.user = matchingReplyUser;
@@ -946,8 +976,7 @@ export default class ThoughtsStore {
             }
 
             return {
-                thoughts,
-                media: {},
+                thoughts: thoughts.map(withMedia),
                 users: {},
             };
         });
@@ -1096,7 +1125,7 @@ export default class ThoughtsStore {
                 }, {});
 
                 const mappedThoughts = thoughts.map((thought) => {
-                    const modifiedThought = thought;
+                    const modifiedThought = withMedia(thought);
                     modifiedThought.user = {};
 
                     // USER
@@ -1113,7 +1142,7 @@ export default class ThoughtsStore {
                     // Reply preview authors (for inline thread display in list views)
                     if (options.withReplies) {
                         modifiedThought.replies = (modifiedThought.replies || []).map((reply) => {
-                            const modifiedReply = reply;
+                            const modifiedReply = withMedia(reply);
                             const matchingReplyUser = usersMap[modifiedReply.fromUserId];
                             if (matchingReplyUser) {
                                 modifiedReply.fromUserName = matchingReplyUser.userName;
@@ -1136,8 +1165,7 @@ export default class ThoughtsStore {
             }
 
             return {
-                thoughts,
-                media: {},
+                thoughts: thoughts.map(withMedia),
                 users: {},
                 isLastPage,
             };
@@ -1167,6 +1195,33 @@ export default class ThoughtsStore {
             hashTags: params.hashTags || '',
             maxViews: params.maxViews || 0,
         };
+
+        /**
+         * Attached media, finally persisted.
+         *
+         * Accepts `media` as well as `medias` because the deployed mobile composer sends
+         * only `media` (`EditThought.signAndUploadImage`) and cannot be force-updated —
+         * the same reason `EditMoment` still carries its `createArgs.medias =
+         * createArgs.media` line. Honoring both is what makes already-installed apps stop
+         * losing photos on the day this deploys, rather than on the day the next release
+         * reaches everyone.
+         *
+         * Only `path` and `type` are carried through. The rest of a client's media object
+         * is presentational, and `type` is load-bearing: it selects the bucket, and
+         * maps-service `getBucket` falls through to the **public** bucket for a value it
+         * does not recognize — so an unfiltered spread here is how a private image ends up
+         * resolved against the public bucket.
+         */
+        const attachedMedia = params.medias || params.media;
+        if (Array.isArray(attachedMedia) && attachedMedia.length) {
+            const normalized = attachedMedia
+                .filter((m) => m && m.path && m.type)
+                .map((m) => ({ path: m.path, type: m.type, altText: m.altText }));
+
+            if (normalized.length) {
+                (sanitizedParams as any).medias = JSON.stringify(normalized);
+            }
+        }
 
         /**
          * Coordinates for a post that names a city.

--- a/therr-services/users-service/src/store/migrations/20260905000001_main.thoughts.medias.js
+++ b/therr-services/users-service/src/store/migrations/20260905000001_main.thoughts.medias.js
@@ -1,0 +1,27 @@
+// Gives thoughts a working media column.
+//
+// `main.thoughts` has carried a `mediaIds text` column since the original 2022 migration,
+// but nothing ever wrote it: the mobile composer uploads an image and posts
+// `media: [{ type, path }]`, and `ThoughtsStore.create`'s allow-list dropped the field on
+// the floor. Every goal or thought posted with a photo since has orphaned the object in
+// the bucket and stored nothing. See docs/WORK_IN_PROGRESS.md § 2.6.7.
+//
+// `medias jsonb` rather than reviving the comma-separated `mediaIds`: moments, spaces and
+// events all moved to a `medias jsonb` of `[{ path, type }]` (20240322140814 and siblings),
+// and matching them is what lets the existing client-side `getUserContentUri(media)` render
+// thought media with no new display code.
+//
+// `mediaIds` is deliberately left in place. It is expand/contract — therr-ai-automator
+// writes `main.thoughts` directly (see docs/CROSS_REPO_INTEGRATION.md), so dropping a
+// column in the same change that adds one risks breaking a Cloud Function at its next
+// firing rather than at deploy. Removing it belongs in a later contract migration.
+
+exports.up = (knex) => knex.raw(`
+    ALTER TABLE main."thoughts"
+    ADD COLUMN IF NOT EXISTS "medias" jsonb
+`);
+
+exports.down = (knex) => knex.raw(`
+    ALTER TABLE main."thoughts"
+    DROP COLUMN IF EXISTS "medias"
+`);

--- a/therr-services/users-service/src/utilities/moderateProofs.ts
+++ b/therr-services/users-service/src/utilities/moderateProofs.ts
@@ -1,0 +1,54 @@
+import logSpan from 'therr-js-utilities/log-or-update-span';
+import { checkIsMediaSafeForWork } from '../handlers/helpers';
+import Store from '../store';
+import { PROOF_MEDIA_TYPE } from './checkinProofs';
+
+/**
+ * Run the same content check the moments upload path runs, over check-in proofs.
+ *
+ * Deliberately **not** awaited by the check-in handler, and deliberately not able
+ * to fail it. Two reasons, and they point the same way:
+ *
+ * - The check-in is the product's core loop and its whole design commits on the
+ *   first tap (§ 2.6.1); making it wait on a third-party HTTP call, or fail when
+ *   Sightengine is down, would undo that for a check no user is waiting on.
+ * - Proofs are owner-only today (`canReadProofs`), so an unmoderated proof is
+ *   visible to exactly one person: the user who uploaded it. The moderation
+ *   result matters at the moment a proof is *shared* — which is what makes this
+ *   a prerequisite for sharing a check-in publicly rather than a gate on
+ *   check-in itself.
+ *
+ * `checkIsMediaSafeForWork` fails **closed**, returning false when signing or the
+ * Sightengine call throws. That asymmetry is right for a share gate and wrong for
+ * a permanent record, so a thrown error is recorded as `pending` — still
+ * unverified, still not shareable — rather than as `rejected`, which would
+ * accuse a user of posting something unsafe because a vendor had an outage.
+ */
+const moderateProofs = (proofs: { id: string; mediaPath: string }[]): Promise<void> => {
+    if (!proofs?.length) {
+        return Promise.resolve();
+    }
+
+    return Promise.all(proofs.map((proof) => checkIsMediaSafeForWork([{
+        type: PROOF_MEDIA_TYPE,
+        path: proof.mediaPath,
+    }])
+        .then((isSafeForWork) => Store.proofs.setModerationResult(proof.id, {
+            isSafeForWork,
+            verificationStatus: isSafeForWork ? 'auto_verified' : 'flagged',
+            moderationFlags: { provider: 'sightengine', isSafeForWork, checkedAt: new Date().toISOString() },
+        }))
+        .catch((err) => {
+            logSpan({
+                level: 'error',
+                messageOrigin: 'API_SERVER',
+                messages: ['proof moderation failed'],
+                traceArgs: {
+                    'error.message': err?.message,
+                    'proof.id': proof.id,
+                },
+            });
+        }))).then(() => undefined);
+};
+
+export default moderateProofs;


### PR DESCRIPTION
`POST /media/signed-urls` resolved any path any caller named. Private media
resolves to a deterministic IMAGE_KIT_URL_PRIVATE URL rather than a signed one,
so handing back a URL for a path was equivalent to handing back the image,
permanently — the handler's own `// TODO: Check that the user has access to this
media` had gone unhonoured since it was written.

Three tiers now, in cost order:

- Public-bucket media resolves unconditionally. The bucket is public, so
  withholding a URL protects nothing and only breaks rendering.
- Private media under the caller's own `<userId>/` prefix resolves with no
  database round trip. Compared as whole path segments, so `user-1` cannot claim
  `user-10/...`.
- Anything else must be referenced by a moment, space or event.

That third tier is what keeps this non-breaking. The nearby feed and map
legitimately hand a client other users' USER_IMAGE_PRIVATE paths — they arrive
inside the area rows, and NearbyWrapper collects them into `missingMedias` — so
an owner-only rule would have blanked those images. It is also what closes the
habit-proof case: `habits.proofs` paths live in users-service and are referenced
by none of those three tables, so a proof path is now resolvable only by its
owner.

Unresolvable paths are omitted from the response rather than rejected. Clients
batch a screenful into one call and already handle a path coming back absent; a
403 for the batch would blank every image in it, including the ones the caller
is entitled to. Same choice the reactions write allow-list makes.

The residual gap is deliberate and recorded: "referenced by content" is weaker
than a real visibility check. Closing that needs per-content visibility
(proximity, connections), which is a much larger change; this refuses the case
that had no referent at all.

`ContentMediaStore` is separate from `MediaStore` because moments, spaces and
events all import the latter — reaching back to their table names from inside it
would make a require cycle out of what is only a read. The containment probe is
written as an OR of `@>` predicates so the new jsonb_path_ops GIN indexes can
answer it; without them it is a sequential scan on `main.moments` on every
nearby-feed render carrying another user's private image.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DLiC5bmdJnnzeWegcVMdrX