### PR TITLE
ci+docs: recover the shared work stranded by the PR #2869 mis-merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,25 +245,41 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Skip unless TherrMobile or shared libraries changed
-          # This job runs on every stage->main merge (alongside `deploy`), but the
-          # Therr mobile app only needs a rebuild when the code it bundles changed:
-          # TherrMobile/ itself, or any of the shared libs in therr-public-library/
-          # (therr-react and its transitive deps therr-js-utilities + therr-styles,
-          # all compiled into the JS bundle). Pure-backend deploys (therr-services/,
-          # therr-api-gateway/) must NOT burn an EAS build. stage->main is a real
-          # merge commit, so HEAD^1 is the previous main tip and `HEAD^1..HEAD` is
-          # exactly the delta merged in. If HEAD^1 can't be resolved (shallow clone),
-          # fail open and build rather than silently skip.
+          name: Skip unless the Android versionCode was bumped
+          # This job runs on every stage->main merge (alongside `deploy`), but an EAS
+          # build is only worth its credits when it will produce a NEW Play release.
+          # Google Play rejects any upload whose versionCode already exists on the
+          # track, so building without a versionCode bump makes --auto-submit try to
+          # republish an existing version and fail — burning an EAS build for nothing.
+          # eas.json uses local appVersionSource, so android/app/build.gradle is the
+          # source of truth for versionCode/versionName. stage->main is a real merge
+          # commit, so HEAD^1 is the previous main tip and `HEAD^1..HEAD` is exactly
+          # the delta merged in; we compare the versionCode there against HEAD. If
+          # HEAD^1 or the versionCode can't be resolved (shallow clone, parse change),
+          # fail open and build rather than silently skip a real release.
           command: |
+            GRADLE_PATH="TherrMobile/android/app/build.gradle"
+            get_version_code() {
+              git show "$1:$GRADLE_PATH" 2>/dev/null \
+                | grep -E '^[[:space:]]*versionCode[[:space:]]' \
+                | head -1 \
+                | sed -E 's/^[[:space:]]*versionCode[[:space:]]+//' \
+                | tr -d '[:space:]'
+            }
             BASE="$(git rev-parse --verify --quiet HEAD^1 || true)"
             if [ -z "$BASE" ]; then
               echo "Could not resolve HEAD^1 (shallow clone?) — building to be safe."
-            elif git diff --name-only "$BASE" HEAD | grep -qE '^(TherrMobile/|therr-public-library/)'; then
-              echo "TherrMobile/ or therr-public-library/ changed in this merge — proceeding with EAS build."
             else
-              echo "No TherrMobile/ or therr-public-library/ changes in this merge — skipping EAS build."
-              circleci-agent step halt
+              BASE_CODE="$(get_version_code "$BASE")"
+              HEAD_CODE="$(get_version_code HEAD)"
+              if [ -z "$HEAD_CODE" ]; then
+                echo "Could not read versionCode at HEAD — building to be safe."
+              elif [ "$BASE_CODE" = "$HEAD_CODE" ]; then
+                echo "versionCode unchanged ($HEAD_CODE) — skipping EAS build to avoid republishing an existing Play version."
+                circleci-agent step halt
+              else
+                echo "versionCode bumped ($BASE_CODE -> $HEAD_CODE) — proceeding with EAS build."
+              fi
             fi
       - run:
           name: Install EAS CLI

--- a/.claude/skills/quality-peer-review-niche/SKILL.md
+++ b/.claude/skills/quality-peer-review-niche/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quality-peer-review-niche
-description: Peer review the **new work** on the current niche/* branch (vs origin/<NICHE_BRANCH> on a -general branch, or vs origin/niche/<TAG>-general on a feature branch). Separately detects backend and shared-library leaks against origin/general (these would never reach production via stage→main) and cherry-picks clean backend-only commits introduced on this branch over to general. Implements low-risk improvements, fixes bugs, adds regression tests for bugfixes where valuable, and resolves quality issues. Requires local Docker Compose infrastructure to be running.
+description: Peer review the work about to ship to Google Play on the current niche/* branch (vs origin/niche/<TAG>-main on a -general or -main branch — the merge that triggers the Android Play build — or vs origin/niche/<TAG>-general on a feature branch). Separately detects backend and shared-library leaks against origin/general and cherry-picks clean backend-only commits introduced on this branch over to general. Implements low-risk improvements, fixes bugs, adds regression tests for bugfixes where valuable, and resolves quality issues. Requires local Docker Compose infrastructure to be running.
 user-invocable: true
 allowed-tools: Bash(docker*), Bash(git*), Bash(npx*), Bash(npm*), Bash(node*), Read, Glob, Grep, Edit, Write, Agent
 argument-hint: [--dry-run]
@@ -8,20 +8,26 @@ argument-hint: [--dry-run]
 
 # Peer Review: niche/* new work
 
-Perform a structured peer review of the **new work** on the current `niche/*` branch — scoped to unpushed commits + uncommitted changes when on `niche/<TAG>-general`, or to commits unique to the feature branch when on `niche/<TAG>-feature-*`. Separately detects and remediates backend / shared-library leaks introduced on this branch (compared to `origin/general`) by cherry-picking them over. This skill is intended to run **locally** with Docker Compose infrastructure active. It will not run automatically — you must invoke it explicitly.
+Perform a structured peer review of the work **about to ship to Google Play** on the current `niche/*` branch — scoped to whatever the next merge into `niche/<TAG>-main` would carry (that merge triggers the Android Play Store build), plus any uncommitted changes. Concretely: on `niche/<TAG>-general` (or `niche/<TAG>-main`) the review base is `origin/niche/<TAG>-main`; on a feature branch (`niche/<TAG>-feature-*`) it is `origin/niche/<TAG>-general`. The intent is to catch issues **before** the merge that kicks off a production Android build. Separately detects and remediates backend / shared-library leaks introduced on this branch (compared to `origin/general`) by cherry-picking them over. This skill is intended to run **locally** with Docker Compose infrastructure active. It will not run automatically — you must invoke it explicitly.
 
 **`--dry-run`**: Analyze and report findings without making any code changes, commits, cherry-picks, or running tests.
 
 ## Why this skill exists (read first)
 
-The deploy pipeline only runs on `stage → main`. Niche branches never merge into `stage`. Therefore:
+There are **two** deploy pipelines, and the niche branch sits on only one of them:
 
-- **Backend service code** (`therr-services/*`, `therr-api-gateway/*`)
-- **Shared library code** (`therr-public-library/*`)
-- **Database migrations**
-- **Shared infrastructure** (root `package.json`, `docker-compose*.yml`, `_bin/*`)
+- **Backend / web / shared-services deploy** runs on `general → stage → main`. Niche branches never merge into `stage`.
+- **Mobile (Android) deploy** runs on `niche/<TAG>-general → niche/<TAG>-main`, which triggers a **Google Play Store build** of the niche app. The mobile build bundles the niche branch's `TherrMobile/*` plus the **compiled** `therr-react` / `therr-js-utilities` it imports.
 
-…committed only to a niche branch is **dead code** — it will never reach production. All such changes must live on `general` instead. This skill's primary job is detecting these leaks and lifting clean ones over to `general`. Niche-appropriate work (mobile branding, brand-specific web views, brand assets, brand-specific config) stays on the niche branch.
+This gives the skill two jobs:
+
+1. **Pre-Play-build review (primary).** Review everything the next merge into `niche/<TAG>-main` would carry into a production Android build — catch bugs, regressions, and backwards-compatibility breaks **before** they reach users on Google Play. This is the diff against `origin/niche/<TAG>-main`.
+
+2. **Leak detection (against `origin/general`).** Some paths can never reach production correctly from a niche branch and must live on `general`:
+   - **Backend service code** (`therr-services/*`, `therr-api-gateway/*`), **database migrations**, and **shared infrastructure** (root `package.json`, `docker-compose*.yml`, `_bin/*`) — these are **dead code** on a niche branch. The mobile Play build does not run them; only `general → stage → main` deploys the backend. The mobile app calls these APIs over HTTP against the production backend, so the niche branch's copy never executes.
+   - **Shared library code** (`therr-public-library/*`) is a special case: it **does** get bundled into the Android Play build (mobile imports it), but it is **also** consumed by the web clients and backend that deploy via `general`. Landing a shared-lib change only on the niche branch ships it to mobile while leaving web/backend on the old version — a silent divergence. So shared-lib changes still belong on `general` first (then merged down), and the skill still flags them as leaks.
+
+   This skill's leak job is detecting these and lifting clean backend/shared commits over to `general`. Niche-appropriate work (mobile branding, brand-specific web views, brand assets, brand-specific config) stays on the niche branch.
 
 ---
 
@@ -125,11 +131,12 @@ If `general` doesn't exist on origin, report it and stop:
 
 This skill uses **two separate diff bases** because leak detection and peer review answer different questions:
 
-- **`<REVIEW_BASE>`** — the peer-review base. Scopes Steps 3–7 to **only the new work on this branch**, not everything that's ever lived on the niche line.
-  - On a main niche branch (`niche/<TAG>-general`): `<REVIEW_BASE>` = `origin/<NICHE_BRANCH>`. Review covers unpushed commits + uncommitted changes.
-  - On a feature branch off a niche line (e.g. `niche/HABITS-feature-foo`): `<REVIEW_BASE>` = `origin/niche/<TAG>-general`. Review covers commits unique to the feature branch + uncommitted changes.
+- **`<REVIEW_BASE>`** — the peer-review base. Scopes Steps 3–7 to **the work about to ship to Google Play**, not everything that's ever lived on the niche line.
+  - On a deploy-track niche branch (`niche/<TAG>-general` or `niche/<TAG>-main`): `<REVIEW_BASE>` = `origin/niche/<TAG>-main`. Review covers everything the next merge into `-main` would carry into a production Android build, plus uncommitted changes. (When the current branch *is* `niche/<TAG>-main`, this naturally reduces to unpushed commits + uncommitted changes.)
+  - On a feature branch off a niche line (e.g. `niche/HABITS-feature-foo`): `<REVIEW_BASE>` = `origin/niche/<TAG>-general`. Review covers commits unique to the feature branch + uncommitted changes (the pre-`-general`-merge review).
+  - **Fallback:** if `origin/niche/<TAG>-main` does not exist (the niche has no Android deploy branch yet), fall back to `<REVIEW_BASE>` = `origin/<NICHE_BRANCH>` (unpushed commits + uncommitted changes) and note in the report that no `-main` deploy branch was found.
 
-- **`origin/general`** — the leak-detection base. Backend / shared-library leaks are dead code regardless of which niche sub-branch introduced them. Used in Step 2 only.
+- **`origin/general`** — the leak-detection base. Backend leaks are dead code, and shared-library leaks diverge mobile from web/backend, regardless of which niche sub-branch introduced them. Used in Step 2 only.
 
 #### Determine `<REVIEW_BASE>`
 
@@ -145,8 +152,9 @@ If extraction fails (output equals input or is empty), warn and stop:
    Expected pattern: niche/<TAG>-... (e.g. niche/HABITS-general, niche/TEEM-feature-foo).
 ```
 
-Fetch the parent niche branch from origin so the comparison is fresh:
+Fetch both the `-main` (Android deploy) and `-general` (parent) branches from origin so the comparison is fresh:
 ```bash
+git fetch origin niche/${NICHE_TAG}-main 2>&1     # may not exist for every niche
 git fetch origin niche/${NICHE_TAG}-general 2>&1
 ```
 
@@ -155,8 +163,15 @@ If `niche/<TAG>-general` doesn't exist on origin, report and stop:
 ⛔ Cannot diff: branch 'niche/<TAG>-general' not found on origin.
 ```
 
+Check whether the `-main` deploy branch exists:
+```bash
+git ls-remote --heads origin niche/${NICHE_TAG}-main 2>&1
+```
+
 Set the review base:
-- If `<NICHE_BRANCH>` == `niche/${NICHE_TAG}-general`: `<REVIEW_BASE>` = `origin/<NICHE_BRANCH>`
+- If `<NICHE_BRANCH>` is `niche/${NICHE_TAG}-general` **or** `niche/${NICHE_TAG}-main`:
+  - If `origin/niche/${NICHE_TAG}-main` exists: `<REVIEW_BASE>` = `origin/niche/${NICHE_TAG}-main` (the Android Play-build gate — review everything the next merge into `-main` would ship).
+  - Otherwise (no `-main` deploy branch yet): `<REVIEW_BASE>` = `origin/<NICHE_BRANCH>` (fallback — unpushed + uncommitted). Note this in the report.
 - Otherwise (feature branch): `<REVIEW_BASE>` = `origin/niche/${NICHE_TAG}-general`
 
 #### Build the review diff (drives Steps 3–7)
@@ -191,6 +206,12 @@ git log --oneline HEAD..origin/niche/${NICHE_TAG}-general 2>&1
 ```
 If non-empty, note it — the feature branch should consider merging the parent niche branch in.
 
+If reviewing against `-main` (deploy-track branch), check whether `-main` has commits this branch lacks — e.g. a hotfix landed directly on `-main`:
+```bash
+git log --oneline HEAD..origin/niche/${NICHE_TAG}-main 2>&1
+```
+If non-empty, note it — the deploy-track branch should merge `-main` back in before shipping so the Play build doesn't drop the hotfix.
+
 #### No-op short-circuit
 
 If the review diff is empty AND no leaked files exist against `origin/general` (Step 2a will compute these — for the short-circuit, do a quick `git diff origin/general --name-only` and grep for must-be-on-general paths):
@@ -205,14 +226,14 @@ If the review diff is empty but pre-existing leaks exist on the broader niche li
 #### Summary
 
 Print:
-- Review base used: `<REVIEW_BASE>`
+- Review base used: `<REVIEW_BASE>` (and whether it's the `-main` Play-build gate, the `-general` parent, or the `-main`-missing fallback)
 - Leak base: `origin/general`
-- Number of commits ahead of `<REVIEW_BASE>` (review scope)
+- Number of commits ahead of `<REVIEW_BASE>` (review scope — for a deploy-track branch, this is **what the next Play build would ship**)
 - Number of commits ahead of `origin/general` (full niche divergence — informational)
 - Files changed in review scope (from `--stat`)
 - Whether unstaged/staged-but-uncommitted changes are included
 - Which packages the review touches (TherrMobile/*, therr-client-web/*, therr-services/*, etc.)
-- Whether the branch is behind `origin/general` and/or behind its parent niche branch
+- Whether the branch is behind `origin/general`, behind `-main` (hotfix not merged back), and/or behind its parent niche branch
 
 ---
 
@@ -424,7 +445,9 @@ For mixed commits, do **not** rewrite history (the niche branch may have been pu
 
 ## Step 3: Backwards compatibility analysis
 
-Even after backend leaks have been moved to `general`, the niche branch still ships frontend/mobile updates that must remain backwards compatible with the API version currently deployed. Mobile apps especially cannot be force-updated.
+Even after backend leaks have been moved to `general`, the niche branch still ships frontend/mobile updates that must remain backwards compatible with the API version currently deployed. This step is the whole point of gating against `-main`: the merge into `niche/<TAG>-main` builds and submits the Android app to Google Play, and **mobile apps cannot be force-updated** — a client that depends on an API or shared-lib change still riding the slower `general → stage → main` backend pipeline will be broken in production until that backend ships. The mobile (Play) and backend (`main`) pipelines run independently, so the mobile release can land *first*.
+
+The cardinal rule: **do not let the Play build go out ahead of the backend it depends on.**
 
 Flag any of the following as **breaking risk**:
 
@@ -615,6 +638,9 @@ take after this review** — items code alone cannot complete.
 
 Examples specific to niche peer reviews:
 
+- Merging `niche/<TAG>-general → niche/<TAG>-main` to trigger the Android
+  Play Store build — only after any backend/shared-lib dependency has
+  shipped (see Step 3), so the mobile release doesn't outrun its API
 - Pushing `general` (after reviewing cherry-picked backend commits)
 - Committing uncommitted backend changes left in `general`'s working tree
 - Manually splitting mixed commits identified in Step 2
@@ -664,13 +690,14 @@ and surface the items only in the final report.
 Output a structured summary:
 
 ```
-## Peer Review Summary: <NICHE_BRANCH> → general
+## Peer Review Summary: <NICHE_BRANCH> → <REVIEW_BASE target> (pre-Play-build)
 
 ### Diff Scope
-  Review base:                       <REVIEW_BASE>
-  Commits ahead of <REVIEW_BASE>:    <N>  (review scope)
+  Review base:                       <REVIEW_BASE>  (<-main Play-build gate | -general parent | -main-missing fallback>)
+  Commits ahead of <REVIEW_BASE>:    <N>  (review scope — what the next Android Play build would ship)
   Commits ahead of origin/general:   <N>  (full niche divergence — informational)
   Behind origin/general by:          <N> commits  (consider merging general → niche)
+  Behind -main by:                   <N> commits  (hotfix on -main not merged back — merge before shipping)  [deploy-track branches only]
   Behind parent niche by:            <N> commits  (consider merging parent → branch)  [feature branches only]
   Niche packages affected:           <list>
   Unstaged/staged local changes:     <yes/no>
@@ -708,6 +735,8 @@ Output a structured summary:
   <"✓ Passed — 0 lint errors, 0 type errors" or list of remaining issues>
 
 ### Manual Steps Required After This Review
+  - Merge to trigger the Android Play build (only after backend deps ship):
+      git checkout niche/<TAG>-main && git merge niche/<TAG>-general && git push origin niche/<TAG>-main
   - Push general (after reviewing cherry-picked commits):
       git checkout general && git push origin general
   - Commit any uncommitted backend changes left on general's working tree

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -180,7 +180,7 @@ These flags control which features are enabled per brand variant. Set in `TherrM
 
 ## Niche App Extensions
 
-### Habits System (Friends With Habits — `BrandVariations.HABITS`)
+### Habits System (Friends with Habits — `BrandVariations.HABITS`)
 
 - **Habit goals** — create from templates or custom; frequency config (daily/weekly/custom), target days; goal-orientation (`goalType`: build_good / break_bad / savings_goal / maintenance)
 - **Pacts** — accountability partnerships; invite partners, set consequences (donation/dare/custom)
@@ -205,7 +205,7 @@ All variants share the same backend and auth system. Current variants defined in
 | Variant | Key | Description |
 |---------|-----|-------------|
 | Therr | `therr` | Core location-based social network |
-| Friends With Habits | `habits` | Accountability and habit tracking |
+| Friends with Habits | `habits` | Accountability and habit tracking |
 | Teem | `teem` | Community/team features |
 | Otaku | `otaku` | Niche interest communities |
 | Appy Social | `appy_social` | General social variant |

--- a/docs/MULTI_BRAND_ARCHITECTURE.md
+++ b/docs/MULTI_BRAND_ARCHITECTURE.md
@@ -216,6 +216,23 @@ const NavigationGuard = ({ children }) => {
 };
 ```
 
+## Firebase: single project, multiple Android apps (current approach)
+
+For MVP, niche apps share the Therr Friend Firebase project and register as additional Android apps under it:
+
+- **Therr** — `applicationId = app.therrmobile`
+- **Friends with Habits** — `applicationId = com.therr.habits`
+- *(future niches add their own `applicationId`)*
+
+Registering each `applicationId` in Firebase Console adds a `client` entry to a single merged `google-services.json`. That file lives at `TherrMobile/android/app/google-services.json` and serves every brand — Gradle picks the correct client block at build time based on the `applicationId` in `build.gradle`. The Android `namespace` stays `app.therrmobile` across brands so Kotlin source paths don't change.
+
+When to split into separate Firebase projects instead:
+- A brand needs isolated Cloud Messaging quotas or Analytics streams.
+- Crashlytics dashboards must not cross brand boundaries.
+- An acquirer, partner, or legal requirement forces separation.
+
+Until one of those applies, stay on the shared-project model — it removes the need for per-brand service-account key management in `push-notifications-service` and simplifies the `switch-brand.sh` workflow.
+
 ## Push Notifications by Brand
 
 Each brand can have its own Firebase project for push notifications:

--- a/docs/NICHE_APP_SETUP_STEPS.md
+++ b/docs/NICHE_APP_SETUP_STEPS.md
@@ -2,6 +2,25 @@
 
 These niche apps are a branch and/or child app of Therr App. The general idea is for a niche app to inherit the core foundations of Therr with unique, niche branding, content filtering specific to that branding, and some simple customizations that are controlled by feature flags.
 
+## Daily switching workflow
+
+Once a niche branch is set up, switching between brands during development is three commands:
+
+```bash
+git checkout niche/HABITS-general            # or general, or niche/TEEM-general
+./_bin/switch-brand.sh habits                # habits | therr | teem
+cd TherrMobile && npm start                  # terminal 1
+cd TherrMobile && npm run android:habits     # terminal 2
+```
+
+`switch-brand.sh` rewrites `CURRENT_BRAND_VARIATION` in `TherrMobile/main/config/brandConfig.ts` when the target differs, kills any running Metro bundler, and clears Metro caches. It warns (does not block) if the current git branch doesn't match the target brand.
+
+## Multi-app-per-Firebase-project pattern
+
+Niche apps reuse the Therr Firebase project by registering a second Android app with a distinct `applicationId` (e.g. `com.therr.habits`) in Firebase Console. The resulting `google-services.json` contains entries for every registered `applicationId`, so a single file in `TherrMobile/android/app/google-services.json` works across brands on the same device. Gradle selects the correct client entry by `applicationId` at build time. Android `namespace` stays `app.therrmobile` across brands so Kotlin sources don't move.
+
+This pattern is preferred over per-brand Firebase projects for MVP; split into separate projects only if a niche app needs isolated Cloud Messaging quotas, Analytics streams, or Crashlytics dashboards.
+
 ## Mobile App Setup (ex. Uses Teem for demonstration)
 
 ### Prerequisites

--- a/docs/SECRETS_AND_LOCAL_BOOTSTRAP.md
+++ b/docs/SECRETS_AND_LOCAL_BOOTSTRAP.md
@@ -168,6 +168,88 @@ This requires Play Console support intervention and can take 1–2 weeks.
 
 ---
 
+## EAS (Expo Application Services) — HABITS Android CI/CD
+
+The `niche/HABITS-main` branch triggers an EAS cloud build + Google Play submit
+via CircleCI (`habits_mobile_release` workflow in `.circleci/config.yml`).
+EAS runs the actual Android build on Expo's infrastructure, so the CI runner
+only needs `eas-cli` installed — no local Android SDK required.
+
+> The `habits_mobile_release` workflow and its `eas_build_habits_android` job are
+> defined only on the `niche/HABITS-*` branches, not on `general`. CircleCI reads
+> `.circleci/config.yml` from the branch it is building, and the only branch that
+> triggers this workflow is `niche/HABITS-main` — so the job belongs there, alongside
+> the brand identity it builds. `general` carries `eas_build_therr_android` instead.
+
+### One-time setup (do this before the first CI build)
+
+1. **Create an Expo account** at https://expo.dev if you don't have one.
+
+2. **Link the project to EAS** from the `TherrMobile` directory:
+   ```bash
+   cd TherrMobile
+   npm install -g eas-cli
+   eas login
+   eas init --id <new-project-id>   # or let eas init auto-create the project
+   ```
+   After `eas init`, commit the updated `app.json` — it will have the real
+   `projectId` replacing `REPLACE_WITH_EAS_PROJECT_ID`, and `owner` set to
+   your Expo username.
+
+3. **Upload the HABITS keystore to EAS credentials**:
+   ```bash
+   eas credentials
+   ```
+   Select **Android** → **habits-internal** → "Upload an existing keystore",
+   then provide `habits-upload.keystore`
+   (see keystore section below). EAS stores it encrypted; the CI job will
+   download it at build time via `credentialsSource: "remote"` in `eas.json`.
+
+4. **Store the Google Maps API key as an EAS secret**:
+   ```bash
+   eas env:create --scope project --name GOOGLE_APIS_ANDROID_KEY \
+     --value <key> --visibility secret
+   ```
+   Use the Android-restricted Maps SDK key for `com.therr.habits`.
+   (On `eas-cli` < 16 this command was `eas secret:create`; it is now
+   `eas env:create`. Verify which environment(s) — `production`/`preview` —
+   the secret should target; `--scope project` applies to all by default.)
+
+5. **Store the Google Play service account key as an EAS secret**:
+   ```bash
+   eas env:create --scope project --name EXPO_GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON \
+     --type file --value ./path-to-service-account.json --visibility secret
+   ```
+   This is the service account JSON from the Google Play Console that has
+   "Release manager" or "Release" permissions on the `com.therr.habits` listing.
+   EAS Submit reads it automatically when `EXPO_GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_JSON`
+   is set.
+
+   > Google Play prerequisite: the `com.therr.habits` app listing must already
+   > exist in Play Console, and **one AAB must have been uploaded to the
+   > Internal track manually** (Google rejects the first API-driven submit until
+   > a build has been promoted by hand). Create the service account under
+   > Play Console → Setup → API access and grant it "Release manager".
+
+6. **Add `EXPO_TOKEN` to CircleCI project environment variables**:
+   - Generate a token at https://expo.dev/settings/access-tokens
+   - In CircleCI: Project Settings → Environment Variables → `EXPO_TOKEN`
+
+7. **Merge the pipeline onto the trigger branch**. The CI workflow only fires
+   on `niche/HABITS-main`, so `eas.json`, the `eas_build_habits_android` job,
+   and the linked `app.json` (with the real `projectId`) must be merged down
+   from `niche/HABITS-general`:
+   ```bash
+   git checkout niche/HABITS-main && git pull --ff-only
+   git merge niche/HABITS-general
+   git push origin niche/HABITS-main   # this push triggers habits_mobile_release
+   ```
+   Do **not** push `niche/HABITS-main` until steps 1–6 are complete — the
+   pushed build/submit will fail at auth without `EXPO_TOKEN` and the EAS
+   secrets in place.
+
+---
+
 ### CircleCI env var: `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
 
 **What it is:** The full JSON key for a Google Play service account, used by


### PR DESCRIPTION
Follow-up to the `general` recovery. **`general` has already been reset** to `22ca60e87`; this PR lifts back only the parts of PR #2869 that belong there.

## What went wrong

PR #2869 (`ci: gate EAS Android builds on a versionCode bump`) had its head branch `claude/eas-build-version-trigger-vfcs09` cut from **`niche/HABITS-general`** but its base set to **`general`**. Merging it as `cfa14ac55` dragged 436 niche commits and the full Habits brand identity onto `general`:

| | before | after the bad merge |
|---|---|---|
| `applicationId` | `app.therrmobile` | `com.therr.habits` |
| `versionCode` | 458 | 37 |
| `versionName` | 3.17.5 | 1.5.2 |
| `CURRENT_BRAND_VARIATION` | `THERR` | `HABITS` |
| `app.json` displayName / slug / EAS projectId | Therr | Friends with Habits |

`versionCode` 458 to 37 alone would have made the flagship app unreleasable on Play — exactly the failure `CLAUDE.md` warns about.

**Blast radius was contained.** The bad merge never reached `stage` or `main`, and was never merged back down into `niche/HABITS-general`. There was **no** backend or shared-library contamination — no changes under `therr-services/`, `therr-api-gateway/`, `therr-public-library/`, `**/migrations/**`, or root `package.json`.

## Recovery

`general` was reset to `22ca60e87` (the merge's first parent, and exactly the commit `stage` already carried) and force-pushed. The contaminated tip is preserved at the tag **`backup/general-bad-merge-pr2869`**. The `Prevent branch deletion` ruleset was disabled for the push and immediately restored — verified `active`, same rules and conditions, no bypass actors added.

## What this PR brings back

- **`.circleci/config.yml`** — the versionCode gate, the actual point of #2869, applied to `eas_build_therr_android` **only**. It replaces the path-based skip: Play rejects any upload whose versionCode already exists on the track, so a build without a bump makes `--auto-submit` fail after burning an EAS build. A versionCode bump also implies `TherrMobile/` changed, so the new gate subsumes the old one. The `eas_build_habits_android` job and `habits_mobile_release` workflow stay on `niche/HABITS-*`, the only branch that triggers them.
- **`docs/SECRETS_AND_LOCAL_BOOTSTRAP.md`** — EAS one-time setup, plus a note recording why the habits job is absent here.
- **`docs/MULTI_BRAND_ARCHITECTURE.md`** — single Firebase project with one Android app per `applicationId`, and when to split.
- **`docs/NICHE_APP_SETUP_STEPS.md`** — daily brand-switching workflow and the same Firebase multi-app pattern.
- **`docs/FEATURES.md`** — "Friends With Habits" to "Friends with Habits".
- **`.claude/skills/quality-peer-review-niche/SKILL.md`** — rebase the review base onto `origin/niche/<TAG>-main` (the merge that triggers the Play build) and document both deploy pipelines.

## Deliberately not brought back

The three mobile fixes on that PR branch all turn out to touch **Habits-only** code:

- `analyticsEvents.ts` (`d09ae3d8c`, `707fe5283`) was introduced on the niche line by `21a7755a` — the file does not exist on `general`.
- `requestAfterCustomPrimer` (`c02743d3d`) was introduced by `73910131` — also absent on `general`, whose `requestAfterPrimer` already has the correct shape without the unreachable guard.

Both stay on `niche/HABITS-general`. Also excluded: all TherrMobile branding, `design-concepts/habits-app-icon/**`, `docs/niche-sub-apps/HABITS_*`, Play-listing screenshots, fastlane changelogs, and the version bump.

## Verification

- No source files changed — docs, CI config, and one skill only.
- `.circleci/config.yml` parses as valid YAML; `grep -i habits` over it returns nothing.
- Brand identity files (`brandConfig.ts`, `build.gradle`, `app.json`, `eas.json`, `package.json`) untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
