### PR TITLE
feat(habits-web): add the brand motto to the Friends with Habits landing page

### DIFF
--- a/therr-client-web/src/__tests__/habitsLandingSeo.test.ts
+++ b/therr-client-web/src/__tests__/habitsLandingSeo.test.ts
@@ -74,6 +74,30 @@ describe('habits landing page SEO markup', () => {
         );
     });
 
+    it('renders the brand motto and keeps the JSON-LD slogans byte-identical to it', () => {
+        // The motto is written in three places (visible copy, WebSite.slogan,
+        // MobileApplication.slogan). Nothing rejects a partial edit, so a reworded
+        // tagline silently leaves two stale copies in the structured data.
+        const MOTTO = "Friends don't let friends give up on change.";
+        expect(template).toContain(`<p class="motto">${MOTTO}</p>`);
+
+        const slogans = getJsonLd()['@graph']
+            .filter((node) => node.slogan)
+            .map((node) => node.slogan);
+        expect(slogans).toHaveLength(2);
+        slogans.forEach((slogan) => expect(slogan).toBe(MOTTO));
+    });
+
+    it('keeps the motto out of the h1', () => {
+        // The headline has to carry the head term this page ranks for; the motto is
+        // additive brand copy and must not displace it.
+        const h1 = template.match(/<h1[^>]*>([\s\S]*?)<\/h1>/);
+        if (!h1) {
+            throw new Error('No h1 found in habits/landing.hbs');
+        }
+        expect(h1[1]).not.toContain('give up on change');
+    });
+
     it('has exactly one h1', () => {
         expect(template.match(/<h1[\s>]/g)).toHaveLength(1);
     });

--- a/therr-client-web/src/views/habits/landing.hbs
+++ b/therr-client-web/src/views/habits/landing.hbs
@@ -97,6 +97,18 @@
                the hero sits directly under the header's own border-bottom. */
             border-top: none;
         }
+        /* The brand motto. Deliberately not the h1: the headline has to carry the
+           head term this page competes for ("habits", "friend"), and a motto that
+           reads well to a person indexes badly. It sits above the headline instead,
+           where it is the first thing read and costs the h1 nothing. */
+        .hero .motto {
+            font-size: 0.9375rem;
+            font-weight: 600;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            color: var(--habits-coral-dark);
+            margin: 0 0 0.875rem;
+        }
         .hero h1 {
             font-size: 2.25rem;
             font-weight: 800;
@@ -364,6 +376,7 @@
         }
         @media (min-width: 640px) {
             .hero { padding: 6rem 0 4rem; }
+            .hero .motto { font-size: 1rem; }
             .hero h1 { font-size: 3rem; }
             .hero p.lede { font-size: 1.25rem; }
             .step-list { grid-template-columns: repeat(3, 1fr); gap: 2rem; }
@@ -390,6 +403,7 @@
           "url": "https://habits.therr.com/",
           "name": "Friends with Habits",
           "description": "A free habit tracker built around accountability partners.",
+          "slogan": "Friends don't let friends give up on change.",
           "inLanguage": "en-US",
           "publisher": { "@id": "https://www.therr.app/#organization" }
         },
@@ -423,6 +437,7 @@
           "alternateName": "Therr: Friends With Habits",
           "url": "https://habits.therr.com/",
           "description": "A habit tracker that requires an accountability partner. Make a pact with a friend, check in daily with a photo or note as proof, and build a shared streak.",
+          "slogan": "Friends don't let friends give up on change.",
           "applicationCategory": "LifestyleApplication",
           "applicationSubCategory": "Habit Tracker",
           "operatingSystem": "Android 8.0 and up",
@@ -551,6 +566,7 @@
     <main>
         <section class="hero">
             <div class="container">
+                <p class="motto">Friends don't let friends give up on change.</p>
                 <h1>Habits that stick when a friend's on the hook too.</h1>
                 <p class="lede">Most habit apps let you give up in private. Friends with Habits doesn't. Pact with a friend, check in daily, and keep each other on streak.</p>
                 <!--


### PR DESCRIPTION
Adds the motto **"Friends don't let friends give up on change."** to the Friends with Habits landing page (`habits.therr.com`).

## What

Three coordinated places, one string:

1. **Hero kicker** above the `<h1>` — a small uppercase coral line in the existing brand palette, scaling up at the wide breakpoint with the rest of the hero.
2. **`slogan`** on the `WebSite` and `MobileApplication` JSON-LD nodes.
3. **Two regression tests** in `habitsLandingSeo.test.ts`.

## Why this shape

The motto carries the product's emotional argument, but it is a poor `h1`. The headline has to hold the head terms this page competes for — "habit tracker", "accountability partner" — and a motto that reads well to a person indexes badly. Putting it above the headline makes it the first thing a visitor reads while costing the `h1` nothing.

`slogan` is a real schema.org property on both node types, so the structured data is where the tagline earns its keep with search and answer engines rather than competing with the headline for the same slot.

That leaves the string written in three places with nothing tying them together — exactly the silent-drift shape the rest of that test file guards. One new test asserts the visible copy and both slogans stay byte-identical; the other asserts the motto never migrates into the `h1`.

## Branch

`therr-client-web` only, no brand-identity surface touched, so there is no niche half to this work — a single PR based on `general` rather than a split pair. It has to land here regardless: `habits.therr.com` is served by the same production pod as `therr.com`, which only deploys via `general → stage → main`. Committed to `niche/HABITS-general` it would render locally and never ship.

## Verification

| Gate | Result |
|---|---|
| `therr-client-web` Jest (all suites) | 220 passed / 220 |
| `habitsLandingSeo.test.ts` | 18 passed / 18 |
| `npm run pr:typecheck:web` | clean |
| `npx eslint` on changed files | clean |
| `npm run locales:check` | 0 errors, 0 warnings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQVAnghASKsoBFkvMBpEcH
