### PR TITLE
feat(habits): show main action menu on habit and pact detail screens

### DIFF
--- a/TherrMobile/main/routes/Habits/HabitDetail.tsx
+++ b/TherrMobile/main/routes/Habits/HabitDetail.tsx
@@ -13,10 +13,12 @@ import { RefreshControl } from 'react-native-gesture-handler';
 import Toast from 'react-native-toast-message';
 import translator from '../../utilities/translator';
 import { buildStyles } from '../../styles';
+import { buildStyles as buildMenuStyles, buttonMenuHeight } from '../../styles/navigation/buttonMenu';
 import { buildStyles as buildHabitStyles } from '../../styles/habits';
 import { buildStyles as buildConfirmModalStyles } from '../../styles/modal/confirmModal';
 import { buildStyles as buildButtonsStyles } from '../../styles/buttons';
 import BaseStatusBar from '../../components/BaseStatusBar';
+import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
 import {
     CheckinButton, CheckinDayDetailSheet, CheckinProofSheet, HabitCalendar, StreakWidget,
 } from '../../components/Habits';
@@ -92,6 +94,7 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
 export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetailState> {
     private translate: (key: string, params?: any) => string;
     private theme = buildStyles();
+    private themeMenu = buildMenuStyles();
     private themeHabits = buildHabitStyles();
     private themeConfirmModal = buildConfirmModalStyles();
     private themeButtons = buildButtonsStyles();
@@ -114,6 +117,7 @@ export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetail
             hasDayProofError: false,
         };
 
+        this.themeMenu = buildMenuStyles(props.user.settings?.mobileThemeName);
         this.themeHabits = buildHabitStyles(props.user.settings?.mobileThemeName);
         this.themeConfirmModal = buildConfirmModalStyles(props.user.settings?.mobileThemeName);
         this.themeButtons = buildButtonsStyles(props.user.settings?.mobileThemeName);
@@ -468,28 +472,41 @@ export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetail
 
         if (!habitGoal) {
             return (
-                <SafeAreaView edges={['bottom']} style={this.theme.styles.safeAreaView}>
-                    <View style={this.themeHabits.styles.emptyStateContainer}>
-                        <Text style={this.themeHabits.styles.emptyStateTitle}>
-                            {this.translate('pages.habits.habitNotFound')}
-                        </Text>
-                    </View>
-                </SafeAreaView>
+                <>
+                    <BaseStatusBar therrThemeName={user.settings?.mobileThemeName} />
+                    <SafeAreaView edges={[]} style={this.theme.styles.safeAreaView}>
+                        <View style={this.themeHabits.styles.emptyStateContainer}>
+                            <Text style={this.themeHabits.styles.emptyStateTitle}>
+                                {this.translate('pages.habits.habitNotFound')}
+                            </Text>
+                        </View>
+                    </SafeAreaView>
+                    {/* A habit reached by a stale deep link or notification may not resolve;
+                        the menu is the way back to a main page rather than a dead end. */}
+                    <MainButtonMenu
+                        navigation={this.props.navigation}
+                        onActionButtonPress={this.handleRefresh}
+                        translate={this.translate}
+                        user={user}
+                        themeMenu={this.themeMenu}
+                    />
+                </>
             );
         }
 
         return (
             <>
                 <BaseStatusBar therrThemeName={user.settings?.mobileThemeName} />
-                {/* `edges={['bottom']}`: Layout pads the header, but this screen has no
-                    ButtonMenu and its ScrollView runs to the bottom edge. React Native's
-                    own SafeAreaView is a no-op on Android, so that last row sat under the
-                    gesture handle. */}
+                {/* `edges={[]}`: Layout pads the header and the MainButtonMenu below pads
+                    the bottom, so this view applies no inset of its own. The ScrollView
+                    reserves `buttonMenuHeight` of bottom padding so its last row clears the
+                    fixed menu. */}
                 <SafeAreaView
-                    edges={['bottom']}
+                    edges={[]}
                     style={[this.theme.styles.safeAreaView, this.themeHabits.styles.dashboardContainer]}
                 >
                     <ScrollView
+                        contentContainerStyle={{ paddingBottom: buttonMenuHeight + 16 }}
                         refreshControl={
                             <RefreshControl
                                 refreshing={isRefreshing}
@@ -581,6 +598,13 @@ export class HabitDetail extends React.Component<IHabitDetailProps, IHabitDetail
                         )}
                     </ScrollView>
                 </SafeAreaView>
+                <MainButtonMenu
+                    navigation={this.props.navigation}
+                    onActionButtonPress={this.handleRefresh}
+                    translate={this.translate}
+                    user={user}
+                    themeMenu={this.themeMenu}
+                />
                 <CheckinDayDetailSheet
                     isVisible={!!selectedDay}
                     date={selectedDay}

--- a/TherrMobile/main/routes/Pacts/PactDetail.tsx
+++ b/TherrMobile/main/routes/Pacts/PactDetail.tsx
@@ -22,7 +22,9 @@ import { PactMemberRow } from '../../components/Habits';
 import { buildStyles } from '../../styles';
 import { buildStyles as buildButtonStyles } from '../../styles/buttons';
 import { buildStyles as buildHabitStyles } from '../../styles/habits';
+import { buildStyles as buildMenuStyles, buttonMenuHeight } from '../../styles/navigation/buttonMenu';
 import BaseStatusBar from '../../components/BaseStatusBar';
+import MainButtonMenu from '../../components/ButtonMenu/MainButtonMenu';
 import ConfirmModal from '../../components/Modals/ConfirmModal';
 import { buildStyles as buildModalStyles } from '../../styles/modal/confirmModal';
 
@@ -75,6 +77,7 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
     private theme = buildStyles();
     private themeButtons = buildButtonStyles();
     private themeHabits = buildHabitStyles();
+    private themeMenu = buildMenuStyles();
     private themeModal = buildModalStyles();
 
     constructor(props: IPactDetailProps) {
@@ -90,6 +93,7 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
         this.theme = buildStyles(props.user.settings?.mobileThemeName);
         this.themeButtons = buildButtonStyles(props.user.settings?.mobileThemeName);
         this.themeHabits = buildHabitStyles(props.user.settings?.mobileThemeName);
+        this.themeMenu = buildMenuStyles(props.user.settings?.mobileThemeName);
         this.themeModal = buildModalStyles(props.user.settings?.mobileThemeName);
         this.translate = (key: string, params?: any) =>
             translator(props.user.settings?.locale || 'en-us', key, params);
@@ -519,32 +523,45 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
 
         if (!pact) {
             return (
-                <SafeAreaView edges={['bottom']} style={this.theme.styles.safeAreaView}>
-                    <View style={this.themeHabits.styles.emptyStateContainer}>
-                        {isRefreshing
-                            ? <ActivityIndicator size="large" color={this.theme.colors.primary3} />
-                            : (
-                                <Text style={this.themeHabits.styles.emptyStateTitle}>
-                                    {this.translate('pages.pacts.pactNotFound')}
-                                </Text>
-                            )}
-                    </View>
-                </SafeAreaView>
+                <>
+                    <BaseStatusBar therrThemeName={user.settings?.mobileThemeName} />
+                    <SafeAreaView edges={[]} style={this.theme.styles.safeAreaView}>
+                        <View style={this.themeHabits.styles.emptyStateContainer}>
+                            {isRefreshing
+                                ? <ActivityIndicator size="large" color={this.theme.colors.primary3} />
+                                : (
+                                    <Text style={this.themeHabits.styles.emptyStateTitle}>
+                                        {this.translate('pages.pacts.pactNotFound')}
+                                    </Text>
+                                )}
+                        </View>
+                    </SafeAreaView>
+                    {/* A pact reached by a stale deep link or notification may not resolve;
+                        the menu is the way back to a main page rather than a dead end. */}
+                    <MainButtonMenu
+                        navigation={this.props.navigation}
+                        onActionButtonPress={this.handleRefresh}
+                        translate={this.translate}
+                        user={user}
+                        themeMenu={this.themeMenu}
+                    />
+                </>
             );
         }
 
         return (
             <>
                 <BaseStatusBar therrThemeName={user.settings?.mobileThemeName} />
-                {/* `edges={['bottom']}`: Layout pads the header, but this screen has no
-                    ButtonMenu and its ScrollView runs to the bottom edge. React Native's
-                    own SafeAreaView is a no-op on Android, so that last row sat under the
-                    gesture handle. */}
+                {/* `edges={[]}`: Layout pads the header and the MainButtonMenu below pads
+                    the bottom, so this view applies no inset of its own. The ScrollView
+                    reserves `buttonMenuHeight` of bottom padding so its last row clears the
+                    fixed menu. */}
                 <SafeAreaView
-                    edges={['bottom']}
+                    edges={[]}
                     style={[this.theme.styles.safeAreaView, this.themeHabits.styles.dashboardContainer]}
                 >
                     <ScrollView
+                        contentContainerStyle={{ paddingBottom: buttonMenuHeight + 16 }}
                         refreshControl={
                             <RefreshControl
                                 refreshing={isRefreshing}
@@ -688,6 +705,13 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
                         )}
                     </ScrollView>
                 </SafeAreaView>
+                <MainButtonMenu
+                    navigation={this.props.navigation}
+                    onActionButtonPress={this.handleRefresh}
+                    translate={this.translate}
+                    user={user}
+                    themeMenu={this.themeMenu}
+                />
 
                 <ConfirmModal
                     isVisible={showConfirmModal}

--- a/context/memory/2026-09-10.md
+++ b/context/memory/2026-09-10.md
@@ -1,0 +1,23 @@
+# 2026-09-10
+
+## Goal
+Add the main action menu (MainButtonMenu) to the HABITS habit-detail and
+pact-detail routes so users who land there from a notification/deep link can
+navigate back to the main pages instead of being stranded.
+
+## Deliverables
+- `TherrMobile/main/routes/Habits/HabitDetail.tsx`: render `MainButtonMenu`
+  (main render + not-found branch), switch SafeAreaView to `edges={[]}`, add
+  `paddingBottom: buttonMenuHeight + 16` to the ScrollView, wire `themeMenu`.
+- `TherrMobile/main/routes/Pacts/PactDetail.tsx`: same treatment.
+
+## Decisions
+- Niche-only change (TherrMobile UI, HABITS-only routes). Targets
+  `niche/HABITS-general`; no `general`/backend code touched, so a single PR.
+- `MainButtonMenu` (→ `HabitsButtonMenu` for HABITS) already lists `HabitDetail`
+  and `PactDetail` as habits-active routes, so the tab highlights correctly.
+- Added the menu to the not-found branches too, since that is exactly the stale
+  deep-link/notification case the user hit.
+
+## Open threads
+- Branch: `claude/habit-pact-detail-action-menu-haa6he`.


### PR DESCRIPTION
## Problem

The habit-detail and pact-detail routes in Friends with Habits render **no `MainButtonMenu`**, so a user who arrives directly — e.g. by tapping a notification that deep-links to a habit — has no bottom navigation to return to the main pages. Getting back means opening the drawer and picking a route that happens to have the menu, which is clunky and unintuitive. This was hit in practice when a notification linked straight to a habit detail route.

## Change

- Render `MainButtonMenu` on both `HabitDetail` and `PactDetail`. For the HABITS brand this resolves to `HabitsButtonMenu`, which already lists `HabitDetail` and `PactDetail` as habits-active routes, so the Habits tab highlights correctly — no menu changes were needed.
- Switch each screen's `SafeAreaView` from `edges={['bottom']}` to `edges={[]}`, since the fixed menu now pads the bottom (the previous `['bottom']` inset existed precisely because there was no menu).
- Reserve `buttonMenuHeight + 16` of bottom padding on each `ScrollView` so the last row clears the fixed menu — matching the established pattern in `MyHabits` and the habits `Dashboard`.
- Add the menu to the **"not found"** branches of both screens as well, which is exactly the stale deep-link / notification case that would otherwise strand the user on a dead-end page.

## Scope / branch

Niche-only: both files live under `TherrMobile/**` and are HABITS-specific routes; no shared/backend/`general` code is touched, so this is a single PR targeting `niche/HABITS-general`.

## Verification

- `npx eslint` on both files — 0 errors (2 pre-existing inline-style warnings in untouched lines).
- `npm run pr:tsc-baseline:mobile` — `current=105 baseline=105`, ✅ no new errors.
- Pre-push hook (changed-package tests) — 1162 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9d1MS7DtTCfd2frsMohhB

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9d1MS7DtTCfd2frsMohhB)_