### PR TITLE
feat(habits mobile): pact streak, member add/remove & continue-solo UI

### DIFF
--- a/TherrMobile/__tests__/routes/PactMemberManagement.test.ts
+++ b/TherrMobile/__tests__/routes/PactMemberManagement.test.ts
@@ -1,0 +1,68 @@
+import { it, describe, expect } from '@jest/globals';
+import {
+    MIN_PACT_MEMBERS,
+    canManagePactMembers,
+    canRemovePactMember,
+} from '../../main/routes/Habits/pactState';
+
+/**
+ * Client-side gates for pact member management — mirror the users-service authority
+ * (`utilities/pactStreak.ts`). A drift here only shows the wrong affordance; the server
+ * re-checks and rejects. These pin the "creator only", "floor of 2", and "solo escape hatch"
+ * rules the UI draws from.
+ */
+describe('canManagePactMembers', () => {
+    const creatorId = 'creator-1';
+
+    it('lets the creator manage an active pact', () => {
+        expect(canManagePactMembers({ creatorUserId: creatorId, status: 'active' }, creatorId)).toBe(true);
+    });
+
+    it('lets the creator manage a still-pending pact', () => {
+        expect(canManagePactMembers({ creatorUserId: creatorId, status: 'pending' }, creatorId)).toBe(true);
+    });
+
+    it('does not let a non-creator manage members', () => {
+        expect(canManagePactMembers({ creatorUserId: creatorId, status: 'active' }, 'someone-else')).toBe(false);
+    });
+
+    it('does not offer management on a finished/abandoned pact', () => {
+        expect(canManagePactMembers({ creatorUserId: creatorId, status: 'completed' }, creatorId)).toBe(false);
+        expect(canManagePactMembers({ creatorUserId: creatorId, status: 'abandoned' }, creatorId)).toBe(false);
+    });
+
+    it('does not offer management on a renewable (ended-but-unswept) pact', () => {
+        const ended = {
+            creatorUserId: creatorId,
+            status: 'active',
+            endDate: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+        };
+        expect(canManagePactMembers(ended, creatorId)).toBe(false);
+    });
+});
+
+describe('canRemovePactMember', () => {
+    it('always allows rescinding a pending invite', () => {
+        expect(canRemovePactMember({ activeMemberCount: 2 }, { role: 'partner', status: 'pending' })).toBe(true);
+    });
+
+    it('allows removing an active member only while the floor still holds', () => {
+        expect(MIN_PACT_MEMBERS).toBe(2);
+        // 3 active -> 2 remain, still a pact
+        expect(canRemovePactMember({ activeMemberCount: 3 }, { role: 'partner', status: 'active' })).toBe(true);
+        // 2 active -> 1 remain, below the floor (the last member takes continue-solo instead)
+        expect(canRemovePactMember({ activeMemberCount: 2 }, { role: 'partner', status: 'active' })).toBe(false);
+    });
+
+    it('never removes the creator', () => {
+        expect(canRemovePactMember({ activeMemberCount: 3 }, { role: 'creator', status: 'active' })).toBe(false);
+    });
+
+    it('treats an unknown active count as not removable (safe direction)', () => {
+        expect(canRemovePactMember({}, { role: 'partner', status: 'active' })).toBe(false);
+    });
+
+    it('does not remove a member who has already left', () => {
+        expect(canRemovePactMember({ activeMemberCount: 3 }, { role: 'partner', status: 'left' })).toBe(false);
+    });
+});

--- a/TherrMobile/main/components/Habits/PactMemberRow.tsx
+++ b/TherrMobile/main/components/Habits/PactMemberRow.tsx
@@ -13,6 +13,8 @@ interface IPactMemberRowProps {
     onPress: () => void;
     /** Omitted when direct messaging is unavailable for the brand. */
     onMessagePress?: () => void;
+    /** Creator-only. Present makes this member removable from the pact. */
+    onRemovePress?: () => void;
     themeHabits: {
         colors: ITherrThemeColors;
         styles: any;
@@ -73,6 +75,7 @@ const PactMemberRow: React.FC<IPactMemberRowProps> = ({
     isDivided,
     onPress,
     onMessagePress,
+    onRemovePress,
     themeHabits,
     translate,
 }) => {
@@ -153,6 +156,23 @@ const PactMemberRow: React.FC<IPactMemberRowProps> = ({
                         name="chat-bubble-outline"
                         size={20}
                         color={themeHabits.colors.primary3}
+                    />
+                </Pressable>
+            )}
+            {onRemovePress && (
+                <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={translate('pages.pacts.removeMemberAction', { name })}
+                    onPress={onRemovePress}
+                    style={({ pressed }) => [
+                        themeHabits.styles.pactMemberAction,
+                        pressed && themeHabits.styles.pactPressedSurface,
+                    ]}
+                >
+                    <MaterialIcon
+                        name="person-remove"
+                        size={20}
+                        color={themeHabits.colors.alertError || themeHabits.colors.textGray}
                     />
                 </Pressable>
             )}

--- a/TherrMobile/main/locales/en-us/dictionary.json
+++ b/TherrMobile/main/locales/en-us/dictionary.json
@@ -2153,6 +2153,31 @@
             "abandonError": "Failed to abandon pact. Please try again.",
             "confirmDecline": "Are you sure you want to decline this pact invitation?",
             "confirmAbandon": "Are you sure you want to abandon this pact? Your progress will be lost.",
+            "confirmRemoveMember": "Remove {name} from this pact?",
+            "addMembers": "Add members",
+            "addMembersTitle": "Add members",
+            "addMembersSubtitle": "Choose friends to invite into this pact.",
+            "addMembersEmpty": "You don't have any connections to add yet.",
+            "addMembersCta": "Invite {count} to the pact",
+            "addMembersSuccessTitle": "Invites sent",
+            "addMembersSuccessMessage": "Invited {count} to the pact.",
+            "addMembersError": "We couldn't add those members. Please try again.",
+            "removeMemberAction": "Remove {name}",
+            "removeMemberSuccess": "Member removed from the pact.",
+            "removeMemberError": "We couldn't remove that member. Please try again.",
+            "pactStreak": {
+                "title": "Pact streak",
+                "currentLabel": "Current",
+                "longestLabel": "Best",
+                "explainer": "Your pact streak grows on any day most of you check in — a couple of misses won't break it."
+            },
+            "solo": {
+                "prompt": "You're the last one keeping this pact. Want to continue it on your own?",
+                "cta": "Continue solo",
+                "successTitle": "You're going solo",
+                "successMessage": "This pact will keep going with just you.",
+                "error": "We couldn't continue this pact solo. Please try again."
+            },
             "onboarding": {
                 "title": "Start with a Friend",
                 "subtitle": "{appName} is built for two — or more. Invite a friend, or form a group around a shared goal (like saving for a vacation), and build habits you'll hold each other to.",

--- a/TherrMobile/main/locales/es/dictionary.json
+++ b/TherrMobile/main/locales/es/dictionary.json
@@ -2153,6 +2153,31 @@
             "abandonError": "No se pudo abandonar el pacto. Inténtalo de nuevo.",
             "confirmDecline": "¿Estás seguro de que quieres rechazar esta invitación al pacto?",
             "confirmAbandon": "¿Estás seguro de que quieres abandonar este pacto? Se perderá tu progreso.",
+            "confirmRemoveMember": "¿Quitar a {name} de este pacto?",
+            "addMembers": "Agregar miembros",
+            "addMembersTitle": "Agregar miembros",
+            "addMembersSubtitle": "Elige amigos para invitar a este pacto.",
+            "addMembersEmpty": "Todavía no tienes conexiones para agregar.",
+            "addMembersCta": "Invitar a {count} al pacto",
+            "addMembersSuccessTitle": "Invitaciones enviadas",
+            "addMembersSuccessMessage": "Invitaste a {count} al pacto.",
+            "addMembersError": "No pudimos agregar a esos miembros. Inténtalo de nuevo.",
+            "removeMemberAction": "Quitar a {name}",
+            "removeMemberSuccess": "Miembro quitado del pacto.",
+            "removeMemberError": "No pudimos quitar a ese miembro. Inténtalo de nuevo.",
+            "pactStreak": {
+                "title": "Racha del pacto",
+                "currentLabel": "Actual",
+                "longestLabel": "Mejor",
+                "explainer": "La racha del pacto crece cualquier día que la mayoría registra su avance: un par de faltas no la rompen."
+            },
+            "solo": {
+                "prompt": "Eres la última persona en este pacto. ¿Quieres continuarlo por tu cuenta?",
+                "cta": "Continuar en solitario",
+                "successTitle": "Continúas en solitario",
+                "successMessage": "Este pacto seguirá solo contigo.",
+                "error": "No pudimos continuar este pacto en solitario. Inténtalo de nuevo."
+            },
             "onboarding": {
                 "title": "Empieza con un amigo",
                 "subtitle": "{appName} está hecho para dos — o más. Invita a un amigo o forma un grupo en torno a una meta compartida (como ahorrar para unas vacaciones) y construyan hábitos a los que se comprometan juntos.",

--- a/TherrMobile/main/locales/fr-ca/dictionary.json
+++ b/TherrMobile/main/locales/fr-ca/dictionary.json
@@ -2153,6 +2153,31 @@
             "abandonError": "Impossible d'abandonner le pacte. Veuillez réessayer.",
             "confirmDecline": "Êtes-vous sûr de vouloir refuser cette invitation au pacte?",
             "confirmAbandon": "Êtes-vous sûr de vouloir abandonner ce pacte? Vos progrès seront perdus.",
+            "confirmRemoveMember": "Retirer {name} de ce pacte?",
+            "addMembers": "Ajouter des membres",
+            "addMembersTitle": "Ajouter des membres",
+            "addMembersSubtitle": "Choisis des amis à inviter dans ce pacte.",
+            "addMembersEmpty": "Tu n'as pas encore de relations à ajouter.",
+            "addMembersCta": "Inviter {count} au pacte",
+            "addMembersSuccessTitle": "Invitations envoyées",
+            "addMembersSuccessMessage": "Tu as invité {count} au pacte.",
+            "addMembersError": "Nous n'avons pas pu ajouter ces membres. Réessaie.",
+            "removeMemberAction": "Retirer {name}",
+            "removeMemberSuccess": "Membre retiré du pacte.",
+            "removeMemberError": "Nous n'avons pas pu retirer ce membre. Réessaie.",
+            "pactStreak": {
+                "title": "Série du pacte",
+                "currentLabel": "Actuelle",
+                "longestLabel": "Record",
+                "explainer": "La série du pacte progresse chaque jour où la majorité fait son suivi — quelques oublis ne la brisent pas."
+            },
+            "solo": {
+                "prompt": "Tu es la dernière personne à tenir ce pacte. Veux-tu le continuer seul(e)?",
+                "cta": "Continuer en solo",
+                "successTitle": "Tu continues en solo",
+                "successMessage": "Ce pacte continuera avec toi seul(e).",
+                "error": "Nous n'avons pas pu continuer ce pacte en solo. Réessaie."
+            },
             "onboarding": {
                 "title": "Commence avec un ami",
                 "subtitle": "{appName} est conçu pour deux — ou plus. Invite un ami ou forme un groupe autour d'un objectif commun (comme épargner pour des vacances) et bâtissez ensemble des habitudes dont vous vous tiendrez responsables.",

--- a/TherrMobile/main/routes/Habits/pactState.ts
+++ b/TherrMobile/main/routes/Habits/pactState.ts
@@ -29,6 +29,57 @@ const getMemberDisplayName = (member: IPactMember): string => {
 };
 
 /**
+ * A pact must keep at least this many members to remain a pact. Mirrors
+ * `MIN_PACT_MEMBERS` in users-service (`utilities/pactStreak.ts`), which is the authority —
+ * the server re-checks removal and 409s one that would drop below it, so a drift here only
+ * shows the wrong affordance rather than corrupting anything.
+ */
+export const MIN_PACT_MEMBERS = 2;
+
+/**
+ * Whether the current user may add or remove members on this pact: only the creator, and only
+ * while the pact is still live (pending or active) and not a finished cycle awaiting re-commit.
+ */
+export const canManagePactMembers = (
+    pact: { creatorUserId?: string; status?: string } | null | undefined,
+    currentUserId?: string,
+): boolean => {
+    if (!pact || !currentUserId || pact.creatorUserId !== currentUserId) {
+        return false;
+    }
+    if (isPactRenewable(pact)) {
+        return false;
+    }
+    return pact.status === 'active' || pact.status === 'pending';
+};
+
+/**
+ * Whether a specific member may be removed by the creator right now.
+ *
+ * A pending invite is always removable (rescinding it never touches the active group). An
+ * active member is removable only while more than the minimum would remain — otherwise the
+ * last remaining member takes the continue-solo path instead. Uses the server-derived
+ * `activeMemberCount`; when it is absent (older service) an active member is treated as not
+ * removable, the safe direction, since the floor cannot be verified client-side.
+ */
+export const canRemovePactMember = (
+    pact: { activeMemberCount?: number } | null | undefined,
+    member: { role?: string; status?: string } | null | undefined,
+): boolean => {
+    if (!pact || !member || member.role !== 'partner') {
+        return false;
+    }
+    if (member.status === 'pending') {
+        return true;
+    }
+    if (member.status !== 'active') {
+        return false;
+    }
+    return typeof pact.activeMemberCount === 'number'
+        && pact.activeMemberCount - 1 >= MIN_PACT_MEMBERS;
+};
+
+/**
  * Names of everyone but the current user who is a partner on the given pacts,
  * optionally narrowed to a single membership status.
  */

--- a/TherrMobile/main/routes/Pacts/AddPactMembers.tsx
+++ b/TherrMobile/main/routes/Pacts/AddPactMembers.tsx
@@ -1,0 +1,269 @@
+import React from 'react';
+import {
+    View, Text, ScrollView, Pressable, ActivityIndicator,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import MaterialIcon from 'react-native-vector-icons/MaterialIcons';
+import Toast from 'react-native-toast-message';
+import { HabitActions } from 'therr-react/redux/actions';
+import { IUserState } from 'therr-react/types';
+import translator from '../../utilities/translator';
+import { Button } from '../../components/BaseButton';
+import { Avatar } from '../../components/BaseAvatar';
+import { getUserImageUri } from '../../utilities/content';
+import { buildStyles } from '../../styles';
+import { buildStyles as buildButtonStyles } from '../../styles/buttons';
+import { buildStyles as buildHabitStyles } from '../../styles/habits';
+import { buttonMenuHeight } from '../../styles/navigation/buttonMenu';
+import BaseStatusBar from '../../components/BaseStatusBar';
+
+// Server caps a single add at this many; keep the client in step so the button disables before
+// a request the API would reject.
+const MAX_ADD_AT_ONCE = 5;
+
+interface IConnectionDetails {
+    id: string;
+    firstName?: string;
+    lastName?: string;
+    userName?: string;
+    media?: any;
+}
+
+interface IDispatchProps {
+    addPactMembers: Function;
+    getPactDetails: Function;
+}
+
+interface IStoreProps extends IDispatchProps {
+    user: IUserState;
+    userConnections: any;
+}
+
+export interface IAddPactMembersProps extends IStoreProps {
+    navigation: any;
+    // `any` (not a strict `{ params: { pactId } }`) so the connected component stays assignable to
+    // React Navigation's ScreenComponentType — the same reason CreatePactInvite types it loosely.
+    route: any;
+}
+
+interface IAddPactMembersState {
+    selectedIds: string[];
+    isSubmitting: boolean;
+}
+
+const mapStateToProps = (state: any) => ({
+    user: state.user,
+    userConnections: state.userConnections,
+});
+
+const mapDispatchToProps = (dispatch: any) => bindActionCreators({
+    addPactMembers: HabitActions.addPactMembers,
+    getPactDetails: HabitActions.getPactDetails,
+}, dispatch);
+
+/**
+ * The other user in a connection record. Mirrors the wizard's `resolvePartnerDetails`: a
+ * connection carries both users, so pick the one that is not the current user.
+ */
+const resolvePartnerDetails = (connection: any, currentUserId: string): IConnectionDetails => {
+    if (connection?.users) {
+        return connection.users.find((u: any) => u.id !== currentUserId) || connection.users[0] || {};
+    }
+    return connection;
+};
+
+const partnerName = (details: IConnectionDetails, fallback: string): string => {
+    const full = `${details.firstName || ''} ${details.lastName || ''}`.trim();
+    return full || details.userName || fallback;
+};
+
+/**
+ * Add people to an existing pact. Deliberately a small, dedicated screen rather than a detour
+ * through the growth-critical create-pact wizard: the habit goal is already fixed (it is the
+ * pact's), so all this needs is a multi-select over the user's connections and one call.
+ */
+export class AddPactMembers extends React.Component<IAddPactMembersProps, IAddPactMembersState> {
+    private translate: (key: string, params?: any) => string;
+    private theme = buildStyles();
+    private themeButtons = buildButtonStyles();
+    private themeHabits = buildHabitStyles();
+
+    constructor(props: IAddPactMembersProps) {
+        super(props);
+
+        this.state = {
+            selectedIds: [],
+            isSubmitting: false,
+        };
+
+        this.theme = buildStyles(props.user.settings?.mobileThemeName);
+        this.themeButtons = buildButtonStyles(props.user.settings?.mobileThemeName);
+        this.themeHabits = buildHabitStyles(props.user.settings?.mobileThemeName);
+        this.translate = (key: string, params?: any) => translator(props.user.settings?.locale || 'en-us', key, params);
+    }
+
+    componentDidMount() {
+        this.props.navigation.setOptions({
+            title: this.translate('pages.pacts.addMembersTitle'),
+        });
+    }
+
+    getFriends = (): IConnectionDetails[] => {
+        const { user, userConnections } = this.props;
+        const currentUserId = user.details?.id || '';
+        const connections = (userConnections?.activeConnections || userConnections?.connections || []) as any[];
+
+        const byId: { [id: string]: IConnectionDetails } = {};
+        const friends: IConnectionDetails[] = [];
+        connections.forEach((c: any) => {
+            const partner = resolvePartnerDetails(c, currentUserId);
+            if (partner?.id && partner.id !== currentUserId && !byId[partner.id]) {
+                byId[partner.id] = partner;
+                friends.push(partner);
+            }
+        });
+        return friends;
+    };
+
+    toggleSelected = (id: string) => {
+        this.setState((prev) => {
+            if (prev.selectedIds.includes(id)) {
+                return { selectedIds: prev.selectedIds.filter((s) => s !== id) } as IAddPactMembersState;
+            }
+            if (prev.selectedIds.length >= MAX_ADD_AT_ONCE) {
+                return prev;
+            }
+            return { selectedIds: [...prev.selectedIds, id] } as IAddPactMembersState;
+        });
+    };
+
+    handleSubmit = () => {
+        const { addPactMembers, getPactDetails, navigation, route } = this.props;
+        const { pactId } = route.params;
+        const { selectedIds } = this.state;
+
+        if (!selectedIds.length) {
+            return;
+        }
+
+        this.setState({ isSubmitting: true });
+
+        addPactMembers(pactId, selectedIds)
+            .then(() => {
+                Toast.show({
+                    type: 'success',
+                    text1: this.translate('pages.pacts.addMembersSuccessTitle'),
+                    text2: this.translate('pages.pacts.addMembersSuccessMessage', { count: selectedIds.length }),
+                    visibilityTime: 2500,
+                });
+                // Refresh the pact the user is returning to so the new pending invites show.
+                Promise.resolve(getPactDetails(pactId)).catch(() => undefined);
+                navigation.goBack();
+            })
+            .catch((error: any) => {
+                const apiMessage = error?.statusCode && typeof error?.message === 'string'
+                    ? error.message
+                    : '';
+                Toast.show({
+                    type: 'error',
+                    text1: this.translate('pages.pacts.errorTitle'),
+                    text2: apiMessage || this.translate('pages.pacts.addMembersError'),
+                    visibilityTime: 3000,
+                });
+            })
+            .finally(() => {
+                this.setState({ isSubmitting: false });
+            });
+    };
+
+    renderFriendRow = (friend: IConnectionDetails, index: number) => {
+        const { selectedIds } = this.state;
+        const isSelected = selectedIds.includes(friend.id);
+        const name = partnerName(friend, this.translate('pages.pacts.partnerFallback'));
+
+        return (
+            <Pressable
+                key={friend.id}
+                accessibilityRole="checkbox"
+                accessibilityState={{ checked: isSelected }}
+                accessibilityLabel={name}
+                onPress={() => this.toggleSelected(friend.id)}
+                style={({ pressed }) => [
+                    this.themeHabits.styles.pactMemberRow,
+                    index > 0 && this.themeHabits.styles.pactMemberRowDivided,
+                    { paddingHorizontal: 16, alignItems: 'center' },
+                    pressed && this.themeHabits.styles.pactPressedSurface,
+                ]}
+            >
+                <Avatar
+                    title={(name[0] || '?').toUpperCase()}
+                    rounded
+                    size="small"
+                    source={{ uri: getUserImageUri({ details: { id: friend.id, media: friend.media } }, 100) }}
+                />
+                <View style={this.themeHabits.styles.pactMemberDetails}>
+                    <Text style={this.themeHabits.styles.pactMemberName}>{name}</Text>
+                </View>
+                <MaterialIcon
+                    name={isSelected ? 'check-box' : 'check-box-outline-blank'}
+                    size={24}
+                    color={isSelected ? this.themeHabits.colors.primary3 : this.themeHabits.colors.textGray}
+                />
+            </Pressable>
+        );
+    };
+
+    render() {
+        const { user } = this.props;
+        const { selectedIds, isSubmitting } = this.state;
+        const friends = this.getFriends();
+
+        return (
+            <>
+                <BaseStatusBar therrThemeName={user.settings?.mobileThemeName} />
+                <SafeAreaView
+                    edges={[]}
+                    style={[this.theme.styles.safeAreaView, this.themeHabits.styles.dashboardContainer]}
+                >
+                    <ScrollView contentContainerStyle={{ paddingBottom: buttonMenuHeight + 96 }}>
+                        <Text style={[this.themeHabits.styles.dashboardSubtitle, { paddingHorizontal: 20, marginTop: 12 }]}>
+                            {this.translate('pages.pacts.addMembersSubtitle')}
+                        </Text>
+                        <Text style={[this.themeHabits.styles.streakMilestoneText, { paddingHorizontal: 20, marginTop: 8 }]}>
+                            {this.translate('pages.pacts.wizard.multiSelectCounter', { count: selectedIds.length })}
+                        </Text>
+
+                        {friends.length > 0
+                            ? friends.map((f, i) => this.renderFriendRow(f, i))
+                            : (
+                                <View style={[this.themeHabits.styles.emptyStateContainer, { paddingTop: 24 }]}>
+                                    <Text style={this.themeHabits.styles.emptyStateEmoji}>{'🤝'}</Text>
+                                    <Text style={this.themeHabits.styles.emptyStateTitle}>
+                                        {this.translate('pages.pacts.addMembersEmpty')}
+                                    </Text>
+                                </View>
+                            )}
+                    </ScrollView>
+
+                    <View style={{ paddingHorizontal: 16, paddingBottom: 16 }}>
+                        {isSubmitting
+                            ? <ActivityIndicator size="large" color={this.theme.colors.primary3} />
+                            : (
+                                <Button
+                                    buttonStyle={this.themeButtons.styles.btnLargeWithText}
+                                    titleStyle={this.themeButtons.styles.btnLargeTitle}
+                                    title={this.translate('pages.pacts.addMembersCta', { count: selectedIds.length })}
+                                    onPress={this.handleSubmit}
+                                    disabled={!selectedIds.length || isSubmitting}
+                                />
+                            )}
+                    </View>
+                </SafeAreaView>
+            </>
+        );
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(AddPactMembers);

--- a/TherrMobile/main/routes/Pacts/PactDetail.tsx
+++ b/TherrMobile/main/routes/Pacts/PactDetail.tsx
@@ -10,7 +10,7 @@ import permissions from '../../utilities/permissionsOrchestrator';
 import isPactInviteAwaitingResponse from '../../utilities/pactInviteState';
 // Shared so the pending-pact wording can't drift between the card and this screen.
 import { getStatusText } from '../../components/Habits/PactCard';
-import { isPactRenewable } from '../Habits/pactState';
+import { isPactRenewable, canManagePactMembers, canRemovePactMember } from '../Habits/pactState';
 import getPactTimeline from '../../utilities/pactTimeline';
 import getConfig from '../../utilities/getConfig';
 import { IUserState, IHabitsState, IPact, IPactMember } from 'therr-react/types';
@@ -35,6 +35,8 @@ interface IPactDetailDispatchProps {
     declinePact: Function;
     abandonPact: Function;
     renewPact: Function;
+    continueSoloPact: Function;
+    removePactMember: Function;
 }
 
 interface IStoreProps extends IPactDetailDispatchProps {
@@ -55,7 +57,9 @@ interface IPactDetailState {
     isRefreshing: boolean;
     isActionLoading: boolean;
     showConfirmModal: boolean;
-    confirmAction: 'decline' | 'abandon' | null;
+    confirmAction: 'decline' | 'abandon' | 'removeMember' | null;
+    /** The member the removal confirm is targeting, set only for confirmAction === 'removeMember'. */
+    memberToRemove: IPactMember | null;
 }
 
 const mapStateToProps = (state: any) => ({
@@ -70,6 +74,8 @@ const mapDispatchToProps = (dispatch: any) => bindActionCreators({
     declinePact: HabitActions.declinePact,
     abandonPact: HabitActions.abandonPact,
     renewPact: HabitActions.renewPact,
+    continueSoloPact: HabitActions.continueSoloPact,
+    removePactMember: HabitActions.removePactMember,
 }, dispatch);
 
 export class PactDetail extends React.Component<IPactDetailProps, IPactDetailState> {
@@ -88,6 +94,7 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
             isActionLoading: false,
             showConfirmModal: false,
             confirmAction: null,
+            memberToRemove: null,
         };
 
         this.theme = buildStyles(props.user.settings?.mobileThemeName);
@@ -228,11 +235,46 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
     };
 
     handleConfirmAction = () => {
-        const { declinePact, abandonPact, route, navigation } = this.props;
+        const { declinePact, abandonPact, removePactMember, route, navigation } = this.props;
         const { pactId } = route.params;
-        const { confirmAction } = this.state;
+        const { confirmAction, memberToRemove } = this.state;
 
         this.setState({ isActionLoading: true, showConfirmModal: false });
+
+        // Member removal stays on this screen (the pact lives on for everyone else); decline and
+        // abandon end the user's involvement, so they pop back to the list.
+        if (confirmAction === 'removeMember') {
+            const targetUserId = memberToRemove?.userId;
+            if (!targetUserId) {
+                this.setState({ isActionLoading: false, confirmAction: null, memberToRemove: null });
+                return;
+            }
+            removePactMember(pactId, targetUserId)
+                .then(() => {
+                    Toast.show({
+                        type: 'success',
+                        text1: this.translate('pages.pacts.successTitle'),
+                        text2: this.translate('pages.pacts.removeMemberSuccess'),
+                        visibilityTime: 2000,
+                    });
+                    this.handleRefresh();
+                })
+                .catch((error: any) => {
+                    const apiMessage = error?.statusCode && typeof error?.message === 'string'
+                        ? error.message
+                        : '';
+                    Toast.show({
+                        type: 'error',
+                        text1: this.translate('pages.pacts.errorTitle'),
+                        text2: apiMessage || this.translate('pages.pacts.removeMemberError'),
+                        visibilityTime: 3000,
+                    });
+                })
+                .finally(() => {
+                    this.setState({ isActionLoading: false, confirmAction: null, memberToRemove: null });
+                });
+            return;
+        }
 
         const action = confirmAction === 'decline' ? declinePact : abandonPact;
         const successKey = confirmAction === 'decline' ? 'declinedMessage' : 'abandonedMessage';
@@ -257,8 +299,51 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
                 });
             })
             .finally(() => {
-                this.setState({ isActionLoading: false, confirmAction: null });
+                this.setState({ isActionLoading: false, confirmAction: null, memberToRemove: null });
             });
+    };
+
+    handleRemoveMember = (member: IPactMember) => {
+        this.setState({ showConfirmModal: true, confirmAction: 'removeMember', memberToRemove: member });
+    };
+
+    handleContinueSolo = () => {
+        const { continueSoloPact, route } = this.props;
+        const { pactId } = route.params;
+
+        this.setState({ isActionLoading: true });
+
+        continueSoloPact(pactId)
+            .then(() => {
+                Toast.show({
+                    type: 'success',
+                    text1: this.translate('pages.pacts.solo.successTitle'),
+                    text2: this.translate('pages.pacts.solo.successMessage'),
+                    visibilityTime: 3000,
+                });
+                this.handleRefresh();
+            })
+            .catch((error: any) => {
+                const apiMessage = error?.statusCode && typeof error?.message === 'string'
+                    ? error.message
+                    : '';
+                Toast.show({
+                    type: 'error',
+                    text1: this.translate('pages.pacts.errorTitle'),
+                    text2: apiMessage || this.translate('pages.pacts.solo.error'),
+                    visibilityTime: 3000,
+                });
+            })
+            .finally(() => {
+                this.setState({ isActionLoading: false });
+            });
+    };
+
+    goToAddMembers = (pact: IPact) => {
+        this.props.navigation.navigate('AddPactMembers', {
+            pactId: pact.id,
+            habitName: pact.habitGoalName,
+        });
     };
 
     /**
@@ -318,7 +403,21 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
     };
 
     handleCancelConfirm = () => {
-        this.setState({ showConfirmModal: false, confirmAction: null });
+        this.setState({ showConfirmModal: false, confirmAction: null, memberToRemove: null });
+    };
+
+    getConfirmText = (confirmAction: IPactDetailState['confirmAction']): string => {
+        if (confirmAction === 'decline') {
+            return this.translate('pages.pacts.confirmDecline');
+        }
+        if (confirmAction === 'removeMember') {
+            const { memberToRemove } = this.state;
+            const name = memberToRemove?.firstName
+                || memberToRemove?.userName
+                || this.translate('pages.pacts.partnerFallback');
+            return this.translate('pages.pacts.confirmRemoveMember', { name });
+        }
+        return this.translate('pages.pacts.confirmAbandon');
     };
 
     renderMemberStats = (
@@ -427,8 +526,11 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
 
     renderMembersCard = (pact: IPact, currentUserId: string) => {
         const otherMembers = (pact.members || []).filter((m) => m.userId !== currentUserId);
+        const canManageMembers = canManagePactMembers(pact, currentUserId);
 
-        if (!otherMembers.length) {
+        // With member management the creator always needs this card — it holds the "add members"
+        // button even on a pact with no partners yet (a solo pact they want to reopen).
+        if (!otherMembers.length && !canManageMembers) {
             return null;
         }
 
@@ -448,10 +550,98 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
                         onMessagePress={isDirectMessagingEnabled && member.userName
                             ? () => this.goToDirectMessage(member)
                             : undefined}
+                        onRemovePress={canManageMembers && canRemovePactMember(pact, member)
+                            ? () => this.handleRemoveMember(member)
+                            : undefined}
                         themeHabits={this.themeHabits}
                         translate={this.translate}
                     />
                 ))}
+                {canManageMembers && (
+                    <Button
+                        buttonStyle={[this.themeButtons.styles.btnClear, { marginTop: 12 }]}
+                        titleStyle={this.themeButtons.styles.btnTitleBlack}
+                        icon={(
+                            <MaterialIcon
+                                name="person-add"
+                                size={20}
+                                color={this.themeHabits.colors.primary3}
+                                style={{ marginRight: 8 }}
+                            />
+                        )}
+                        title={this.translate('pages.pacts.addMembers')}
+                        onPress={() => this.goToAddMembers(pact)}
+                    />
+                )}
+            </View>
+        );
+    };
+
+    /**
+     * The shared pact streak — the group's own streak, distinct from each member's. Shown on the
+     * detail screen for an active pact once the group has built one. The number carries across a
+     * renewal, so it is not gated on the current cycle's age.
+     */
+    renderPactStreakCard = (pact: IPact) => {
+        if (pact.status !== 'active' || !pact.currentPactStreak) {
+            return null;
+        }
+
+        return (
+            <View style={this.themeHabits.styles.streakWidgetContainer}>
+                <Text style={this.themeHabits.styles.streakWidgetTitle}>
+                    {this.translate('pages.pacts.pactStreak.title')}
+                </Text>
+                <View style={this.themeHabits.styles.pactComparisonContainer}>
+                    <View style={this.themeHabits.styles.pactComparisonItem}>
+                        <Text style={this.themeHabits.styles.pactComparisonValue}>
+                            {'🔥 '}{pact.currentPactStreak}
+                        </Text>
+                        <Text style={this.themeHabits.styles.pactComparisonLabel}>
+                            {this.translate('pages.pacts.pactStreak.currentLabel')}
+                        </Text>
+                    </View>
+                    {!!pact.longestPactStreak && (
+                        <View style={this.themeHabits.styles.pactComparisonItem}>
+                            <Text style={this.themeHabits.styles.pactComparisonValue}>
+                                {pact.longestPactStreak}
+                            </Text>
+                            <Text style={this.themeHabits.styles.pactComparisonLabel}>
+                                {this.translate('pages.pacts.pactStreak.longestLabel')}
+                            </Text>
+                        </View>
+                    )}
+                </View>
+                <Text style={this.themeHabits.styles.streakMilestoneText}>
+                    {this.translate('pages.pacts.pactStreak.explainer')}
+                </Text>
+            </View>
+        );
+    };
+
+    /**
+     * Offered only when the server says this is the last active member of a group pact
+     * (`canContinueSolo`). Keeping the pact going alone is a deliberate opt-in, not the default
+     * outcome of everyone else leaving.
+     */
+    renderContinueSoloCard = (pact: IPact, isActionLoading: boolean) => {
+        if (!pact.canContinueSolo) {
+            return null;
+        }
+
+        return (
+            <View style={this.themeHabits.styles.streakWidgetContainer}>
+                <Text style={this.themeHabits.styles.pactCardInvitePrompt}>
+                    {this.translate('pages.pacts.solo.prompt')}
+                </Text>
+                <Button
+                    buttonStyle={this.themeButtons.styles.btnLargeWithText}
+                    titleStyle={this.themeButtons.styles.btnLargeTitle}
+                    title={this.translate('pages.pacts.solo.cta')}
+                    onPress={this.handleContinueSolo}
+                    loading={isActionLoading}
+                    disabled={isActionLoading}
+                />
             </View>
         );
     };
@@ -619,6 +809,10 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
 
                         {this.renderMembersCard(pact, currentUserId)}
 
+                        {this.renderPactStreakCard(pact)}
+
+                        {this.renderContinueSoloCard(pact, isActionLoading)}
+
                         {isActive && pact.members && pact.members.length > 1 && (
                             <View style={this.themeHabits.styles.streakWidgetContainer}>
                                 <Text style={this.themeHabits.styles.streakWidgetTitle}>
@@ -717,11 +911,7 @@ export class PactDetail extends React.Component<IPactDetailProps, IPactDetailSta
                     isVisible={showConfirmModal}
                     onCancel={this.handleCancelConfirm}
                     onConfirm={this.handleConfirmAction}
-                    text={this.translate(
-                        confirmAction === 'decline'
-                            ? 'pages.pacts.confirmDecline'
-                            : 'pages.pacts.confirmAbandon',
-                    )}
+                    text={this.getConfirmText(confirmAction)}
                     textConfirm={this.translate('modals.confirmModal.confirm')}
                     textCancel={this.translate('modals.confirmModal.cancel')}
                     translate={this.translate}

--- a/TherrMobile/main/routes/Pacts/index.tsx
+++ b/TherrMobile/main/routes/Pacts/index.tsx
@@ -1,8 +1,10 @@
+import AddPactMembers from './AddPactMembers';
 import CreatePactInvite from './CreatePactInvite';
 import HabitsPushOptIn from './HabitsPushOptIn';
 import PactDetail from './PactDetail';
 
 export {
+    AddPactMembers,
     CreatePactInvite,
     HabitsPushOptIn,
     PactDetail,

--- a/TherrMobile/main/routes/index.tsx
+++ b/TherrMobile/main/routes/index.tsx
@@ -62,7 +62,7 @@ import ViewUser from './ViewUser';
 // HABITS routes
 import { HabitsDashboard, HabitDetail, UpgradePaywall } from './Habits';
 import Journal from './Journal';
-import { PactDetail, CreatePactInvite, HabitsPushOptIn } from './Pacts';
+import { PactDetail, CreatePactInvite, HabitsPushOptIn, AddPactMembers } from './Pacts';
 import { AccessPresets } from './access';
 import { editStackOptions, momentStackOptions, viewStackOptions } from './stackOptions';
 
@@ -609,6 +609,15 @@ const routes: RouteConfig<
         component: CreatePactInvite,
         options: () => ({
             title: 'Invite a Friend',
+            requiredFeatures: [FeatureFlags.ENABLE_HABITS],
+            access: AccessPresets.EMAIL_VERIFIED,
+        }),
+    },
+    {
+        name: 'AddPactMembers',
+        component: AddPactMembers,
+        options: () => ({
+            title: 'Add Members',
             requiredFeatures: [FeatureFlags.ENABLE_HABITS],
             access: AccessPresets.EMAIL_VERIFIED,
         }),


### PR DESCRIPTION
## Summary

Surfaces the pact group-management features in the Friends with Habits app, on the pact detail screen. This is the **mobile/niche half**; the shared/backend half is #2891 (targets `general`).

## Changes (pact detail screen)

- **Shared pact streak card** — the group's own streak (current + best), distinct from each member's personal streak. Shown on an active pact once the group has built one.
- **Continue solo** prompt + CTA — shown only when the server flags the viewer as the last active member (`canContinueSolo`); a deliberate opt-in, not the default outcome of everyone leaving.
- **Add members** button + a new lightweight `AddPactMembers` screen (multi-select over the user's connections → `addPactMembers`). Deliberately a small dedicated screen rather than routing through the growth-critical create-pact wizard, since the habit goal is already fixed to the pact's.
- **Remove member** — creator-only per-member remove affordance with a confirm modal.
- `pactState.ts`: `canManagePactMembers` / `canRemovePactMember` client gates mirroring the users-service authority (creator-only, floor of 2, solo escape hatch), with unit tests.
- Error/UI copy in `en-us`, `es`, `fr-ca`.

## Depends on #2891

The mobile code calls the new `therr-react` `PactsService`/`Habits` actions and reads the new `IPact` fields, and the endpoints live in users-service — all on `general` via #2891. Those reach this branch when `general` is merged down into `niche/HABITS-general`, so **merge #2891 (and let it propagate to niche) before this PR's mobile build will go fully green in CI**. Locally everything passes against the rebuilt shared lib.

## Verification (local)

- Mobile tsc baseline: **105 = 105**, no new errors.
- Full mobile jest suite **1883 passing** (incl. new `PactMemberManagement` gate tests).
- ESLint 0 errors on changed files (inline-style warnings only, consistent with surrounding screens).
- `locales:check` clean across all three locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGEhEd8YnRFuHtvZqLFrdv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGEhEd8YnRFuHtvZqLFrdv)_