### PR TITLE
feat(habits): social feed screen, Feed tab, and public check-in sharing (mobile)

### DIFF
--- a/TherrMobile/__tests__/components/HabitsTabLayout.test.ts
+++ b/TherrMobile/__tests__/components/HabitsTabLayout.test.ts
@@ -4,14 +4,18 @@ import { getHabitsTabLayout, HABITS_TAB_COUNT_MAX } from '../../main/components/
 
 /**
  * The HABITS tab bar's dependence on ENABLE_HABITS_JOURNAL and
- * ENABLE_ACHIEVEMENTS.
+ * ENABLE_HABITS_FEED.
  *
- * `routes/index.tsx` registers the `Journal` and `Achievements` screens only
+ * `routes/index.tsx` registers the `Journal` and `HabitsFeed` screens only
  * when their flag is on. Either tab used to render unconditionally, so
  * switching the flag off left a visible button calling `navigate('Journal')`
  * against a navigator with no such screen — which does nothing at all: no
  * error, no screen change, no clue. A kill-switch that leaves a dead button
  * behind has not killed anything.
+ *
+ * The optional feed tab replaced the Awards (Achievements) tab; Achievements is
+ * still reachable from the drawer, so the layout counts ENABLE_HABITS_FEED here
+ * and no longer ENABLE_ACHIEVEMENTS.
  *
  * The width arithmetic is pinned alongside it because the two have to move
  * together — a hidden tab whose slot is still reserved leaves a visible gap.
@@ -20,7 +24,7 @@ const SCREEN_WIDTH = 400;
 
 const BOTH_ON = {
     [FeatureFlags.ENABLE_HABITS_JOURNAL]: true,
-    [FeatureFlags.ENABLE_ACHIEVEMENTS]: true,
+    [FeatureFlags.ENABLE_HABITS_FEED]: true,
 };
 
 describe('getHabitsTabLayout', () => {
@@ -28,7 +32,7 @@ describe('getHabitsTabLayout', () => {
         const layout = getHabitsTabLayout(SCREEN_WIDTH, BOTH_ON);
 
         expect(layout.isJournalEnabled).toBe(true);
-        expect(layout.isAchievementsEnabled).toBe(true);
+        expect(layout.isFeedEnabled).toBe(true);
         expect(layout.tabCount).toBe(HABITS_TAB_COUNT_MAX);
         expect(layout.buttonWidth).toBe(80);
     });
@@ -46,13 +50,13 @@ describe('getHabitsTabLayout', () => {
         expect(layout.buttonWidth).toBe(100);
     });
 
-    it('hides the achievements tab and reclaims its width when the flag is off', () => {
+    it('hides the feed tab and reclaims its width when the flag is off', () => {
         const layout = getHabitsTabLayout(SCREEN_WIDTH, {
             ...BOTH_ON,
-            [FeatureFlags.ENABLE_ACHIEVEMENTS]: false,
+            [FeatureFlags.ENABLE_HABITS_FEED]: false,
         });
 
-        expect(layout.isAchievementsEnabled).toBe(false);
+        expect(layout.isFeedEnabled).toBe(false);
         expect(layout.tabCount).toBe(4);
         expect(layout.buttonWidth).toBe(100);
     });
@@ -67,12 +71,12 @@ describe('getHabitsTabLayout', () => {
 
     it('treats a missing flag as off', () => {
         expect(getHabitsTabLayout(SCREEN_WIDTH, {}).isJournalEnabled).toBe(false);
-        expect(getHabitsTabLayout(SCREEN_WIDTH, {}).isAchievementsEnabled).toBe(false);
+        expect(getHabitsTabLayout(SCREEN_WIDTH, {}).isFeedEnabled).toBe(false);
     });
 
     it('treats an absent flag map as off rather than throwing', () => {
         expect(getHabitsTabLayout(SCREEN_WIDTH).isJournalEnabled).toBe(false);
-        expect(getHabitsTabLayout(SCREEN_WIDTH).isAchievementsEnabled).toBe(false);
+        expect(getHabitsTabLayout(SCREEN_WIDTH).isFeedEnabled).toBe(false);
     });
 
     it('requires exactly true, matching how Layout filters routes on requiredFeatures', () => {
@@ -80,19 +84,19 @@ describe('getHabitsTabLayout', () => {
         // would let the tab appear for a route that was never registered.
         const truthyButNotTrue = getHabitsTabLayout(SCREEN_WIDTH, {
             [FeatureFlags.ENABLE_HABITS_JOURNAL]: 1 as any,
-            [FeatureFlags.ENABLE_ACHIEVEMENTS]: 'yes' as any,
+            [FeatureFlags.ENABLE_HABITS_FEED]: 'yes' as any,
         });
 
         expect(truthyButNotTrue.isJournalEnabled).toBe(false);
-        expect(truthyButNotTrue.isAchievementsEnabled).toBe(false);
+        expect(truthyButNotTrue.isFeedEnabled).toBe(false);
     });
 
     it('never exceeds the tab ceiling validateFeatureFlags enforces', () => {
         [true, false].forEach((journal) => {
-            [true, false].forEach((achievements) => {
+            [true, false].forEach((feed) => {
                 const layout = getHabitsTabLayout(SCREEN_WIDTH, {
                     [FeatureFlags.ENABLE_HABITS_JOURNAL]: journal,
-                    [FeatureFlags.ENABLE_ACHIEVEMENTS]: achievements,
+                    [FeatureFlags.ENABLE_HABITS_FEED]: feed,
                 });
 
                 expect(layout.tabCount).toBeLessThanOrEqual(HABITS_TAB_COUNT_MAX);

--- a/TherrMobile/env-config.js
+++ b/TherrMobile/env-config.js
@@ -51,6 +51,8 @@ const baseFeatureFlags = {
     ENABLE_PACTS: false,
     REQUIRE_PACT_ONBOARDING: false,
     ENABLE_HABITS_JOURNAL: false,
+    // Public social feed of shared check-ins. Off by default; enabled per brand below.
+    ENABLE_HABITS_FEED: false,
     ENABLE_HABITS_SOLO: false,
     ENABLE_HABITS_LIFETIME_OFFER: false,
 
@@ -93,6 +95,11 @@ const brandFeatureFlagOverrides = {
         ENABLE_PACTS: true,
         REQUIRE_PACT_ONBOARDING: true,
         ENABLE_HABITS_JOURNAL: true,
+        // Public feed of shared check-ins. On for HABITS, where it replaces the Awards tab in
+        // the bottom bar (Achievements stays reachable from the drawer). To A/B the feed, ship
+        // a build with this off to bank a baseline, then flip it on and compare via
+        // analyticsEvents — there is no per-user cohort framework, so this is a per-build toggle.
+        ENABLE_HABITS_FEED: true,
         // Solo habits still require the user to have sent a pact invite first;
         // this flag only controls whether the affordance exists at all. The
         // server enforces the onboarding gate independently.

--- a/TherrMobile/main/components/ButtonMenu/HabitsButtonMenu.tsx
+++ b/TherrMobile/main/components/ButtonMenu/HabitsButtonMenu.tsx
@@ -102,11 +102,15 @@ const ViewProfileButton = ({
 );
 
 /**
- * HABITS app button menu with Habits, Journal, Awards, Connect, and Profile tabs.
+ * HABITS app button menu with Habits, Journal, Feed, Connect, and Profile tabs.
  *
  * There is no Pacts tab: the pact lists are segments of the Habits screen now,
  * so a second tab pointing at the same screen would only have split the two
- * halves of one flow across the bar. Awards (Achievements) took the slot.
+ * halves of one flow across the bar.
+ *
+ * The optional social slot holds the public Feed (`ENABLE_HABITS_FEED`), which
+ * replaced the Awards (Achievements) tab. Achievements is still reachable from
+ * the drawer, so removing its tab did not remove the feature.
  */
 class HabitsButtonMenu extends ButtonMenu {
     constructor(props) {
@@ -195,13 +199,13 @@ class HabitsButtonMenu extends ButtonMenu {
         const {
             isCompact, translate, themeMenu, user, habits,
         } = (this.props as unknown as IHabitsButtonMenuProps);
-        const { isJournalEnabled, isAchievementsEnabled, buttonWidth } = getTabLayout();
+        const { isJournalEnabled, isFeedEnabled, buttonWidth } = getTabLayout();
         const activeRoute = this.getActiveRoute();
         const isHabitsActive = [
             'HabitsDashboard', 'HabitDetail', 'PactDetail', 'CreatePact', 'CreatePactInvite',
         ].includes(activeRoute);
         const isJournalActive = activeRoute === 'Journal';
-        const isAchievementsActive = ['Achievements', 'AchievementClaim'].includes(activeRoute);
+        const isFeedActive = activeRoute === 'HabitsFeed';
         const isConnectActive = activeRoute === 'Connect';
         // Badge counts only invites awaiting this user's reply, and the landing
         // segment follows it — see `habitsBadgeState.ts` for why the sent-invite
@@ -313,16 +317,17 @@ class HabitsButtonMenu extends ButtonMenu {
                     onPress={() => this.onNavPressDynamic('Journal')}
                 />}
 
-                {/* Achievements Tab — gated on the same flag that registers the route */}
-                {isAchievementsEnabled && <Button
-                    title={!isCompact ? translate('menus.habits.buttons.achievements') : null}
+                {/* Feed Tab — gated on the same flag that registers the route. Replaced the
+                    Awards tab; Achievements now lives in the drawer only. */}
+                {isFeedEnabled && <Button
+                    title={!isCompact ? translate('menus.habits.buttons.feed') : null}
                     buttonStyle={
-                        isAchievementsActive
+                        isFeedActive
                             ? themeMenu.styles.buttonsActive
                             : themeMenu.styles.buttons
                     }
                     containerStyle={[
-                        (isAchievementsActive
+                        (isFeedActive
                             ? themeMenu.styles.buttonContainerActive
                             : themeMenu.styles.buttonContainer),
                         {
@@ -330,22 +335,22 @@ class HabitsButtonMenu extends ButtonMenu {
                         },
                     ]}
                     titleStyle={
-                        isAchievementsActive
+                        isFeedActive
                             ? themeMenu.styles.buttonsTitleActive
                             : themeMenu.styles.buttonsTitle
                     }
                     icon={
-                        <TherrIcon
-                            name="achievement"
+                        <MaterialIcon
+                            name="dynamic-feed"
                             size={24}
                             style={
-                                isAchievementsActive
+                                isFeedActive
                                     ? themeMenu.styles.buttonIconActive
                                     : themeMenu.styles.buttonIcon
                             }
                         />
                     }
-                    onPress={() => this.onNavPressDynamic('Achievements')}
+                    onPress={() => this.onNavPressDynamic('HabitsFeed')}
                 />}
 
                 {/* Connect Tab (for finding partners) */}

--- a/TherrMobile/main/components/ButtonMenu/habitsTabLayout.ts
+++ b/TherrMobile/main/components/ButtonMenu/habitsTabLayout.ts
@@ -10,12 +10,21 @@ import { FeatureFlags } from 'therr-js-utilities/constants';
  *
  * WHY THE COUNT IS DERIVED RATHER THAN CONSTANT
  *
- * `routes/index.tsx` registers the `Journal` and `Achievements` screens only
+ * `routes/index.tsx` registers the `Journal` and `HabitsFeed` screens only
  * when their flag is on. A tab rendered unconditionally would therefore survive
  * the flag being switched off and call `navigate('Journal')` against a
  * navigator with no such screen — which does nothing at all, no error, no
  * screen change. A kill-switch that leaves a dead button behind has not killed
  * anything, so each tab and its route read the same flag.
+ *
+ * WHY FEED, NOT AWARDS
+ *
+ * The public feed (`ENABLE_HABITS_FEED`) takes the optional-tab slot the Awards
+ * (Achievements) tab used to hold. Achievements is still reachable from the
+ * drawer, so it keeps its route and its `ENABLE_ACHIEVEMENTS` gate — it is only
+ * off the bottom bar. That is why this layout counts the feed flag here and no
+ * longer the achievements flag: the bar shows at most one of these optional
+ * social tabs, and the product chose the feed for it.
  *
  * 5 is also the ceiling `validateFeatureFlags` enforces, and that check is not
  * cosmetic: every tab is `screenWidth / tabCount` wide, so a sixth would push
@@ -28,7 +37,7 @@ const HABITS_TAB_COUNT_MIN = 3;
 
 export interface IHabitsTabLayout {
     isJournalEnabled: boolean;
-    isAchievementsEnabled: boolean;
+    isFeedEnabled: boolean;
     tabCount: number;
     buttonWidth: number;
 }
@@ -41,14 +50,14 @@ export const getHabitsTabLayout = (
     // routes on `requiredFeatures`. A flag that is merely present must not
     // count as enabled, or the tab and the route could disagree.
     const isJournalEnabled = featureFlags[FeatureFlags.ENABLE_HABITS_JOURNAL] === true;
-    const isAchievementsEnabled = featureFlags[FeatureFlags.ENABLE_ACHIEVEMENTS] === true;
+    const isFeedEnabled = featureFlags[FeatureFlags.ENABLE_HABITS_FEED] === true;
     const tabCount = HABITS_TAB_COUNT_MIN
         + (isJournalEnabled ? 1 : 0)
-        + (isAchievementsEnabled ? 1 : 0);
+        + (isFeedEnabled ? 1 : 0);
 
     return {
         isJournalEnabled,
-        isAchievementsEnabled,
+        isFeedEnabled,
         tabCount,
         buttonWidth: screenWidth / tabCount,
     };

--- a/TherrMobile/main/components/Habits/CheckinDayDetailSheet.tsx
+++ b/TherrMobile/main/components/Habits/CheckinDayDetailSheet.tsx
@@ -40,6 +40,11 @@ interface ICheckinDayDetailSheetProps {
     hasProofError: boolean;
     onClose: () => void;
     onRetryProofs: () => void;
+    /**
+     * Opens the public post this check-in was shared as. Passed only when the check-in carries a
+     * `sharedThoughtId`; the sheet renders a "View post" action when both this and the id exist.
+     */
+    onViewSharedPost?: () => void;
     translate: (key: string, params?: any) => string;
     themeConfirmModal: {
         colors: ITherrThemeColors;
@@ -88,6 +93,7 @@ const CheckinDayDetailSheet: React.FC<ICheckinDayDetailSheetProps> = ({
     hasProofError,
     onClose,
     onRetryProofs,
+    onViewSharedPost,
     translate,
     themeConfirmModal,
     themeButtons,
@@ -95,6 +101,8 @@ const CheckinDayDetailSheet: React.FC<ICheckinDayDetailSheetProps> = ({
     if (!date) {
         return null;
     }
+
+    const isShared = !!checkin?.sharedThoughtId;
 
     const statusLabelKey = getStatusLabelKey(checkin);
     const isFuture = isDayInFuture(date, new Date());
@@ -205,6 +213,15 @@ const CheckinDayDetailSheet: React.FC<ICheckinDayDetailSheetProps> = ({
                 )}
 
                 {renderProofs()}
+
+                {isShared && (
+                    <View style={localStyles.sharedRow}>
+                        <MaterialIcon name="public" size={16} color={themeConfirmModal.colors.brand} />
+                        <Text style={[localStyles.sharedText, { color: themeConfirmModal.colors.brand }]}>
+                            {translate('pages.habits.dayDetail.sharedToFeed')}
+                        </Text>
+                    </View>
+                )}
             </>
         );
     };
@@ -240,6 +257,15 @@ const CheckinDayDetailSheet: React.FC<ICheckinDayDetailSheetProps> = ({
                         iconRight={false}
                         themeButtons={themeButtons}
                     />
+                    {isShared && onViewSharedPost && (
+                        <ModalButton
+                            iconName="open-in-new"
+                            title={translate('pages.habits.dayDetail.viewPost')}
+                            onPress={onViewSharedPost}
+                            iconRight={false}
+                            themeButtons={themeButtons}
+                        />
+                    )}
                 </Dialog.Actions>
             </Dialog>
         </Portal>
@@ -264,6 +290,16 @@ const localStyles = StyleSheet.create({
     },
     notesPlaceholder: {
         fontStyle: 'italic',
+    },
+    sharedRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+        paddingTop: 12,
+    },
+    sharedText: {
+        fontSize: 13,
+        fontWeight: '600',
     },
     ratingRow: {
         flexDirection: 'row',

--- a/TherrMobile/main/components/Habits/CheckinProofSheet.tsx
+++ b/TherrMobile/main/components/Habits/CheckinProofSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Image, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
-import { Dialog, Divider, Portal } from 'react-native-paper';
+import { Dialog, Divider, Portal, Switch } from 'react-native-paper';
 import { ScrollView } from 'react-native-gesture-handler';
 import ImageCropPicker, { Image as CroppedImage } from 'react-native-image-crop-picker';
 import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
@@ -32,8 +32,12 @@ interface ICheckinProofSheetProps {
     isSubmitting?: boolean;
     habitName?: string;
     userId?: string;
+    // When true, a "Share publicly" toggle is offered once a photo is attached (gated by the
+    // ENABLE_HABITS_FEED flag upstream). Sharing requires a photo — it is what keeps the feed
+    // on-topic — so the toggle only appears with an image selected.
+    canShare?: boolean;
     onCancel: () => void;
-    onConfirm: (args: { notes?: string; image?: ISelectedProofImage }) => void;
+    onConfirm: (args: { notes?: string; image?: ISelectedProofImage; sharePublicly?: boolean }) => void;
     translate: (key: string, params?: any) => string;
     themeConfirmModal: {
         colors: ITherrThemeColors;
@@ -52,6 +56,7 @@ const CheckinProofSheet: React.FC<ICheckinProofSheetProps> = ({
     isSubmitting = false,
     habitName,
     userId,
+    canShare = false,
     onCancel,
     onConfirm,
     translate,
@@ -61,11 +66,13 @@ const CheckinProofSheet: React.FC<ICheckinProofSheetProps> = ({
     const [notes, setNotes] = useState('');
     const [selectedImage, setSelectedImage] = useState<ISelectedProofImage | null>(null);
     const [imagePreviewPath, setImagePreviewPath] = useState<string>('');
+    const [sharePublicly, setSharePublicly] = useState(false);
 
     const reset = () => {
         setNotes('');
         setSelectedImage(null);
         setImagePreviewPath('');
+        setSharePublicly(false);
     };
 
     const handleCancel = () => {
@@ -78,6 +85,9 @@ const CheckinProofSheet: React.FC<ICheckinProofSheetProps> = ({
         onConfirm({
             notes: trimmed.length ? trimmed : undefined,
             image: selectedImage || undefined,
+            // Sharing requires a photo; never signal share without one even if the toggle was
+            // left on from before the image was removed.
+            sharePublicly: canShare && !!selectedImage && sharePublicly,
         });
         reset();
     };
@@ -242,6 +252,26 @@ const CheckinProofSheet: React.FC<ICheckinProofSheetProps> = ({
                                 </View>
                             )}
                         </View>
+                        {canShare && imagePreviewPath ? (
+                            <View style={localStyles.shareSection}>
+                                <View style={localStyles.shareRow}>
+                                    <View style={localStyles.shareTextContainer}>
+                                        <Text style={[themeConfirmModal.styles.bodyTextBold, localStyles.shareLabel]}>
+                                            {translate('pages.habits.checkinProof.sharePubliclyLabel')}
+                                        </Text>
+                                        <Text style={[themeConfirmModal.styles.bodyText, localStyles.shareHint]}>
+                                            {translate('pages.habits.checkinProof.sharePubliclyHint')}
+                                        </Text>
+                                    </View>
+                                    <Switch
+                                        value={sharePublicly}
+                                        onValueChange={setSharePublicly}
+                                        disabled={isSubmitting}
+                                        color={themeConfirmModal.colors.brand}
+                                    />
+                                </View>
+                            </View>
+                        ) : null}
                     </ScrollView>
                 </Dialog.ScrollArea>
                 <Divider />
@@ -297,6 +327,26 @@ const localStyles = StyleSheet.create({
     photoSection: {
         paddingHorizontal: 10,
         paddingBottom: 10,
+    },
+    shareSection: {
+        paddingHorizontal: 10,
+        paddingBottom: 12,
+    },
+    shareRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+    },
+    shareTextContainer: {
+        flex: 1,
+    },
+    shareLabel: {
+        fontSize: 15,
+    },
+    shareHint: {
+        fontSize: 12,
+        paddingTop: 2,
     },
     photoButtonRow: {
         flexDirection: 'row',

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -2051,6 +2051,8 @@
                 "proofsFailed": "We couldn't load your photos.",
                 "proofsUnavailable": "The photos for this day are no longer available.",
                 "proofImageAlt": "Check-in photo",
+                "sharedToFeed": "Shared to the feed",
+                "viewPost": "View post",
                 "dayAccessibilityLabel": "{month} {day}, view check-in details",
                 "status": {
                     "completed": "Completed",

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -1176,7 +1176,8 @@
                 "achievements": "Awards",
                 "partners": "Friends",
                 "profile": "Profile",
-                "journal": "Journal"
+                "journal": "Journal",
+                "feed": "Feed"
             },
             "accessibility": {
                 "habitsWithInvites": "Habits, {count} invite(s) awaiting your reply"
@@ -2029,7 +2030,14 @@
                 "cancel": "Cancel",
                 "addDetailTitle": "Add a note or photo",
                 "addDetailPrompt": "Checked in. Add anything you want to remember (optional).",
+                "sharePubliclyLabel": "Share to the feed",
+                "sharePubliclyHint": "Post this photo publicly so others can cheer you on.",
+                "sharedTitle": "Shared to the feed",
+                "shareFailed": "We couldn't share this check-in. Try again later.",
                 "save": "Save"
+            },
+            "feed": {
+                "emptyMessage": "No shared check-ins yet. Share one of yours to get the feed started."
             },
             "dayDetail": {
                 "title": "{weekday}, {month} {day}",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -2051,6 +2051,8 @@
                 "proofsFailed": "No pudimos cargar tus fotos.",
                 "proofsUnavailable": "Las fotos de este día ya no están disponibles.",
                 "proofImageAlt": "Foto del registro",
+                "sharedToFeed": "Compartido en el feed",
+                "viewPost": "Ver publicación",
                 "dayAccessibilityLabel": "{day} de {month}, ver detalles del registro",
                 "status": {
                     "completed": "Completado",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -1176,7 +1176,8 @@
                 "achievements": "Logros",
                 "partners": "Amigos",
                 "profile": "Perfil",
-                "journal": "Diario"
+                "journal": "Diario",
+                "feed": "Feed"
             },
             "accessibility": {
                 "habitsWithInvites": "Hábitos, {count} invitación(es) esperando tu respuesta"
@@ -2029,7 +2030,14 @@
                 "cancel": "Cancelar",
                 "addDetailTitle": "Añadir una nota o foto",
                 "addDetailPrompt": "Registrado. Añade lo que quieras recordar (opcional).",
+                "sharePubliclyLabel": "Compartir en el feed",
+                "sharePubliclyHint": "Publica esta foto para que otros te animen.",
+                "sharedTitle": "Compartido en el feed",
+                "shareFailed": "No pudimos compartir este registro. Inténtalo más tarde.",
                 "save": "Guardar"
+            },
+            "feed": {
+                "emptyMessage": "Aún no hay registros compartidos. Comparte uno de los tuyos para empezar el feed."
             },
             "dayDetail": {
                 "title": "{weekday}, {day} de {month}",

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -2051,6 +2051,8 @@
                 "proofsFailed": "Impossible de charger vos photos.",
                 "proofsUnavailable": "Les photos de cette journée ne sont plus disponibles.",
                 "proofImageAlt": "Photo de l'enregistrement",
+                "sharedToFeed": "Partagé au fil",
+                "viewPost": "Voir la publication",
                 "dayAccessibilityLabel": "{day} {month}, voir les détails de l'enregistrement",
                 "status": {
                     "completed": "Complété",

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -1176,7 +1176,8 @@
                 "achievements": "Succès",
                 "partners": "Amis",
                 "profile": "Profil",
-                "journal": "Journal"
+                "journal": "Journal",
+                "feed": "Fil"
             },
             "accessibility": {
                 "habitsWithInvites": "Habitudes, {count} invitation(s) en attente de votre réponse"
@@ -2029,7 +2030,14 @@
                 "cancel": "Annuler",
                 "addDetailTitle": "Ajouter une note ou une photo",
                 "addDetailPrompt": "Enregistré. Ajoutez ce que vous voulez retenir (optionnel).",
+                "sharePubliclyLabel": "Partager au fil",
+                "sharePubliclyHint": "Publiez cette photo pour que d'autres vous encouragent.",
+                "sharedTitle": "Partagé au fil",
+                "shareFailed": "Impossible de partager ce suivi. Réessayez plus tard.",
                 "save": "Enregistrer"
+            },
+            "feed": {
+                "emptyMessage": "Aucun suivi partagé pour l'instant. Partagez l'un des vôtres pour lancer le fil."
             },
             "dayDetail": {
                 "title": "{weekday} {day} {month}",

--- a/TherrMobile/main/routes/Habits/Dashboard.tsx
+++ b/TherrMobile/main/routes/Habits/Dashboard.tsx
@@ -103,6 +103,7 @@ interface IHabitsDashboardDispatchProps {
     getPendingInvites: Function;
     getUserHabitEligibility: Function;
     createCheckin: Function;
+    shareCheckin: Function;
     acceptPact: Function;
     declinePact: Function;
     nudgePact: Function;
@@ -145,6 +146,7 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
     getPendingInvites: HabitActions.getPendingInvites,
     getUserHabitEligibility: HabitActions.getUserHabitEligibility,
     createCheckin: HabitActions.createCheckin,
+    shareCheckin: HabitActions.shareCheckin,
     acceptPact: HabitActions.acceptPact,
     declinePact: HabitActions.declinePact,
     nudgePact: HabitActions.nudgePact,
@@ -342,14 +344,18 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
         });
     };
 
-    handleProofSheetConfirm = ({ notes, image }: { notes?: string; image?: ISelectedProofImage }) => {
+    isFeedEnabled = (): boolean => getConfig().featureFlags?.[FeatureFlags.ENABLE_HABITS_FEED] === true;
+
+    handleProofSheetConfirm = (
+        { notes, image, sharePublicly }: { notes?: string; image?: ISelectedProofImage; sharePublicly?: boolean },
+    ) => {
         const { proofSheetHabit } = this.state;
 
         if (!proofSheetHabit) {
             return;
         }
 
-        this.submitCheckin(proofSheetHabit, { notes, image });
+        this.submitCheckin(proofSheetHabit, { notes, image, sharePublicly });
     };
 
     /**
@@ -361,9 +367,9 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
      */
     submitCheckin = (
         habitGoal: IHabitGoal,
-        { notes, image }: { notes?: string; image?: ISelectedProofImage },
+        { notes, image, sharePublicly }: { notes?: string; image?: ISelectedProofImage; sharePublicly?: boolean },
     ) => {
-        const { createCheckin, getActiveStreaks } = this.props;
+        const { createCheckin, shareCheckin, getActiveStreaks } = this.props;
         const { checkinLoadingIds } = this.state;
 
         const habitGoalId = habitGoal.id;
@@ -391,6 +397,29 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
             }))
             .then((checkin: any) => {
                 if (isAddingDetail) {
+                    // Opt-in public share: only with a photo (the backend copies that proof into
+                    // the public bucket, moderates it, and mints a public post). Fire-and-forget
+                    // — a failed share must not fail the check-in, which already committed.
+                    const wantsShare = sharePublicly && !!image && !!checkin?.id;
+                    if (wantsShare) {
+                        shareCheckin(checkin.id, notes)
+                            .then(() => {
+                                logAppEvent('habit_checkin_shared', {
+                                    userId: this.props.user?.details?.id,
+                                    source: 'dashboard',
+                                });
+                                showToast.success({
+                                    text1: this.translate('pages.habits.checkinProof.sharedTitle'),
+                                });
+                            })
+                            .catch(() => {
+                                showToast.error({
+                                    text1: this.translate('pages.habits.checkinProof.shareFailed'),
+                                });
+                            });
+                        return;
+                    }
+
                     showToast.success({
                         text1: this.translate('pages.habits.checkinToast.detailSavedTitle'),
                     });
@@ -1189,6 +1218,7 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
                     isSubmitting={isSubmittingCheckin}
                     habitName={proofSheetHabit?.name}
                     userId={user?.details?.id}
+                    canShare={this.isFeedEnabled()}
                     onCancel={this.handleProofSheetCancel}
                     onConfirm={this.handleProofSheetConfirm}
                     translate={this.translate}

--- a/TherrMobile/main/routes/Habits/HabitDetail.tsx
+++ b/TherrMobile/main/routes/Habits/HabitDetail.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import RNFB from 'react-native-blob-util';
-import { FilePaths } from 'therr-js-utilities/constants';
+import { FeatureFlags, FilePaths } from 'therr-js-utilities/constants';
 import { HabitActions, MapActions } from 'therr-react/redux/actions';
 import {
     IUserState, IHabitsState, IHabitGoal, IHabitCheckin, IHabitCheckinProof, IStreak,
@@ -31,11 +31,13 @@ import { signImageUrl } from '../../utilities/content';
 import { logAppEvent } from '../../utilities/analyticsEvents';
 import { toLocalDateKey } from '../../utilities/localDateKey';
 import { DURATION, showToast } from '../../utilities/toasts';
+import getConfig from '../../utilities/getConfig';
 
 interface IHabitDetailDispatchProps {
     getCheckinsByRange: Function;
     getStreakByHabit: Function;
     createCheckin: Function;
+    shareCheckin: Function;
     getCheckinProofs: Function;
     fetchMedia: Function;
 }
@@ -82,6 +84,7 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
     getCheckinsByRange: HabitActions.getCheckinsByRange,
     getStreakByHabit: HabitActions.getStreakByHabit,
     createCheckin: HabitActions.createCheckin,
+    shareCheckin: HabitActions.shareCheckin,
     getCheckinProofs: HabitActions.getCheckinProofs,
     fetchMedia: MapActions.fetchMedia,
 }, dispatch);
@@ -214,8 +217,12 @@ export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetail
         });
     };
 
-    handleProofSheetConfirm = ({ notes, image }: { notes?: string; image?: ISelectedProofImage }) => {
-        this.submitCheckin({ notes, image });
+    isFeedEnabled = (): boolean => getConfig().featureFlags?.[FeatureFlags.ENABLE_HABITS_FEED] === true;
+
+    handleProofSheetConfirm = (
+        { notes, image, sharePublicly }: { notes?: string; image?: ISelectedProofImage; sharePublicly?: boolean },
+    ) => {
+        this.submitCheckin({ notes, image, sharePublicly });
     };
 
     /**
@@ -224,8 +231,10 @@ export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetail
      * (`getTodayDateString`), so the local-calendar `toLocalDateKey` used to
      * render the month grid must not be used for the write.
      */
-    submitCheckin = ({ notes, image }: { notes?: string; image?: ISelectedProofImage }) => {
-        const { createCheckin, route } = this.props;
+    submitCheckin = (
+        { notes, image, sharePublicly }: { notes?: string; image?: ISelectedProofImage; sharePublicly?: boolean },
+    ) => {
+        const { createCheckin, shareCheckin, route } = this.props;
         const { habitGoalId } = route.params;
         const isAddingDetail = !!notes || !!image;
 
@@ -247,6 +256,27 @@ export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetail
             }))
             .then((checkin: any) => {
                 if (isAddingDetail) {
+                    const wantsShare = sharePublicly && !!image && !!checkin?.id;
+                    if (wantsShare) {
+                        // Fire-and-forget public share of the proof photo — see Dashboard.tsx.
+                        shareCheckin(checkin.id, notes)
+                            .then(() => {
+                                logAppEvent('habit_checkin_shared', {
+                                    userId: this.props.user?.details?.id,
+                                    source: 'habitDetail',
+                                });
+                                showToast.success({
+                                    text1: this.translate('pages.habits.checkinProof.sharedTitle'),
+                                });
+                            })
+                            .catch(() => {
+                                showToast.error({
+                                    text1: this.translate('pages.habits.checkinProof.shareFailed'),
+                                });
+                            });
+                        return;
+                    }
+
                     showToast.success({
                         text1: this.translate('pages.habits.checkinToast.detailSavedTitle'),
                     });
@@ -555,6 +585,7 @@ export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetail
                     isSubmitting={isCheckinLoading}
                     habitName={habitGoal.name}
                     userId={user?.details?.id}
+                    canShare={this.isFeedEnabled()}
                     onCancel={this.handleProofSheetCancel}
                     onConfirm={this.handleProofSheetConfirm}
                     translate={this.translate}

--- a/TherrMobile/main/routes/Habits/HabitDetail.tsx
+++ b/TherrMobile/main/routes/Habits/HabitDetail.tsx
@@ -418,6 +418,26 @@ export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetail
         });
     };
 
+    // Open the public post a shared check-in became. ViewThought renders the sparse thought
+    // handed in immediately and merges its own (brand-scoped) fetch on top, so a bare id is
+    // enough; `previousView` sends the back button here rather than to the author's profile.
+    handleViewSharedPost = () => {
+        const { navigation } = this.props;
+        const { selectedDayCheckin } = this.state;
+        const sharedThoughtId = selectedDayCheckin?.sharedThoughtId;
+
+        if (!sharedThoughtId) {
+            return;
+        }
+
+        this.handleDayDetailClose();
+        navigation.navigate('ViewThought', {
+            isMyContent: true,
+            previousView: 'HabitDetail',
+            thought: { id: sharedThoughtId },
+        });
+    };
+
     getTodayCheckin = (): IHabitCheckin | undefined => {
         const { habits, route } = this.props;
         const { habitGoalId } = route.params;
@@ -576,6 +596,9 @@ export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetail
                     hasProofError={hasDayProofError}
                     onClose={this.handleDayDetailClose}
                     onRetryProofs={this.handleRetryDayProofs}
+                    onViewSharedPost={selectedDayCheckin?.sharedThoughtId
+                        ? this.handleViewSharedPost
+                        : undefined}
                     translate={this.translate}
                     themeConfirmModal={this.themeConfirmModal}
                     themeButtons={this.themeButtons}

--- a/TherrMobile/main/routes/HabitsFeed/index.tsx
+++ b/TherrMobile/main/routes/HabitsFeed/index.tsx
@@ -1,0 +1,243 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { SheetManager } from 'react-native-actions-sheet';
+import { ContentActions } from 'therr-react/redux/actions';
+import { MapActions } from 'therr-react/redux/actions';
+import { IUserState, IContentState } from 'therr-react/types';
+import { buildStyles } from '../../styles';
+import { buildStyles as buildLoaderStyles } from '../../styles/loaders';
+import { buildStyles as buildFormStyles } from '../../styles/forms';
+import { buildStyles as buildMenuStyles } from '../../styles/navigation/buttonMenu';
+import translator from '../../utilities/translator';
+import BaseStatusBar from '../../components/BaseStatusBar';
+import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
+import LottieLoader, { ILottieId } from '../../components/LottieLoader';
+import getActiveCarouselData from '../../utilities/getActiveCarouselData';
+import { handleThoughtReaction, navToViewContent } from '../../utilities/postViewHelpers';
+import { IContentSelectionType } from '../../components/ActionSheet/ContentOptionsSheet';
+import { CAROUSEL_TABS } from '../../constants';
+import AreaCarousel from '../Areas/AreaCarousel';
+
+/**
+ * The Friends with Habits public feed: the shared check-ins (public `main.thoughts` rows carrying
+ * a proof photo) plus goals, ranked. Content can only be authored by making a check-in public,
+ * which keeps the feed on-topic — there is no composer here on purpose.
+ *
+ * This reuses the existing thoughts feed machinery (`getActiveCarouselData` +
+ * `AreaCarousel` + the Content reaction actions) rather than a second rendering path; the
+ * thoughts it reads are already brand-scoped server-side by `BRAND_THOUGHTS_VISIBILITY`, so a
+ * HABITS build sees HABITS posts (and a Therr build additionally sees them, which is intended).
+ *
+ * Gated behind `ENABLE_HABITS_FEED`: the route is only registered, and the bottom-bar Feed tab
+ * only rendered, when the flag is on — see routes/index.tsx and ButtonMenu/habitsTabLayout.ts.
+ */
+interface IHabitsFeedDispatchProps {
+    searchActiveThoughts: Function;
+    updateActiveThoughtsStream: Function;
+    createOrUpdateThoughtReaction: Function;
+    fetchMedia: Function;
+}
+
+interface IStoreProps extends IHabitsFeedDispatchProps {
+    user: IUserState;
+    content: IContentState;
+}
+
+export interface IHabitsFeedProps extends IStoreProps {
+    navigation: any;
+}
+
+interface IHabitsFeedState {
+    isLoading: boolean;
+}
+
+const mapStateToProps = (state: any) => ({
+    user: state.user,
+    content: state.content,
+});
+
+const mapDispatchToProps = (dispatch: any) => bindActionCreators({
+    searchActiveThoughts: ContentActions.searchActiveThoughts,
+    updateActiveThoughtsStream: ContentActions.updateActiveThoughtsStream,
+    createOrUpdateThoughtReaction: ContentActions.createOrUpdateThoughtReaction,
+    fetchMedia: MapActions.fetchMedia,
+}, dispatch);
+
+export class HabitsFeed extends React.Component<IHabitsFeedProps, IHabitsFeedState> {
+    private translate: (key: string, params?: any) => string;
+
+    private theme = buildStyles();
+
+    private themeLoader = buildLoaderStyles();
+
+    private themeForms = buildFormStyles();
+
+    private themeMenu = buildMenuStyles();
+
+    private loaderId: ILottieId = 'earth';
+
+    private carouselRef;
+
+    constructor(props: IHabitsFeedProps) {
+        super(props);
+
+        this.state = {
+            isLoading: true,
+        };
+
+        this.theme = buildStyles(props.user.settings?.mobileThemeName);
+        this.themeLoader = buildLoaderStyles(props.user.settings?.mobileThemeName);
+        this.themeForms = buildFormStyles(props.user.settings?.mobileThemeName);
+        this.themeMenu = buildMenuStyles(props.user.settings?.mobileThemeName);
+        this.translate = (key: string, params: any = {}) => translator(props.user.settings?.locale || 'en-us', key, params);
+    }
+
+    componentDidMount() {
+        this.loadFeed();
+    }
+
+    loadFeed = () => {
+        const { updateActiveThoughtsStream, user } = this.props;
+
+        this.setState({ isLoading: true });
+
+        return updateActiveThoughtsStream({
+            withUser: true,
+            withReplies: true,
+            offset: 0,
+            blockedUsers: user.details?.blockedUsers,
+            shouldHideMatureContent: user.details?.shouldHideMatureContent,
+        })
+            .catch(() => {})
+            .finally(() => {
+                this.setState({ isLoading: false });
+            });
+    };
+
+    handleRefresh = () => {
+        this.loadFeed();
+    };
+
+    // Mirrors the thoughts branch of postViewHelpers.loadMorePosts, inlined so this screen
+    // never has to hand it the moment/space/event searchers it does not use.
+    tryLoadMore = () => {
+        const { content, searchActiveThoughts, user } = this.props;
+
+        if (content.activeThoughtsPagination?.isLastPage) {
+            return;
+        }
+
+        const lastContentCreatedAt = content.activeThoughts?.length
+            ? content.activeThoughts[content.activeThoughts.length - 1].createdAt
+            : null;
+
+        searchActiveThoughts({
+            withUser: true,
+            withReplies: true,
+            offset: (content.activeThoughtsPagination?.offset || 0)
+                + (content.activeThoughtsPagination?.itemsPerPage || 0),
+            blockedUsers: user.details?.blockedUsers,
+            shouldHideMatureContent: user.details?.shouldHideMatureContent,
+            lastContentCreatedAt,
+        });
+    };
+
+    goToContent = (contentItem) => {
+        const { navigation, user } = this.props;
+        navToViewContent(contentItem, user, navigation.navigate);
+    };
+
+    goToViewUser = (userId) => {
+        const { navigation } = this.props;
+        navigation.navigate('ViewUser', { userInView: { id: userId } });
+    };
+
+    goToViewMap = (lat, long) => {
+        const { navigation } = this.props;
+        navigation.navigate('Map', { latitude: lat, longitude: long });
+    };
+
+    onThoughtOptionSelect = (type: IContentSelectionType, thought: any) => {
+        const { createOrUpdateThoughtReaction, user } = this.props;
+        handleThoughtReaction(thought, type, {
+            user,
+            createOrUpdateThoughtReaction,
+            translate: this.translate,
+        });
+    };
+
+    toggleThoughtOptions = (displayThought) => {
+        const thought = displayThought || {};
+        SheetManager.show('content-options-sheet', {
+            payload: {
+                contentType: 'thought',
+                translate: this.translate,
+                themeForms: this.themeForms,
+                onSelect: (type: IContentSelectionType) => this.onThoughtOptionSelect(type, thought),
+            },
+        });
+    };
+
+    // Reaction props AreaCarousel requires but that never fire for thought items.
+    noop = () => {};
+
+    render() {
+        const {
+            content, createOrUpdateThoughtReaction, fetchMedia, navigation, user,
+        } = this.props;
+        const { isLoading } = this.state;
+
+        const feedData = isLoading ? [] : getActiveCarouselData({
+            activeTab: CAROUSEL_TABS.THOUGHTS,
+            content,
+            isForBookmarks: false,
+            shouldIncludeThoughts: true,
+            translate: this.translate,
+            contentAlgorithm: user.settings?.settingsContentAlgorithm,
+        }, 'ranked');
+
+        return (
+            <>
+                <BaseStatusBar therrThemeName={user.settings?.mobileThemeName} />
+                <SafeAreaView style={this.theme.styles.safeAreaView} edges={[]}>
+                    <AreaCarousel
+                        activeData={feedData}
+                        content={content}
+                        inspectContent={this.goToContent}
+                        isLoading={isLoading}
+                        fetchMedia={fetchMedia}
+                        goToViewMap={this.goToViewMap}
+                        goToViewUser={this.goToViewUser}
+                        toggleAreaOptions={this.noop}
+                        toggleThoughtOptions={this.toggleThoughtOptions}
+                        translate={this.translate}
+                        containerRef={(component) => { this.carouselRef = component; }}
+                        handleRefresh={this.handleRefresh}
+                        onEndReached={this.tryLoadMore}
+                        updateEventReaction={this.noop}
+                        updateMomentReaction={this.noop}
+                        updateSpaceReaction={this.noop}
+                        updateThoughtReaction={createOrUpdateThoughtReaction}
+                        emptyListMessage={this.translate('pages.habits.feed.emptyMessage')}
+                        emptyIconName="idea"
+                        renderHeader={() => null}
+                        renderLoader={() => <LottieLoader id={this.loaderId} theme={this.themeLoader} />}
+                        user={user}
+                        rootStyles={this.theme.styles}
+                    />
+                </SafeAreaView>
+                <MainButtonMenu
+                    navigation={navigation}
+                    onActionButtonPress={this.handleRefresh}
+                    translate={this.translate}
+                    user={user}
+                    themeMenu={this.themeMenu}
+                />
+            </>
+        );
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(HabitsFeed);

--- a/TherrMobile/main/routes/index.tsx
+++ b/TherrMobile/main/routes/index.tsx
@@ -21,6 +21,7 @@ import Landing from './Landing';
 import Login from './Login';
 import Map from './Map';
 import Achievements from './Achievements';
+import HabitsFeed from './HabitsFeed';
 import ApiAccess from './ApiAccess';
 import AchievementClaim from './Achievements/AchievementClaim';
 import Leaderboard from './Leaderboard';
@@ -138,6 +139,17 @@ const routes: RouteConfig<
         options: () => ({
             title: 'Achievements',
             requiredFeatures: [FeatureFlags.ENABLE_ACHIEVEMENTS],
+            access: AccessPresets.EMAIL_VERIFIED,
+        }),
+    },
+    {
+        name: 'HabitsFeed',
+        component: HabitsFeed,
+        options: () => ({
+            title: 'Feed',
+            // Same flag the bottom-bar Feed tab reads — a tab and its route must agree, or the
+            // tab navigates to a screen the navigator never registered. See habitsTabLayout.ts.
+            requiredFeatures: [FeatureFlags.ENABLE_HABITS_FEED],
             access: AccessPresets.EMAIL_VERIFIED,
         }),
     },

--- a/TherrMobile/main/utilities/validateFeatureFlags.ts
+++ b/TherrMobile/main/utilities/validateFeatureFlags.ts
@@ -8,9 +8,11 @@ interface IFeatureDependency {
 // Navigation tab flags for counting visible tabs (across all brands)
 //
 // ENABLE_PACTS is absent because pacts no longer have a tab of their own — they
-// are segments of the habits screen. Achievements took the slot, but only on
-// the HABITS button menu, so it is counted conditionally below rather than
-// listed here (on Therr it is a drawer item, and counting it there would push a
+// are segments of the habits screen. The optional HABITS social tab is the
+// public Feed (ENABLE_HABITS_FEED), which replaced the Awards (Achievements)
+// tab; it is counted conditionally below rather than listed here because it is a
+// tab only on the HABITS button menu (Achievements is now a drawer item on
+// HABITS, and never a tab on Therr — counting either there would push a
 // perfectly valid five-tab bar over the ceiling).
 const NAVIGATION_TAB_FLAGS = [
     FeatureFlags.ENABLE_AREAS,
@@ -23,10 +25,10 @@ const NAVIGATION_TAB_FLAGS = [
 
 const countNavigationTabs = (flags: Record<string, boolean>): number => {
     const listed = NAVIGATION_TAB_FLAGS.filter(flag => flags[flag]).length;
-    const hasAchievementsTab = !!flags[FeatureFlags.ENABLE_HABITS]
-        && !!flags[FeatureFlags.ENABLE_ACHIEVEMENTS];
+    const hasFeedTab = !!flags[FeatureFlags.ENABLE_HABITS]
+        && !!flags[FeatureFlags.ENABLE_HABITS_FEED];
 
-    return listed + (hasAchievementsTab ? 1 : 0);
+    return listed + (hasFeedTab ? 1 : 0);
 };
 
 // Define dependencies (feature X requires feature Y)

--- a/therr-api-gateway/src/services/users/router.ts
+++ b/therr-api-gateway/src/services/users/router.ts
@@ -776,6 +776,11 @@ usersServiceRouter.post('/habits/checkins', handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
     method: 'post',
 }));
+// Promote a check-in's proof photo to a public post (main.thoughts)
+usersServiceRouter.post('/habits/checkins/:id/share', handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'post',
+}));
 usersServiceRouter.put('/habits/checkins/:id/skip', handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
     method: 'put',

--- a/therr-public-library/therr-js-utilities/src/constants/enums/FeatureFlags.ts
+++ b/therr-public-library/therr-js-utilities/src/constants/enums/FeatureFlags.ts
@@ -26,6 +26,11 @@ enum FeatureFlags {
     ENABLE_PACTS = 'ENABLE_PACTS',
     REQUIRE_PACT_ONBOARDING = 'REQUIRE_PACT_ONBOARDING',
     ENABLE_HABITS_JOURNAL = 'ENABLE_HABITS_JOURNAL',
+    // Public social feed of shared check-ins (see docs/WORK_IN_PROGRESS.md 2.6.8).
+    // Off by default so it can ship dark and be flipped on per brand build; when on
+    // for HABITS it replaces the Awards tab in the bottom bar. A tab and its route
+    // read this same flag — see TherrMobile habitsTabLayout.ts for why.
+    ENABLE_HABITS_FEED = 'ENABLE_HABITS_FEED',
     ENABLE_HABITS_SOLO = 'ENABLE_HABITS_SOLO',
     ENABLE_HABITS_LIFETIME_OFFER = 'ENABLE_HABITS_LIFETIME_OFFER',
 

--- a/therr-public-library/therr-react/src/redux/actions/Habits.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Habits.ts
@@ -230,6 +230,19 @@ const Habits = {
             return response.data;
         }),
 
+    // Share a check-in's proof photo publicly as a post. The response carries `sharedThoughtId`
+    // (and the created `thought` on first share); the dispatch merges just that id onto the
+    // matching check-in so the "shared" state shows without a refetch — see the SHARE_CHECKIN
+    // reducer case, which is a merge rather than the full-object replace UPDATE_CHECKIN does.
+    shareCheckin: (id: string, message?: string) => (dispatch: any) => HabitCheckinsService
+        .share(id, message).then((response) => {
+            dispatch({
+                type: HabitsActionTypes.SHARE_CHECKIN,
+                data: { id, sharedThoughtId: response.data?.sharedThoughtId },
+            });
+            return response.data;
+        }),
+
     // Streaks
     getUserStreaks: (isActive?: boolean) => (dispatch: any) => StreaksService
         .getUserStreaks(isActive).then((response: any) => {

--- a/therr-public-library/therr-react/src/redux/reducers/habits.ts
+++ b/therr-public-library/therr-react/src/redux/reducers/habits.ts
@@ -174,6 +174,16 @@ const habits = produce((draft: IHabitsState, action: any) => {
             break;
         }
 
+        // Merge, not replace: the share response is only `{ id, sharedThoughtId }`, so overwriting
+        // the row (as UPDATE_CHECKIN does with a full check-in) would drop every other field.
+        case HabitsActionTypes.SHARE_CHECKIN: {
+            const checkinIdx = draft.todayCheckins.findIndex((c) => c.id === action.data.id);
+            if (checkinIdx > -1) {
+                draft.todayCheckins[checkinIdx].sharedThoughtId = action.data.sharedThoughtId;
+            }
+            break;
+        }
+
         // Streaks
         case HabitsActionTypes.GET_USER_STREAKS:
             draft.streaks = action.data || [];

--- a/therr-public-library/therr-react/src/services/HabitCheckinsService.ts
+++ b/therr-public-library/therr-react/src/services/HabitCheckinsService.ts
@@ -88,6 +88,20 @@ class HabitCheckinsService {
         });
     };
 
+    /**
+     * Share a check-in's proof photo publicly as a post (main.thoughts).
+     *
+     * The backend copies the private proof image into the public bucket, moderates the copy,
+     * creates a public thought carrying it, and records the link on the check-in. Idempotent:
+     * a check-in that is already shared returns `{ sharedThoughtId, alreadyShared: true }`
+     * without creating a second post. `message` is an optional lead-in for the post.
+     */
+    share = (id: string, message?: string) => axios({
+        method: 'post',
+        url: `/users-service/habits/checkins/${id}/share`,
+        data: { message },
+    });
+
     update = (id: string, data: IUpdateCheckinBody) => axios({
         method: 'put',
         url: `/users-service/habits/checkins/${id}`,

--- a/therr-public-library/therr-react/src/types/redux/habits.ts
+++ b/therr-public-library/therr-react/src/types/redux/habits.ts
@@ -146,6 +146,10 @@ export interface IHabitCheckin {
     hasProof: boolean;
     proofVerified: boolean;
     contributedToStreak: boolean;
+    // Set once the check-in has been shared publicly — the id of the main.thoughts post that
+    // carries the public copy of the proof. Absent/undefined until shared. Lets the calendar
+    // day show "shared" and deep-link to the post.
+    sharedThoughtId?: string;
     createdAt: string;
     updatedAt: string;
     // Joined fields
@@ -360,6 +364,7 @@ export enum HabitsActionTypes {
     CREATE_CHECKIN = 'CREATE_CHECKIN',
     UPDATE_CHECKIN = 'UPDATE_CHECKIN',
     SKIP_CHECKIN = 'SKIP_CHECKIN',
+    SHARE_CHECKIN = 'SHARE_CHECKIN',
 
     // Streaks
     GET_USER_STREAKS = 'GET_USER_STREAKS',

--- a/therr-services/users-service/src/handlers/habitCheckins.ts
+++ b/therr-services/users-service/src/handlers/habitCheckins.ts
@@ -22,6 +22,8 @@ import {
 import { isUserInPact } from '../utilities/pactHelpers';
 import { canReadProofs, serializeProofs } from '../utilities/checkinProofs';
 import moderateProofs from '../utilities/moderateProofs';
+import { copyProofToPublicBucket, deleteSharedCheckinPublicObject } from '../utilities/shareCheckinMedia';
+import { checkIsMediaSafeForWork } from './helpers';
 import recordFunnelMetric from '../utilities/recordFunnelMetric';
 import { resolvePactPartnerIds } from './helpers/pactPartners';
 import {
@@ -490,6 +492,124 @@ const createCheckin: RequestHandler = async (req: any, res: any) => {
         .catch((err) => handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' }));
 };
 
+// SHARE — turn a check-in with a proof photo into a public post (main.thoughts).
+//
+// This is the opt-in step past pact visibility (§ 2.6.2): a check-in's proof is owner-only in
+// the private bucket, so making one public is not a flag flip but a copy. The proof image is
+// copied into the public bucket, moderated *on that public copy* (fail-closed — a share can
+// wait on a content check in a way the check-in tap deliberately cannot), and only then does a
+// public `main.thoughts` row get created carrying the copy. The check-in's `sharedThoughtId`
+// records the link so a repeat share is a no-op and the calendar day can deep-link to the post.
+//
+// brandVariation flows from the request headers onto the thought, so a HABITS share is a HABITS
+// thought — which BRAND_THOUGHTS_VISIBILITY already surfaces in the Therr feed too, and keeps
+// out of other niche feeds. No visibility change is needed here for cross-brand reach.
+const shareCheckin: RequestHandler = async (req: any, res: any) => {
+    const {
+        locale,
+        userId,
+        brandVariation,
+    } = parseHeaders(req.headers);
+    const { id } = req.params;
+    const { message } = req.body;
+
+    let checkin;
+    try {
+        checkin = await Store.habitCheckins.getById(id);
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' });
+    }
+
+    // Ownership is the whole access story for a proof image (see checkinProofs.canReadProofs):
+    // only the check-in's owner may promote it to a public post.
+    const { allowed, error } = canReadProofs(checkin, userId);
+    if (!allowed) {
+        return error === 'notFound'
+            ? handleHttpError({
+                res,
+                message: translate(locale, 'errorMessages.habitCheckins.notFound'),
+                statusCode: 404,
+                errorCode: ErrorCodes.NOT_FOUND,
+            })
+            : handleHttpError({
+                res,
+                message: translate(locale, 'errorMessages.habitCheckins.notAuthorizedToView'),
+                statusCode: 403,
+                errorCode: ErrorCodes.NOT_PERMITTED,
+            });
+    }
+
+    // Already shared: return the existing link rather than minting a second post. This is what
+    // makes a double-tap or a retry safe.
+    if (checkin.sharedThoughtId) {
+        return res.status(200).send({ sharedThoughtId: checkin.sharedThoughtId, alreadyShared: true });
+    }
+
+    // A public post needs an image. The proof is what keeps the feed on-topic (a check-in with a
+    // photo), so a check-in with no image proof cannot be shared.
+    let proofs: any[] = [];
+    try {
+        proofs = checkin.hasProof ? await Store.proofs.getByCheckinId(id) : [];
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' });
+    }
+    const imageProof = (proofs || []).find((p) => p && p.mediaPath && p.mediaType !== 'video');
+    if (!imageProof) {
+        return handleHttpError({
+            res,
+            message: translate(locale, 'errorMessages.habitCheckins.shareRequiresImage'),
+            statusCode: 400,
+            errorCode: ErrorCodes.BAD_REQUEST,
+        });
+    }
+
+    const habitGoal = await Store.habitGoals.getById(checkin.habitGoalId).catch(() => null);
+    const altText = habitGoal?.name ? String(habitGoal.name).substring(0, 255) : '';
+    // Lead-in text: prefer what the client sent, then the check-in note, then the habit name.
+    // The thought column truncates to 255 itself; this just avoids sending an empty post.
+    const leadIn = (message || checkin.notes || habitGoal?.name || '').toString();
+
+    let publicMedia: { path: string; type: string };
+    try {
+        publicMedia = await copyProofToPublicBucket(userId, checkin.id, imageProof.mediaPath);
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' });
+    }
+
+    // Moderate the PUBLIC copy before it can be seen. `checkIsMediaSafeForWork` fails closed
+    // (returns false on any signing / Sightengine error), which is the right asymmetry for a
+    // share gate: refuse rather than risk exposing unmoderated content.
+    const isSafeForWork = await checkIsMediaSafeForWork([publicMedia]).catch(() => false);
+    if (!isSafeForWork) {
+        await deleteSharedCheckinPublicObject(publicMedia.path);
+        return handleHttpError({
+            res,
+            message: translate(locale, 'errorMessages.habitCheckins.shareModerationFailed'),
+            statusCode: 422,
+            errorCode: ErrorCodes.NOT_PERMITTED,
+        });
+    }
+
+    try {
+        const [thought] = await Store.thoughts.create(brandVariation, {
+            fromUserId: userId as any,
+            locale,
+            isPublic: true,
+            message: leadIn,
+            medias: [{ path: publicMedia.path, type: publicMedia.type, altText }],
+        });
+
+        await Store.habitCheckins.update(checkin.id, { sharedThoughtId: thought.id });
+
+        return res.status(201).send({ thought, sharedThoughtId: thought.id });
+    } catch (err: any) {
+        // The public copy is already written; leave it for the bucket lifecycle rule rather than
+        // deleting it, since a transient thought-write failure is retryable and the next attempt
+        // overwrites the same deterministic path.
+        return handleHttpError({ err, res, message: 'SQL:HABIT_CHECKINS_ROUTES:ERROR' });
+    }
+};
+
 // READ
 const getCheckin: RequestHandler = async (req: any, res: any) => {
     const { locale, userId } = parseHeaders(req.headers);
@@ -739,6 +859,7 @@ const deleteCheckin: RequestHandler = async (req: any, res: any) => {
 
 export {
     createCheckin,
+    shareCheckin,
     getCheckin,
     getCheckinProofs,
     getTodayCheckins,

--- a/therr-services/users-service/src/locales/en-us/dictionary.json
+++ b/therr-services/users-service/src/locales/en-us/dictionary.json
@@ -83,7 +83,9 @@
             "notAuthorizedToUpdate": "You can only change your own check-in",
             "notAuthorizedToView": "You can only view your own check-ins",
             "notFound": "We couldn't find that check-in",
-            "notFoundOrNotAuthorizedToDelete": "We couldn't find that check-in, or it isn't yours to delete"
+            "notFoundOrNotAuthorizedToDelete": "We couldn't find that check-in, or it isn't yours to delete",
+            "shareRequiresImage": "Add a photo to this check-in before sharing it",
+            "shareModerationFailed": "We couldn't share this check-in right now. Please try a different photo."
         },
         "streaks": {
             "noGraceDaysAvailable": "You've used every grace day on this streak",

--- a/therr-services/users-service/src/locales/es/dictionary.json
+++ b/therr-services/users-service/src/locales/es/dictionary.json
@@ -83,7 +83,9 @@
             "notAuthorizedToUpdate": "Solo puedes modificar tu propio registro",
             "notAuthorizedToView": "Solo puedes ver tus propios registros",
             "notFound": "No encontramos ese registro",
-            "notFoundOrNotAuthorizedToDelete": "No encontramos ese registro, o no es tuyo para eliminarlo"
+            "notFoundOrNotAuthorizedToDelete": "No encontramos ese registro, o no es tuyo para eliminarlo",
+            "shareRequiresImage": "Agrega una foto a este registro antes de compartirlo",
+            "shareModerationFailed": "No pudimos compartir este registro ahora. Prueba con otra foto."
         },
         "streaks": {
             "noGraceDaysAvailable": "Ya usaste todos los días de gracia de esta racha",

--- a/therr-services/users-service/src/locales/fr-ca/dictionary.json
+++ b/therr-services/users-service/src/locales/fr-ca/dictionary.json
@@ -83,7 +83,9 @@
             "notAuthorizedToUpdate": "Tu ne peux modifier que ton propre suivi",
             "notAuthorizedToView": "Tu ne peux voir que tes propres suivis",
             "notFound": "Nous n'avons pas trouvé ce suivi",
-            "notFoundOrNotAuthorizedToDelete": "Nous n'avons pas trouvé ce suivi, ou il ne t'appartient pas"
+            "notFoundOrNotAuthorizedToDelete": "Nous n'avons pas trouvé ce suivi, ou il ne t'appartient pas",
+            "shareRequiresImage": "Ajoute une photo à ce suivi avant de le partager",
+            "shareModerationFailed": "Nous n'avons pas pu partager ce suivi pour le moment. Essaie une autre photo."
         },
         "streaks": {
             "noGraceDaysAvailable": "Tu as utilisé toutes les journées de grâce de cette série",

--- a/therr-services/users-service/src/routes/habitCheckinsRouter.ts
+++ b/therr-services/users-service/src/routes/habitCheckinsRouter.ts
@@ -1,6 +1,7 @@
 import * as express from 'express';
 import {
     createCheckin,
+    shareCheckin,
     getCheckin,
     getCheckinProofs,
     getTodayCheckins,
@@ -22,6 +23,9 @@ router.get('/:id', getCheckin);
 
 // CREATE
 router.post('/', createCheckin);
+
+// SHARE — promote a check-in's proof photo to a public post (main.thoughts)
+router.post('/:id/share', shareCheckin);
 
 // UPDATE
 router.put('/:id', updateCheckin);

--- a/therr-services/users-service/src/store/HabitCheckinsStore.ts
+++ b/therr-services/users-service/src/store/HabitCheckinsStore.ts
@@ -34,6 +34,10 @@ export interface IUpdateHabitCheckinParams {
     hasProof?: boolean;
     proofVerified?: boolean;
     contributedToStreak?: boolean;
+    // Set when the check-in is shared publicly — points at the main.thoughts row that
+    // carries the public copy of the proof. Nullable/absent otherwise. See migration
+    // 20260906000001_habits.habit_checkins.sharedThoughtId.js.
+    sharedThoughtId?: string;
 }
 
 export default class HabitCheckinsStore {

--- a/therr-services/users-service/src/store/migrations/20260906000001_habits.habit_checkins.sharedThoughtId.js
+++ b/therr-services/users-service/src/store/migrations/20260906000001_habits.habit_checkins.sharedThoughtId.js
@@ -1,0 +1,45 @@
+// Link from a check-in to the public post it was shared as (see docs/WORK_IN_PROGRESS.md 2.6.8).
+//
+// Sharing a check-in publicly mints a `main.thoughts` row carrying a *copy* of the proof image
+// in the public bucket (the private proof is never referenced — see handlers/habitCheckins.ts
+// § SHARE and the media copy in utilities/shareCheckinMedia.ts). `sharedThoughtId` is the edge
+// from the check-in to that post, so:
+//   - a repeat share is a no-op rather than a second post (the handler short-circuits when this
+//     is already set), and
+//   - the calendar day / day sheet can show "shared" and deep-link to ViewThought, the same way
+//     the journal already opens a goal.
+//
+// No FK to main.thoughts(id), and deliberately so: the two rows have independent lifecycles.
+// Deleting the check-in must not retract a post that already has replies, and deleting the post
+// must not destroy the user's own check-in record. A dangling id is harmless — the client
+// resolves the post through a normal (brand-scoped) thought read and renders nothing when it
+// misses, which is also what a deleted or cross-brand post requires. This matches the reasoning
+// for main.thoughts."repostThoughtId" and habits.pacts."renewedFromPactId", neither of which
+// carries an FK.
+//
+// Index: the only read is "resolve the shared post for this check-in" / "which of this range's
+// check-ins are shared", both `sharedThoughtId IS NOT NULL` probes. Partial on NOT NULL — shared
+// check-ins are a small fraction of the table, so the index stays small and the planner still
+// uses it.
+//
+// Idempotent (ADD COLUMN IF NOT EXISTS / CREATE INDEX IF NOT EXISTS) per
+// therr/require-idempotent-migration.
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async (knex) => {
+    await knex.raw('ALTER TABLE habits."habit_checkins" ADD COLUMN IF NOT EXISTS "sharedThoughtId" uuid');
+    await knex.raw(
+        'CREATE INDEX IF NOT EXISTS "idx_habit_checkins_shared_thought_id" '
+        + 'ON habits."habit_checkins" ("sharedThoughtId") WHERE "sharedThoughtId" IS NOT NULL',
+    );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async (knex) => {
+    await knex.raw('DROP INDEX IF EXISTS habits."idx_habit_checkins_shared_thought_id"');
+    await knex.raw('ALTER TABLE habits."habit_checkins" DROP COLUMN IF EXISTS "sharedThoughtId"');
+};

--- a/therr-services/users-service/src/utilities/shareCheckinMedia.ts
+++ b/therr-services/users-service/src/utilities/shareCheckinMedia.ts
@@ -1,0 +1,68 @@
+import path from 'path';
+import { Content } from 'therr-js-utilities/constants';
+import { storage } from '../api/aws';
+import { PROOF_MEDIA_TYPE } from './checkinProofs';
+
+/**
+ * Copy a check-in proof image from the private bucket into the public bucket so it can back a
+ * public post, and hand back the new public path.
+ *
+ * WHY COPY RATHER THAN REFERENCE (see docs/WORK_IN_PROGRESS.md 2.6.8)
+ *
+ * Three independent reasons, any one of which is sufficient:
+ *  - Proofs live in the private bucket (`PROOF_MEDIA_TYPE === USER_IMAGE_PRIVATE`); a public
+ *    thought needs a public-bucket object, because the client resolves `USER_IMAGE_PUBLIC`
+ *    media against the public ImageKit endpoint with no signed round-trip.
+ *  - Nothing has necessarily moderated the proof for a public audience yet, and the copy is
+ *    the natural object to run the content check against before the post is created.
+ *  - The two objects have independent lifecycles: deleting the check-in must not retract a
+ *    post that has replies, and deleting the post must not destroy the user's own record.
+ *
+ * The destination path is deterministic per check-in (`{userId}/content/shared_checkin_{checkinId}`),
+ * so a repeat share overwrites the same object rather than accumulating orphans — the handler's
+ * `sharedThoughtId` short-circuit means that normally never happens, but a share that failed
+ * after the copy but before the thought was written leaves one recoverable object, not many.
+ */
+export const buildSharedCheckinPublicPath = (userId: string, checkinId: string, sourcePath: string): string => {
+    const ext = path.extname(sourcePath) || '.jpg';
+    return `${userId}/content/shared_checkin_${checkinId}${ext}`;
+};
+
+export const copyProofToPublicBucket = async (
+    userId: string,
+    checkinId: string,
+    proofPath: string,
+): Promise<{ path: string; type: string }> => {
+    const privateBucketName = process.env.BUCKET_PRIVATE_USER_DATA || '';
+    const publicBucketName = process.env.BUCKET_PUBLIC_USER_DATA || '';
+
+    const destinationPath = buildSharedCheckinPublicPath(userId, checkinId, proofPath);
+
+    const sourceFile = storage.bucket(privateBucketName).file(proofPath);
+    const destinationFile = storage.bucket(publicBucketName).file(destinationPath);
+
+    await sourceFile.copy(destinationFile);
+
+    return {
+        path: destinationPath,
+        type: Content.mediaTypes.USER_IMAGE_PUBLIC,
+    };
+};
+
+/**
+ * Best-effort cleanup of a public copy when the share is abandoned (e.g. moderation rejected it).
+ * Never throws: an orphaned public object is a lifecycle-rule problem, not a request failure.
+ */
+export const deleteSharedCheckinPublicObject = (publicPath: string): Promise<void> => {
+    const publicBucketName = process.env.BUCKET_PUBLIC_USER_DATA || '';
+    return storage
+        .bucket(publicBucketName)
+        .file(publicPath)
+        .delete({ ignoreNotFound: true })
+        .then(() => undefined)
+        .catch(() => undefined);
+};
+
+// Re-exported for symmetry / discoverability alongside the copy: the source bucket is derived
+// from the proof media type, which is always private today.
+export const PROOF_SOURCE_MEDIA_TYPE = PROOF_MEDIA_TYPE;

--- a/therr-services/users-service/tests/unit/shareCheckinMedia.test.ts
+++ b/therr-services/users-service/tests/unit/shareCheckinMedia.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { Content } from 'therr-js-utilities/constants';
+import { buildSharedCheckinPublicPath, PROOF_SOURCE_MEDIA_TYPE } from '../../src/utilities/shareCheckinMedia';
+
+/**
+ * Sharing a check-in copies its private proof image into the public bucket so a public post can
+ * carry it. The GCS copy itself needs a live client, but the destination path is pure and
+ * load-bearing, so it is pinned here.
+ *
+ * The path is deterministic per check-in on purpose: a repeat share overwrites the same object
+ * rather than accumulating orphans, and it stays inside the sharing user's own namespace so it
+ * lands where every other of that user's content lives.
+ */
+describe('shareCheckinMedia', () => {
+    describe('buildSharedCheckinPublicPath', () => {
+        it('is deterministic per (user, check-in) and preserves the extension', () => {
+            const path = buildSharedCheckinPublicPath('user-1', 'checkin-9', 'user-1/content/habits_proof_abc.jpg');
+            expect(path).to.equal('user-1/content/shared_checkin_checkin-9.jpg');
+
+            // Same inputs → same object, so a retry overwrites rather than duplicating.
+            expect(buildSharedCheckinPublicPath('user-1', 'checkin-9', 'user-1/content/habits_proof_abc.jpg'))
+                .to.equal(path);
+        });
+
+        it('carries a non-jpg extension through', () => {
+            expect(buildSharedCheckinPublicPath('u', 'c', 'u/content/proof_x.png'))
+                .to.equal('u/content/shared_checkin_c.png');
+        });
+
+        it('falls back to .jpg when the source path has no extension', () => {
+            // A private proof path with no extension must still produce a valid public object key
+            // rather than one ending in a bare dot.
+            expect(buildSharedCheckinPublicPath('u', 'c', 'u/content/proof_no_ext'))
+                .to.equal('u/content/shared_checkin_c.jpg');
+        });
+
+        it('nests the copy under the sharing user, not the source path owner', () => {
+            // The first segment is always the passed userId, so the public object lands in the
+            // sharer's namespace even if the proof path were ever shaped differently.
+            expect(buildSharedCheckinPublicPath('owner-7', 'ck', 'someone/else/thing.jpg'))
+                .to.equal('owner-7/content/shared_checkin_ck.jpg');
+        });
+    });
+
+    describe('PROOF_SOURCE_MEDIA_TYPE', () => {
+        it('is the private media type — proofs are always copied FROM the private bucket', () => {
+            expect(PROOF_SOURCE_MEDIA_TYPE).to.equal(Content.mediaTypes.USER_IMAGE_PRIVATE);
+        });
+    });
+});


### PR DESCRIPTION
## What

The **mobile half** of the Friends with Habits social feed (WORK_IN_PROGRESS 2.6.8 / #2841). The habits mobile app ships to Play from this niche line, so its UI lands here. The backend + shared libraries are in the companion `general` PR **#2867** — **merge #2867 first.**

This branch also carries the merge of #2867's backend/shared-lib commits so it builds standalone; those converge when `general` merges down normally.

### Mobile (`TherrMobile`)
- **New `HabitsFeed` screen** (`routes/HabitsFeed`) — reuses the existing thoughts feed machinery (`getActiveCarouselData` + `AreaCarousel` + Content reaction actions); registered in `routes/index.tsx` gated on `ENABLE_HABITS_FEED`.
- **Bottom bar: Feed tab replaces the Awards tab** (Achievements stays reachable in the drawer). `habitsTabLayout` + `validateFeatureFlags` now count the feed flag in the optional social slot; `HabitsTabLayout` tests updated.
- **Check-in flow:** a "Share to the feed" toggle in `CheckinProofSheet` (shown once a photo is attached); `Dashboard` and `HabitDetail` call `shareCheckin` fire-and-forget after the check-in commits.
- **Deep link:** the calendar day sheet shows a "Shared to the feed" marker and a "View post" action opening the public post (`ViewThought`) when the check-in carries `sharedThoughtId`.
- Locales for the tab, toggle, share toasts, empty feed and day-sheet strings (en-us/es/fr-ca).
- `env-config`: `ENABLE_HABITS_FEED` off by default, on for the HABITS build.

## Why

Post-only-via-check-in keeps the feed on-topic and makes posts a byproduct of the core loop. Default-off + drawer fallback for Awards keeps the whole feature reversible if metrics don't justify it.

### A/B note
No per-user cohort framework exists — this is a per-build flag. To A/B: ship one build with the flag off to bank a baseline, then flip it on and compare via `analyticsEvents` (`habit_checkin_shared` is emitted on share). Simultaneous same-build cohorts would need remote config (out of scope).

## Verification
- `pr:tsc-baseline:mobile` — no new errors (105 = baseline)
- `locales:check` — parity across en-us/es/fr-ca
- Jest: `HabitsTabLayout` + `validateFeatureFlags` — 31 passing
- Brand identity intact after merging the shared branch (`verify-brand`: brandConfig = HABITS, gradle app id/versionCode unchanged)

## Merge order
Merge **#2867 (general) first**, then this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkBPB8MPkbbyMhN2WZqbEC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkBPB8MPkbbyMhN2WZqbEC)_