### PR TITLE
feat(habits): add push-reminder toggles to ManageNotifications

### DIFF
--- a/TherrMobile/__tests__/routes/SettingsPushPreferences.test.ts
+++ b/TherrMobile/__tests__/routes/SettingsPushPreferences.test.ts
@@ -1,0 +1,68 @@
+import getHabitsPushPreferences from '../../main/routes/Settings/pushPreferences';
+
+/**
+ * The asymmetry these pin is the whole point of the helper: the digest mutes on an
+ * explicit `false` and on nothing else, so anything that is not `false` must show as On.
+ *
+ * Getting this backwards is not a cosmetic bug. The screen would report reminders as
+ * disabled while they kept arriving, and the next save would write the `false` it
+ * invented — turning a display bug into a real, silent opt-out the user never chose.
+ */
+describe('getHabitsPushPreferences', () => {
+    it('treats an explicit false as muted', () => {
+        expect(getHabitsPushPreferences({
+            settingsPushHabitReminders: false,
+            settingsPushStreakAlerts: false,
+        })).toEqual({
+            settingsPushHabitReminders: false,
+            settingsPushStreakAlerts: false,
+        });
+    });
+
+    it('treats an explicit true as enabled', () => {
+        expect(getHabitsPushPreferences({
+            settingsPushHabitReminders: true,
+            settingsPushStreakAlerts: true,
+        })).toEqual({
+            settingsPushHabitReminders: true,
+            settingsPushStreakAlerts: true,
+        });
+    });
+
+    // The common case until the users-service half ships: nothing returns these columns,
+    // so both arrive undefined on every load.
+    it('treats an absent value as enabled, matching the schema default', () => {
+        expect(getHabitsPushPreferences({})).toEqual({
+            settingsPushHabitReminders: true,
+            settingsPushStreakAlerts: true,
+        });
+    });
+
+    it('treats a missing settings object as enabled rather than throwing', () => {
+        expect(getHabitsPushPreferences(undefined)).toEqual({
+            settingsPushHabitReminders: true,
+            settingsPushStreakAlerts: true,
+        });
+    });
+
+    // null is what a column that exists but was never written comes back as.
+    it('treats null as enabled', () => {
+        expect(getHabitsPushPreferences({
+            settingsPushHabitReminders: null,
+            settingsPushStreakAlerts: null,
+        })).toEqual({
+            settingsPushHabitReminders: true,
+            settingsPushStreakAlerts: true,
+        });
+    });
+
+    it('mutes each toggle independently', () => {
+        expect(getHabitsPushPreferences({
+            settingsPushHabitReminders: true,
+            settingsPushStreakAlerts: false,
+        })).toEqual({
+            settingsPushHabitReminders: true,
+            settingsPushStreakAlerts: false,
+        });
+    });
+});

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -880,7 +880,9 @@
                 "settingsEmailBackground": "Social App automated e-mails",
                 "on": "On",
                 "off": "Off",
-                "myQRCodes": "Manage My QR Codes"
+                "myQRCodes": "Manage My QR Codes",
+                "settingsPushHabitReminders": "Daily habit reminders",
+                "settingsPushStreakAlerts": "Evening streak reminders"
             },
             "errorMessages": {
                 "repeatPassword": "Passwords do not match",
@@ -1502,7 +1504,8 @@
             "alertMessages": {
                 "notificationSettingsUpdated": "Your notification & alert settings have been updated.",
                 "notificationSettingsUpdatedError": "Oops! Something went wrong."
-            }
+            },
+            "pageHeaderPushSettings": "Push Preferences"
         },
         "managePreferences": {
             "headerTitle": "Content Settings",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -880,7 +880,9 @@
                 "settingsEmailBackground": "Correos automatizados de la app social",
                 "on": "Activado",
                 "off": "Desactivado",
-                "myQRCodes": "Gestionar mis códigos QR"
+                "myQRCodes": "Gestionar mis códigos QR",
+                "settingsPushHabitReminders": "Recordatorios diarios de hábitos",
+                "settingsPushStreakAlerts": "Recordatorios de racha por la noche"
             },
             "errorMessages": {
                 "repeatPassword": "Las contraseñas no coinciden",
@@ -1502,7 +1504,8 @@
             "alertMessages": {
                 "notificationSettingsUpdated": "Tu configuración de notificaciones y alertas ha sido actualizada.",
                 "notificationSettingsUpdatedError": "¡Ups! Algo salió mal."
-            }
+            },
+            "pageHeaderPushSettings": "Preferencias de notificaciones"
         },
         "managePreferences": {
             "headerTitle": "Config. de Contenido",

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -880,7 +880,9 @@
                 "settingsEmailBackground": "Courriels automatisés de l'application",
                 "on": "Activé",
                 "off": "Désactivé",
-                "myQRCodes": "Gérer mes codes QR"
+                "myQRCodes": "Gérer mes codes QR",
+                "settingsPushHabitReminders": "Rappels quotidiens d’habitudes",
+                "settingsPushStreakAlerts": "Rappels de série en soirée"
             },
             "errorMessages": {
                 "repeatPassword": "Les mots de passe ne correspondent pas",
@@ -1502,7 +1504,8 @@
             "alertMessages": {
                 "notificationSettingsUpdated": "Vos paramètres de notification et d'alerte ont été mis à jour.",
                 "notificationSettingsUpdatedError": "Oups! Une erreur est survenue."
-            }
+            },
+            "pageHeaderPushSettings": "Préférences de notifications"
         },
         "managePreferences": {
             "headerTitle": "Paramètres de contenu",

--- a/TherrMobile/main/routes/Settings/ManageNotifications.tsx
+++ b/TherrMobile/main/routes/Settings/ManageNotifications.tsx
@@ -7,6 +7,8 @@ import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { IUserState } from 'therr-react/types';
+import { BrandVariations } from 'therr-js-utilities/constants';
+import { CURRENT_BRAND_VARIATION } from '../../config/brandConfig';
 import { showToast } from '../../utilities/toasts';
 import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
 import UsersActions from '../../redux/actions/UsersActions';
@@ -18,6 +20,16 @@ import { buildStyles as buildFormStyles } from '../../styles/forms';
 import { buildStyles as buildSettingsFormStyles } from '../../styles/forms/settingsForm';
 import { buildStyles as buildModalStyles } from '../../styles/modal';
 import spacingStyles from '../../styles/layouts/spacing';
+import getHabitsPushPreferences from './pushPreferences';
+
+/**
+ * These two columns are read only by the HABITS daily digest
+ * (users-service `handlers/habitsDigest`), so the section is gated rather than shown to
+ * every brand. The gate is belt-and-braces on this branch — `niche/HABITS-general` only
+ * ever builds the Habits app — but it keeps the screen correct if this file is ever
+ * shared, and it documents who the toggles belong to.
+ */
+const isHabitsApp = CURRENT_BRAND_VARIATION === BrandVariations.HABITS;
 import BaseStatusBar from '../../components/BaseStatusBar';
 
 interface IManageNotificationsDispatchProps {
@@ -127,6 +139,9 @@ export class ManageNotifications extends React.Component<IManageNotificationsPro
                 settingsEmailMessages: props.user.settings.settingsEmailMessages,
                 settingsEmailReminders: props.user.settings.settingsEmailReminders,
                 settingsEmailBackground: props.user.settings.settingsEmailBackground,
+                // An absent value renders as On, because absent means opted in. See
+                // `getHabitsPushPreferences` for why.
+                ...getHabitsPushPreferences(props.user.settings),
             },
             isSubmitting: false,
         };
@@ -211,6 +226,7 @@ export class ManageNotifications extends React.Component<IManageNotificationsPro
         const { navigation, user } = this.props;
         const  { inputs, isSubmitting } = this.state;
         const pageHeaderAdvancedSettings = this.translate('pages.manageNotifications.pageHeaderEmailSettings');
+        const pageHeaderPushSettings = this.translate('pages.manageNotifications.pageHeaderPushSettings');
 
         return (
             <>
@@ -309,6 +325,38 @@ export class ManageNotifications extends React.Component<IManageNotificationsPro
                                     disabled={isSubmitting}
                                 />
                             </View>
+                            {
+                                isHabitsApp &&
+                                    <>
+                                        <View style={this.theme.styles.sectionContainer}>
+                                            <Text style={this.theme.styles.sectionTitle}>
+                                                {pageHeaderPushSettings}
+                                            </Text>
+                                        </View>
+                                        <View style={this.themeSettingsForm.styles.advancedContainer}>
+                                            <NotificationSettingSwitch
+                                                label={this.translate('forms.settings.buttons.settingsPushHabitReminders')}
+                                                value={inputs.settingsPushHabitReminders}
+                                                onChange={() => this.onSwitchChange('settingsPushHabitReminders')}
+                                                theme={this.theme}
+                                                themeForms={this.themeForms}
+                                                themeModal={this.themeModal}
+                                                translate={this.translate}
+                                                disabled={isSubmitting}
+                                            />
+                                            <NotificationSettingSwitch
+                                                label={this.translate('forms.settings.buttons.settingsPushStreakAlerts')}
+                                                value={inputs.settingsPushStreakAlerts}
+                                                onChange={() => this.onSwitchChange('settingsPushStreakAlerts')}
+                                                theme={this.theme}
+                                                themeForms={this.themeForms}
+                                                themeModal={this.themeModal}
+                                                translate={this.translate}
+                                                disabled={isSubmitting}
+                                            />
+                                        </View>
+                                    </>
+                            }
                         </View>
                     </KeyboardAwareScrollView>
                 </SafeAreaView>

--- a/TherrMobile/main/routes/Settings/pushPreferences.ts
+++ b/TherrMobile/main/routes/Settings/pushPreferences.ts
@@ -1,0 +1,29 @@
+/**
+ * Initial state for the HABITS push toggles on ManageNotifications.
+ *
+ * Kept RN-free so it can be exercised without a renderer, matching
+ * `HabitsDashboardPactState` and `checkinDayDetail`.
+ *
+ * The rule that matters: both columns default to `true` in the schema
+ * (`20260126000010_main.users_habits`), and the digest treats **only an explicit
+ * `false`** as a mute — see `settingsPushHabitReminders` / `settingsPushStreakAlerts`
+ * in users-service `handlers/habitsDigest`. A user who has never opened this screen is
+ * therefore opted *in*.
+ *
+ * So an absent value has to render as On. Rendering it Off would tell the user their
+ * reminders are disabled while the reminders keep arriving — and worse, submitting the
+ * form would then write the `false` the screen invented and make the lie true. `undefined`
+ * is the common case today: until the users-service half of this ships, nothing returns
+ * these columns to the client at all.
+ */
+export interface IHabitsPushPreferences {
+    settingsPushHabitReminders: boolean;
+    settingsPushStreakAlerts: boolean;
+}
+
+const getHabitsPushPreferences = (settings: any): IHabitsPushPreferences => ({
+    settingsPushHabitReminders: settings?.settingsPushHabitReminders !== false,
+    settingsPushStreakAlerts: settings?.settingsPushStreakAlerts !== false,
+});
+
+export default getHabitsPushPreferences;


### PR DESCRIPTION
Gives Friends with Habits users a way to turn off the daily and evening reminder pushes without reaching for the OS switch, which takes every notification with it.

## Why now

The daily digest has honoured `settingsPushHabitReminders` (both daily slots) and `settingsPushStreakAlerts` (the evening escalation only) since local scheduling shipped — the first push preference columns anything read server-side. No client has ever written either, so `remindersMutedByPreference` and `lastChanceMutedByPreference` sit at 0 and the toggles simply did not exist.

Closes the "Build the push-preference UI" item under § Habits push pipeline in `docs/WORK_IN_PROGRESS.md`.

## What's here

- A **Push Preferences** section on `ManageNotifications`, alongside the existing email one, with a toggle for each column.
- Gated to the HABITS brand. These two columns are read only by the habits digest, so they are not preferences the other apps have — the gate is belt-and-braces on this branch, but keeps the screen correct if the file is ever shared.
- Copy in all three locales (`en-us`, `es`, `fr-ca`).
- The default rule extracted to `routes/Settings/pushPreferences.ts` with six tests.

## The one subtle bit

Both columns default to `true` in the schema and the digest mutes on an **explicit `false` and nothing else**. So an absent value has to render as **On**.

Rendering it Off would report reminders as disabled while they kept arriving — and the next save would then write the `false` the screen invented, turning a display bug into a silent opt-out the user never chose. `undefined` is the common case today, not an edge case: until the users-service half below is live, nothing returns these columns to the client at all. That asymmetry is what `pushPreferences.test.ts` pins.

## ⚠️ Depends on a `general` PR — do not ship alone

Both users-service write gates omitted these columns, so a save was accepted and silently dropped:

- the `updateArgs` allow-list in `handlers/users.ts`
- the param filter in `UsersStore.updateUser`

That half cannot ship from a niche branch. It is on `claude/work-plan-habits-argument-svdqxt` (targeting `general`) and must reach production first, or these toggles render and save with no effect.

The two halves also travel different routes: users-service goes `general → stage → main`; this goes `niche/HABITS-general → niche/HABITS-main` plus a Play release. A flat 0 on both mute counters after this merges means "not shipped yet", not "nobody mutes".

## Backlog entries that were already done

Audited against this branch rather than taken at face value — the `pactEnded` mobile half is **already complete** here and needed no work: the `PACT_ENDED` intent filter is in `AndroidManifest.xml` and the `pactRenew` press action is handled in `Layout.tsx`. `DAILY_HABIT_REMINDER`, `MORNING_MOTIVATION` and `EVENING_CHECK_IN` are all in `REMINDER_ACTION_KEYS`. Those backlog entries are stale; the work landed after they were written.

## Testing

- `pushPreferences` — 6 new tests, passing
- Mobile Jest route suites: 744 passing
- `npm run pr:tsc-baseline:mobile` — 105 = 105, no new errors
- `npm run locales:check` — parity OK across all three dictionaries
- ESLint clean (one pre-existing inline-style warning on an untouched line)

Not verified on a handset — the toggles cannot do anything end-to-end until the `general` half is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLiC5bmdJnnzeWegcVMdrX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLiC5bmdJnnzeWegcVMdrX)_