### PR TITLE
feat(habits): awaiting-partner card offers "continue solo" / "archive" (mobile)

### DIFF
--- a/TherrMobile/__tests__/routes/HabitsDashboardPactState.test.ts
+++ b/TherrMobile/__tests__/routes/HabitsDashboardPactState.test.ts
@@ -190,4 +190,73 @@ describe('splitHabitsByPactState', () => {
         expect(live).toHaveLength(0);
         expect(pending[0].awaitingPartnerNames).toEqual([]);
     });
+
+    // The archive escape hatch: an archived habit is muted, so it must leave the
+    // active dashboard entirely rather than keep firing its awaiting-partner card.
+    const userHabit = (habitGoalId: string, status: string): any => ({
+        id: `uh-${habitGoalId}`,
+        userId: 'me',
+        habitGoalId,
+        status,
+        startedAt: '2026-01-01T00:00:00.000Z',
+        goalName: `Habit ${habitGoalId}`,
+        goalType: 'build_good',
+        frequencyType: 'daily',
+        isSolo: true,
+        activePactCount: 0,
+        currentStreak: 0,
+        longestStreak: 0,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    it('drops an archived habit from both lists when the registry is supplied', () => {
+        const pendingPact = pact('pact-1', 'goal-1', 'pending', [
+            member('me', 'creator', 'active'),
+            member('friend', 'partner', 'pending', 'Dana'),
+        ]);
+
+        const { live, pending } = splitHabitsByPactState(
+            [goal('goal-1')],
+            [],
+            [pendingPact],
+            'me',
+            [userHabit('goal-1', 'archived')],
+        );
+
+        expect(live).toHaveLength(0);
+        expect(pending).toHaveLength(0);
+    });
+
+    it('attaches the tracking row to an awaiting-partner entry so the card can act on it', () => {
+        const pendingPact = pact('pact-1', 'goal-1', 'pending', [
+            member('me', 'creator', 'active'),
+            member('friend', 'partner', 'pending', 'Dana'),
+        ]);
+
+        const { pending } = splitHabitsByPactState(
+            [goal('goal-1')],
+            [],
+            [pendingPact],
+            'me',
+            [userHabit('goal-1', 'active')],
+        );
+
+        expect(pending).toHaveLength(1);
+        expect(pending[0].userHabit?.id).toBe('uh-goal-1');
+    });
+
+    it('never makes a habit vanish when its tracking row has not loaded', () => {
+        const pendingPact = pact('pact-1', 'goal-1', 'pending', [
+            member('me', 'creator', 'active'),
+            member('friend', 'partner', 'pending', 'Dana'),
+        ]);
+
+        // Registry supplied but empty (e.g. mid-refresh): the goal stays, just
+        // without a tracking row on the entry.
+        const { pending } = splitHabitsByPactState([goal('goal-1')], [], [pendingPact], 'me', []);
+
+        expect(pending).toHaveLength(1);
+        expect(pending[0].userHabit).toBeUndefined();
+    });
 });

--- a/TherrMobile/main/components/Habits/HabitCard.tsx
+++ b/TherrMobile/main/components/Habits/HabitCard.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { View, Text, Pressable } from 'react-native';
+import {
+    View, Text, Pressable, ActivityIndicator,
+} from 'react-native';
 import { IHabitGoal, IHabitCheckin, IStreak } from 'therr-react/types';
 import { ITherrThemeColors } from '../../styles/themes';
 import CheckinButton from './CheckinButton';
@@ -23,6 +25,16 @@ interface IHabitCardProps {
     awaitingPartnerNames?: string[];
     /** Partners already checked into this habit's active pact. */
     partnerNames?: string[];
+    /**
+     * "Keep this habit alone." Present only on an awaiting-partner card whose
+     * tracking row is known. When set, the card offers the solo/archive choice
+     * that ends the annoying reminders for a habit nobody has joined.
+     */
+    onContinueSolo?: () => void;
+    /** "Stop the reminders until a partner joins." Pairs with `onContinueSolo`. */
+    onArchive?: () => void;
+    /** Disables both decision buttons and shows a spinner while a request runs. */
+    isAwaitingActionLoading?: boolean;
     themeHabits: {
         colors: ITherrThemeColors;
         styles: any;
@@ -73,10 +85,14 @@ const HabitCard: React.FC<IHabitCardProps> = ({
     isAwaitingPartner = false,
     awaitingPartnerNames,
     partnerNames,
+    onContinueSolo,
+    onArchive,
+    isAwaitingActionLoading = false,
     themeHabits,
     translate,
 }) => {
     const isCompleted = todayCheckin?.status === 'completed';
+    const showSoloOrArchive = isAwaitingPartner && !!onContinueSolo && !!onArchive;
 
     return (
         <Pressable
@@ -129,6 +145,49 @@ const HabitCard: React.FC<IHabitCardProps> = ({
                         })
                         : translate('pages.habits.awaitingAnyPartnerAcceptance')}
                 </Text>
+            )}
+
+            {showSoloOrArchive && (
+                <View style={themeHabits.styles.habitCardSoloPrompt}>
+                    <Text style={themeHabits.styles.habitCardSoloPromptText}>
+                        {translate('pages.habits.soloOrArchivePrompt')}
+                    </Text>
+                    {isAwaitingActionLoading ? (
+                        <ActivityIndicator
+                            color={themeHabits.colors.primary3}
+                            style={themeHabits.styles.habitCardSoloSpinner}
+                        />
+                    ) : (
+                        <View style={themeHabits.styles.habitCardSoloActions}>
+                            <Pressable
+                                accessibilityRole="button"
+                                accessibilityLabel={translate('pages.habits.continueSolo')}
+                                style={({ pressed }) => [
+                                    themeHabits.styles.habitCardSoloButton,
+                                    pressed && themeHabits.styles.pressedOpacity,
+                                ]}
+                                onPress={onContinueSolo}
+                            >
+                                <Text style={themeHabits.styles.habitCardSoloButtonText}>
+                                    {translate('pages.habits.continueSolo')}
+                                </Text>
+                            </Pressable>
+                            <Pressable
+                                accessibilityRole="button"
+                                accessibilityLabel={translate('pages.habits.archiveHabit')}
+                                style={({ pressed }) => [
+                                    themeHabits.styles.habitCardArchiveButton,
+                                    pressed && themeHabits.styles.pressedOpacity,
+                                ]}
+                                onPress={onArchive}
+                            >
+                                <Text style={themeHabits.styles.habitCardArchiveButtonText}>
+                                    {translate('pages.habits.archiveHabit')}
+                                </Text>
+                            </Pressable>
+                        </View>
+                    )}
+                </View>
             )}
 
             {onCheckin && !isAwaitingPartner && (

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -2020,6 +2020,24 @@
             "pactWithPartners": "Pact with {partners}",
             "awaitingPartnerAcceptance": "Waiting for {partners} to accept before this pact starts.",
             "awaitingAnyPartnerAcceptance": "Waiting for your invite to be accepted before this pact starts.",
+            "soloOrArchivePrompt": "No one has joined yet. Keep going on your own, or pause the reminders?",
+            "continueSolo": "Continue solo",
+            "archiveHabit": "Archive",
+            "soloContinued": {
+                "successTitle": "You're on your own — nice.",
+                "successMessage": "{habit} is now a solo habit. Keep that streak going!",
+                "lockedTitle": "Almost there",
+                "lockedMessage": "Invite {remaining} more friend(s) to track habits on your own — or archive this one for now.",
+                "lockedMessageGeneric": "Invite a few more friends to track habits on your own — or archive this one for now.",
+                "errorMessage": "We couldn't switch this habit to solo. Please try again."
+            },
+            "habitArchived": {
+                "confirm": "Archive this habit? Reminders stop until a partner accepts your invite — then it comes back automatically.",
+                "confirmButton": "Archive",
+                "successTitle": "Habit archived",
+                "successMessage": "We'll stop the reminders. It'll return if a partner joins.",
+                "errorMessage": "We couldn't archive this habit. Please try again."
+            },
             "habitNotFound": "Habit not found",
             "checkinProof": {
                 "notePlaceholder": "How did it go? Any wins to share?",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -2020,6 +2020,24 @@
             "pactWithPartners": "Pacto con {partners}",
             "awaitingPartnerAcceptance": "Esperando a que {partners} acepte para que comience este pacto.",
             "awaitingAnyPartnerAcceptance": "Esperando a que se acepte tu invitación para que comience este pacto.",
+            "soloOrArchivePrompt": "Nadie se ha unido todavía. ¿Sigues por tu cuenta o pausas los recordatorios?",
+            "continueSolo": "Seguir en solitario",
+            "archiveHabit": "Archivar",
+            "soloContinued": {
+                "successTitle": "Por tu cuenta: ¡genial!",
+                "successMessage": "{habit} ahora es un hábito en solitario. ¡Mantén esa racha!",
+                "lockedTitle": "Ya casi",
+                "lockedMessage": "Invita a {remaining} amigo(s) más para seguir hábitos por tu cuenta, o archiva este por ahora.",
+                "lockedMessageGeneric": "Invita a algunos amigos más para seguir hábitos por tu cuenta, o archiva este por ahora.",
+                "errorMessage": "No pudimos cambiar este hábito a solitario. Inténtalo de nuevo."
+            },
+            "habitArchived": {
+                "confirm": "¿Archivar este hábito? Los recordatorios se detienen hasta que un compañero acepte tu invitación; luego vuelve automáticamente.",
+                "confirmButton": "Archivar",
+                "successTitle": "Hábito archivado",
+                "successMessage": "Detendremos los recordatorios. Volverá si un compañero se une.",
+                "errorMessage": "No pudimos archivar este hábito. Inténtalo de nuevo."
+            },
             "habitNotFound": "Hábito no encontrado",
             "checkinProof": {
                 "notePlaceholder": "¿Cómo te fue? ¿Algún logro para compartir?",

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -2020,6 +2020,24 @@
             "pactWithPartners": "Pacte avec {partners}",
             "awaitingPartnerAcceptance": "En attente de l'acceptation de {partners} pour démarrer ce pacte.",
             "awaitingAnyPartnerAcceptance": "En attente de l'acceptation de votre invitation pour démarrer ce pacte.",
+            "soloOrArchivePrompt": "Personne ne s'est joint pour l'instant. Continuer seul ou suspendre les rappels?",
+            "continueSolo": "Continuer en solo",
+            "archiveHabit": "Archiver",
+            "soloContinued": {
+                "successTitle": "En solo, bravo!",
+                "successMessage": "{habit} est maintenant une habitude en solo. Continue cette série!",
+                "lockedTitle": "Presque",
+                "lockedMessage": "Invite {remaining} ami(s) de plus pour suivre des habitudes en solo, ou archive celle-ci pour l'instant.",
+                "lockedMessageGeneric": "Invite quelques amis de plus pour suivre des habitudes en solo, ou archive celle-ci pour l'instant.",
+                "errorMessage": "Impossible de rendre cette habitude solo. Veuillez réessayer."
+            },
+            "habitArchived": {
+                "confirm": "Archiver cette habitude? Les rappels s'arrêtent jusqu'à ce qu'un partenaire accepte votre invitation, puis elle revient automatiquement.",
+                "confirmButton": "Archiver",
+                "successTitle": "Habitude archivée",
+                "successMessage": "Nous arrêtons les rappels. Elle reviendra si un partenaire se joint.",
+                "errorMessage": "Impossible d'archiver cette habitude. Veuillez réessayer."
+            },
             "habitNotFound": "Habitude introuvable",
             "checkinProof": {
                 "notePlaceholder": "Comment ça s'est passé? Une réussite à partager?",

--- a/TherrMobile/main/routes/Habits/Dashboard.tsx
+++ b/TherrMobile/main/routes/Habits/Dashboard.tsx
@@ -7,7 +7,7 @@ import RNFB from 'react-native-blob-util';
 import { FeatureFlags, FilePaths } from 'therr-js-utilities/constants';
 import { HabitActions } from 'therr-react/redux/actions';
 import {
-    IUserState, IHabitsState, IHabitGoal, IHabitCheckin, IStreak, IPact, IPactNudgeResult,
+    IUserState, IHabitsState, IHabitGoal, IHabitCheckin, IStreak, IPact, IPactNudgeResult, IUserHabit,
 } from 'therr-react/types';
 import { FlatList, RefreshControl } from 'react-native-gesture-handler';
 import Toast from 'react-native-toast-message';
@@ -102,11 +102,14 @@ interface IHabitsDashboardDispatchProps {
     getUserPacts: Function;
     getPendingInvites: Function;
     getUserHabitEligibility: Function;
+    getUserHabits: Function;
     createCheckin: Function;
     acceptPact: Function;
     declinePact: Function;
     nudgePact: Function;
     renewPact: Function;
+    archiveUserHabit: Function;
+    continueSoloUserHabit: Function;
 }
 
 interface IStoreProps extends IHabitsDashboardDispatchProps {
@@ -129,6 +132,13 @@ interface IHabitsDashboardState {
     renewingPactId: string | null;
     nudgingPactId: string | null;
     pactIdPendingDecline: string | null;
+    // The awaiting-partner habit whose "continue solo" / "archive" request is in
+    // flight, keyed by goal id so its card can show a spinner while both buttons
+    // are disabled.
+    awaitingActionGoalId: string | null;
+    // The tracking row queued for archive confirmation, or null when the modal is
+    // closed.
+    habitPendingArchive: IUserHabit | null;
 }
 
 const mapStateToProps = (state: any) => ({
@@ -144,11 +154,14 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
     getUserPacts: HabitActions.getUserPacts,
     getPendingInvites: HabitActions.getPendingInvites,
     getUserHabitEligibility: HabitActions.getUserHabitEligibility,
+    getUserHabits: HabitActions.getUserHabits,
     createCheckin: HabitActions.createCheckin,
     acceptPact: HabitActions.acceptPact,
     declinePact: HabitActions.declinePact,
     nudgePact: HabitActions.nudgePact,
     renewPact: HabitActions.renewPact,
+    archiveUserHabit: HabitActions.archiveUserHabit,
+    continueSoloUserHabit: HabitActions.continueSoloUserHabit,
 }, dispatch);
 
 export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHabitsDashboardState> {
@@ -177,6 +190,7 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
         habitGoals: any;
         activePacts: any;
         pacts: any;
+        userHabits: any;
         userId?: string;
         split: { live: IHabitWithPactState[]; pending: IHabitWithPactState[] };
         rows: IHabitsRow[];
@@ -195,6 +209,8 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
             renewingPactId: null,
             nudgingPactId: null,
             pactIdPendingDecline: null,
+            awaitingActionGoalId: null,
+            habitPendingArchive: null,
         };
 
         this.theme = buildStyles(props.user.settings?.mobileThemeName);
@@ -261,7 +277,7 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
     handleRefresh = () => {
         const {
             getUserGoals, getTodayCheckins, getActiveStreaks, getActivePacts, getUserPacts,
-            getPendingInvites, getUserHabitEligibility,
+            getPendingInvites, getUserHabitEligibility, getUserHabits,
         } = this.props;
 
         this.setState({ isRefreshing: true });
@@ -275,6 +291,11 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
             // invite is still outstanding — getActivePacts only returns the former.
             getUserPacts(),
             getPendingInvites(),
+            // The tracking registry. Drives the archived filter (an archived habit
+            // leaves the active list) and carries the id the continue-solo/archive
+            // actions address. Failing drops the two decision buttons rather than
+            // blocking the refresh.
+            getUserHabits().catch(() => {}),
             // Feeds the solo-unlock banner below, and the same progress on the
             // onboarding overlay — which renders in place of this screen's
             // children and so never gets a fetch of its own. Failing drops the
@@ -669,6 +690,112 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
             });
     };
 
+    /**
+     * "Keep this habit, on my own." Abandons the outstanding invite server-side
+     * and re-gates on the solo-unlock threshold. A 403 `solo-locked` is not an
+     * error to swallow — it is the growth loop telling the user to invite more
+     * friends, so it surfaces the remaining count and points at the invite flow.
+     */
+    handleContinueSolo = (entry: IHabitWithPactState) => {
+        const { continueSoloUserHabit } = this.props;
+        const { userHabit, goal } = entry;
+
+        if (!userHabit || this.state.awaitingActionGoalId) {
+            return;
+        }
+
+        this.setState({ awaitingActionGoalId: goal.id });
+
+        continueSoloUserHabit(userHabit.id)
+            .then(() => {
+                showToast.success({
+                    text1: this.translate('pages.habits.soloContinued.successTitle'),
+                    text2: this.translate('pages.habits.soloContinued.successMessage', { habit: goal.name }),
+                    duration: DURATION.SHORT,
+                });
+                this.handleRefresh();
+            })
+            .catch((err: any) => {
+                const data = err?.response?.data;
+                if (data?.error === 'solo-locked') {
+                    const remaining = typeof data.requiredCount === 'number' && typeof data.invitedCount === 'number'
+                        ? Math.max(data.requiredCount - data.invitedCount, 1)
+                        : undefined;
+                    showToast.info({
+                        text1: this.translate('pages.habits.soloContinued.lockedTitle'),
+                        text2: remaining !== undefined
+                            ? this.translate('pages.habits.soloContinued.lockedMessage', { remaining })
+                            : this.translate('pages.habits.soloContinued.lockedMessageGeneric'),
+                        duration: DURATION.LONG,
+                    });
+                    return;
+                }
+                showToast.error({
+                    text1: this.translate('pages.pacts.errorTitle'),
+                    text2: this.translate('pages.habits.soloContinued.errorMessage'),
+                    duration: DURATION.SHORT,
+                });
+            })
+            .finally(() => {
+                this.setState((prev) => (prev.awaitingActionGoalId === goal.id
+                    ? { ...prev, awaitingActionGoalId: null }
+                    : prev));
+            });
+    };
+
+    handleArchiveHabitPress = (entry: IHabitWithPactState) => {
+        if (!entry.userHabit) {
+            return;
+        }
+        this.setState({ habitPendingArchive: entry.userHabit });
+    };
+
+    handleCancelArchive = () => {
+        this.setState({ habitPendingArchive: null });
+    };
+
+    /**
+     * Archive mutes the habit without walking away from the invite: the pact
+     * stays pending, so if the friend does accept later the server revives the
+     * habit automatically (see users-service acceptPact). The row simply leaves
+     * the active dashboard until then.
+     */
+    handleConfirmArchive = () => {
+        const { archiveUserHabit } = this.props;
+        const { habitPendingArchive } = this.state;
+
+        if (!habitPendingArchive) {
+            return;
+        }
+
+        this.setState({
+            awaitingActionGoalId: habitPendingArchive.habitGoalId,
+            habitPendingArchive: null,
+        });
+
+        archiveUserHabit(habitPendingArchive.id)
+            .then(() => {
+                showToast.success({
+                    text1: this.translate('pages.habits.habitArchived.successTitle'),
+                    text2: this.translate('pages.habits.habitArchived.successMessage'),
+                    duration: DURATION.SHORT,
+                });
+                this.handleRefresh();
+            })
+            .catch(() => {
+                showToast.error({
+                    text1: this.translate('pages.pacts.errorTitle'),
+                    text2: this.translate('pages.habits.habitArchived.errorMessage'),
+                    duration: DURATION.SHORT,
+                });
+            })
+            .finally(() => {
+                this.setState((prev) => (prev.awaitingActionGoalId === habitPendingArchive.habitGoalId
+                    ? { ...prev, awaitingActionGoalId: null }
+                    : prev));
+            });
+    };
+
     setActiveTab = (tab: HabitsTab) => {
         this.setState({ activeTab: tab });
     };
@@ -693,6 +820,7 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
         const habitGoals = habits.habitGoals || [];
         const activePacts = habits.activePacts || [];
         const pacts = habits.pacts || [];
+        const userHabits = habits.userHabits || [];
         const userId = user.details?.id;
         const memo = this.habitsRowsMemo;
 
@@ -700,16 +828,18 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
             && memo.habitGoals === habitGoals
             && memo.activePacts === activePacts
             && memo.pacts === pacts
+            && memo.userHabits === userHabits
             && memo.userId === userId) {
             return memo;
         }
 
-        const split = splitHabitsByPactState(habitGoals, activePacts, pacts, userId);
+        const split = splitHabitsByPactState(habitGoals, activePacts, pacts, userId, userHabits);
 
         this.habitsRowsMemo = {
             habitGoals,
             activePacts,
             pacts,
+            userHabits,
             userId,
             split,
             rows: this.buildHabitsRows(split),
@@ -904,7 +1034,7 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
     );
 
     renderHabitsRow = ({ item }: { item: IHabitsRow }) => {
-        const { checkinLoadingIds } = this.state;
+        const { checkinLoadingIds, awaitingActionGoalId } = this.state;
 
         if (item.kind === 'sectionTitle') {
             return (
@@ -917,7 +1047,13 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
             );
         }
 
-        const { goal, partnerNames, awaitingPartnerNames } = item.entry;
+        const {
+            goal, partnerNames, awaitingPartnerNames, userHabit,
+        } = item.entry;
+
+        // The two decision buttons only make sense on an awaiting-partner habit
+        // whose tracking row has loaded — that is the row the actions address.
+        const canDecideSoloOrArchive = item.isAwaitingPartner && !!userHabit;
 
         return (
             <HabitCard
@@ -931,6 +1067,9 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
                 isAwaitingPartner={item.isAwaitingPartner}
                 awaitingPartnerNames={awaitingPartnerNames}
                 partnerNames={partnerNames}
+                onContinueSolo={canDecideSoloOrArchive ? () => this.handleContinueSolo(item.entry) : undefined}
+                onArchive={canDecideSoloOrArchive ? () => this.handleArchiveHabitPress(item.entry) : undefined}
+                isAwaitingActionLoading={awaitingActionGoalId === goal.id}
                 themeHabits={this.themeHabits}
                 translate={this.translate}
             />
@@ -1114,6 +1253,7 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
         const {
             isRefreshing, proofSheetHabit, isSubmittingCheckin, pactIdPendingDecline,
             checkinLoadingIds, respondingPactId, renewingPactId, nudgingPactId,
+            awaitingActionGoalId, habitPendingArchive,
         } = this.state;
         const arePactsEnabled = this.arePactsEnabled();
         const isHabitsTab = this.getEffectiveTab() === 'habits';
@@ -1122,6 +1262,10 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
         // it is never `===` to the previous value once any of these moves.
         const extraData = [
             respondingPactId, renewingPactId, nudgingPactId,
+            // The awaiting-partner card's spinner keys off this; without it here the
+            // continue-solo/archive buttons would neither spin nor disable while their
+            // request runs — the same second-tap hole the pact flags close.
+            awaitingActionGoalId,
             // The ids themselves, not the count: one check-in finishing as another starts
             // leaves the size unchanged while the row that should be spinning has moved.
             [...checkinLoadingIds].sort().join(','),
@@ -1201,6 +1345,16 @@ export class HabitsDashboard extends React.Component<IHabitsDashboardProps, IHab
                     onConfirm={this.handleConfirmDecline}
                     text={this.translate('pages.pacts.confirmDecline')}
                     textConfirm={this.translate('modals.confirmModal.confirm')}
+                    textCancel={this.translate('modals.confirmModal.cancel')}
+                    translate={this.translate}
+                    themeButtons={this.themeButtons}
+                />
+                <ConfirmModal
+                    isVisible={!!habitPendingArchive}
+                    onCancel={this.handleCancelArchive}
+                    onConfirm={this.handleConfirmArchive}
+                    text={this.translate('pages.habits.habitArchived.confirm')}
+                    textConfirm={this.translate('pages.habits.habitArchived.confirmButton')}
                     textCancel={this.translate('modals.confirmModal.cancel')}
                     translate={this.translate}
                     themeButtons={this.themeButtons}

--- a/TherrMobile/main/routes/Habits/pactState.ts
+++ b/TherrMobile/main/routes/Habits/pactState.ts
@@ -1,4 +1,6 @@
-import { IHabitGoal, IPact, IPactMember } from 'therr-react/types';
+import {
+    IHabitGoal, IPact, IPactMember, IUserHabit,
+} from 'therr-react/types';
 
 /**
  * A habit goal paired with the state of the pact(s) it belongs to. A goal is
@@ -12,6 +14,13 @@ export interface IHabitWithPactState {
     goal: IHabitGoal;
     partnerNames: string[];
     awaitingPartnerNames: string[];
+    /**
+     * The tracking row for this goal, when one is loaded. Carries the id the
+     * archive / continue-solo actions address and the `status` the archived
+     * filter reads. Undefined when the user-habit list has not loaded yet — the
+     * card then renders read-only, without the two decision buttons.
+     */
+    userHabit?: IUserHabit;
 }
 
 const getMemberDisplayName = (member: IPactMember): string => {
@@ -108,37 +117,69 @@ export const hasTrackedHabit = (
  * Splits the habit list by whether its pact has started. Goals with no pact at
  * all are treated as live so a habit can never become un-checkin-able through
  * missing pact data.
+ *
+ * `userHabits` is the tracking registry. When supplied it does two things:
+ *
+ *   - **Hides archived habits.** Archiving is the user saying "stop bugging me
+ *     about this"; the reminders already stop server-side, and the dashboard has
+ *     to match by dropping the row from the active list. Passing an empty list
+ *     (the default) skips the filter, so callers that do not load the registry —
+ *     and the existing unit tests — behave exactly as before.
+ *   - **Attaches the tracking row** to each entry, so the awaiting-partner card
+ *     can offer "continue solo" / "archive" against the right habit id.
+ *
+ * The goal is matched to its tracking row by `habitGoalId`.
  */
 export const splitHabitsByPactState = (
     habitGoals: IHabitGoal[],
     activePacts: IPact[],
     allPacts: IPact[],
     currentUserId?: string,
-): { live: IHabitWithPactState[]; pending: IHabitWithPactState[] } => habitGoals.reduce(
-    (acc: { live: IHabitWithPactState[]; pending: IHabitWithPactState[] }, goal) => {
-        const goalActivePacts = activePacts.filter((p) => p.habitGoalId === goal.id);
-        const goalPendingPacts = allPacts.filter(
-            (p) => p.habitGoalId === goal.id && p.status === 'pending',
-        );
+    userHabits: IUserHabit[] = [],
+): { live: IHabitWithPactState[]; pending: IHabitWithPactState[] } => {
+    const userHabitByGoalId = new Map<string, IUserHabit>();
+    userHabits.forEach((habit) => {
+        userHabitByGoalId.set(habit.habitGoalId, habit);
+    });
 
-        if (goalActivePacts.length > 0 || goalPendingPacts.length === 0) {
-            acc.live.push({
-                goal,
-                partnerNames: getPartnerNames(goalActivePacts, currentUserId, 'active'),
-                awaitingPartnerNames: [],
-            });
-        } else {
-            acc.pending.push({
-                goal,
-                partnerNames: [],
-                awaitingPartnerNames: getPartnerNames(goalPendingPacts, currentUserId),
-            });
-        }
+    return habitGoals.reduce(
+        (acc: { live: IHabitWithPactState[]; pending: IHabitWithPactState[] }, goal) => {
+            const userHabit = userHabitByGoalId.get(goal.id);
 
-        return acc;
-    },
-    { live: [], pending: [] },
-);
+            // An archived habit is intentionally muted — keep it off the active
+            // dashboard entirely. A goal with no tracking row loaded is left in
+            // (undefined status is not "archived"), so an unloaded registry can
+            // never make habits vanish.
+            if (userHabit?.status === 'archived') {
+                return acc;
+            }
+
+            const goalActivePacts = activePacts.filter((p) => p.habitGoalId === goal.id);
+            const goalPendingPacts = allPacts.filter(
+                (p) => p.habitGoalId === goal.id && p.status === 'pending',
+            );
+
+            if (goalActivePacts.length > 0 || goalPendingPacts.length === 0) {
+                acc.live.push({
+                    goal,
+                    partnerNames: getPartnerNames(goalActivePacts, currentUserId, 'active'),
+                    awaitingPartnerNames: [],
+                    userHabit,
+                });
+            } else {
+                acc.pending.push({
+                    goal,
+                    partnerNames: [],
+                    awaitingPartnerNames: getPartnerNames(goalPendingPacts, currentUserId),
+                    userHabit,
+                });
+            }
+
+            return acc;
+        },
+        { live: [], pending: [] },
+    );
+};
 
 /**
  * Has this cycle already been continued by a re-commit?

--- a/TherrMobile/main/styles/habits/index.ts
+++ b/TherrMobile/main/styles/habits/index.ts
@@ -284,6 +284,57 @@ const buildStyles = (themeName?: IMobileThemeName) => {
             borderTopColor: therrTheme.colors.primary4,
         },
 
+        // "Continue solo / archive?" prompt on an awaiting-partner card — the
+        // escape hatch from reminders for a habit nobody has joined.
+        habitCardSoloPrompt: {
+            marginTop: 12,
+        },
+        habitCardSoloPromptText: {
+            fontFamily: therrFontFamily,
+            fontSize: 13,
+            color: therrTheme.colors.onSurfaceMuted,
+            marginBottom: 10,
+        },
+        habitCardSoloActions: {
+            flexDirection: 'row',
+            alignItems: 'center',
+        },
+        habitCardSoloButton: {
+            flex: 1,
+            backgroundColor: therrTheme.colors.brand,
+            borderRadius: 10,
+            paddingVertical: 10,
+            paddingHorizontal: 12,
+            alignItems: 'center',
+            marginRight: 8,
+        },
+        habitCardSoloButtonText: {
+            fontFamily: therrFontFamily,
+            fontSize: 14,
+            fontWeight: '600',
+            color: therrTheme.colors.onBrand,
+        },
+        habitCardArchiveButton: {
+            flex: 1,
+            backgroundColor: therrTheme.colors.surface,
+            borderRadius: 10,
+            borderWidth: 1,
+            borderColor: therrTheme.colors.primary4,
+            paddingVertical: 10,
+            paddingHorizontal: 12,
+            alignItems: 'center',
+        },
+        habitCardArchiveButtonText: {
+            fontFamily: therrFontFamily,
+            fontSize: 14,
+            fontWeight: '600',
+            color: therrTheme.colors.textGray,
+        },
+        habitCardSoloSpinner: {
+            alignSelf: 'flex-start',
+            paddingVertical: 10,
+        },
+
         // Calendar
         calendarContainer: {
             backgroundColor: therrTheme.colors.surface,


### PR DESCRIPTION
## What & why

On the habits dashboard, a habit whose invite is still **unanswered** now shows two buttons instead of just "waiting on a friend" — so the user can stop the annoying streak reminders for a habit nobody has joined.

- **Continue solo** — keep the habit alone. Abandons the invite server-side; a `solo-locked` 403 surfaces the "invite N more friends" progress rather than a dead end.
- **Archive** — mute the reminders (with a confirm). The pact stays *pending*, so the habit **auto-revives if the friend accepts later**.

This is the **mobile half**. It depends on the backend/shared PR **#2872** (base `general`). Merge **#2872 first**, then this.

## Changes (all `niche/HABITS-general`-bound — feature UI, no brand identity touched)

- **Dashboard** loads the user-habits registry and threads it through `splitHabitsByPactState` to (a) drop archived habits from the active list and (b) attach the tracking row each action addresses. Adds the two handlers, an archive confirm modal, and in-flight spinner state (wired into `FlatList` `extraData` so the buttons disable while a request runs).
- **HabitCard** renders the prompt + two buttons on an awaiting-partner card.
- Styles for the prompt/buttons; locale strings in `en-us`, `es`, `fr-ca` (kept in parity).
- `pactState` helper extended + regression tests for the archived filter and the row attach.

## Verification
- Locale JSON parses; all three dictionaries are in exact parity.
- Added `pactState` unit tests.
- ⚠️ `node_modules` was empty in the authoring env, so `jest` and the mobile `pr:tsc-baseline:mobile` could not run locally — CI must validate. No brand-identity files (brandConfig value, app.json, gradle, icons/splash) were touched, so the split is a clean feature-only change.

## Related
Backend/shared half: PR **#2872** (base `general`). **Merge order: #2872 first, this second.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pxYseTePZUtddFSM9GTwM

---
_Generated by [Claude Code](https://claude.ai/code/session_011pxYseTePZUtddFSM9GTwM)_