### PR TITLE
fix(users-service,skills): make the habits push toggles real, and fix the gate that hid a silent push

### DIFF
--- a/.claude/skills/push-notification-guard/scripts/check-push-wiring.js
+++ b/.claude/skills/push-notification-guard/scripts/check-push-wiring.js
@@ -526,10 +526,17 @@ let mobileBrandLabel = null;
 
         // Data-only pushes are rendered by Notifee, which picks the channel from
         // the clickActionId suffix. A key in no bucket lands on `default`.
-        const bucketed = new Set([
-            ...(constants.match(/REMINDER_ACTION_KEYS[\s\S]*?\]\)/) || [''])[0].matchAll(/'([A-Z_0-9]+)'/g),
-            ...(constants.match(/REWARD_ACTION_KEYS[\s\S]*?\]\)/) || [''])[0].matchAll(/'([A-Z_0-9]+)'/g),
-        ].map((m) => m[1]));
+        //
+        // Every `*_ACTION_KEYS` set is collected rather than a hardcoded list of
+        // them. This named REMINDER and REWARD only, so when
+        // CONTENT_DISCOVERY_ACTION_KEYS was added for the habits "Friend
+        // Activity" channel its five keys started reporting as unbucketed — and
+        // five false positives are how the one true finding beside them
+        // (PACT_ENDED, in no bucket at all) went unread. A gate nobody believes
+        // is a gate nobody reads.
+        const bucketNames = [...constants.matchAll(/const\s+(\w+_ACTION_KEYS)\s*=\s*new Set<string>\(\[([\s\S]*?)\]\)/g)];
+        const bucketed = new Set(bucketNames
+            .flatMap((m) => [...m[2].matchAll(/'([A-Z_0-9]+)'/g)].map((k) => k[1])));
         // Only data-only pushes go through Notifee, and only those pick their
         // channel from the clickActionId suffix. A display push names its
         // channel in the FCM payload and never reaches this code.
@@ -542,10 +549,16 @@ let mobileBrandLabel = null;
             .flatMap(([, f]) => f.clickKeys);
         const unbucketed = [...new Set(dataOnlyKeys)].filter((k) => !bucketed.has(k)).sort();
         if (unbucketed.length) {
+            // Naming the buckets actually found, rather than a fixed pair, keeps
+            // the remedy correct as channels are added — and makes an empty
+            // `bucketed` (the regex having stopped matching) visible here instead
+            // of arriving disguised as every key being unbucketed.
+            const bucketList = bucketNames.map((m) => m[1]).join(', ') || '(none found — check the regex above)';
             warn('clickaction-channel-default', `${unbucketed.length} data-only intent key(s) fall through to the "default" channel on the "${forBrand}" build`,
                 unbucketed.map((k) => `${k} (${keyToType.get(k)})`).join(', '),
                 `Notifee renders these on the "default" channel at DEFAULT importance — no heads-up banner. If the type `
-                + `is meant to interrupt, add its key to REMINDER_ACTION_KEYS (or REWARD_ACTION_KEYS) in ${P.mobileConstants}. `
+                + `is meant to interrupt, add its key to one of the channel buckets in ${P.mobileConstants} `
+                + `(${bucketList}). `
                 + 'Note Android locks a channel\'s importance at first creation, so this only takes effect on installs '
                 + 'that had not created the channel yet.');
         }

--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -475,6 +475,22 @@ are the steps code cannot do. Strategy, thresholds and the decision log live in
   that would accept a value nothing sends. First non-zero value is the only evidence the
   pair is wired. No migration and no env var — both columns already exist and default to
   `true`.
+- [ ] (2026-09-05, /work-plan) **Re-check the `PACT_ENDED` channel on an install that
+  already created it.** Android locks a notification channel's importance at first
+  creation, so moving `PACT_ENDED` into `REMINDER_ACTION_KEYS` only reaches devices that
+  had not yet posted on `reminders`. Existing habits installs already created that channel
+  the first time a daily reminder arrived, so they pick up the change for free — but an
+  install that somehow created `default` first keeps the silent behaviour until the user
+  clears app data. Worth one handset check alongside the ended-pact renewal test below
+  rather than a code change.
+- [ ] (2026-09-05, /work-plan) **`LEADERBOARD_RANK_MILESTONE` is unbucketed on the Therr
+  build.** Surfaced by `check-push-wiring.js` once its false positives were cleared. The
+  key is in `REWARD_ACTION_KEYS` on `niche/HABITS-general` but not on `general`, so the
+  Therr app renders the rank-milestone push at DEFAULT importance. Deliberately left alone
+  here: it is a Therr-side product call about whether a leaderboard move should interrupt,
+  and it is outside the habits batch that found it. The deeper issue it points at is that
+  the HABITS channel buckets live only on the niche branch, so `general`'s copy of
+  `getAndroidChannelFromClickActionId` is permanently a subset.
 - [ ] (2026-09-05, /work-plan) **Run the two new migrations after this reaches `main`.**
   maps-service `20260905000000_main.medias_gin_indexes` and users-service
   `20260905000001_main.thoughts.medias` — automated by `_bin/cicd/run-migrations.sh` on `main`
@@ -503,8 +519,8 @@ are the steps code cannot do. Strategy, thresholds and the decision log live in
   installs that predate the `EditThought` change stop losing photos as soon as users-service
   rolls — no app release required. Historical posts stay imageless: their uploads are
   orphaned objects with no row pointing at them (see § 2.6.7 "Still open").
-- [ ] (2026-09-01, /work-plan) **Ship the `niche/HABITS-general` half of `pactEnded` before
-  this reaches production traffic.** Two things are missing there and neither errors: the
+- [x] ~~**Ship the `niche/HABITS-general` half of `pactEnded` before
+  this reaches production traffic.**~~ Two things are missing there and neither errors: the
   `${notificationActionPrefix}.PACT_ENDED` `<intent-filter>` in
   `TherrMobile/android/app/src/main/AndroidManifest.xml`, and a handler for the `renew-pact`
   press action. Without the filter an installed app ignores the notification outright; with
@@ -514,6 +530,15 @@ are the steps code cannot do. Strategy, thresholds and the decision log live in
   `node .claude/skills/push-notification-guard/scripts/check-push-wiring.js --brand-branch niche/HABITS-general`
   — that run could not be completed in the session that wrote this (the branch would not
   fetch), so the niche half is **unverified**, not known-good.
+  > **Verified 2026-09-05.** Both halves are on `niche/HABITS-general`: the intent filter
+  > (`7db85fb`) and the `renew-pact` branch in `Layout.tsx`, which reads `pactId` from the
+  > data payload, falls back to the dashboard's `all` tab when it is missing, and defers to
+  > `PactDetail` when the user is signed out. The wiring check now runs clean on that branch.
+  > What the check *did* surface, and this entry did not anticipate, is that `PACT_ENDED` was
+  > in no channel bucket, so the push carrying the primary re-commit CTA rendered at DEFAULT
+  > importance with no heads-up banner — fixed by adding it to `REMINDER_ACTION_KEYS`
+  > alongside `PACT_EXPIRING`, the same lifecycle one step earlier. Handset confirmation is
+  > still the next item below.
 - [ ] (2026-09-01, /work-plan) **Confirm on a handset that the ended-pact push renews.** This
   is link 5 and nothing server-side reports it. Let a HABITS pact pass its `endDate`, run the
   digest, then on a real device confirm: the notification arrives, shows **two** buttons
@@ -1969,12 +1994,27 @@ retry and a stale CTA all converge on the one real cycle. The guard reads
 "which pacts does this check-in credit" and an unanswered invite must never be
 one of them.
 
+**The mobile half shipped on `niche/HABITS-general`** — corrected 2026-09-05, this
+entry previously said it was not built. The `PACT_ENDED` intent filter is in
+`AndroidManifest.xml` (`7db85fb`) and `Layout.tsx` handles the `renew-pact` press
+action: it reads `pactId` off the data payload, renews with no duration override so
+the previous cycle's `durationDays` carries, and falls back to the dashboard's `all`
+tab (not `habits` — that segment does not list finished pacts) when the id is absent.
+
+One thing this section did not anticipate, found by
+`.claude/skills/push-notification-guard/scripts/check-push-wiring.js` on 2026-09-05:
+**`PACT_ENDED` was in no channel bucket.** `pactEnded` is data-only — that is what
+lets the renew button exist at all — so Notifee picks its channel from the
+`clickActionId` suffix, and a key in no bucket lands on `default` at DEFAULT
+importance. The push carrying the primary re-commit CTA arrived with no heads-up
+banner. It is now in `REMINDER_ACTION_KEYS` alongside `PACT_EXPIRING`, the same
+lifecycle one step earlier. Nothing reported this: the notification arrived, the
+button worked, and only its prominence was wrong.
+
 Still open:
 
-- **The mobile half is not built** — `niche/HABITS-general` must declare the
-  `PACT_ENDED` intent filter in `AndroidManifest.xml` and handle the
-  `renew-pact` press action. Until it ships, an installed app ignores the
-  notification entirely; nothing errors on either side.
+- Handset confirmation that the ended-pact push renews (see § Manual Operational
+  Follow-ups). Nothing server-side reports link 5 of this chain.
 - Optional follow-on: a long-form "your pact ended — here's what you built"
   re-commit email in `therr-messaging-automator`, which owns the SES templates
   and unsubscribe-token path (see `docs/HABIT_LIFECYCLE_MESSAGING.md` § Where

--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -216,7 +216,7 @@ here is what code cannot close.
   the gate is not firing and users are being nagged after they have already done
   the thing. Kill switch is `HABIT_LAST_CHANCE_REMINDERS_ENABLED=false` on
   users-service — no deploy needed.
-- [ ] **Build the push-preference UI, now that two columns are finally read.** The
+- [x] **Build the push-preference UI, now that two columns are finally read.** The
   digest honours `settingsPushHabitReminders` (both daily slots) and
   `settingsPushStreakAlerts` (the evening escalation only) — the first server-side
   reading of any push preference column. No client writes either, so
@@ -224,6 +224,15 @@ here is what code cannot close.
   until `TherrMobile/main/routes/Settings/ManageNotifications.tsx` grows push
   toggles alongside its email ones. Until then a user's only way to turn the
   evening nudge off is the OS switch, which takes everything with it.
+  > Both halves are in as of 2026-09-05. The toggles shipped on
+  > `niche/HABITS-general` (`c45a0bc5`) **before** the server could accept them —
+  > `updateArgs` in `handlers/users.ts` and the param filter in
+  > `UsersStore.updateUser` are both explicit allow-lists and neither named these
+  > columns, so a save returned 202 with the values dropped and the screen showed a
+  > success toast. Both allow-lists now carry them, guarded on `!= null` rather than
+  > truthiness: the digest mutes on an explicit `false` and nothing else, so `false`
+  > is the only value that changes anything. **The write half is on `general` and the
+  > toggles are on the niche branch — the counters stay at 0 until both are out.**
 
 ## Standing items (always re-verify after a deploy that touches the area)
 
@@ -455,6 +464,17 @@ are the steps code cannot do. Strategy, thresholds and the decision log live in
 > `[ ] (YYYY-MM-DD, /<skill-name>) <action> — <why>`
 
 <!-- skill-followups:start -->
+- [ ] (2026-09-05, /work-plan) **Watch `remindersMutedByPreference` and
+  `lastChanceMutedByPreference` leave 0 once BOTH halves of the push toggles are out.**
+  The two counters have been structurally pinned at 0, not merely unused: the digest has
+  read `settingsPushHabitReminders` / `settingsPushStreakAlerts` for weeks, but until this
+  deploy no code path could write either column. The toggles are on
+  `niche/HABITS-general` (`c45a0bc5`) and the write half is on `general` — order does not
+  matter, but **both** are required, and neither reports its absence. A user on the old
+  server sees a success toast and keeps every reminder; a user on the old app has a server
+  that would accept a value nothing sends. First non-zero value is the only evidence the
+  pair is wired. No migration and no env var — both columns already exist and default to
+  `true`.
 - [ ] (2026-09-05, /work-plan) **Run the two new migrations after this reaches `main`.**
   maps-service `20260905000000_main.medias_gin_indexes` and users-service
   `20260905000001_main.thoughts.medias` — automated by `_bin/cicd/run-migrations.sh` on `main`

--- a/therr-services/users-service/src/handlers/users.ts
+++ b/therr-services/users-service/src/handlers/users.ts
@@ -951,6 +951,14 @@ const updateUser = (req, res) => {
                 settingsContentAlgorithm: req.body.settingsContentAlgorithm,
                 settingsPushMarketing: req.body.settingsPushMarketing,
                 settingsPushBackground: req.body.settingsPushBackground,
+                // The only two push preferences the server actually reads (the habits
+                // digest: `settingsPushHabitReminders` mutes both daily slots,
+                // `settingsPushStreakAlerts` the evening escalation). They were readable
+                // before they were writable, so the mobile toggles that ship against them
+                // spread the fields into this request and got a 200 with the values
+                // dropped here — a save that reported success and changed nothing.
+                settingsPushHabitReminders: req.body.settingsPushHabitReminders,
+                settingsPushStreakAlerts: req.body.settingsPushStreakAlerts,
                 settingsLocale: req.body.settingsLocale,
                 settingsTimezone: rawTimezone,
                 settingsIsAccountSoftDeleted: req.body.settingsIsAccountSoftDeleted,

--- a/therr-services/users-service/src/store/UsersStore.ts
+++ b/therr-services/users-service/src/store/UsersStore.ts
@@ -737,6 +737,18 @@ export default class UsersStore {
             modifiedParams.settingsPushBackground = params.settingsPushBackground;
         }
 
+        // `!= null` rather than a truthiness check, and that is the whole point of these
+        // two: the habits digest mutes on an explicit `false` and nothing else, so `false`
+        // is the only value a user can send that changes anything. An `undefined` is still
+        // skipped, which is what lets a client PUT a partial settings payload.
+        if (params.settingsPushHabitReminders != null) {
+            modifiedParams.settingsPushHabitReminders = params.settingsPushHabitReminders;
+        }
+
+        if (params.settingsPushStreakAlerts != null) {
+            modifiedParams.settingsPushStreakAlerts = params.settingsPushStreakAlerts;
+        }
+
         if (params.shouldHideMatureContent != null) {
             modifiedParams.shouldHideMatureContent = params.shouldHideMatureContent;
         }

--- a/therr-services/users-service/tests/unit/UsersStore.test.ts
+++ b/therr-services/users-service/tests/unit/UsersStore.test.ts
@@ -292,6 +292,49 @@ describe('UsersStore', () => {
             expect(mockStore.write.query.args[0][0].includes(expected)).to.be.equal(true);
         });
 
+        // Regression: the habits digest read `settingsPushHabitReminders` /
+        // `settingsPushStreakAlerts` months before anything could write them, so the
+        // mobile toggles built against those columns PUT the fields, got a 200, and had
+        // the values dropped here. `false` is the only value that changes anything —
+        // the digest mutes on an explicit `false` and treats null/undefined as "on" —
+        // so a truthiness guard would have left the feature exactly as broken.
+        it('writes an explicit false for the two habits push preferences', () => {
+            const mockStore = {
+                write: {
+                    query: sinon.stub().callsFake(() => Promise.resolve({})),
+                },
+            };
+            const store = new UsersStore(mockStore);
+            store.updateUser({
+                settingsPushHabitReminders: false,
+                settingsPushStreakAlerts: false,
+            }, {
+                id: 5,
+            });
+
+            const generatedSql = mockStore.write.query.args[0][0];
+            expect(generatedSql.includes(`"settingsPushHabitReminders" = false`)).to.be.equal(true);
+            expect(generatedSql.includes(`"settingsPushStreakAlerts" = false`)).to.be.equal(true);
+        });
+
+        it('omits the habits push preferences when they are not submitted', () => {
+            const mockStore = {
+                write: {
+                    query: sinon.stub().callsFake(() => Promise.resolve({})),
+                },
+            };
+            const store = new UsersStore(mockStore);
+            store.updateUser({
+                userName: 'tests',
+            }, {
+                id: 5,
+            });
+
+            const generatedSql = mockStore.write.query.args[0][0];
+            expect(generatedSql.includes('settingsPushHabitReminders')).to.be.equal(false);
+            expect(generatedSql.includes('settingsPushStreakAlerts')).to.be.equal(false);
+        });
+
         it('requires email or id', () => {
             const mockStore = {
                 write: {

--- a/therr-services/users-service/tests/unit/handlers-users.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-users.test.ts
@@ -841,6 +841,65 @@ describe('Users Handler', () => {
         });
     });
 
+    describe('updateUser habits push preferences', () => {
+        // Regression: `updateArgs` is an explicit allow-list, and these two columns were
+        // read by the habits digest for months before anything could write them. The
+        // mobile toggles built against them PUT the fields, the allow-list dropped them,
+        // and the handler still answered 202 — so the screen showed a success toast and
+        // the user kept getting every reminder. Nothing errored on either side.
+        const makeReq = (body: any) => ({
+            headers: { 'x-userid': 'user-1', 'x-brand-variation': 'habits' },
+            body,
+        });
+
+        const stubUpdateChain = () => {
+            const updateStub = sinon.stub(Store.users, 'updateUser').resolves([{ id: 'user-1' }] as any);
+            sinon.stub(Store.userOrganizations, 'get').resolves([] as any);
+            return updateStub;
+        };
+
+        it('forwards an explicit false for both preferences to the store', async () => {
+            sinon.stub(Store.users, 'getUserById').resolves([{
+                id: 'user-1',
+                phoneNumber: '+1 317-555-1234',
+                userName: 'someone',
+                isBusinessAccount: false,
+                isCreatorAccount: false,
+                accessLevels: [AccessLevels.DEFAULT],
+            }] as any);
+            const updateStub = stubUpdateChain();
+
+            const res = makeRes();
+            await updateUser(makeReq({
+                settingsPushHabitReminders: false,
+                settingsPushStreakAlerts: false,
+            }), res);
+
+            expect(res.statusCode).to.equal(202);
+            expect(updateStub.firstCall.args[0].settingsPushHabitReminders).to.equal(false);
+            expect(updateStub.firstCall.args[0].settingsPushStreakAlerts).to.equal(false);
+        });
+
+        it('leaves both undefined when the save does not mention them', async () => {
+            sinon.stub(Store.users, 'getUserById').resolves([{
+                id: 'user-1',
+                phoneNumber: '+1 317-555-1234',
+                userName: 'someone',
+                isBusinessAccount: false,
+                isCreatorAccount: false,
+                accessLevels: [AccessLevels.DEFAULT],
+            }] as any);
+            const updateStub = stubUpdateChain();
+
+            const res = makeRes();
+            await updateUser(makeReq({ settingsBio: 'a new bio' }), res);
+
+            expect(res.statusCode).to.equal(202);
+            expect(updateStub.firstCall.args[0].settingsPushHabitReminders).to.be.eq(undefined);
+            expect(updateStub.firstCall.args[0].settingsPushStreakAlerts).to.be.eq(undefined);
+        });
+    });
+
     describe('updateUserCoins', () => {
         // Internal-only route (`PUT /users/:id/coins`, not registered in the gateway) whose
         // sole caller is reactions-service and sends nothing but `settingsTherrCoinTotal`.


### PR DESCRIPTION
The shared half of a Tier 2 § 2.6 batch from `/work-plan habits`. The niche half is **#2863** — merge **this one first**.

## The push toggles shipped inert

`c45a0bc5` (yesterday, on `niche/HABITS-general`) added `settingsPushHabitReminders` / `settingsPushStreakAlerts` switches to `ManageNotifications`. The habits digest has read both columns for weeks — the first server-side reading of any push preference column — but nothing could ever *write* them, because both gates on the write path are explicit allow-lists and neither named them:

- `updateArgs` in `handlers/users.ts`
- the param filter in `UsersStore.updateUser`

The failure was not a 400. The screen spread the fields into its PUT, the handler answered **202**, the store dropped the values, and the toast said the settings were saved. A habits user could turn the evening nudge off, be told it saved, and keep receiving it — with the OS switch (which takes every notification with it) as their only real recourse.

Both allow-lists now carry the pair. The `!= null` guard is the load-bearing part rather than house style: **the digest mutes on an explicit `false` and treats null/undefined as "on"**, so `false` is the only value a user can send that changes anything. A truthiness check would have looked like a fix and left the feature exactly as broken.

Four tests, covering both directions at both layers — the store emitting `"settingsPushHabitReminders" = false`, the handler forwarding `false` through the allow-list, and the omission case, since a partial settings PUT must not write columns it never mentioned.

## The wiring gate was crying wolf

`check-push-wiring.js` built its set of bucketed intent keys from two hardcoded names, `REMINDER_ACTION_KEYS` and `REWARD_ACTION_KEYS`. When `CONTENT_DISCOVERY_ACTION_KEYS` was added for the habits "Friend Activity" channel, its five keys started reporting as falling through to `default`. They do not.

The cost was not the noise. Underneath those five false positives sat a sixth finding that was real: **`PACT_ENDED` was in no bucket at all**, so the data-only push carrying the pact-renewal CTA rendered at DEFAULT importance with no heads-up banner. A gate that is wrong five times out of six is a gate nobody reads, which is how a true finding sat in its output unread. That one is fixed in #2863, where the file lives.

The set is now derived from every `*_ACTION_KEYS` declaration, so a future channel does not reintroduce this. The remedy line names the buckets it actually found rather than a fixed pair — which also surfaces an empty match (the regex having stopped matching) as itself, instead of disguised as every key being unbucketed.

## Backlog

Two entries were wrong and would have caused rework:

- **§ 2.6.3** said the `pactEnded` mobile half was not built. It is — intent filter in `7db85fb`, `renew-pact` handler in `Layout.tsx`. Corrected, with what the wiring check found instead.
- The **2026-09-01 follow-up** asking for that half is closed for the same reason; it had recorded itself as *unverified* because the branch would not fetch in that session.

Three new follow-ups recorded: the Android channel-importance lock as it applies to `PACT_ENDED`; `LEADERBOARD_RANK_MILESTONE` being unbucketed on the Therr build (a Therr-side product call, deliberately not touched here); and the structural note that the HABITS channel buckets live only on the niche branch, so `general`'s `getAndroidChannelFromClickActionId` is permanently a subset.

## Verification

| Gate | Result |
|---|---|
| `pr:test:unit:users` | 1058 passing, 0 failing |
| `pr:typecheck:users` | clean |
| `eslint` (changed files) | 0 errors (13 pre-existing warnings) |
| `check-push-wiring.js` on `general` | unchanged — one pre-existing finding, recorded as a follow-up |
| `check-push-wiring.js` on `niche/HABITS-general` | 0 blockers, 0 warnings (with #2863 applied) |
| `locales:check` | all packages OK |

## Deploy notes

No migration, no env var — both columns already exist and default to `true`.

Neither half does anything alone, and **neither reports the other's absence**: a user on the old server sees a success toast and keeps every reminder; a user on the old app has a server that would accept a value nothing sends. `remindersMutedByPreference` / `lastChanceMutedByPreference` leaving 0 is the only evidence the pair is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QzAKV5HbRXFi5DRt57SR2g