### PR TITLE
fix: stop "Unable to display replies" on feed posts + fix feed image right gutter

### DIFF
--- a/TherrMobile/main/routes/ViewThought/index.tsx
+++ b/TherrMobile/main/routes/ViewThought/index.tsx
@@ -81,6 +81,24 @@ const hapticFeedbackOptions = {
     ignoreAndroidSystemSettings: false,
 };
 
+/**
+ * Newest-first, addressable replies only.
+ *
+ * Shared by the initial seed and the details refetch so the thread renders the same way from
+ * either source. The seed comes from the thought handed over in route params: every screen that
+ * opens this one (the feed, a profile, the journal) already loads its thoughts `withReplies`, so
+ * the replies are in hand before the details request resolves. Rendering them immediately — the
+ * way the post body itself already renders from route params — is what keeps a transient details
+ * or reactions-service hiccup from turning a working thread into the "we couldn't load the
+ * replies" error, which is all the user ever saw when the enrichment request failed.
+ *
+ * The id filter guards against a backend that has not yet shipped the phantom-reply fix: an
+ * id-less reply renders as an empty card, inflates the reply count, and cannot be opened.
+ */
+const sortReplies = (list: any[]): any[] => (list || [])
+    .filter((reply) => !!reply?.id)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
 const SendIcon = ({ disabled, colors }: { disabled: boolean; colors: { active: string; inactive: string } }) => (
     <TherrIcon name="send" size={22} color={disabled ? colors.inactive : colors.active} />
 );
@@ -188,7 +206,9 @@ const ViewThought = ({
     );
 
     // State
-    const [replies, setReplies] = useState<any[]>([]);
+    // Seeded from the thought handed over in route params (the opening screen loaded it
+    // `withReplies`), so the thread is on screen before the details refetch resolves.
+    const [replies, setReplies] = useState<any[]>(() => sortReplies(route.params?.thought?.replies));
     const [inputMessage, setInputMessage] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
@@ -250,23 +270,31 @@ const ViewThought = ({
             withReplies: true,
             withParent: true,
         }).then((response) => {
-            setFetchedThought(response?.thought || {});
-            setReplies(
-                // The id filter guards against a backend that has not yet shipped the
-                // phantom-reply fix: an id-less reply renders as an empty card, inflates the
-                // reply count, and cannot be opened.
-                response?.thought?.replies?.filter((reply) => !!reply?.id).sort(
-                    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-                ) || []
-            );
+            // An offline fallback resolves to undefined (see the interceptor); keep the
+            // route-param seed rather than blanking the thread out to an empty response.
+            if (!response?.thought) {
+                return;
+            }
+            setFetchedThought(response.thought);
+            setReplies(sortReplies(response.thought.replies));
         }).catch(() => {
             // Deliberately not navigating away: the thought passed through route params is
             // enough to render the post itself, and bouncing the user back to the feed on a
             // transient failure reads as "tapping a reply does nothing".
-            showToast.error({
-                text1: translate('alertTitles.backendErrorMessage'),
-                text2: translate('pages.viewThought.repliesFailed'),
-            });
+            //
+            // The replies are already on screen too, seeded from the same route-param thought,
+            // so this refetch only misses enrichment (the parent banner, replies past the feed's
+            // preview cap, fresh reaction state). Surfacing the error only when there was nothing
+            // to fall back on keeps the common feed path — where the thread is already visible —
+            // from flashing "we couldn't load the replies" over content the user can plainly see,
+            // while a deep link straight into a thought (which carries no preloaded replies) still
+            // reports the failure.
+            if (!sortReplies(thought.replies).length) {
+                showToast.error({
+                    text1: translate('alertTitles.backendErrorMessage'),
+                    text2: translate('pages.viewThought.repliesFailed'),
+                });
+            }
         });
 
         const unsubscribeNavListener = navigation.addListener('beforeRemove', () => {

--- a/TherrMobile/main/styles/user-content/thoughts/viewing.ts
+++ b/TherrMobile/main/styles/user-content/thoughts/viewing.ts
@@ -71,6 +71,12 @@ const buildStyles = (themeName?: IMobileThemeName, isDarkMode = true) => {
             display: 'flex',
             flexDirection: 'row',
             paddingLeft: 4,
+            // The post body (message, attached image, reaction row) sits in a flex column that
+            // fills the width to the right of the author avatar. Without a right inset it runs
+            // flush to the card edge — a full-width image then touches the screen edge on the
+            // right while the avatar insets it on the left, which reads as lopsided. This gutter
+            // gives the image (and the wrapped message) symmetric breathing room on the right.
+            paddingRight: 12,
         },
         thoughtAuthorContainer: {
             display: 'flex',

--- a/therr-services/users-service/src/handlers/thoughts.ts
+++ b/therr-services/users-service/src/handlers/thoughts.ts
@@ -535,7 +535,13 @@ const getThoughtDetails = (req, res) => {
                 }
 
                 let createReactionsPromise = Promise.resolve({});
-                countReactionsPromise = countReactions(thoughtId, req.headers);
+                // Fail-soft: the like count is enrichment, not the thread itself. This is the
+                // only reactions call on the path of a plain top-level post (a shared check-in,
+                // say), so an unguarded rejection here 500s the whole details response — the
+                // client reads that as "we couldn't load the replies" and blanks a thread it
+                // could otherwise render. Degrade to a zero count instead, matching the soft
+                // handling `countReactionsByThoughtId`/`findReactionsByUser` already apply below.
+                countReactionsPromise = countReactions(thoughtId, req.headers).catch(() => ({ count: '0' }));
 
                 const replyIds = (thought.replies || []).map((reply) => reply.id).filter((id) => !!id);
                 // Activating this thought too (when it is itself a reply) keeps a reply reachable
@@ -548,7 +554,12 @@ const getThoughtDetails = (req, res) => {
 
                 // Activate child thoughts otherwise
                 if (idsToActivate.length) {
-                    createReactionsPromise = createReactions(idsToActivate, req.headers);
+                    // Best-effort: activation keeps a reply reachable on its own later, but the
+                    // thread must still render if the write fails. `createReactions` already
+                    // swallows a 403 but rethrows every other error, which would otherwise reject
+                    // the whole details fetch and hide replies that loaded fine — the write's
+                    // result is not read below (only its rejection matters), so drop it softly.
+                    createReactionsPromise = createReactions(idsToActivate, req.headers).catch(() => ({}));
                 }
 
                 // Access to a reply is not access to the thought it replies to. `createThought`

--- a/therr-services/users-service/tests/unit/handlers-thoughts-getThoughtDetails.test.ts
+++ b/therr-services/users-service/tests/unit/handlers-thoughts-getThoughtDetails.test.ts
@@ -144,6 +144,41 @@ describe('handlers/thoughts getThoughtDetails (parent thread context)', () => {
         expect(hasUserReactedStub.called).to.equal(false);
     });
 
+    // A plain top-level post (a shared check-in) makes exactly one reactions call on the way to
+    // rendering its thread — the like count — plus, when it has replies, a best-effort activation
+    // write. Neither is the thread. A reactions-service hiccup on either used to reject the whole
+    // details response, which the client surfaced as "we couldn't load the replies" over a thread
+    // it could otherwise show. Both must now degrade rather than 500.
+    const buildPublicPost = (replies: any[] = []) => ({
+        id: PARENT_ID,
+        fromUserId: OTHER_USER_ID,
+        isPublic: true,
+        message: 'a shared check-in',
+        replies,
+    });
+
+    it('still returns the thread when the like-count lookup fails', async () => {
+        (reactionsApi.countReactions as sinon.SinonStub).rejects(new Error('reactions-service down'));
+
+        const payload = await runWith(buildPublicPost());
+
+        expect(res.status.calledWith(200)).to.equal(true);
+        expect(payload.thought.id).to.equal(PARENT_ID);
+        expect(payload.thought.likeCount).to.equal(0);
+    });
+
+    it('still returns the thread when reply activation fails', async () => {
+        createReactionsStub.rejects(new Error('reactions-service down'));
+
+        const payload = await runWith(buildPublicPost([
+            { id: REPLY_ID, fromUserId: OTHER_USER_ID, createdAt: new Date().toISOString() },
+        ]));
+
+        expect(res.status.calledWith(200)).to.equal(true);
+        expect(payload.thought.id).to.equal(PARENT_ID);
+        expect(payload.thought.replies.map((reply: any) => reply.id)).to.include(REPLY_ID);
+    });
+
     it('does not pay for a parent lookup when withParent was not requested', async () => {
         getByIdStub.resolves({ thoughts: [buildOwnReply()], users: {} });
 


### PR DESCRIPTION
## Summary

Fixes two issues reported on the Friends with Habits feed when viewing a check-in (a public `main.thoughts` post): the **"Unable to display replies"** error, and a **feed image that bled off the right card edge** with no spacing. Both fixes are cross-brand — they also apply to the Therr app.

### Why this is one PR to `general`, not a split
All three changed files are shared code — mobile *feature* UI (not brand identity) and a backend handler — so per the branch-strategy rules they all belong on `general` (the only path to production). There is no brand-identity file (`brandConfig`, app id, assets, per-brand config) in this work, so there is no niche half. This corrects the earlier targeting, where the mobile fixes had been pushed to a `niche/HABITS-general`-based branch, which would have stranded shared code off the production path.

## Root cause

`getThoughtDetails` makes two reactions-service calls on the way to rendering a thread that are *enrichment, not the thread itself*:
- the main post's like count (`countReactions`) — the **only** reactions call on the path of a plain top-level post such as a shared check-in, and it had no `catch`;
- a best-effort reply-activation write (`createReactions`) when the post has replies — which rethrows anything that isn't a 403.

So a transient reactions-service failure rejected the entire details response with a 500. The mobile client surfaced that as *"we couldn't load the replies"* over a thread it could otherwise show.

## Changes

**Backend — `therr-services/users-service/src/handlers/thoughts.ts`**
- Make both calls fail soft, matching the handling `countReactionsByThoughtId` / `findReactionsByUser` already apply: the like count degrades to `0`, the activation write is dropped (its result was never read — only its rejection mattered). The thread renders regardless.
- Two regression tests assert a `200` with the post (and its replies) when each call rejects.

**Mobile — `TherrMobile/main/routes/ViewThought/index.tsx`**
- Seed the reply list from the same route-param thought the post body already renders from (every opening screen loads its thoughts `withReplies`), so the thread is on screen before the details refetch resolves and a failed refetch no longer blanks it. The error toast now only fires when there was genuinely nothing to fall back on (e.g. a deep link straight into a thought). Defence-in-depth alongside the backend fix.

**Mobile — `TherrMobile/main/styles/user-content/thoughts/viewing.ts`**
- Add a right inset to the post-body container so a full-width image no longer runs flush to the card's right edge while the avatar insets it on the left.

## Verification
- users-service unit tests: `1186 passing` (incl. the 2 new fail-soft tests); `pr:typecheck:users` clean; ESLint 0 errors.
- Mobile: `pr:tsc-baseline:mobile` `100 = 100` (no new errors); full mobile Jest suite green via pre-push.
- therr-react / web / dashboard / api-gateway suites all green via pre-push.
- No Docker in this environment, so backend integration tests were not run.

## Deploy note
`general → stage → main` ships this to the Therr app; Friends with Habits picks it up on the next `general → niche/HABITS-general` merge and Play build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Thj3dwzkmcCLmj65gs1yvX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Thj3dwzkmcCLmj65gs1yvX)_