### PR TITLE
feat(habits): continue-solo / archive for unanswered habit invites (backend + shared)

### DIFF
--- a/therr-api-gateway/src/services/users/router.ts
+++ b/therr-api-gateway/src/services/users/router.ts
@@ -850,6 +850,10 @@ usersServiceRouter.put('/habits/user-habits/:id/restore', handleServiceRequest({
     basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
     method: 'put',
 }));
+usersServiceRouter.put('/habits/user-habits/:id/continue-solo', handleServiceRequest({
+    basePath: `${globalConfig[process.env.NODE_ENV].baseUsersServiceRoute}`,
+    method: 'put',
+}));
 
 // HABITS — Lifetime founder purchase (Google Play Billing)
 usersServiceRouter.get('/habits/lifetime', handleServiceRequest({

--- a/therr-public-library/therr-react/src/redux/actions/Habits.ts
+++ b/therr-public-library/therr-react/src/redux/actions/Habits.ts
@@ -329,6 +329,18 @@ const Habits = {
             return response.data;
         }),
 
+    // Returns the updated habit detail (or throws the axios error so the caller
+    // can read a 403 `solo-locked` / 402 cap payload and route accordingly). The
+    // reducer merges the detail the same way archive/restore do.
+    continueSoloUserHabit: (id: string) => (dispatch: any) => UserHabitsService.continueSolo(id)
+        .then((response: any) => {
+            dispatch({
+                type: HabitsActionTypes.CONTINUE_SOLO_USER_HABIT,
+                data: response.data,
+            });
+            return response.data;
+        }),
+
     // Journal
     /**
      * Pass `before` to page. The reducer appends rather than replaces when a

--- a/therr-public-library/therr-react/src/redux/reducers/habits.ts
+++ b/therr-public-library/therr-react/src/redux/reducers/habits.ts
@@ -222,13 +222,17 @@ const habits = produce((draft: IHabitsState, action: any) => {
             break;
         }
         case HabitsActionTypes.ARCHIVE_USER_HABIT:
-        case HabitsActionTypes.RESTORE_USER_HABIT: {
+        case HabitsActionTypes.RESTORE_USER_HABIT:
+        case HabitsActionTypes.CONTINUE_SOLO_USER_HABIT: {
             const habitIdx = draft.userHabits.findIndex((h) => h.id === action.data?.id);
             if (habitIdx > -1) {
                 // The archive/restore endpoints return the bare tracking row
                 // rather than the joined detail shape, so merge instead of
                 // replacing — otherwise the list loses the goal name and streak
-                // and the row renders blank until the next full fetch.
+                // and the row renders blank until the next full fetch. Merging is
+                // right for continue-solo too: it returns the full detail, so the
+                // merge simply overwrites every field (including the now-null
+                // pendingPactId) while never blanking a row.
                 draft.userHabits[habitIdx] = { ...draft.userHabits[habitIdx], ...action.data };
             }
             break;

--- a/therr-public-library/therr-react/src/services/UserHabitsService.ts
+++ b/therr-public-library/therr-react/src/services/UserHabitsService.ts
@@ -55,6 +55,18 @@ class UserHabitsService {
         method: 'put',
         url: `/users-service/habits/user-habits/${id}/restore`,
     });
+
+    /**
+     * Keep a habit whose invite went unanswered as a solo one: abandons the
+     * outstanding pact and re-gates on the solo-unlock threshold. A 403
+     * `solo-locked` (with `invitedCount`/`requiredCount`) means the caller has
+     * not invited enough distinct people yet — the client renders progress rather
+     * than treating it as a hard error.
+     */
+    continueSolo = (id: string) => axios({
+        method: 'put',
+        url: `/users-service/habits/user-habits/${id}/continue-solo`,
+    });
 }
 
 export default new UserHabitsService();

--- a/therr-public-library/therr-react/src/types/redux/habits.ts
+++ b/therr-public-library/therr-react/src/types/redux/habits.ts
@@ -223,6 +223,15 @@ export interface IUserHabit {
     activePactCount: number;
     currentStreak: number;
     longestStreak: number;
+    /**
+     * A pact this user created for this habit that is still `pending` — no invitee
+     * has accepted yet. Null once a partner joins or when the habit was started
+     * solo. Present alongside `isSolo === true` is what marks a habit as "waiting
+     * on a friend" rather than a genuine solo habit, and is the signal behind the
+     * "continue solo or archive?" prompt. Absent on responses from a users-service
+     * that predates it; treat `undefined` like `null`.
+     */
+    pendingPactId?: string | null;
 }
 
 /**
@@ -374,6 +383,7 @@ export enum HabitsActionTypes {
     CREATE_USER_HABIT = 'CREATE_USER_HABIT',
     ARCHIVE_USER_HABIT = 'ARCHIVE_USER_HABIT',
     RESTORE_USER_HABIT = 'RESTORE_USER_HABIT',
+    CONTINUE_SOLO_USER_HABIT = 'CONTINUE_SOLO_USER_HABIT',
 
     // Journal
     GET_JOURNAL_FEED = 'GET_JOURNAL_FEED',

--- a/therr-services/users-service/src/handlers/pacts.ts
+++ b/therr-services/users-service/src/handlers/pacts.ts
@@ -583,14 +583,27 @@ const acceptPact: RequestHandler = async (req: any, res: any) => {
             await Promise.all(streakPromises);
 
             // Tracking rows, mirroring the streak logic above: always for the
-            // accepter, and for the creator only on first acceptance (their row
-            // already exists from createPact — getOrCreate makes the repeat a
-            // no-op, and notably will not resurrect a row they have archived).
-            const trackingPromises: Promise<any>[] = [
-                Store.userHabits.getOrCreate(userId, pact.habitGoalId),
-            ];
+            // accepter, and for the creator only on first acceptance.
+            //
+            // Both go through getOrCreate *and* reviveArchivedByHabit. getOrCreate
+            // deliberately will not resurrect an archived row (a stray check-in must
+            // not un-archive a habit and put the user back over the cap), but a
+            // partner accepting the invite is precisely the event that should:
+            //   - the creator may have archived this habit to stop the reminders
+            //     while nobody had accepted — "revive only if an invitee accepts
+            //     after the fact" is exactly this path;
+            //   - the accepter may have archived the same goal in a past life, and
+            //     they just passed the capacity check above for the slot.
+            // reviveArchivedByHabit is a no-op when the row is already active, so
+            // every acceptance after the first costs one guarded UPDATE and nothing
+            // else.
+            const ensureActiveTracking = async (trackingUserId: string) => {
+                await Store.userHabits.getOrCreate(trackingUserId, pact.habitGoalId);
+                await Store.userHabits.reviveArchivedByHabit(trackingUserId, pact.habitGoalId);
+            };
+            const trackingPromises: Promise<any>[] = [ensureActiveTracking(userId)];
             if (pact.status === 'pending') {
-                trackingPromises.push(Store.userHabits.getOrCreate(pact.creatorUserId, pact.habitGoalId));
+                trackingPromises.push(ensureActiveTracking(pact.creatorUserId));
             }
             await Promise.all(trackingPromises);
 

--- a/therr-services/users-service/src/handlers/userHabits.ts
+++ b/therr-services/users-service/src/handlers/userHabits.ts
@@ -230,6 +230,105 @@ const restoreUserHabit: RequestHandler = async (req: any, res: any) => {
 };
 
 /**
+ * Commit to a habit whose invite went unanswered as a personal ("solo") one.
+ *
+ * The situation this exists for: a user creates a habit with a partner, invites
+ * someone, nobody accepts — and meanwhile the daily reminders fire as if it were
+ * an ordinary habit they signed up to do alone. The dashboard offers two ways
+ * out, this and archive. Archiving mutes the habit and keeps the invite open to
+ * auto-revive on acceptance; "continue solo" is the other choice — stop waiting
+ * on anyone and keep the habit, alone.
+ *
+ * So it does two things:
+ *
+ *   1. Enforces the solo-habit constraint. Tracking a habit alone is gated on
+ *      the same invite threshold every solo habit is (see `getSoloInviteProgress`
+ *      and the note atop this file) — an unanswered pact does not buy a pass
+ *      around the growth loop. A user short of the threshold gets the same
+ *      403 `solo-locked` the create path returns, with progress, so the client
+ *      can render "invite N more, or archive" rather than a dead end.
+ *   2. Abandons the outstanding invite(s). This is what makes the two options
+ *      genuinely distinct: after this the habit is solo with nothing pending, so
+ *      it stops being surfaced as "waiting on a friend" and there is nothing left
+ *      to accept. (Archive, by contrast, leaves the pact pending on purpose.)
+ *      The pact rows are abandoned, not deleted, so the invites still count
+ *      toward the user's solo-unlock progress for their other habits.
+ *
+ * The tracking row is already `active` in the common case (the habit has been
+ * tracked since the pact was created), so no capacity slot is consumed and none
+ * is checked. The one exception is a habit the user had archived and is now
+ * un-archiving into solo: reviving occupies a slot, so it is gated exactly like
+ * restore.
+ */
+const continueSoloHabit: RequestHandler = async (req: any, res: any) => {
+    const {
+        locale, userId, brandVariation,
+    } = parseHeaders(req.headers);
+    const { id } = req.params;
+
+    try {
+        const existing = await Store.userHabits.getById(id);
+
+        if (!existing || existing.userId !== userId) {
+            return handleHttpError({
+                res,
+                message: `Habit not found with id ${id}`,
+                statusCode: 404,
+            });
+        }
+
+        // Solo constraint first. Failing closed here is deliberate: wrongly
+        // letting someone bypass the invite requirement cannot be undone once the
+        // habit is theirs, while wrongly denying is a retryable error on a screen
+        // they are already on (mirrors createUserHabit).
+        const soloProgress = await getSoloInviteProgress(userId);
+
+        if (!soloProgress.canCreateSolo) {
+            return res.status(403).send({
+                error: 'solo-locked',
+                message: translate(locale, 'errorMessages.habits.soloLocked', {
+                    remaining: soloProgress.requiredCount - soloProgress.invitedCount,
+                    required: soloProgress.requiredCount,
+                }),
+                invitedCount: soloProgress.invitedCount,
+                requiredCount: soloProgress.requiredCount,
+            });
+        }
+
+        // Reviving an archived habit into solo takes a slot; an already-active one
+        // occupies its slot already. `countActiveByUser` counts only active rows,
+        // so checking before the flip is naturally safe.
+        if (existing.status === 'archived') {
+            const denial = await checkHabitCapacity({ userId, brandVariation, locale });
+
+            if (denial) {
+                return res.status(402).send(denial);
+            }
+
+            await Store.userHabits.setStatus(existing.id, userId, 'active');
+        }
+
+        // Abandon the outstanding invite(s) — pending pacts this user created for
+        // this goal. Abandon rather than delete so the invites keep counting
+        // toward solo-unlock progress; deleting the pact_members would silently
+        // re-lock the user's other habits.
+        const pendingPacts = await Store.pacts.get({
+            creatorUserId: userId,
+            habitGoalId: existing.habitGoalId,
+            status: 'pending',
+        });
+        await Promise.all(pendingPacts.map((pact: any) => Store.pacts.abandon(pact.id, userId, true)));
+
+        const [detail] = await Store.userHabits.getDetailByUser(userId, 'active')
+            .then((rows) => rows.filter((row) => row.habitGoalId === existing.habitGoalId));
+
+        return res.status(200).send(detail || { ...existing, status: 'active' });
+    } catch (err: any) {
+        return handleHttpError({ err, res, message: 'SQL:USER_HABITS_ROUTES:ERROR' });
+    }
+};
+
+/**
  * Whether the caller may start habits on their own yet, how close they are to
  * earning it, and where they stand against the free-tier cap.
  *
@@ -269,4 +368,5 @@ export {
     createUserHabit,
     archiveUserHabit,
     restoreUserHabit,
+    continueSoloHabit,
 };

--- a/therr-services/users-service/src/routes/userHabitsRouter.ts
+++ b/therr-services/users-service/src/routes/userHabitsRouter.ts
@@ -5,6 +5,7 @@ import {
     createUserHabit,
     archiveUserHabit,
     restoreUserHabit,
+    continueSoloHabit,
 } from '../handlers/userHabits';
 
 const router = express.Router();
@@ -21,5 +22,8 @@ router.post('/', createUserHabit);
 // UPDATE
 router.put('/:id/archive', archiveUserHabit);
 router.put('/:id/restore', restoreUserHabit);
+// "Stop waiting on the invite — keep this habit alone." Distinct from restore:
+// it also abandons the outstanding pact and enforces the solo-unlock gate.
+router.put('/:id/continue-solo', continueSoloHabit);
 
 export default router;

--- a/therr-services/users-service/src/store/UserHabitsStore.ts
+++ b/therr-services/users-service/src/store/UserHabitsStore.ts
@@ -55,6 +55,18 @@ export interface IUserHabitDetail extends IUserHabitRow {
     activePactCount: number;
     currentStreak: number;
     longestStreak: number;
+    /**
+     * A pact this user created for this habit that is still `pending` — i.e. no
+     * invitee has accepted yet. Null once a partner joins (the pact activates) or
+     * when the habit was started solo in the first place.
+     *
+     * This is what lets a client tell "waiting on a friend" apart from a genuine
+     * solo habit: both read `isSolo = true` (no *active* pact backs them), but
+     * only the former has an outstanding invite. It is the signal behind the
+     * "continue solo or archive?" prompt — a habit whose reminders are firing
+     * while the user waits on someone who may never accept.
+     */
+    pendingPactId: string | null;
 }
 
 /**
@@ -158,7 +170,16 @@ export default class UserHabitsStore {
                 COALESCE(s."currentStreak", 0) AS "currentStreak",
                 COALESCE(s."longestStreak", 0) AS "longestStreak",
                 COALESCE(pact_counts."activePactCount", 0) AS "activePactCount",
-                COALESCE(pact_counts."activePactCount", 0) = 0 AS "isSolo"
+                COALESCE(pact_counts."activePactCount", 0) = 0 AS "isSolo",
+                (
+                    SELECT p."id"
+                    FROM ${PACTS_TABLE_NAME} p
+                    WHERE p."creatorUserId" = uh."userId"
+                        AND p."habitGoalId" = uh."habitGoalId"
+                        AND p."status" = 'pending'
+                    ORDER BY p."createdAt" ASC
+                    LIMIT 1
+                ) AS "pendingPactId"
             FROM ${USER_HABITS_TABLE_NAME} uh
             INNER JOIN ${HABIT_GOALS_TABLE_NAME} g ON g."id" = uh."habitGoalId"
             LEFT JOIN ${STREAKS_TABLE_NAME} s
@@ -294,6 +315,38 @@ export default class UserHabitsStore {
              WHERE "id" = ?::uuid AND "userId" = ?::uuid AND "status" <> ?
              RETURNING *`,
             [nextStatus, nextStatus, id, userId, nextStatus],
+        ).toString();
+
+        return this.db.write.query(queryString)
+            .then((response) => response.rows[0] as IUserHabitRow | undefined);
+    }
+
+    /**
+     * Bring an archived habit back to `active`, addressed by (userId, habitGoalId)
+     * rather than by row id.
+     *
+     * The one caller is pact acceptance: a user who archived a habit while its
+     * invite sat unanswered — to stop the reminders for something they were
+     * waiting on — should have it come back the moment a partner actually joins.
+     * `getOrCreate` deliberately will *not* do this (an archived row must survive
+     * a stray check-in), so reviving is a separate, explicit verb used only where
+     * the resurrection is the intended effect.
+     *
+     * Keyed on the habit rather than the row id because the caller (acceptPact)
+     * holds the pact's habitGoalId, not the creator's tracking-row id, and looking
+     * the id up first would be a redundant round trip. The `status = 'archived'`
+     * guard makes it a no-op (rowCount 0) for a habit that is already active,
+     * which every acceptance after the first will be.
+     */
+    reviveArchivedByHabit(userId: string, habitGoalId: string) {
+        const queryString = knexBuilder.raw(
+            `UPDATE ${USER_HABITS_TABLE_NAME}
+             SET "status" = 'active',
+                 "archivedAt" = NULL,
+                 "updatedAt" = now()
+             WHERE "userId" = ?::uuid AND "habitGoalId" = ?::uuid AND "status" = 'archived'
+             RETURNING *`,
+            [userId, habitGoalId],
         ).toString();
 
         return this.db.write.query(queryString)

--- a/therr-services/users-service/tests/unit/handlers-user-habits.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-user-habits.test.ts
@@ -2,7 +2,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { BrandVariations, HABITS_FREE_HABIT_LIMIT, HABITS_SOLO_UNLOCK_INVITE_COUNT } from 'therr-js-utilities/constants';
 import Store from '../../src/store';
-import { createUserHabit, restoreUserHabit, archiveUserHabit } from '../../src/handlers/userHabits';
+import {
+    createUserHabit, restoreUserHabit, archiveUserHabit, continueSoloHabit,
+} from '../../src/handlers/userHabits';
 
 /**
  * Personal ("solo") habits.
@@ -298,6 +300,117 @@ describe('Solo habits', () => {
             await archiveUserHabit(makeReq({ params: { id: 'uh-1' } }) as any, res, (() => {}) as any);
 
             expect(res.statusCode).to.equal(200);
+        });
+    });
+
+    /**
+     * "Continue solo" is the other half of the escape hatch for a habit whose
+     * invite went unanswered (archive is the first). It has to do two things the
+     * other paths don't, and both are easy to get wrong:
+     *   1. Re-gate on the solo-unlock threshold — an unanswered pact does not buy
+     *      a way around the growth loop.
+     *   2. Abandon the outstanding invite so the habit stops being "waiting on a
+     *      friend", without deleting the pact rows (which would silently re-lock
+     *      the user's other habits by dropping their invite count).
+     */
+    describe('continue solo', () => {
+        let getByIdStub: sinon.SinonStub;
+        let pactsGetStub: sinon.SinonStub;
+        let abandonStub: sinon.SinonStub;
+
+        beforeEach(() => {
+            getByIdStub = sinon.stub(Store.userHabits, 'getById').resolves({
+                id: 'uh-1', userId: 'user-1', habitGoalId: 'goal-1', status: 'active',
+            } as any);
+            pactsGetStub = sinon.stub(Store.pacts, 'get').resolves([
+                { id: 'pact-1', creatorUserId: 'user-1', habitGoalId: 'goal-1', status: 'pending' },
+            ] as any);
+            abandonStub = sinon.stub(Store.pacts, 'abandon').resolves({} as any);
+        });
+
+        it('abandons the outstanding invite and keeps the habit for an eligible user', async () => {
+            const res = makeRes();
+            await continueSoloHabit(makeReq({ params: { id: 'uh-1' } }) as any, res, (() => {}) as any);
+
+            expect(res.statusCode).to.equal(200);
+            expect(abandonStub.calledOnceWithExactly('pact-1', 'user-1', true)).to.equal(true);
+            // The habit is already active, so no slot is charged and no status flip.
+            expect(setStatusStub.called).to.equal(false);
+        });
+
+        it('does not consult the cap for an already-active habit', async () => {
+            const res = makeRes();
+            await continueSoloHabit(makeReq({ params: { id: 'uh-1' } }) as any, res, (() => {}) as any);
+
+            // Re-committing an active habit to solo consumes nothing; a cap check
+            // here would 402 a no-op.
+            expect(countActiveStub.called).to.equal(false);
+        });
+
+        it('re-gates on the solo unlock and does not touch the pact when locked', async () => {
+            countInvitedStub.resolves(HABITS_SOLO_UNLOCK_INVITE_COUNT - 1);
+
+            const res = makeRes();
+            await continueSoloHabit(makeReq({ params: { id: 'uh-1' } }) as any, res, (() => {}) as any);
+
+            expect(res.statusCode).to.equal(403);
+            expect(res.body.error).to.equal('solo-locked');
+            expect(res.body.requiredCount).to.equal(HABITS_SOLO_UNLOCK_INVITE_COUNT);
+            expect(abandonStub.called).to.equal(false);
+        });
+
+        it('abandons every outstanding invite on the habit, not just one', async () => {
+            pactsGetStub.resolves([
+                { id: 'pact-1', creatorUserId: 'user-1', habitGoalId: 'goal-1', status: 'pending' },
+                { id: 'pact-2', creatorUserId: 'user-1', habitGoalId: 'goal-1', status: 'pending' },
+            ] as any);
+
+            const res = makeRes();
+            await continueSoloHabit(makeReq({ params: { id: 'uh-1' } }) as any, res, (() => {}) as any);
+
+            expect(abandonStub.callCount).to.equal(2);
+        });
+
+        it('un-archives into solo, gated by the cap like restore', async () => {
+            getByIdStub.resolves({
+                id: 'uh-1', userId: 'user-1', habitGoalId: 'goal-1', status: 'archived',
+            } as any);
+            countActiveStub.resolves(HABITS_FREE_HABIT_LIMIT);
+
+            const res = makeRes();
+            await continueSoloHabit(makeReq({ params: { id: 'uh-1' } }) as any, res, (() => {}) as any);
+
+            // Reviving an archived habit takes a slot, so the cap applies here —
+            // and blocks before the pact is touched.
+            expect(res.statusCode).to.equal(402);
+            expect(setStatusStub.called).to.equal(false);
+            expect(abandonStub.called).to.equal(false);
+        });
+
+        it('flips an archived habit active before abandoning the invite when there is room', async () => {
+            getByIdStub.resolves({
+                id: 'uh-1', userId: 'user-1', habitGoalId: 'goal-1', status: 'archived',
+            } as any);
+            countActiveStub.resolves(0);
+
+            const res = makeRes();
+            await continueSoloHabit(makeReq({ params: { id: 'uh-1' } }) as any, res, (() => {}) as any);
+
+            expect(res.statusCode).to.equal(200);
+            expect(setStatusStub.firstCall.args[2]).to.equal('active');
+            expect(abandonStub.calledOnce).to.equal(true);
+        });
+
+        it('404s on a habit belonging to someone else', async () => {
+            getByIdStub.resolves({
+                id: 'uh-1', userId: 'someone-else', habitGoalId: 'goal-1', status: 'active',
+            } as any);
+
+            const res = makeRes();
+            await continueSoloHabit(makeReq({ params: { id: 'uh-1' } }) as any, res, (() => {}) as any);
+
+            expect(res.statusCode).to.equal(404);
+            expect(abandonStub.called).to.equal(false);
         });
     });
 });


### PR DESCRIPTION
## What & why

A habit created with a partner keeps firing daily streak reminders while its invite sits **unanswered** — for a habit the user may not even want to do alone. This gives them an explicit choice and stops the reminders when they don't want them.

This is the **shared/backend half**. The mobile UI that consumes it is PR **#2873** (base `niche/HABITS-general`) — merge **this one first**.

## Changes (all `general`-bound)

**users-service**
- `UserHabitsStore.getDetailByUser` now returns `pendingPactId` — the user's own still-pending pact for a habit — so a client can distinguish "waiting on a friend" from a genuine solo habit (both read `isSolo = true`).
- New `reviveArchivedByHabit(userId, habitGoalId)`: brings an archived habit back to `active`. `getOrCreate` deliberately will *not* resurrect an archived row (a stray check-in must not un-archive); reviving is the explicit verb for where resurrection is intended.
- `acceptPact` now revives the creator's (and accepter's) archived habit on acceptance — implementing **"revive only if an invitee accepts after the fact"**.
- New `continueSoloHabit` handler + route (`PUT /habits/user-habits/:id/continue-solo`): abandons the outstanding invite(s) and keeps the habit solo. Re-gated on the **solo-unlock threshold** (an unanswered pact buys no pass around the growth loop) and, when un-archiving, on the **free-tier cap**. Pacts are *abandoned, not deleted*, so the invites keep counting toward solo-unlock progress for the user's other habits.
- Gateway route registered.
- Unit tests: eligibility gate, cap gate on revive, abandon-every-invite, ownership.

**therr-react (shared lib)**
- `UserHabitsService.continueSolo`, `HabitActions.continueSoloUserHabit`, `CONTINUE_SOLO_USER_HABIT` reducer case, `IUserHabit.pendingPactId`.

## Design notes
- **Continue-solo abandons the pending pact; archive keeps it** and auto-revives on acceptance. Clean split, no new schema column.
- The solo-unlock gate is applied to continue-solo per "account for the constraints of creating solo habits" (the growth-loop philosophy) — commented so a reviewer can relax it if product prefers.
- Archiving reuses the existing `user_habits` archived state; the digest reminder pass already reads only `active` rows, so **no new push type or producer** was introduced.

## Verification
- `npx tsc -p therr-services/users-service` and gateway: clean (only pre-existing tsconfig env deprecations).
- Added unit tests for the continue-solo handler.
- ⚠️ `node_modules` was empty in the authoring env, so `jest` / `therr-react` webpack build could not run locally — CI must validate.

## Related
Mobile half: PR **#2873** (base `niche/HABITS-general`). **Merge order: this PR (#2872) first, #2873 second.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pxYseTePZUtddFSM9GTwM