### PR TITLE
docs(wip): Habits 1.7.x release follow-ups from the niche peer review

### DIFF
--- a/docs/WORK_IN_PROGRESS.md
+++ b/docs/WORK_IN_PROGRESS.md
@@ -1580,6 +1580,9 @@ are the steps code cannot do. Strategy, thresholds and the decision log live in
   row already exist — the handler rolls the post back, so the visible symptom is a 500 on share
   rather than silent corruption. The premium migration item above is a separate file; both are needed.
 
+- [ ] (2026-09-12, /quality-peer-review-niche) **Halt the Friends with Habits 1.7.0 (versionCode 41) rollout in Play Console** if it is still staged — it crashes on first frame (`ChameleonLoader` passed `useAnimatedProps` a factory-built closure the worklets plugin never compiled; fixed in `ad27118d4`, shipping as 1.7.1 / 42 from `niche/HABITS-main@0a4d36f53`). Promote 42 the moment it clears review.
+- [ ] (2026-09-12, /quality-peer-review-niche) **Ship `6dc1823fb` (pact member add/remove, continue-solo, shared pact streak) via `general → stage → main`** and run `20260911000001_habits.pacts.pactStreak.js` + `20260911000002_habits.pact_streak_days.js` at each step. Habits 1.7.x is already on Play advertising these in its release notes; the app feature-detects on `activeMemberCount` / `currentPactStreak` / `canContinueSolo` and hides every affordance until the users-service that hydrates them is live, so nothing breaks — users just cannot reach the features yet.
+- [ ] (2026-09-12, /quality-peer-review-niche) **After that backend lands on `main`, verify on a handset running Habits ≥ 1.7.1** that a pact creator sees "Add members" on PactDetail and the pact-streak card on an active pact — the first proof the mobile ↔ backend pair is wired end to end.
 <!-- skill-followups:end -->
 
 ---


### PR DESCRIPTION
## What

Appends three post-deploy follow-ups to the `skill-followups` block of `docs/WORK_IN_PROGRESS.md`, from the `/quality-peer-review-niche` run and the 1.7.0 crash hotfix:

1. **Halt the Friends with Habits 1.7.0 (versionCode 41) Play rollout** — it crashed on first frame (`ChameleonLoader` handed `useAnimatedProps` a factory-built closure the worklets babel plugin never compiled). Fixed in `ad27118d4`; 1.7.1 / 42 is building from `niche/HABITS-main@0a4d36f53`.
2. **Ship `6dc1823fb`** (pact member add/remove, continue-solo, shared pact streak) via `general → stage → main` with its two `20260911*` migrations. The Habits app feature-detects on the new response fields and hides the UI until this lands.
3. **Handset verification** once the backend is live: a pact creator sees "Add members" and the pact-streak card.

## Why this is a single, shared-only PR

Everything else from the session — the peer-review fixes (`b985e7dd2`), the worklet crash fix (`ad27118d4`), and both version bumps — touches only `TherrMobile/routes/Habits/**`, `routes/Pacts/**`, `Loaders/ChameleonLoader.tsx`, per-brand changelogs, and the gradle `versionCode`/`versionName`. None of the Habits mobile route tree exists on `general` (the repo keeps it on the niche line, cf. #2891 / #2892), and the gradle values are brand identity. That niche bucket is already merged on `niche/HABITS-general` and `niche/HABITS-main` (pushed directly to trigger the Play builds), so there is no second PR to raise. `docs/**` is `general`-owned, hence this one.

No code, no gates to run. Merge whenever — nothing depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3nkecC1LXufDeCUZ3fWsW
