### PR TITLE
feat(habits): share a check-in publicly as a post — backend + shared libs

### DIFF
--- a/therr-api-gateway/src/services/users/router.ts
+++ b/therr-api-gateway/src/services/users/router.ts
@@ -776,6 +776,11 @@ usersServiceRouter.post('/habits/checkins', handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
     method: 'post',
 }));
+// Promote a check-in's proof photo to a public post (main.thoughts)
+usersServiceRouter.post('/habits/checkins/:id/share', handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
+}));
 usersServiceRouter.put('/habits/checkins/:id/skip', handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
     method: 'put',

--- a/therr-public-library/therr-js-utilities/src/constants/enums/FeatureFlags.ts
+++ b/therr-public-library/therr-js-utilities/src/constants/enums/FeatureFlags.ts
@@ -26,6 +26,11 @@ enum FeatureFlags {
     ENABLE_PACTS = 'ENABLE_PACTS',
     REQUIRE_PACT_ONBOARDING = 'REQUIRE_PACT_ONBOARDING',
     ENABLE_HABITS_JOURNAL = 'ENABLE_HABITS_JOURNAL',
+    // Public social feed of shared check-ins (see docs/WORK_IN_PROGRESS.md 2.6.8).
+    // Off by default so it can ship dark and be flipped on per brand build; when on
+    // for HABITS it replaces the Awards tab in the bottom bar. A tab and its route
+    // read this same flag — see TherrMobile habitsTabLayout.ts for why.
+    ENABLE_HABITS_FEED = 'ENABLE_HABITS_FEED',
     ENABLE_HABITS_SOLO = 'ENABLE_HABITS_SOLO',
     ENABLE_HABITS_LIFETIME_OFFER = 'ENABLE_HABITS_LIFETIME_OFFER',
 

--- a/therr-public-library/therr-react/src/redux/actions/Habits.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Habits.ts
@@ -230,6 +230,19 @@ const Habits = {
             return response.data;
         }),
 
+    // Share a check-in's proof photo publicly as a post. The response carries `sharedThoughtId`
+    // (and the created `thought` on first share); the dispatch merges just that id onto the
+    // matching check-in so the "shared" state shows without a refetch — see the SHARE_CHECKIN
+    // reducer case, which is a merge rather than the full-object replace UPDATE_CHECKIN does.
+    shareCheckin: (id: string, message?: string) => (dispatch: any) => HabitCheckinsService
+        .share(id, message).then((response) => {
+            dispatch({
+                type: HabitsActionTypes.SHARE_CHECKIN,
+                data: { id, sharedThoughtId: response.data?.sharedThoughtId },
+            });
+            return response.data;
+        }),
+
     // Streaks
     getUserStreaks: (isActive?: boolean) => (dispatch: any) => StreaksService
         .getUserStreaks(isActive).then((response: any) => {

--- a/therr-public-library/therr-react/src/redux/reducers/habits.ts
+++ b/therr-public-library/therr-react/src/redux/reducers/habits.ts
@@ -174,6 +174,16 @@ const habits = produce((draft: IHabitsState, action: any) => {
             break;
         }
 
+        // Merge, not replace: the share response is only `{ id, sharedThoughtId }`, so overwriting
+        // the row (as UPDATE_CHECKIN does with a full check-in) would drop every other field.
+        case HabitsActionTypes.SHARE_CHECKIN: {
+            const checkinIdx = draft.todayCheckins.findIndex((c) => c.id === action.data.id);
+            if (checkinIdx > -1) {
+                draft.todayCheckins[checkinIdx].sharedThoughtId = action.data.sharedThoughtId;
+            }
+            break;
+        }
+
         // Streaks
         case HabitsActionTypes.GET_USER_STREAKS:
             draft.streaks = action.data || [];

--- a/therr-public-library/therr-react/src/services/HabitCheckinsService.ts
+++ b/therr-public-library/therr-react/src/services/HabitCheckinsService.ts
@@ -88,6 +88,20 @@ class HabitCheckinsService {
         });
     };
 
+    /**
+     * Share a check-in's proof photo publicly as a post (main.thoughts).
+     *
+     * The backend copies the private proof image into the public bucket, moderates the copy,
+     * creates a public thought carrying it, and records the link on the check-in. Idempotent:
+     * a check-in that is already shared returns `{ sharedThoughtId, alreadyShared: true }`
+     * without creating a second post. `message` is an optional lead-in for the post.
+     */
+    share = (id: string, message?: string) => axios({
+        method: 'post',
+        url: `/users-service/habits/checkins/${id}/share`,
+        data: { message },
+    });
+
     update = (id: string, data: IUpdateCheckinBody) => axios({
         method: 'put',
         url: `/users-service/habits/checkins/${id}`,

--- a/therr-public-library/therr-react/src/types/redux/habits.ts
+++ b/therr-public-library/therr-react/src/types/redux/habits.ts
@@ -146,6 +146,10 @@ export interface IHabitCheckin {
     hasProof: boolean;
     proofVerified: boolean;
     contributedToStreak: boolean;
+    // Set once the check-in has been shared publicly — the id of the main.thoughts post that
+    // carries the public copy of the proof. Absent/undefined until shared. Lets the calendar
+    // day show "shared" and deep-link to the post.
+    sharedThoughtId?: string;
     createdAt: string;
     updatedAt: string;
     // Joined fields
@@ -360,6 +364,7 @@ export enum HabitsActionTypes {
     CREATE_CHECKIN = 'CREATE_CHECKIN',
     UPDATE_CHECKIN = 'UPDATE_CHECKIN',
     SKIP_CHECKIN = 'SKIP_CHECKIN',
+    SHARE_CHECKIN = 'SHARE_CHECKIN',
 
     // Streaks
     GET_USER_STREAKS = 'GET_USER_STREAKS',

--- a/therr-services/users-service/src/handlers/habitCheckins.ts
+++ b/therr-services/users-service/src/handlers/habitCheckins.ts
@@ -22,6 +22,8 @@ import {
 import { isUserInPact } from '../utilities/pactHelpers';
 import { canReadProofs, serializeProofs } from '../utilities/checkinProofs';
 import moderateProofs from '../utilities/moderateProofs';
+import { copyProofToPublicBucket, deleteSharedCheckinPublicObject } from '../utilities/shareCheckinMedia';
+import { checkIsMediaSafeForWork } from './helpers';
 import recordFunnelMetric from '../utilities/recordFunnelMetric';
 import { resolvePactPartnerIds } from './helpers/pactPartners';
 import {
@@ -490,6 +492,124 @@ const createCheckin: RequestHandler = async (req: any, res: any) => {
         .catch((err) => handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' }));
 };
 
+// SHARE — turn a check-in with a proof photo into a public post (main.thoughts).
+//
+// This is the opt-in step past pact visibility (§ 2.6.2): a check-in's proof is owner-only in
+// the private bucket, so making one public is not a flag flip but a copy. The proof image is
+// copied into the public bucket, moderated *on that public copy* (fail-closed — a share can
+// wait on a content check in a way the check-in tap deliberately cannot), and only then does a
+// public `main.thoughts` row get created carrying the copy. The check-in's `sharedThoughtId`
+// records the link so a repeat share is a no-op and the calendar day can deep-link to the post.
+//
+// brandVariation flows from the request headers onto the thought, so a HABITS share is a HABITS
+// thought — which BRAND_THOUGHTS_VISIBILITY already surfaces in the Therr feed too, and keeps
+// out of other niche feeds. No visibility change is needed here for cross-brand reach.
+const shareCheckin: RequestHandler = async (req: any, res: any) => {
+    const {
+        locale,
+        userId,
+        brandVariation,
+    } = parseHeaders(req.headers);
+    const { id } = req.params;
+    const { message } = req.body;
+
+    let checkin;
+    try {
+        checkin = await Store.habitCheckins.getById(id);
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' });
+    }
+
+    // Ownership is the whole access story for a proof image (see checkinProofs.canReadProofs):
+    // only the check-in's owner may promote it to a public post.
+    const { allowed, error } = canReadProofs(checkin, userId);
+    if (!allowed) {
+        return error === 'notFound'
+            ? handleHttpError({
+                res,
+                message: translate(locale, 'errorMessages.habitCheckins.notFound'),
+                statusCode: 404,
+                errorCode: ErrorCodes.NOT_FOUND,
+            })
+            : handleHttpError({
+                res,
+                message: translate(locale, 'errorMessages.habitCheckins.notAuthorizedToView'),
+                statusCode: 403,
+                errorCode: ErrorCodes.NOT_PERMITTED,
+            });
+    }
+
+    // Already shared: return the existing link rather than minting a second post. This is what
+    // makes a double-tap or a retry safe.
+    if (checkin.sharedThoughtId) {
+        return res.status(200).send({ sharedThoughtId: checkin.sharedThoughtId, alreadyShared: true });
+    }
+
+    // A public post needs an image. The proof is what keeps the feed on-topic (a check-in with a
+    // photo), so a check-in with no image proof cannot be shared.
+    let proofs: any[] = [];
+    try {
+        proofs = checkin.hasProof ? await Store.proofs.getByCheckinId(id) : [];
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' });
+    }
+    const imageProof = (proofs || []).find((p) => p && p.mediaPath && p.mediaType !== 'video');
+    if (!imageProof) {
+        return handleHttpError({
+            res,
+            message: translate(locale, 'errorMessages.habitCheckins.shareRequiresImage'),
+            statusCode: 400,
+            errorCode: ErrorCodes.BAD_REQUEST,
+        });
+    }
+
+    const habitGoal = await Store.habitGoals.getById(checkin.habitGoalId).catch(() => null);
+    const altText = habitGoal?.name ? String(habitGoal.name).substring(0, 255) : '';
+    // Lead-in text: prefer what the client sent, then the check-in note, then the habit name.
+    // The thought column truncates to 255 itself; this just avoids sending an empty post.
+    const leadIn = (message || checkin.notes || habitGoal?.name || '').toString();
+
+    let publicMedia: { path: string; type: string };
+    try {
+        publicMedia = await copyProofToPublicBucket(userId, checkin.id, imageProof.mediaPath);
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' });
+    }
+
+    // Moderate the PUBLIC copy before it can be seen. `checkIsMediaSafeForWork` fails closed
+    // (returns false on any signing / Sightengine error), which is the right asymmetry for a
+    // share gate: refuse rather than risk exposing unmoderated content.
+    const isSafeForWork = await checkIsMediaSafeForWork([publicMedia]).catch(() => false);
+    if (!isSafeForWork) {
+        await deleteSharedCheckinPublicObject(publicMedia.path);
+        return handleHttpError({
+            res,
+            message: translate(locale, 'errorMessages.habitCheckins.shareModerationFailed'),
+            statusCode: 422,
+            errorCode: ErrorCodes.NOT_PERMITTED,
+        });
+    }
+
+    try {
+        const [thought] = await Store.thoughts.create(brandVariation, {
+            fromUserId: userId as any,
+            locale,
+            isPublic: true,
+            message: leadIn,
+            medias: [{ path: publicMedia.path, type: publicMedia.type, altText }],
+        });
+
+        await Store.habitCheckins.update(checkin.id, { sharedThoughtId: thought.id });
+
+        return res.status(201).send({ thought, sharedThoughtId: thought.id });
+    } catch (err: any) {
+        // The public copy is already written; leave it for the bucket lifecycle rule rather than
+        // deleting it, since a transient thought-write failure is retryable and the next attempt
+        // overwrites the same deterministic path.
+        return handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' });
+    }
+};
+
 // READ
 const getCheckin: RequestHandler = async (req: any, res: any) => {
     const { locale, userId } = parseHeaders(req.headers);
@@ -739,6 +859,7 @@ const deleteCheckin: RequestHandler = async (req: any, res: any) => {
 
 export {
     createCheckin,
+    shareCheckin,
     getCheckin,
     getCheckinProofs,
     getTodayCheckins,

--- a/therr-services/users-service/src/locales/en-us/dictionary.json
+++ b/therr-services/users-service/src/locales/en-us/dictionary.json
@@ -83,7 +83,9 @@
             "notAuthorizedToUpdate": "You can only change your own check-in",
             "notAuthorizedToView": "You can only view your own check-ins",
             "notFound": "We couldn't find that check-in",
-            "notFoundOrNotAuthorizedToDelete": "We couldn't find that check-in, or it isn't yours to delete"
+            "notFoundOrNotAuthorizedToDelete": "We couldn't find that check-in, or it isn't yours to delete",
+            "shareRequiresImage": "Add a photo to this check-in before sharing it",
+            "shareModerationFailed": "We couldn't share this check-in right now. Please try a different photo."
         },
         "streaks": {
             "noGraceDaysAvailable": "You've used every grace day on this streak",

--- a/therr-services/users-service/src/locales/es/dictionary.json
+++ b/therr-services/users-service/src/locales/es/dictionary.json
@@ -83,7 +83,9 @@
             "notAuthorizedToUpdate": "Solo puedes modificar tu propio registro",
             "notAuthorizedToView": "Solo puedes ver tus propios registros",
             "notFound": "No encontramos ese registro",
-            "notFoundOrNotAuthorizedToDelete": "No encontramos ese registro, o no es tuyo para eliminarlo"
+            "notFoundOrNotAuthorizedToDelete": "No encontramos ese registro, o no es tuyo para eliminarlo",
+            "shareRequiresImage": "Agrega una foto a este registro antes de compartirlo",
+            "shareModerationFailed": "No pudimos compartir este registro ahora. Prueba con otra foto."
         },
         "streaks": {
             "noGraceDaysAvailable": "Ya usaste todos los días de gracia de esta racha",

--- a/therr-services/users-service/src/locales/fr-ca/dictionary.json
+++ b/therr-services/users-service/src/locales/fr-ca/dictionary.json
@@ -83,7 +83,9 @@
             "notAuthorizedToUpdate": "Tu ne peux modifier que ton propre suivi",
             "notAuthorizedToView": "Tu ne peux voir que tes propres suivis",
             "notFound": "Nous n'avons pas trouvé ce suivi",
-            "notFoundOrNotAuthorizedToDelete": "Nous n'avons pas trouvé ce suivi, ou il ne t'appartient pas"
+            "notFoundOrNotAuthorizedToDelete": "Nous n'avons pas trouvé ce suivi, ou il ne t'appartient pas",
+            "shareRequiresImage": "Ajoute une photo à ce suivi avant de le partager",
+            "shareModerationFailed": "Nous n'avons pas pu partager ce suivi pour le moment. Essaie une autre photo."
         },
         "streaks": {
             "noGraceDaysAvailable": "Tu as utilisé toutes les journées de grâce de cette série",

--- a/therr-services/users-service/src/routes/habitCheckinsRouter.ts
+++ b/therr-services/users-service/src/routes/habitCheckinsRouter.ts
@@ -1,6 +1,7 @@
 import * as express from 'express';
 import {
     createCheckin,
+    shareCheckin,
     getCheckin,
     getCheckinProofs,
     getTodayCheckins,
@@ -22,6 +23,9 @@ router.get('/:id', getCheckin);
 
 // CREATE
 router.post('/', createCheckin);
+
+// SHARE — promote a check-in's proof photo to a public post (main.thoughts)
+router.post('/:id/share', shareCheckin);
 
 // UPDATE
 router.put('/:id', updateCheckin);

--- a/therr-services/users-service/src/store/HabitCheckinsStore.ts
+++ b/therr-services/users-service/src/store/HabitCheckinsStore.ts
@@ -34,6 +34,10 @@ export interface IUpdateHabitCheckinParams {
     hasProof?: boolean;
     proofVerified?: boolean;
     contributedToStreak?: boolean;
+    // Set when the check-in is shared publicly — points at the main.thoughts row that
+    // carries the public copy of the proof. Nullable/absent otherwise. See migration
+    // 20260906000001_habits.habit_checkins.sharedThoughtId.js.
+    sharedThoughtId?: string;
 }
 
 export default class HabitCheckinsStore {

--- a/therr-services/users-service/src/store/migrations/20260906000001_habits.habit_checkins.sharedThoughtId.js
+++ b/therr-services/users-service/src/store/migrations/20260906000001_habits.habit_checkins.sharedThoughtId.js
@@ -1,0 +1,45 @@
+// Link from a check-in to the public post it was shared as (see docs/WORK_IN_PROGRESS.md 2.6.8).
+//
+// Sharing a check-in publicly mints a `main.thoughts` row carrying a *copy* of the proof image
+// in the public bucket (the private proof is never referenced — see handlers/habitCheckins.ts
+// § SHARE and the media copy in utilities/shareCheckinMedia.ts). `sharedThoughtId` is the edge
+// from the check-in to that post, so:
+//   - a repeat share is a no-op rather than a second post (the handler short-circuits when this
+//     is already set), and
+//   - the calendar day / day sheet can show "shared" and deep-link to ViewThought, the same way
+//     the journal already opens a goal.
+//
+// No FK to main.thoughts(id), and deliberately so: the two rows have independent lifecycles.
+// Deleting the check-in must not retract a post that already has replies, and deleting the post
+// must not destroy the user's own check-in record. A dangling id is harmless — the client
+// resolves the post through a normal (brand-scoped) thought read and renders nothing when it
+// misses, which is also what a deleted or cross-brand post requires. This matches the reasoning
+// for main.thoughts."repostThoughtId" and habits.pacts."renewedFromPactId", neither of which
+// carries an FK.
+//
+// Index: the only read is "resolve the shared post for this check-in" / "which of this range's
+// check-ins are shared", both `sharedThoughtId IS NOT NULL` probes. Partial on NOT NULL — shared
+// check-ins are a small fraction of the table, so the index stays small and the planner still
+// uses it.
+//
+// Idempotent (ADD COLUMN IF NOT EXISTS / CREATE INDEX IF NOT EXISTS) per
+// therr/require-idempotent-migration.
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async (knex) => {
+    await knex.raw('ALTER TABLE habits."habit_checkins" ADD COLUMN IF NOT EXISTS "sharedThoughtId" uuid');
+    await knex.raw(
+        'CREATE INDEX IF NOT EXISTS "idx_habit_checkins_shared_thought_id" '
+        + 'ON habits."habit_checkins" ("sharedThoughtId") WHERE "sharedThoughtId" IS NOT NULL',
+    );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS habits."idx_habit_checkins_shared_thought_id"');
+    await knex.raw('ALTER TABLE habits."habit_checkins" DROP COLUMN IF EXISTS "sharedThoughtId"');
+};

--- a/therr-services/users-service/src/utilities/shareCheckinMedia.ts
+++ b/therr-services/users-service/src/utilities/shareCheckinMedia.ts
@@ -1,0 +1,68 @@
+import path from 'path';
+import { Content } from 'therr-js-utilities/constants';
+import { storage } from '../api/aws';
+import { PROOF_MEDIA_TYPE } from './checkinProofs';
+
+/**
+ * Copy a check-in proof image from the private bucket into the public bucket so it can back a
+ * public post, and hand back the new public path.
+ *
+ * WHY COPY RATHER THAN REFERENCE (see docs/WORK_IN_PROGRESS.md 2.6.8)
+ *
+ * Three independent reasons, any one of which is sufficient:
+ *  - Proofs live in the private bucket (`PROOF_MEDIA_TYPE === USER_IMAGE_PRIVATE`); a public
+ *    thought needs a public-bucket object, because the client resolves `USER_IMAGE_PUBLIC`
+ *    media against the public ImageKit endpoint with no signed round-trip.
+ *  - Nothing has necessarily moderated the proof for a public audience yet, and the copy is
+ *    the natural object to run the content check against before the post is created.
+ *  - The two objects have independent lifecycles: deleting the check-in must not retract a
+ *    post that has replies, and deleting the post must not destroy the user's own record.
+ *
+ * The destination path is deterministic per check-in (`{userId}/content/shared_checkin_{checkinId}`),
+ * so a repeat share overwrites the same object rather than accumulating orphans — the handler's
+ * `sharedThoughtId` short-circuit means that normally never happens, but a share that failed
+ * after the copy but before the thought was written leaves one recoverable object, not many.
+ */
+export const buildSharedCheckinPublicPath = (userId: string, checkinId: string, sourcePath: string): string => {
+    const ext = path.extname(sourcePath) || '.jpg';
+    return `${userId}/content/shared_checkin_${checkinId}${ext}`;
+};
+
+export const copyProofToPublicBucket = async (
+    userId: string,
+    checkinId: string,
+    proofPath: string,
+): Promise<{ path: string; type: string }> => {
+    const privateBucketName = process.env.BUCKET_PRIVATE_USER_DATA || '';
+    const publicBucketName = process.env.BUCKET_PUBLIC_USER_DATA || '';
+
+    const destinationPath = buildSharedCheckinPublicPath(userId, checkinId, proofPath);
+
+    const sourceFile = storage.bucket(privateBucketName).file(proofPath);
+    const destinationFile = storage.bucket(publicBucketName).file(destinationPath);
+
+    await sourceFile.copy(destinationFile);
+
+    return {
+        path: destinationPath,
+        type: Content.mediaTypes.USER_IMAGE_PUBLIC,
+    };
+};
+
+/**
+ * Best-effort cleanup of a public copy when the share is abandoned (e.g. moderation rejected it).
+ * Never throws: an orphaned public object is a lifecycle-rule problem, not a request failure.
+ */
+export const deleteSharedCheckinPublicObject = (publicPath: string): Promise<void> => {
+    const publicBucketName = process.env.BUCKET_PUBLIC_USER_DATA || '';
+    return storage
+        .bucket(publicBucketName)
+        .file(publicPath)
+        .delete({ ignoreNotFound: true })
+        .then(() => undefined)
+        .catch(() => undefined);
+};
+
+// Re-exported for symmetry / discoverability alongside the copy: the source bucket is derived
+// from the proof media type, which is always private today.
+export const PROOF_SOURCE_MEDIA_TYPE = PROOF_MEDIA_TYPE;

--- a/therr-services/users-service/tests/unit/shareCheckinMedia.test.ts
+++ b/therr-services/users-service/tests/unit/shareCheckinMedia.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { Content } from 'therr-js-utilities/constants';
+import { buildSharedCheckinPublicPath, PROOF_SOURCE_MEDIA_TYPE } from '../../src/utilities/shareCheckinMedia';
+
+/**
+ * Sharing a check-in copies its private proof image into the public bucket so a public post can
+ * carry it. The GCS copy itself needs a live client, but the destination path is pure and
+ * load-bearing, so it is pinned here.
+ *
+ * The path is deterministic per check-in on purpose: a repeat share overwrites the same object
+ * rather than accumulating orphans, and it stays inside the sharing user's own namespace so it
+ * lands where every other of that user's content lives.
+ */
+describe('shareCheckinMedia', () => {
+    describe('buildSharedCheckinPublicPath', () => {
+        it('is deterministic per (user, check-in) and preserves the extension', () => {
+            const path = buildSharedCheckinPublicPath('user-1', 'checkin-9', 'user-1/content/habits_proof_abc.jpg');
+            expect(path).to.equal('user-1/content/shared_checkin_checkin-9.jpg');
+
+            // Same inputs → same object, so a retry overwrites rather than duplicating.
+            expect(buildSharedCheckinPublicPath('user-1', 'checkin-9', 'user-1/content/habits_proof_abc.jpg'))
+                .to.equal(path);
+        });
+
+        it('carries a non-jpg extension through', () => {
+            expect(buildSharedCheckinPublicPath('u', 'c', 'u/content/proof_x.png'))
+                .to.equal('u/content/shared_checkin_c.png');
+        });
+
+        it('falls back to .jpg when the source path has no extension', () => {
+            // A private proof path with no extension must still produce a valid public object key
+            // rather than one ending in a bare dot.
+            expect(buildSharedCheckinPublicPath('u', 'c', 'u/content/proof_no_ext'))
+                .to.equal('u/content/shared_checkin_c.jpg');
+        });
+
+        it('nests the copy under the sharing user, not the source path owner', () => {
+            // The first segment is always the passed userId, so the public object lands in the
+            // sharer's namespace even if the proof path were ever shaped differently.
+            expect(buildSharedCheckinPublicPath('owner-7', 'ck', 'someone/else/thing.jpg'))
+                .to.equal('owner-7/content/shared_checkin_ck.jpg');
+        });
+    });
+
+    describe('PROOF_SOURCE_MEDIA_TYPE', () => {
+        it('is the private media type — proofs are always copied FROM the private bucket', () => {
+            expect(PROOF_SOURCE_MEDIA_TYPE).to.equal(Content.mediaTypes.USER_IMAGE_PRIVATE);
+        });
+    });
+});


### PR DESCRIPTION
## What

The **shared half** of the Friends with Habits social feed (WORK_IN_PROGRESS 2.6.8 / #2841). This is the backend + shared-library work that must land on `general` to ship. The **mobile UI half** is PR #2868 (base `niche/HABITS-general`); **merge this one first.**

### Backend (`therr-services/users-service`, `therr-api-gateway`)
- **`POST /habits/checkins/:id/share`** — promotes a check-in's proof photo to a public `main.thoughts` post. Owner-only; copies the private proof image into the public bucket (`utilities/shareCheckinMedia`), moderates the *public copy* fail-closed (`checkIsMediaSafeForWork`), creates a public brand-scoped thought carrying it, and records `sharedThoughtId`. Idempotent on re-share.
- Migration: nullable `habits.habit_checkins.sharedThoughtId` (idempotent, partial index, no FK — the check-in and the post have independent lifecycles).
- Gateway route + users-service error strings (en-us/es/fr-ca).
- Unit tests for the media-path builder.

### Shared libraries (`therr-public-library`)
- `therr-js-utilities`: new `ENABLE_HABITS_FEED` feature flag (default off).
- `therr-react`: `HabitCheckinsService.share()`, `shareCheckin` action + `SHARE_CHECKIN` reducer case (merges `sharedThoughtId` onto the check-in rather than replacing the row), and `sharedThoughtId` on `IHabitCheckin`.

## Why

Social accountability is the strongest retention lever in habit apps. The "content can only be created via a check-in" constraint keeps the feed on-topic and avoids the empty-social-network problem. Cross-brand reach is already correct — a HABITS-branded thought surfaces in the Therr feed via `BRAND_THOUGHTS_VISIBILITY`, so no visibility change was needed.

## Verification
- `pr:typecheck:users`, `:gateway`, `:js-utils`, `:therr-react` — clean
- `test:lint-rules` (migration idempotency in scope) — clean
- `locales:check` — parity across en-us/es/fr-ca
- users-service unit suite — passing (incl. new `shareCheckinMedia` tests)

## Merge order
**Merge this PR (#2867) first**, then the mobile PR #2868 merges `general` down and builds on the flag + endpoint added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkBPB8MPkbbyMhN2WZqbEC