### PR TITLE
Add right spacing to thought post images in feed

### DIFF
--- a/TherrMobile/main/styles/user-content/thoughts/viewing.ts
+++ b/TherrMobile/main/styles/user-content/thoughts/viewing.ts
@@ -254,10 +254,14 @@ const buildStyles = (themeName?: IMobileThemeName, isDarkMode = true) => {
         // portrait photo is not letterboxed; `resizeMode="cover"` at the call site keeps
         // it filling the frame either way.
         thoughtMediaImage: {
-            width: '100%',
+            // `alignSelf: 'stretch'` rather than `width: '100%'` so the right margin insets the
+            // frame instead of overflowing it — the image now lines up with the message text's
+            // right edge (which carries the same 14 right inset via `thoughtMessage.paddingRight`).
+            alignSelf: 'stretch',
             aspectRatio: 4 / 3,
             borderRadius: 8,
             marginTop: 4,
+            marginRight: 14,
             marginBottom: 8,
             backgroundColor: isDarkMode ? therrTheme.colors.accent1 : therrTheme.colorVariations.backgroundNeutral,
         },


### PR DESCRIPTION
## Summary

Thought-post images in the Friends With Habits feed rendered flush against the card's right edge, while the message text above them is inset from the right. This gives the image the same right spacing as the text so they line up.

## Change

- `TherrMobile/main/styles/user-content/thoughts/viewing.ts` — `thoughtMediaImage` now uses `alignSelf: 'stretch'` with `marginRight: 14` instead of `width: '100%'`. In the column flex container the image already stretches on the cross axis, so the margin insets the frame rather than overflowing it. The `14` matches the message text's existing `thoughtMessage.paddingRight: 14`, so the image's right edge aligns with the text.

Style-only change to the shared `ThoughtDisplay` component (its sole consumer). No backend, shared-library, or root files touched.

## Testing

Visual/style change only. Dependencies are not installed in this environment, so lint/tsc were not run here; the edit uses standard React Native `ImageStyle` properties (`alignSelf`, `marginRight`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPUEdJXM9aQZrfaKuPD6Ws

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPUEdJXM9aQZrfaKuPD6Ws)_